### PR TITLE
Enable using BuildQueryPlanOptions in the gateway via the wasm package

### DIFF
--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@apollo/federation": "file:../federation-js",
-    "@apollo/query-planner-wasm": "0.0.2",
+    "@apollo/query-planner-wasm": "0.0.3",
     "@types/node-fetch": "2.5.4",
     "apollo-engine-reporting-protobuf": "^0.5.2",
     "apollo-graphql": "^0.6.0",

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -1041,7 +1041,7 @@ describe('buildQueryPlan', () => {
     `);
   });
 
-  describe.skip(`experimental compression to downstream services`, () => {
+  describe(`experimental compression to downstream services`, () => {
     it(`should generate fragments internally to downstream requests`, () => {
       const operationString = `#graphql
         query {
@@ -1080,13 +1080,6 @@ describe('buildQueryPlan', () => {
                   ...__QueryPlanFragment_1__
                 }
               }
-              fragment __QueryPlanFragment_1__ on Review {
-                body
-                author
-                product {
-                  ...__QueryPlanFragment_0__
-                }
-              }
               fragment __QueryPlanFragment_0__ on Product {
                 __typename
                 ... on Book {
@@ -1096,6 +1089,13 @@ describe('buildQueryPlan', () => {
                 ... on Furniture {
                   __typename
                   upc
+                }
+              }
+              fragment __QueryPlanFragment_1__ on Review {
+                body
+                author
+                product {
+                  ...__QueryPlanFragment_0__
                 }
               }
             },
@@ -1287,13 +1287,6 @@ describe('buildQueryPlan', () => {
                   ...__QueryPlanFragment_1__
                 }
               }
-              fragment __QueryPlanFragment_1__ on Review {
-                content: body
-                author
-                product {
-                  ...__QueryPlanFragment_0__
-                }
-              }
               fragment __QueryPlanFragment_0__ on Product {
                 __typename
                 ... on Book {
@@ -1303,6 +1296,13 @@ describe('buildQueryPlan', () => {
                 ... on Furniture {
                   __typename
                   upc
+                }
+              }
+              fragment __QueryPlanFragment_1__ on Review {
+                content: body
+                author
+                product {
+                  ...__QueryPlanFragment_0__
                 }
               }
             },

--- a/gateway-js/src/buildQueryPlan.ts
+++ b/gateway-js/src/buildQueryPlan.ts
@@ -20,12 +20,13 @@ export interface BuildQueryPlanOptions {
 
 export function buildQueryPlan(
   operationContext: OperationContext,
-  _options: BuildQueryPlanOptions = { autoFragmentization: false },
+  options: BuildQueryPlanOptions = { autoFragmentization: false },
 ): QueryPlan {
 
   return getQueryPlan(
     operationContext.queryPlannerPointer,
     operationContext.operationString,
+    options
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "version": "file:gateway-js",
       "requires": {
         "@apollo/federation": "file:federation-js",
-        "@apollo/query-planner-wasm": "0.0.2",
+        "@apollo/query-planner-wasm": "0.0.3",
         "@types/node-fetch": "2.5.4",
         "apollo-engine-reporting-protobuf": "^0.5.2",
         "apollo-graphql": "^0.6.0",
@@ -73,9 +73,9 @@
       }
     },
     "@apollo/query-planner-wasm": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner-wasm/-/query-planner-wasm-0.0.2.tgz",
-      "integrity": "sha512-qkth7quSzSXEujJ8FXnMPtVh4v/V2fbv/LNHAayBMKdNxb/ZKPaSYgQSx1Y87Alli/GOwS3Jc5j+0KplqgHrVQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner-wasm/-/query-planner-wasm-0.0.3.tgz",
+      "integrity": "sha512-BTPPaByd0nY35gu9EQUC1Z2BqO7Wf4Fg6wYmilFEsmbIRIZU4dHYGyT1guJKg2lFe41/p+4AyEZsYCAFogpqtg=="
     },
     "@apollographql/apollo-tools": {
       "version": "0.4.8",
@@ -4669,6 +4669,16 @@
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6855,6 +6865,13 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -9351,6 +9368,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION
This PR uses the updated API to thread through the `BuildQueryPlanOptions` object to wasm. It contains a single flag at the moment: `autoFragmentization`. 

This flag is now supported and implemented by the Rust query planner.

We also had to update the test snapshots to have the fragments sorted by name.