### PR TITLE
Rename github actions and make shield specific.

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -1,4 +1,4 @@
-name: Code Coverage
+name: Rust Code Coverage
 
 on:
   push:

--- a/.github/workflows/rust-slow-test.yml
+++ b/.github/workflows/rust-slow-test.yml
@@ -1,4 +1,4 @@
-name: Tests (all platforms)
+name: Rust Tests (all platforms)
 
 on:
   push:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,4 +1,4 @@
-name: Lint and Tests
+name: Rust Lint and Tests
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 <img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/rocket1.svg" width="100%" height="144">
 
-[![Rust Tests (all platforms)](https://github.com/apollographql/federation/workflows/Rust%20Tests%20(all%20platforms)/badge.svg)](https://github.com/apollographql/federation/actions?query=branch%3Amain+workflow%3A%22Rust+Tests+%28all+platforms%29%22)
-[![Security audit](https://github.com/apollographql/federation/workflows/Security%20audit/badge.svg)](https://github.com/apollographql/federation/actions?query=workflow%3A%22Security+audit%22)
-[![codecov](https://codecov.io/gh/apollographql/federation/branch/main/graph/badge.svg)](https://codecov.io/gh/apollographql/federation)
+<table>
+    <tbody>
+        <tr>
+            <td></td>
+            <td><img src="https://codecov.io/gh/apollographql/federation/branch/main/graph/badge.svg"><img src="https://api.netlify.com/api/v1/badges/3a012f93-2d02-41f7-bb2b-848cf005b831/deploy-status"></td>
+        </tr>
+        <tr>
+            <td>Rust</td>
+            <td><img src="https://github.com/apollographql/federation/workflows/Rust%20Tests%20(all%20platforms)/badge.svg?branch=main"><img src="https://github.com/apollographql/federation/workflows/Security%20audit/badge.svg"/> </td>
+        </tr>
+        <tr>
+            <td>Typescript</td>
+            <td><img src="https://circleci.com/gh/apollographql/federation/tree/main.svg?style=shield"/></td>
+        </tr>
+    </tbody>
+</table>
+
 
 # Apollo Federation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/rocket1.svg" width="100%" height="144">
 
-[![Tests (all platforms)](https://github.com/apollographql/federation/workflows/Tests%20(all%20platforms)/badge.svg)](https://github.com/apollographql/federation/actions?query=branch%3Amain+workflow%3A%22Tests+%28all+platforms%29%22)
+[![Rust Tests (all platforms)](https://github.com/apollographql/federation/workflows/Rust%20Tests%20(all%20platforms)/badge.svg)](https://github.com/apollographql/federation/actions?query=branch%3Amain+workflow%3A%22Rust+Tests+%28all+platforms%29%22)
 [![Security audit](https://github.com/apollographql/federation/workflows/Security%20audit/badge.svg)](https://github.com/apollographql/federation/actions?query=workflow%3A%22Security+audit%22)
 [![codecov](https://codecov.io/gh/apollographql/federation/branch/main/graph/badge.svg)](https://codecov.io/gh/apollographql/federation)
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
     <tbody>
         <tr>
             <td></td>
-            <td><img src="https://codecov.io/gh/apollographql/federation/branch/main/graph/badge.svg"><img src="https://api.netlify.com/api/v1/badges/3a012f93-2d02-41f7-bb2b-848cf005b831/deploy-status"></td>
+            <td><img src="https://codecov.io/gh/apollographql/federation/branch/main/graph/badge.svg"> <img src="https://api.netlify.com/api/v1/badges/3a012f93-2d02-41f7-bb2b-848cf005b831/deploy-status"></td>
         </tr>
         <tr>
             <td>Rust</td>
-            <td><img src="https://github.com/apollographql/federation/workflows/Rust%20Tests%20(all%20platforms)/badge.svg?branch=main"><img src="https://github.com/apollographql/federation/workflows/Security%20audit/badge.svg"/> </td>
+            <td><img src="https://github.com/apollographql/federation/workflows/Rust%20Tests%20(all%20platforms)/badge.svg?branch=main"> <img src="https://github.com/apollographql/federation/workflows/Security%20audit/badge.svg"/></td>
         </tr>
         <tr>
             <td>Typescript</td>


### PR DESCRIPTION
Clarify in our README what each badge stands for, and add a netlify badge (which will stop failing once #158 is merged)

closes #149 