### PR TITLE
Auto Fragmentization in the Rust Query Planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
 name = "apollo-query-planner"
 version = "0.0.1"
 dependencies = [
+ "derive_builder",
  "gherkin_rust",
  "graphql-parser",
  "lazy_static",
@@ -105,11 +106,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derivative"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -140,6 +201,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "gherkin_rust"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +231,12 @@ dependencies = [
  "pretty_assertions",
  "thiserror",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "insta"
@@ -402,6 +475,12 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +147,7 @@ dependencies = [
  "bytecount",
  "combine",
  "insta",
+ "ordered-float",
  "paste",
  "pretty_assertions",
  "thiserror",
@@ -207,6 +214,24 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "num-traits"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "output_vt100"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +157,7 @@ version = "0.3.0"
 dependencies = [
  "bytecount",
  "combine",
+ "derivative",
  "insta",
  "ordered-float",
  "paste",

--- a/graphql-parser/Cargo.toml
+++ b/graphql-parser/Cargo.toml
@@ -15,10 +15,11 @@ authors = ["Paul Colomiets <paul@colomiets.name>"]
 edition = "2018"
 
 [dependencies]
-combine = "3.8.1"
-thiserror = "1.0.20"
 bytecount = "0.6.0"
+combine = "3.8.1"
+derivative = "2.1.1"
 ordered-float = "2.0.0"
+thiserror = "1.0.20"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/graphql-parser/Cargo.toml
+++ b/graphql-parser/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 combine = "3.8.1"
 thiserror = "1.0.20"
 bytecount = "0.6.0"
+ordered-float = "2.0.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/graphql-parser/src/common.rs
+++ b/graphql-parser/src/common.rs
@@ -12,8 +12,10 @@ use crate::position::Pos;
 use crate::tokenizer::{Kind as T, Token, TokenStream};
 use ordered_float::NotNan;
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct Directive<'a> {
+    #[derivative(Hash = "ignore")]
     pub position: Pos,
     pub name: &'a str,
     pub arguments: Vec<(Txt<'a>, Value<'a>)>,

--- a/graphql-parser/src/common.rs
+++ b/graphql-parser/src/common.rs
@@ -10,8 +10,9 @@ use combine::{parser, ParseResult, Parser};
 use crate::helpers::{ident, kind, name, punct};
 use crate::position::Pos;
 use crate::tokenizer::{Kind as T, Token, TokenStream};
+use ordered_float::NotNan;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct Directive<'a> {
     pub position: Pos,
     pub name: &'a str,
@@ -20,11 +21,11 @@ pub struct Directive<'a> {
 
 pub type Txt<'a> = &'a str;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub enum Value<'a> {
     Variable(Txt<'a>),
     Int(i64),
-    Float(f64),
+    Float(NotNan<f64>),
     String(String),
     Boolean(bool),
     Null,
@@ -33,7 +34,7 @@ pub enum Value<'a> {
     Object(BTreeMap<Txt<'a>, Value<'a>>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub enum Type<'a> {
     NamedType(Txt<'a>),
     ListType(Box<Type<'a>>),
@@ -78,7 +79,7 @@ pub fn int_value<'a>(input: &mut TokenStream<'a>) -> ParseResult<Value<'a>, Toke
 
 pub fn float_value<'a>(input: &mut TokenStream<'a>) -> ParseResult<Value<'a>, TokenStream<'a>> {
     kind(T::FloatValue)
-        .and_then(|tok| tok.value.parse())
+        .and_then(|tok| tok.value.parse::<NotNan<f64>>())
         .map(Value::Float)
         .parse_stream(input)
 }

--- a/graphql-parser/src/lib.rs
+++ b/graphql-parser/src/lib.rs
@@ -171,6 +171,9 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+#[macro_use]
+extern crate derivative;
+
 mod common;
 #[macro_use]
 mod format;

--- a/graphql-parser/src/query/ast.rs
+++ b/graphql-parser/src/query/ast.rs
@@ -9,19 +9,19 @@ pub use crate::common::{Directive, Txt, Type, Value};
 use crate::position::Pos;
 
 /// Root of query data
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Document<'a> {
     pub definitions: Vec<Definition<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Definition<'a> {
     SelectionSet(SelectionSet<'a>),
     Operation(OperationDefinition<'a>),
     Fragment(FragmentDefinition<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FragmentDefinition<'a> {
     pub position: Pos,
     pub description: Option<String>,
@@ -31,7 +31,7 @@ pub struct FragmentDefinition<'a> {
     pub selection_set: SelectionSet<'a>,
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OperationDefinition<'a> {
     pub position: Pos,
     pub kind: Operation,
@@ -42,7 +42,7 @@ pub struct OperationDefinition<'a> {
     pub selection_set: SelectionSet<'a>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Operation {
     Query,
     Mutation,
@@ -60,14 +60,18 @@ impl Operation {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct SelectionSet<'a> {
+    #[derivative(Hash = "ignore")]
     pub span: (Pos, Pos),
     pub items: Vec<Selection<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct VariableDefinition<'a> {
+    #[derivative(Hash = "ignore")]
     pub position: Pos,
     pub name: Txt<'a>,
     pub var_type: Type<'a>,
@@ -81,8 +85,10 @@ pub enum Selection<'a> {
     InlineFragment(InlineFragment<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct Field<'a> {
+    #[derivative(Hash = "ignore")]
     pub position: Pos,
     pub alias: Option<Txt<'a>>,
     pub name: Txt<'a>,
@@ -91,15 +97,19 @@ pub struct Field<'a> {
     pub selection_set: SelectionSet<'a>,
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct FragmentSpread<'a> {
+    #[derivative(Hash = "ignore")]
     pub position: Pos,
     pub fragment_name: Txt<'a>,
     pub directives: Vec<Directive<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct InlineFragment<'a> {
+    #[derivative(Hash = "ignore")]
     pub position: Pos,
     pub type_condition: Option<Txt<'a>>,
     pub directives: Vec<Directive<'a>>,

--- a/graphql-parser/src/query/ast.rs
+++ b/graphql-parser/src/query/ast.rs
@@ -9,19 +9,19 @@ pub use crate::common::{Directive, Txt, Type, Value};
 use crate::position::Pos;
 
 /// Root of query data
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct Document<'a> {
     pub definitions: Vec<Definition<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub enum Definition<'a> {
     SelectionSet(SelectionSet<'a>),
     Operation(OperationDefinition<'a>),
     Fragment(FragmentDefinition<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct FragmentDefinition<'a> {
     pub position: Pos,
     pub description: Option<String>,
@@ -31,7 +31,7 @@ pub struct FragmentDefinition<'a> {
     pub selection_set: SelectionSet<'a>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct OperationDefinition<'a> {
     pub position: Pos,
     pub kind: Operation,
@@ -42,7 +42,7 @@ pub struct OperationDefinition<'a> {
     pub selection_set: SelectionSet<'a>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
 pub enum Operation {
     Query,
     Mutation,
@@ -60,13 +60,13 @@ impl Operation {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SelectionSet<'a> {
     pub span: (Pos, Pos),
     pub items: Vec<Selection<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct VariableDefinition<'a> {
     pub position: Pos,
     pub name: Txt<'a>,
@@ -74,14 +74,14 @@ pub struct VariableDefinition<'a> {
     pub default_value: Option<Value<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub enum Selection<'a> {
     Field(Field<'a>),
     FragmentSpread(FragmentSpread<'a>),
     InlineFragment(InlineFragment<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct Field<'a> {
     pub position: Pos,
     pub alias: Option<Txt<'a>>,
@@ -91,14 +91,14 @@ pub struct Field<'a> {
     pub selection_set: SelectionSet<'a>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct FragmentSpread<'a> {
     pub position: Pos,
     pub fragment_name: Txt<'a>,
     pub directives: Vec<Directive<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct InlineFragment<'a> {
     pub position: Pos,
     pub type_condition: Option<Txt<'a>>,

--- a/graphql-parser/src/query/format.rs
+++ b/graphql-parser/src/query/format.rs
@@ -3,7 +3,9 @@ use std::fmt;
 use crate::format::{format_directives, Displayable, Formatter, Style};
 
 use crate::query::ast::*;
-use crate::query::refs::{FieldRef, InlineFragmentRef, SelectionRef, SelectionSetRef};
+use crate::query::refs::{
+    FieldRef, FragmentSpreadRef, InlineFragmentRef, SelectionRef, SelectionSetRef,
+};
 
 impl<'a> Document<'a> {
     /// Format a document according to style
@@ -100,6 +102,7 @@ impl<'a> Displayable for SelectionRef<'a> {
             SelectionRef::Field(field) => field.display(f),
             SelectionRef::FieldRef(fr) => fr.display(f),
             SelectionRef::InlineFragmentRef(inline) => inline.display(f),
+            SelectionRef::FragmentSpreadRef(fsr) => fsr.display(f),
         }
     }
 }
@@ -293,6 +296,15 @@ impl<'a> Displayable for FragmentSpread<'a> {
         f.write("...");
         f.write(self.fragment_name.as_ref());
         format_directives(&self.directives, f);
+        f.endline();
+    }
+}
+
+impl Displayable for FragmentSpreadRef {
+    fn display(&self, f: &mut Formatter) {
+        f.indent();
+        f.write("...");
+        f.write(self.name.as_ref());
         f.endline();
     }
 }

--- a/graphql-parser/src/query/minified.rs
+++ b/graphql-parser/src/query/minified.rs
@@ -106,7 +106,14 @@ impl<'a> MinifiedString for FragmentDefinition<'a> {
         write!(f, "fragment ", self.name, " on ", self.type_condition);
         minify_each!(f, self.directives);
         self.selection_set.minify(f);
+        self.selection_set.items.is_empty()
+    }
+}
 
+impl<'a> MinifiedString for FragmentDefinitionRef<'a> {
+    fn minify(&self, f: &mut MinifiedFormatter) -> bool {
+        write!(f, "fragment ", &self.name, " on ", &self.type_condition);
+        self.selection_set.minify(f);
         self.selection_set.items.is_empty()
     }
 }
@@ -163,8 +170,16 @@ minify_enum!(
     SelectionRef::Ref,
     SelectionRef::Field,
     SelectionRef::FieldRef,
-    SelectionRef::InlineFragmentRef
+    SelectionRef::InlineFragmentRef,
+    SelectionRef::FragmentSpreadRef
 );
+
+impl<'a> MinifiedString for FragmentSpreadRef {
+    fn minify(&self, f: &mut MinifiedFormatter) -> bool {
+        write!(f, "...", &self.name);
+        true
+    }
+}
 
 impl<'a> MinifiedString for Field<'a> {
     fn minify(&self, f: &mut MinifiedFormatter) -> bool {

--- a/graphql-parser/src/query/refs.rs
+++ b/graphql-parser/src/query/refs.rs
@@ -10,6 +10,8 @@ pub enum SelectionRef<'a> {
     Field(&'a Field<'a>),
     FieldRef(FieldRef<'a>),
     InlineFragmentRef(InlineFragmentRef<'a>),
+    // only used with auto fragmentation at before writing the "operation" field into a FetchNode.
+    FragmentSpreadRef(FragmentSpreadRef),
 }
 
 impl<'a> SelectionRef<'a> {
@@ -65,6 +67,11 @@ impl<'a> SelectionRef<'a> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct FragmentSpreadRef {
+    pub name: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Default, Hash)]
 pub struct SelectionSetRef<'a> {
     pub span: (Pos, Pos),
@@ -101,6 +108,14 @@ pub struct InlineFragmentRef<'a> {
     pub position: Pos,
     pub type_condition: Option<Txt<'a>>,
     pub directives: Vec<Directive<'a>>,
+    pub selection_set: SelectionSetRef<'a>,
+}
+
+// only used with auto fragmentation at before writing the "operation" field into a FetchNode.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FragmentDefinitionRef<'a> {
+    pub name: String,
+    pub type_condition: String,
     pub selection_set: SelectionSetRef<'a>,
 }
 

--- a/graphql-parser/src/query/refs.rs
+++ b/graphql-parser/src/query/refs.rs
@@ -107,7 +107,7 @@ impl<'a> FieldRef<'a> {
 pub struct InlineFragmentRef<'a> {
     pub position: Pos,
     pub type_condition: Option<Txt<'a>>,
-    pub directives: Vec<Directive<'a>>,
+    pub directives: &'a Vec<Directive<'a>>,
     pub selection_set: SelectionSetRef<'a>,
 }
 

--- a/graphql-parser/src/query/refs.rs
+++ b/graphql-parser/src/query/refs.rs
@@ -4,7 +4,7 @@ use crate::query::{Field, SelectionSet};
 use crate::{node_trait, visit, visit_each};
 use crate::{query, Pos};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub enum SelectionRef<'a> {
     Ref(&'a query::Selection<'a>),
     Field(&'a Field<'a>),
@@ -65,7 +65,7 @@ impl<'a> SelectionRef<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Hash)]
 pub struct SelectionSetRef<'a> {
     pub span: (Pos, Pos),
     pub items: Vec<SelectionRef<'a>>,
@@ -80,7 +80,7 @@ impl<'a> From<&'a SelectionSet<'a>> for SelectionSetRef<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct FieldRef<'a> {
     pub position: Pos,
     pub alias: Option<Txt<'a>>,
@@ -96,7 +96,7 @@ impl<'a> FieldRef<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct InlineFragmentRef<'a> {
     pub position: Pos,
     pub type_condition: Option<Txt<'a>>,

--- a/graphql-parser/src/query/refs.rs
+++ b/graphql-parser/src/query/refs.rs
@@ -72,8 +72,10 @@ pub struct FragmentSpreadRef {
     pub name: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Hash)]
+#[derive(Debug, Clone, PartialEq, Default, Derivative)]
+#[derivative(Hash)]
 pub struct SelectionSetRef<'a> {
+    #[derivative(Hash = "ignore")]
     pub span: (Pos, Pos),
     pub items: Vec<SelectionRef<'a>>,
 }
@@ -87,8 +89,10 @@ impl<'a> From<&'a SelectionSet<'a>> for SelectionSetRef<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct FieldRef<'a> {
+    #[derivative(Hash = "ignore")]
     pub position: Pos,
     pub alias: Option<Txt<'a>>,
     pub name: Txt<'a>,
@@ -103,8 +107,10 @@ impl<'a> FieldRef<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Derivative)]
+#[derivative(Hash)]
 pub struct InlineFragmentRef<'a> {
+    #[derivative(Hash = "ignore")]
     pub position: Pos,
     pub type_condition: Option<Txt<'a>>,
     pub directives: &'a Vec<Directive<'a>>,

--- a/graphql-parser/tests/snapshots/tests__extend_input__parse_schema__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__extend_input__parse_schema__unix.snap
@@ -26,7 +26,9 @@ Ok(
                                 ),
                                 default_value: Some(
                                     Float(
-                                        12300.0,
+                                        NotNan(
+                                            12300.0,
+                                        ),
                                     ),
                                 ),
                                 directives: [],

--- a/graphql-parser/tests/snapshots/tests__extend_input__parse_schema__win.snap
+++ b/graphql-parser/tests/snapshots/tests__extend_input__parse_schema__win.snap
@@ -26,7 +26,9 @@ Ok(
                                 ),
                                 default_value: Some(
                                     Float(
-                                        12300.0,
+                                        NotNan(
+                                            12300.0,
+                                        ),
                                     ),
                                 ),
                                 directives: [],

--- a/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_query__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_query__unix.snap
@@ -27,7 +27,9 @@ Ok(
                             ),
                             default_value: Some(
                                 Float(
-                                    0.5,
+                                    NotNan(
+                                        0.5,
+                                    ),
                                 ),
                             ),
                         },

--- a/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_query__win.snap
+++ b/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_query__win.snap
@@ -27,7 +27,9 @@ Ok(
                             ),
                             default_value: Some(
                                 Float(
-                                    0.5,
+                                    NotNan(
+                                        0.5,
+                                    ),
                                 ),
                             ),
                         },

--- a/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_schema__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_schema__unix.snap
@@ -27,7 +27,9 @@ Ok(
                             ),
                             default_value: Some(
                                 Float(
-                                    0.5,
+                                    NotNan(
+                                        0.5,
+                                    ),
                                 ),
                             ),
                         },

--- a/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_schema__win.snap
+++ b/graphql-parser/tests/snapshots/tests__query_var_default_float__parse_schema__win.snap
@@ -27,7 +27,9 @@ Ok(
                             ),
                             default_value: Some(
                                 Float(
-                                    0.5,
+                                    NotNan(
+                                        0.5,
+                                    ),
                                 ),
                             ),
                         },

--- a/graphql-parser/tests/snapshots/tests__schema_kitchen_sink__parse_schema__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__schema_kitchen_sink__parse_schema__unix.snap
@@ -971,7 +971,9 @@ Ok(
                                 ),
                                 default_value: Some(
                                     Float(
-                                        12300.0,
+                                        NotNan(
+                                            12300.0,
+                                        ),
                                     ),
                                 ),
                                 directives: [],

--- a/graphql-parser/tests/snapshots/tests__schema_kitchen_sink__parse_schema__win.snap
+++ b/graphql-parser/tests/snapshots/tests__schema_kitchen_sink__parse_schema__win.snap
@@ -971,7 +971,9 @@ Ok(
                                 ),
                                 default_value: Some(
                                     Float(
-                                        12300.0,
+                                        NotNan(
+                                            12300.0,
+                                        ),
                                     ),
                                 ),
                                 directives: [],

--- a/query-planner-wasm/src/lib.rs
+++ b/query-planner-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate wasm_bindgen;
 
-use apollo_query_planner::QueryPlanner;
+use apollo_query_planner::{QueryPlanner, QueryPlanningOptionsBuilder};
 use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
@@ -27,7 +27,8 @@ pub fn get_query_plan(planner_ptr: usize, query: &str) -> JsValue {
     unsafe {
         let planner = planner_ptr as *const QueryPlanner;
         let planner: &QueryPlanner = &*planner;
-        let plan = planner.plan(query, false).unwrap();
+        let options = QueryPlanningOptionsBuilder::default().build().unwrap();
+        let plan = planner.plan(query, options).unwrap();
         JsValue::from_serde(&plan).unwrap()
     }
 }

--- a/query-planner-wasm/src/lib.rs
+++ b/query-planner-wasm/src/lib.rs
@@ -27,7 +27,7 @@ pub fn get_query_plan(planner_ptr: usize, query: &str) -> JsValue {
     unsafe {
         let planner = planner_ptr as *const QueryPlanner;
         let planner: &QueryPlanner = &*planner;
-        let plan = planner.plan(query).unwrap();
+        let plan = planner.plan(query, false).unwrap();
         JsValue::from_serde(&plan).unwrap()
     }
 }

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -8,7 +8,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# workspace
 graphql-parser = { path = "../graphql-parser" }
+
+# 3rd party
+derive_builder = "0.9.0"
 lazy_static = "1.4.0"
 linked-hash-map = "0.5.3"
 serde = { version = "1.0.116", features = ["derive"] }

--- a/query-planner/src/autofrag.rs
+++ b/query-planner/src/autofrag.rs
@@ -197,6 +197,7 @@ mod tests {
     use crate::context::QueryPlanningContext;
     use crate::federation::Federation;
     use crate::helpers::{build_possible_types, names_to_types, variable_name_to_def, Op};
+    use crate::QueryPlanningOptionsBuilder;
     use graphql_parser::query::refs::SelectionSetRef;
     use graphql_parser::query::{Definition, Operation};
     use graphql_parser::{parse_query, parse_schema, DisplayMinified};
@@ -279,15 +280,19 @@ mod tests {
         };
 
         let types = names_to_types(&schema);
+        let options = QueryPlanningOptionsBuilder::default()
+            .auto_fragmentization(true)
+            .build()
+            .unwrap();
         let context = QueryPlanningContext {
             schema: &schema,
             operation,
             fragments: HashMap::new(),
-            auto_fragmentization: true,
             possible_types: build_possible_types(&schema, &types),
             variable_name_to_def: variable_name_to_def(&query),
             federation: Federation::new(&schema),
             names_to_types: types,
+            options,
         };
         let (frags, ssr) = auto_fragmentization(
             &context,

--- a/query-planner/src/autofrag.rs
+++ b/query-planner/src/autofrag.rs
@@ -11,7 +11,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
-pub(crate) fn auto_fragmentation<'q>(
+pub(crate) fn auto_fragmentization<'q>(
     context: &'q QueryPlanningContext<'q>,
     selection_set: SelectionSetRef<'q>,
 ) -> (Vec<FragmentDefinitionRef<'q>>, SelectionSetRef<'q>) {
@@ -215,7 +215,7 @@ impl Counter {
 
 #[cfg(test)]
 mod tests {
-    use crate::autofrag::auto_fragmentation;
+    use crate::autofrag::auto_fragmentization;
     use crate::context::QueryPlanningContext;
     use crate::federation::Federation;
     use crate::helpers::{build_possible_types, names_to_types, variable_name_to_def, Op};
@@ -225,7 +225,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn test_auto_fragmentation() {
+    fn test_auto_fragmentization() {
         let schema = "schema {
             query: Query
         }
@@ -311,7 +311,7 @@ mod tests {
             federation: Federation::new(&schema),
             names_to_types: types,
         };
-        let (frags, ssr) = auto_fragmentation(
+        let (frags, ssr) = auto_fragmentization(
             &context,
             SelectionSetRef::from(context.operation.selection_set),
         );

--- a/query-planner/src/autofrag.rs
+++ b/query-planner/src/autofrag.rs
@@ -225,7 +225,6 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    #[should_panic]
     fn test_auto_fragmentation() {
         let schema = "schema {
             query: Query
@@ -277,18 +276,16 @@ mod tests {
             "
             fragment __QueryPlanFragment_0__ on B { f1 f2 f4 }
             fragment __QueryPlanFragment_1__ on SomeField {
-                field {
-                  a { b { ...__QueryPlanFragment_0__ } }
-                  b { ...__QueryPlanFragment_0__ }
-                  iface {
-                    ...on IFaceImpl1 { x }
-                    ...on IFaceImpl2 { x }
-                  }
-                }
+              a { b { ...__QueryPlanFragment_0__ } }
+              b { ...__QueryPlanFragment_0__ }
+              iface {
+                ...on IFaceImpl1 { x }
+                ...on IFaceImpl2 { x }
+              }
             }
             
             {
-              ...__QueryPlanFragment_1__
+              field { ...__QueryPlanFragment_1__ }
             }
         ",
         )
@@ -318,8 +315,12 @@ mod tests {
             &context,
             SelectionSetRef::from(context.operation.selection_set),
         );
-        assert_eq!(1, frags.len());
-        let got = format!("{} {}", frags[0].minified(), ssr.minified());
+        assert_eq!(2, frags.len());
+        let frags = frags
+            .into_iter()
+            .map(|fd| fd.minified())
+            .collect::<String>();
+        let got = format!("{}{}", frags, ssr.minified());
         let new_query = parse_query(&got).unwrap().minified();
         assert_eq!(expected, new_query);
     }

--- a/query-planner/src/autofrag.rs
+++ b/query-planner/src/autofrag.rs
@@ -1,0 +1,113 @@
+use crate::context::QueryPlanningContext;
+use graphql_parser::query::refs::{FragmentDefinitionRef, SelectionSetRef};
+
+pub(crate) fn auto_fragmentation<'a, 'q: 'a>(
+    context: &'q QueryPlanningContext<'q>,
+    selection_set: SelectionSetRef<'q>,
+) -> (Vec<FragmentDefinitionRef<'a>>, SelectionSetRef<'a>) {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::autofrag::auto_fragmentation;
+    use crate::context::QueryPlanningContext;
+    use crate::federation::Federation;
+    use crate::helpers::{build_possible_types, names_to_types, variable_name_to_def, Op};
+    use graphql_parser::query::refs::SelectionSetRef;
+    use graphql_parser::query::{Definition, Operation};
+    use graphql_parser::{parse_query, parse_schema, DisplayMinified};
+    use std::collections::HashMap;
+
+    #[test]
+    #[should_panic]
+    fn test_auto_fragmentation() {
+        let schema = "schema {
+            query: Query
+        }
+
+        type Query {
+            field: SomeField
+        }
+
+        interface IFace {
+            x: Int
+        }
+
+        type IFaceImpl1 implements IFace { x: Int }
+        type IFaceImpl2 implements IFace { x: Int }
+
+        type SomeField {
+          a: A
+          b: B
+          iface: IFace
+        }
+
+        type A {
+          b: B
+        }
+
+        type B {
+          f1: String
+          f2: String
+          f3: String
+          f4: String
+          f5: String
+          f6: String
+        }
+        ";
+
+        let query = "{
+          field {
+            a { b { f1 f2 f4 } }
+            b { f1 f2 f4 }
+            iface {
+                ...on IFaceImpl1 { x }
+                ...on IFaceImpl2 { x }
+            }
+          }
+        }";
+
+        let expected = parse_query(
+            "
+            fragment __QueryPlanFragment_1__ on B { f1 f2 f4 }
+            {
+                field {
+                  a { b { ...__QueryPlanFragment_1__ } }
+                  b { ...__QueryPlanFragment_1__ }
+                }
+            }
+        ",
+        )
+        .unwrap()
+        .minified();
+
+        let schema = parse_schema(schema).unwrap();
+        let query = parse_query(query).unwrap();
+        let ss = letp!(Definition::SelectionSet(ref ss) = query.definitions[0] => ss);
+        let operation = Op {
+            selection_set: ss,
+            kind: Operation::Query,
+        };
+
+        let types = names_to_types(&schema);
+        let context = QueryPlanningContext {
+            schema: &schema,
+            operation,
+            fragments: HashMap::new(),
+            auto_fragmentization: true,
+            possible_types: build_possible_types(&schema, &types),
+            variable_name_to_def: variable_name_to_def(&query),
+            federation: Federation::new(&schema),
+            names_to_types: types,
+        };
+        let (frags, ssr) = auto_fragmentation(
+            &context,
+            SelectionSetRef::from(context.operation.selection_set),
+        );
+        assert_eq!(1, frags.len());
+        let got = format!("{} {}", frags[0].minified(), ssr.minified());
+        let new_query = parse_query(&got).unwrap().minified();
+        assert_eq!(expected, new_query);
+    }
+}

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -490,7 +490,7 @@ fn execution_node_for_group(
     let (variable_names, variable_defs) = context.get_variable_usages(&selection_set);
 
     let operation = if requires.is_some() {
-        operation_for_entities_fetch(context, selection_set, variable_defs)
+        operation_for_entities_fetch(selection_set, variable_defs)
     } else {
         operation_for_root_fetch(
             context,
@@ -627,7 +627,6 @@ fn selection_set_from_field_set<'q>(
 }
 
 fn operation_for_entities_fetch<'q>(
-    context: &'q QueryPlanningContext<'q>,
     selection_set: SelectionSetRef<'q>,
     variable_definitions: Vec<&'q VariableDefinition<'q>>,
 ) -> GraphQLDocument {
@@ -636,13 +635,10 @@ fn operation_for_entities_fetch<'q>(
         .chain(variable_definitions.iter().map(|vd| vd.minified()))
         .collect::<String>();
 
-    let (frags, selection_set) = maybe_auto_fragmentization(context, selection_set);
-
     format!(
-        "query({}){{_entities(representations:$representations){}}}{}",
+        "query({}){{_entities(representations:$representations){}}}",
         vars,
         selection_set.minified(),
-        frags
     )
 }
 

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -191,6 +191,9 @@ pub(crate) fn collect_fields<'q>(
                         }
                     }
                 }
+                SelectionRef::FragmentSpreadRef(_) => {
+                    unreachable!("FragmentSpreadRef is only used at the end of query planning")
+                }
             }
         }
     }
@@ -731,6 +734,9 @@ fn ref_into_model_selection_set(selection_set_ref: SelectionSetRef) -> ModelSele
                     type_condition: inline.type_condition.map(String::from),
                     selections: ref_into_model_selection_set(inline.selection_set),
                 })
+            }
+            SelectionRef::FragmentSpreadRef(_) => {
+                unreachable!("FragmentSpreadRef is only used at the end of query planning")
             }
         }
     }

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -766,7 +766,7 @@ fn flat_wrap(kind: NodeCollectionKind, mut nodes: Vec<PlanNode>) -> PlanNode {
     }
 }
 
-fn maybe_auto_fragmentization<'a, 'q: 'a>(
+fn maybe_auto_fragmentization<'q>(
     context: &'q QueryPlanningContext<'q>,
     selection_set: SelectionSetRef<'q>,
 ) -> (String, String) {

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::autofrag::auto_fragmentation;
 use crate::consts::{
-    typename_field_def, typename_field_node, MUTATION_TYPE_NAME, QUERY_TYPE_NAME,
+    typename_field_def, typename_field_node, EMPTY_DIRECTIVES, MUTATION_TYPE_NAME, QUERY_TYPE_NAME,
     TYPENAME_FIELD_NAME,
 };
 use crate::context::*;
@@ -325,7 +325,10 @@ fn split_fields<'a, 'q: 'a>(
     }
 }
 
-fn get_field_def_from_type<'q>(td: &'q TypeDefinition<'q>, name: &'q str) -> &'q schema::Field<'q> {
+pub(crate) fn get_field_def_from_type<'q>(
+    td: &'q TypeDefinition<'q>,
+    name: &'q str,
+) -> &'q schema::Field<'q> {
     if name == TYPENAME_FIELD_NAME {
         typename_field_def()
     } else {
@@ -543,7 +546,7 @@ fn selection_set_from_field_set<'q>(
             vec![SelectionRef::InlineFragmentRef(InlineFragmentRef {
                 position: pos(),
                 type_condition: type_condition.name(),
-                directives: vec![],
+                directives: &EMPTY_DIRECTIVES,
                 selection_set: SelectionSetRef {
                     span: span(),
                     items: selections,

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -667,7 +667,7 @@ fn operation_for_root_fetch<'q>(
         _ => op_kind.as_str(),
     };
 
-    format!("{}{}{}{}", op_kind, vars, selection_set.minified(), frags)
+    format!("{}{}{}{}", op_kind, vars, selection_set, frags)
 }
 
 fn field_into_model_selection(field: &query::Field) -> ModelSelection {
@@ -769,15 +769,15 @@ fn flat_wrap(kind: NodeCollectionKind, mut nodes: Vec<PlanNode>) -> PlanNode {
 fn maybe_auto_fragmentization<'a, 'q: 'a>(
     context: &'q QueryPlanningContext<'q>,
     selection_set: SelectionSetRef<'q>,
-) -> (String, SelectionSetRef<'a>) {
+) -> (String, String) {
     if context.auto_fragmentization {
         let (frags, selection_set) = auto_fragmentization(context, selection_set);
         let frags = frags
             .into_iter()
             .map(|fd| fd.minified())
             .collect::<String>();
-        (frags, selection_set)
+        (frags, selection_set.minified())
     } else {
-        (String::from(""), selection_set)
+        (String::from(""), selection_set.minified())
     }
 }

--- a/query-planner/src/context.rs
+++ b/query-planner/src/context.rs
@@ -3,6 +3,7 @@ use crate::consts::{typename_field_def, typename_field_node};
 use crate::federation::Federation;
 use crate::helpers::Op;
 use crate::visitors::VariableUsagesMap;
+use crate::QueryPlanningOptions;
 use graphql_parser::query::refs::{FieldRef, Node, SelectionRef, SelectionSetRef};
 use graphql_parser::query::*;
 use graphql_parser::schema::TypeDefinition;
@@ -10,7 +11,7 @@ use graphql_parser::{schema, Name};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct QueryPlanningContext<'q> {
     pub schema: &'q schema::Document<'q>,
     pub operation: Op<'q>,
@@ -19,7 +20,7 @@ pub struct QueryPlanningContext<'q> {
     pub names_to_types: HashMap<&'q str, &'q TypeDefinition<'q>>,
     pub variable_name_to_def: HashMap<&'q str, &'q VariableDefinition<'q>>,
     pub federation: Federation<'q>,
-    pub auto_fragmentization: bool,
+    pub options: QueryPlanningOptions,
 }
 
 impl<'q> QueryPlanningContext<'q> {

--- a/query-planner/src/context.rs
+++ b/query-planner/src/context.rs
@@ -204,6 +204,9 @@ impl<'q> QueryPlanningContext<'q> {
                             )
                         }
                     }
+                    SelectionRef::FragmentSpreadRef(_) => {
+                        unreachable!("FragmentSpreadRef is only used at the end of query planning")
+                    }
                 }
             }
         }

--- a/query-planner/src/context.rs
+++ b/query-planner/src/context.rs
@@ -4,7 +4,6 @@ use crate::federation::Federation;
 use crate::helpers::Op;
 use crate::visitors::VariableUsagesMap;
 use graphql_parser::query::refs::{FieldRef, Node, SelectionRef, SelectionSetRef};
-use graphql_parser::query::Node as QueryNode;
 use graphql_parser::query::*;
 use graphql_parser::schema::TypeDefinition;
 use graphql_parser::{schema, Name};
@@ -55,21 +54,13 @@ impl<'q> QueryPlanningContext<'q> {
     pub fn get_variable_usages(
         &self,
         selection_set: &SelectionSetRef,
-        fragments: &[&'q FragmentDefinition<'q>],
     ) -> (Vec<String>, Vec<&VariableDefinition>) {
-        let mut v = selection_set
+        selection_set
             .map(VariableUsagesMap::new(&self.variable_name_to_def))
             .output
-            .unwrap();
-
-        v.extend(fragments.iter().flat_map(|fd| {
-            fd.selection_set
-                .map(VariableUsagesMap::new(&self.variable_name_to_def))
-                .output
-                .unwrap()
-        }));
-
-        v.into_iter().unzip()
+            .unwrap()
+            .into_iter()
+            .unzip()
     }
 
     pub fn type_def_for_object(

--- a/query-planner/src/lib.rs
+++ b/query-planner/src/lib.rs
@@ -7,6 +7,7 @@ use graphql_parser::{parse_query, parse_schema, schema, ParseError};
 
 #[macro_use]
 mod macros;
+mod autofrag;
 mod builder;
 mod consts;
 mod context;

--- a/query-planner/src/lib.rs
+++ b/query-planner/src/lib.rs
@@ -50,6 +50,7 @@ impl<'s> QueryPlanner<'s> {
 // simple #[derive(Builder)] will generate a FooBuilder for your struct Foo with all setter-methods and a build method.
 #[derive(Default, Builder, Debug)]
 pub struct QueryPlanningOptions {
+    #[builder(default)]
     auto_fragmentization: bool,
 }
 
@@ -128,5 +129,11 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn query_planning_options_initialization() {
+        let options = QueryPlanningOptionsBuilder::default().build().unwrap();
+        assert_eq!(false, options.auto_fragmentization);
     }
 }

--- a/query-planner/src/macros.rs
+++ b/query-planner/src/macros.rs
@@ -1,4 +1,3 @@
-#[macro_export]
 macro_rules! get_directive {
     ($directives:expr , $name:expr) => {
         $directives.iter().filter(|d| d.name == $name)
@@ -16,7 +15,6 @@ macro_rules! get_directive {
     };
 }
 
-#[macro_export]
 macro_rules! letp {
     ($pat:pat = $expr:expr => $stmt:stmt ) => {
         if let $pat = $expr {
@@ -27,7 +25,6 @@ macro_rules! letp {
     };
 }
 
-#[macro_export]
 macro_rules! get_field_def {
     ($obj:ident, $name:expr) => {
         if $name == crate::consts::TYPENAME_FIELD_NAME {
@@ -50,7 +47,6 @@ macro_rules! values {
     };
 }
 
-#[macro_export]
 macro_rules! field_ref {
     ($f:expr, $ss:expr) => {
         graphql_parser::query::refs::FieldRef {
@@ -70,7 +66,6 @@ macro_rules! field_ref {
     };
 }
 
-#[macro_export]
 macro_rules! inline_fragment_ref {
     ($f:expr, $ss:expr) => {
         graphql_parser::query::refs::InlineFragmentRef {

--- a/query-planner/src/macros.rs
+++ b/query-planner/src/macros.rs
@@ -50,6 +50,7 @@ macro_rules! values {
     };
 }
 
+#[macro_export]
 macro_rules! field_ref {
     ($f:expr, $ss:expr) => {
         graphql_parser::query::refs::FieldRef {
@@ -63,6 +64,24 @@ macro_rules! field_ref {
     };
     ($f:expr) => {
         field_ref!(
+            $f,
+            graphql_parser::query::refs::SelectionSetRef::from(&$f.selection_set)
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! inline_fragment_ref {
+    ($f:expr, $ss:expr) => {
+        graphql_parser::query::refs::InlineFragmentRef {
+            position: $f.position,
+            type_condition: $f.type_condition,
+            directives: &$f.directives,
+            selection_set: $ss,
+        }
+    };
+    ($f:expr) => {
+        inline_fragment_ref!(
             $f,
             graphql_parser::query::refs::SelectionSetRef::from(&$f.selection_set)
         )

--- a/query-planner/src/visitors.rs
+++ b/query-planner/src/visitors.rs
@@ -92,6 +92,9 @@ impl<'q> refs::Map for VariableUsagesMap<'q> {
             SelectionRef::Field(field) => build_variables_map!(field: field, self),
             SelectionRef::FieldRef(field) => build_variables_map!(field: field, self),
             SelectionRef::InlineFragmentRef(inline) => build_variables_map!(inline, self),
+            SelectionRef::FragmentSpreadRef(_) => {
+                unreachable!("FragmentSpreadRef is only used at the end of query planning")
+            }
         }
     }
 }

--- a/query-planner/tests/features/autofrag/auto-fragmentization.feature
+++ b/query-planner/tests/features/autofrag/auto-fragmentization.feature
@@ -1,0 +1,58 @@
+Feature: Auto fragmentization in Query Planning
+  Scenario: Using interfaces
+    Given query
+    """
+    {
+      field {
+        a { b { f1 f2 f4 } }
+        b { f1 f2 f4 }
+        iface {
+            ...on IFaceImpl1 { x }
+            ...on IFaceImpl2 { x }
+        }
+      }
+    }
+    """
+    When using autofragmentization
+    Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "users",
+        "variableUsages": [],
+        "operation": "{field{...__QueryPlanFragment_2__}}fragment __QueryPlanFragment_0__ on B{f1 f2 f4}fragment __QueryPlanFragment_1__ on IFace{__typename ...on IFaceImpl1{x}...on IFaceImpl2{x}}fragment __QueryPlanFragment_2__ on SomeField{a{b{...__QueryPlanFragment_0__}}b{...__QueryPlanFragment_0__}iface{...__QueryPlanFragment_1__}}"
+      }
+    }
+    """
+
+  Scenario: Identical selection sets in different types
+    Given query
+    """
+    {
+      sender {
+       name
+       address
+       location
+      }
+      receiver {
+       name
+       address
+       location
+      }
+    }
+    """
+    When using autofragmentization
+    Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "users",
+        "variableUsages": [],
+        "operation": "{sender{...__QueryPlanFragment_0__}receiver{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_0__ on SendingUser{name address location}fragment __QueryPlanFragment_1__ on ReceivingUser{name address location}"
+      }
+    }
+    """

--- a/query-planner/tests/features/autofrag/csdl.graphql
+++ b/query-planner/tests/features/autofrag/csdl.graphql
@@ -1,0 +1,68 @@
+schema
+  @graph(name: "users", url: "undefined")
+  @composedGraph(version: 1)
+{
+  query: Query
+}
+
+scalar Location
+
+type Query {
+  sender: SendingUser @resolve(graph: "users")
+  receiver: ReceivingUser @resolve(graph: "users")
+  field: SomeField @resolve(graph: "users")
+}
+
+type SendingUser
+  @owner(graph: "users")
+  @key(fields: "{ id }", graph: "users")
+{
+  id: ID!
+  name: String
+  address: String
+  location: Location
+}
+
+type ReceivingUser
+  @owner(graph: "users")
+  @key(fields: "{ id }", graph: "users")
+{
+  id: ID!
+  name: String
+  address: String
+  location: Location
+}
+
+interface IFace {
+  x: Int
+}
+
+type IFaceImpl1 implements IFace { x: Int }
+type IFaceImpl2 implements IFace { x: Int }
+
+type SomeField {
+  a: A
+  b: B
+  iface: IFace
+}
+
+type A {
+  b: B
+}
+
+type B {
+  f1: String
+  f2: String
+  f3: String
+  f4: String
+  f5: String
+  f6: String
+}
+
+directive @composedGraph(version: Int!) on SCHEMA
+directive @graph(name: String!, url: String!) on SCHEMA
+directive @owner(graph: String!) on OBJECT
+directive @key(fields: String!, graph: String!) on OBJECT
+directive @resolve(graph: String!) on FIELD_DEFINITION
+directive @provides(fields: String!) on FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION

--- a/query-planner/tests/features/basic/build-query-plan.feature
+++ b/query-planner/tests/features/basic/build-query-plan.feature
@@ -853,7 +853,7 @@ Scenario: experimental compression to downstream services should generate fragme
             "kind": "Fetch",
             "serviceName": "reviews",
             "variableUsages": [],
-            "operation": "{topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
+            "operation": "{topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}fragment __QueryPlanFragment_1__ on Review{body author product{...__QueryPlanFragment_0__}}"
           },
           {
             "kind": "Parallel",
@@ -1018,7 +1018,7 @@ Scenario: experimental compression to downstream services should generate fragme
             "kind": "Fetch",
             "serviceName": "reviews",
             "variableUsages": [],
-            "operation": "{reviews:topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{content:body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
+            "operation": "{reviews:topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}fragment __QueryPlanFragment_1__ on Review{content:body author product{...__QueryPlanFragment_0__}}"
           },
           {
             "kind": "Parallel",


### PR DESCRIPTION
This PR implements the Auto Fragmentization feature in the Rust Query Planner.

Be sure to "ignore whitespace" when reviewing.

## Process

Prior to this PR, we have copied over the scaffolding from the .ts implementation of the query planner to implement this feature later. In the .ts implementation, we discover and create "internal fragments" as we work through the query planner. However, as I started working at this problem, I decided that separating auto-frag to a processing phase that happens separately makes for simpler, more extensible code, that will allow us to iterate on this specific feature in a decoupled way from the rest of the query planner.

The main query planning process creates `FetchNode`s, each of which has an `operation` field that contains the literal string that will be sent to the downstream process. This is where we want to use queries that contain fragments we've automatically discovered.
When a query is planned with auto-frag enabled (a new flag to the `plan` function in `QueryPlanner`), right before we serialize the `operation` for the `FetchNode`, we _move_ the selection set through an auto fragmentization pass.

The process recursively iterates through the selection set, where for each selection set that has more than 2 fields (see parity section below) we first check if we've seen this selection set before (see hashing section below). If we create a fragment if there is none, and replace the selection set with one that only has one selection, the fragment spread for the fragment that we just found/created.

### Parity, not optimization

This implementation is not very intelligent, and the resulting query highly depends on the incoming query. For example, we may create many fragments that are only used once or we may not create fragments for actually really complex selection sets, e.g. selection sets with 2 selections whose sub-trees are deeply nested selection sets that repeat often.

The goal for this initial implementation is to reach parity with the .ts implementation so that we could completely replace the .ts implementation with an invocation of this one via wasm, without affecting users who are relying on the existing implementation.

Down the line, we can work on various optimizations for this code, as the need arises, or accept contributions to it from the community. (e.g. detecting fragments in subsets of selection sets? :)).

### Hashing

In order to identify if we've seen a selection set before, to use as a key in a map, we need the ability to hash a selection set based on _content_. In order to get this hash value we had to do 2 things:

1. Limit the `f64` values to `NotNan` [using this crate](https://docs.rs/ordered-float/2.0.0/ordered_float/struct.NotNan.html). Rust cannot derive a `Hash` for `f64` because of NaN values. This is a whole beast you can read about [here](https://internals.rust-lang.org/t/f32-f64-should-implement-hash/5436). Looking at the GraphQL Spec, a Float literal is defined as
```
FloatValue :: 
  IntegerPart FractionalPart
  IntegerPart ExponentPart
  IntegerPart FractionalPart ExponentPart
```
which as far as I can tell, from a _parsing_ perspective, any literal value cannot be a `NaN`, and thus, hashable. graphql-js doesn't allow this as well. [See this issue](https://github.com/graphql/graphql-spec/issues/778) by @glasser 

2. In order for the hash values to be based on _content_, the `Hash` implementations have to skip any field that references a _position_ for the element in the original query. I used the `derivative` crate for this (good find @trevor-scheer !!) to derive `Hash` and skip `position` and `span` fields.

## Important note about testing

This code prints out the fragments in each operation in predictable order; sorted by fragment name.
The tests we have in the `.feature` files have different ordering. We only have test cases with 1 or 2 fragments, so I can't really say if this is always "reverse" order, in any case it most likely depends on insertion order in the .ts implementation. But because this implementation is different, we can't resolve that by using a LinkedHashMap like in other cases before.

And so I changed the relevant expected result in the .feature files to use the lexicographic ordering. This is the 2nd case where we'll have to adapt if we want to use the same feature files for different code bases. My recommendation would be to either make the other implementations' output have predictable ordering, or do the comparison in the test in a way that doesn't rely on ordering where it's not important.
In this PR's case, if we wanted to make the test agnostic to fragment ordering, it'd mean parsing the `operation` in a FetchNode and comparing the parsed object, while _ignoring_ any position/span fields (which means we can't use the derived `PartialEq` unless we change that too), given the complexity of that, I opted to change the .feature file instead. Lmk if this is a problem.

My one simple test case passed, but when enabling testing using the `.feature` files that have auto-frag, I saw some failures but had to go afk, I will debug these before this PR is opened as not a draft.

## Integration with Javascript

This PR doesn't change the API used by the wasm module just yet. I figured we'd do that in a separate PR that involves a minor version update to the wasm crate.

## Separate question on versions

This PR changes the `.plan` function signature, which is public. Do we want to update the version in the same PR? And if so, do we not want all 3 versions (`query-planner`, `query-planner-wasm` and `query-planner-wasm`'s package.json) to use the same version? Right now they do not.

TODO:
- [x] fix tests
- [x] macroify similar code blocks in the auto-frag