### PR TITLE
FIX: Minifying a String argument should escape quotes and slashes

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- __FIX__: Minifying a String argument should escape quotes and slashes [PR #174](https://github.com/apollographql/federation/pull/174)
+
+## v0.20.1
+
+- Replace the query planner implementation with a new implementation written in rust and integrated into the gateway
+  via wasm. [PR #4534](https://github.com/apollographql/apollo-server/pull/4534)
 
 ## v0.20.0
 

--- a/query-planner-wasm/Cargo.toml
+++ b/query-planner-wasm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Apollo <opensource@apollographql.com>"]
 homepage = "https://github.com/apollographql/federation"
 description = "Bridge code written in Rust to Javascript/Typescript, to be internally used by Apollo Gateway. This package is not meant to be independently consumed."
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT"
 repository = "https://github.com/apollographql/federation"
 
 [lib]

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.3"
 authors = ["Apollo <opensource@apollographql.com>"]
 homepage = "https://github.com/apollographql/federation"
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT"
 repository = "https://github.com/apollographql/federation"
 
 [dependencies]

--- a/query-planner/tests/features/basic/variables.feature
+++ b/query-planner/tests/features/basic/variables.feature
@@ -242,3 +242,22 @@ Scenario: works with default variables in the schema
   }
   """
 
+Scenario: String arguments with quotes that need to be escaped.
+  Given query
+  """
+  query {
+   vehicle(id: "{\"make\":\"Toyota\",\"model\":\"Rav4\",\"trim\":\"Limited\"}")
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Fetch",
+      "serviceName": "product",
+      "variableUsages": [],
+      "operation": "{vehicle(id:\"{\\\"make\\\":\\\"Toyota\\\",\\\"model\\\":\\\"Rav4\\\",\\\"trim\\\":\\\"Limited\\\"}\"){__typename}}"
+    }
+  }
+  """


### PR DESCRIPTION
fixes #170
    
This was a regression with the new Rust query planner; the minified implementation has a bug where if a String argument contains either `\` character or a `"` character, they should be printed with escaping so that the eventual operation string is valid.
    
Test cases were added to ensure we don't regress. I've verified they fail without the fix.

Unrelated: Update license in Cargo.toml, this was wrong initially.