### PR TITLE
federation: fix warning for mismatched unnamed `@external`

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- Fix warning for non-matching `@external` types when the declaration's type is non-null or a list [PR #4392](https://github.com/apollographql/apollo-server/pull/4392)
 
 ## v0.20.0
 

--- a/federation-js/src/composition/validate/postComposition/__tests__/externalTypeMismatch.test.ts
+++ b/federation-js/src/composition/validate/postComposition/__tests__/externalTypeMismatch.test.ts
@@ -9,8 +9,9 @@ describe('validateExternalDirectivesOnSchema', () => {
   it('warns when the type of an @external field doesnt match the base', () => {
     const serviceA = {
       typeDefs: gql`
-        type Product @key(fields: "sku") {
+        type Product @key(fields: "sku skew") {
           sku: String!
+          skew: String
           upc: String!
         }
       `,
@@ -21,7 +22,8 @@ describe('validateExternalDirectivesOnSchema', () => {
       typeDefs: gql`
         extend type Product {
           sku: String @external
-          price: Int! @requires(fields: "sku")
+          skew: String! @external
+          price: Int! @requires(fields: "sku skew")
         }
       `,
       name: 'serviceB',
@@ -35,6 +37,10 @@ describe('validateExternalDirectivesOnSchema', () => {
         Object {
           "code": "EXTERNAL_TYPE_MISMATCH",
           "message": "[serviceB] Product.sku -> Type \`String\` does not match the type of the original field in serviceA (\`String!\`)",
+        },
+        Object {
+          "code": "EXTERNAL_TYPE_MISMATCH",
+          "message": "[serviceB] Product.skew -> Type \`String!\` does not match the type of the original field in serviceA (\`String\`)",
         },
       ]
     `);

--- a/federation-js/src/composition/validate/postComposition/externalTypeMismatch.ts
+++ b/federation-js/src/composition/validate/postComposition/externalTypeMismatch.ts
@@ -1,4 +1,4 @@
-import { isObjectType, typeFromAST, isEqualType, GraphQLError } from 'graphql';
+import { isObjectType, typeFromAST, isEqualType, GraphQLError, GraphQLType } from 'graphql';
 import { logServiceAndType, errorWithCode, getFederationMetadata } from '../../utils';
 import { PostCompositionValidator } from '.';
 
@@ -34,7 +34,7 @@ export const externalTypeMismatch: PostCompositionValidator = ({ schema }) => {
           const externalFieldType = typeFromAST(
             schema,
             externalField.type as any,
-          );
+          ) as GraphQLType;
 
           if (!externalFieldType) {
             errors.push(
@@ -52,7 +52,7 @@ export const externalTypeMismatch: PostCompositionValidator = ({ schema }) => {
               errorWithCode(
                 'EXTERNAL_TYPE_MISMATCH',
                 logServiceAndType(serviceName, typeName, externalFieldName) +
-                  `Type \`${externalFieldType.name}\` does not match the type of the original field in ${typeFederationMetadata.serviceName} (\`${matchingBaseField.type}\`)`,
+                  `Type \`${externalFieldType}\` does not match the type of the original field in ${typeFederationMetadata.serviceName} (\`${matchingBaseField.type}\`)`,
               ),
             );
           }


### PR DESCRIPTION
Some TypeScript weirdness means we were getting the GraphQLNamedType overload of
typeFromAST, which meant we were calling `.name` on it, which is undefined for
non-null and list types.