### PR TITLE
Remove custom windows newline replacements from .feature files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "gherkin_rust"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f80699e24afe5188930ae74427575088633e80455b073fa101892aa1571b66f1"
+checksum = "53418b6c9c3c05928f426ac13a7ea3f77f03ffb03d62fa42b076eb71665965f5"
 dependencies = [
  "peg",
  "textwrap",

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -15,4 +15,4 @@ serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 
 [dev-dependencies]
-gherkin_rust = "0.8.1"
+gherkin_rust = "0.8.2"

--- a/query-planner/src/lib.rs
+++ b/query-planner/src/lib.rs
@@ -93,12 +93,6 @@ mod tests {
             for path in feature_paths {
                 let feature = read_to_string(&path).unwrap();
 
-                let feature = if cfg!(windows) {
-                    feature.replace("\r\n", "\n")
-                } else {
-                    feature
-                };
-
                 let feature = match Feature::parse(feature) {
                     Result::Ok(feature) => feature,
                     Result::Err(e) => panic!("Unparseable .feature file {:?} -- {}", &path, e),


### PR DESCRIPTION
No need for the `\r\n` replacement, gherkin-rust's recent version fixed the bug.
see https://github.com/bbqsrc/gherkin-rust/issues/14

Before this, our **windows** tests in CI failed. 