### PR TITLE
Integrate Rust auto-fragmentization into the query-planner-wasm

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -7,3 +7,4 @@
 # Editor-based HTTP Client requests
 /httpRequests/
 dataSources.xml
+/codeStyles/

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/gateway-js.iml" filepath="$PROJECT_DIR$/.idea/modules/gateway-js.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/graphql-parser.iml" filepath="$PROJECT_DIR$/.idea/modules/graphql-parser.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/query-planner.iml" filepath="$PROJECT_DIR$/.idea/modules/query-planner.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/query-planner-wasm.iml" filepath="$PROJECT_DIR$/.idea/modules/query-planner-wasm.iml" />

--- a/.idea/modules/gateway-js.iml
+++ b/.idea/modules/gateway-js.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../gateway-js" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-query-planner"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "derive_builder",
  "gherkin_rust",
@@ -20,6 +20,18 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "apollo-query-planner-wasm"
+version = "0.0.2"
+dependencies = [
+ "apollo-query-planner",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -398,18 +410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "query-planner-wasm"
-version = "0.0.2"
-dependencies = [
- "apollo-query-planner",
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/query-planner-wasm/Cargo.toml
+++ b/query-planner-wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "query-planner-wasm"
+name = "apollo-query-planner-wasm"
 version = "0.0.2" # keep in sync with package.json
 authors = ["Apollo <opensource@apollographql.com>"]
 homepage = "https://github.com/apollographql/federation"
@@ -8,13 +8,14 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/apollographql/federation"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type=["cdylib"]
 
 [dependencies]
+# workspace
 apollo-query-planner = { path = "../query-planner" }
+
+# 3rd party
 wasm-bindgen = { version = "0.2.67", features = ["serde-serialize"] }
 js-sys = "0.3.45"
 

--- a/query-planner-wasm/src/lib.rs
+++ b/query-planner-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate wasm_bindgen;
 
-use apollo_query_planner::{QueryPlanner, QueryPlanningOptionsBuilder};
+use apollo_query_planner::{QueryPlanner, QueryPlanningOptions};
 use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
@@ -23,11 +23,11 @@ pub fn get_query_planner(schema: JsString) -> usize {
 }
 
 #[wasm_bindgen(js_name = getQueryPlan)]
-pub fn get_query_plan(planner_ptr: usize, query: &str) -> JsValue {
+pub fn get_query_plan(planner_ptr: usize, query: &str, options: &JsValue) -> JsValue {
+    let options: QueryPlanningOptions = options.into_serde().unwrap();
     unsafe {
         let planner = planner_ptr as *const QueryPlanner;
         let planner: &QueryPlanner = &*planner;
-        let options = QueryPlanningOptionsBuilder::default().build().unwrap();
         let plan = planner.plan(query, options).unwrap();
         JsValue::from_serde(&plan).unwrap()
     }
@@ -37,7 +37,9 @@ pub fn get_query_plan(planner_ptr: usize, query: &str) -> JsValue {
 mod tests {
     use crate::{get_query_plan, get_query_planner};
     use apollo_query_planner::model::{FetchNode, PlanNode, QueryPlan};
+    use apollo_query_planner::QueryPlanningOptionsBuilder;
     use js_sys::JsString;
+    use wasm_bindgen::JsValue;
     use wasm_bindgen_test::*;
 
     #[wasm_bindgen_test]
@@ -55,7 +57,9 @@ mod tests {
             })),
         };
 
-        let result = get_query_plan(planner, query);
+        let options = QueryPlanningOptionsBuilder::default().build().unwrap();
+        let options = JsValue::from_serde(&options).unwrap();
+        let result = get_query_plan(planner, query, &options);
         let plan = result.into_serde::<QueryPlan>().unwrap();
         assert_eq!(plan, expected);
     }

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "apollo-query-planner"
-version = "0.0.1"
+version = "0.0.3"
 authors = ["Apollo <opensource@apollographql.com>"]
 homepage = "https://github.com/apollographql/federation"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "MIT/Apache-2.0"
+repository = "https://github.com/apollographql/federation"
 
 [dependencies]
 # workspace

--- a/query-planner/src/lib.rs
+++ b/query-planner/src/lib.rs
@@ -7,6 +7,7 @@ extern crate derive_builder;
 pub use crate::builder::build_query_plan;
 use crate::model::QueryPlan;
 use graphql_parser::{parse_query, parse_schema, schema, ParseError};
+use serde::{Deserialize, Serialize};
 
 #[macro_use]
 mod macros;
@@ -48,7 +49,8 @@ impl<'s> QueryPlanner<'s> {
 // NB: By deriving Builder (using the derive_builder crate) we automatically implement
 // the builder pattern for arbitrary structs.
 // simple #[derive(Builder)] will generate a FooBuilder for your struct Foo with all setter-methods and a build method.
-#[derive(Default, Builder, Debug)]
+#[derive(Default, Builder, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct QueryPlanningOptions {
     #[builder(default)]
     auto_fragmentization: bool,


### PR DESCRIPTION
This PR updates the API between the wasm exported functions and the Javascript code to enable setting autoFragmentization on or off, as introduced in #157 .

The only version update in this PR is in `query-planner`, that version is not external anywhere currently since we're not yet publishing it as a standalone crate.

Other version updates in relevant package.json will be made in a 2 follow up release PRs (one to release the wasm package, and another to release the gateway package that uses it)

Unrelated: There are some IntelliJ files I removed from source control, and a module added for `gateway-js`