### PR TITLE
Lost directives on inline fragment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-query-planner"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "derive_builder",
  "gherkin_rust",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- __FIX__: Directives which are located on inline fragments should not be skipped and should be sent to the service [PR #178](https://github.com/apollographql/federation/pull/178)
 
 ## v0.20.2
 

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-query-planner"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Apollo <opensource@apollographql.com>"]
 homepage = "https://github.com/apollographql/federation"
 edition = "2018"

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -560,7 +560,7 @@ fn selection_set_from_field_set<'q>(
     }
 
     fn combine_fields<'q>(
-        fields_with_same_reponse_name: Vec<context::Field<'q>>,
+        fields_with_same_reponse_name: FieldSet<'q>,
         context: &'q QueryPlanningContext,
     ) -> SelectionRef<'q> {
         let is_composite_type = {

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -625,9 +625,7 @@ fn selection_set_from_field_set<'q>(
             parent_type,
             directives,
         );
-        for sel in selections {
-            items.push(sel);
-        }
+        items.extend(selections);
     }
 
     SelectionSetRef {

--- a/query-planner/src/context.rs
+++ b/query-planner/src/context.rs
@@ -24,10 +24,11 @@ pub struct QueryPlanningContext<'q> {
 }
 
 impl<'q> QueryPlanningContext<'q> {
-    pub fn new_scope(
+    pub fn new_scope_with_directives(
         &self,
         parent_type: &'q TypeDefinition<'q>,
         enclosing_scope: Option<Rc<Scope<'q>>>,
+        scope_directives: Option<&'q Vec<Directive<'q>>>,
     ) -> Rc<Scope<'q>> {
         let possible_types: Vec<&'q schema::ObjectType<'q>> = self
             .get_possible_types(parent_type)
@@ -45,7 +46,16 @@ impl<'q> QueryPlanningContext<'q> {
             parent_type,
             possible_types,
             enclosing_scope,
+            scope_directives,
         })
+    }
+
+    pub fn new_scope(
+        &self,
+        parent_type: &'q TypeDefinition<'q>,
+        enclosing_scope: Option<Rc<Scope<'q>>>,
+    ) -> Rc<Scope<'q>> {
+        self.new_scope_with_directives(parent_type, enclosing_scope, None)
     }
 
     fn get_possible_types(&self, td: &'q TypeDefinition<'q>) -> &Vec<&'q schema::ObjectType<'q>> {
@@ -242,6 +252,7 @@ pub struct Scope<'q> {
     pub parent_type: &'q TypeDefinition<'q>,
     pub possible_types: Vec<&'q schema::ObjectType<'q>>,
     pub enclosing_scope: Option<Rc<Scope<'q>>>,
+    pub scope_directives: Option<&'q Vec<Directive<'q>>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/query-planner/tests/features/basic/csdl.graphql
+++ b/query-planner/tests/features/basic/csdl.graphql
@@ -53,6 +53,7 @@ type Car implements Vehicle
     description: String
     price: String
     retailPrice: String @resolve(graph: "reviews") @requires(fields: "{price}")
+    thing: Thing
 }
 
 type Error {
@@ -238,6 +239,7 @@ type Van implements Vehicle
     description: String
     price: String
     retailPrice: String @resolve(graph: "reviews") @requires(fields: "{price}")
+    thing: Thing
 }
 
 interface Vehicle {
@@ -245,6 +247,7 @@ interface Vehicle {
     description: String
     price: String
     retailPrice: String
+    thing: Thing
 }
 
 directive @composedGraph(version: Int!) on SCHEMA

--- a/query-planner/tests/features/basic/fragments.feature
+++ b/query-planner/tests/features/basic/fragments.feature
@@ -327,6 +327,11 @@ Scenario: supports directives on inline fragments (https://github.com/apollograp
     vehicle(id:"rav4") {
       ... on Car @fragmentDirective {
         price
+        thing {
+          ... on Ikea {
+            asile
+          }
+        }
       }
       ... on Van {
         price @fieldDirective
@@ -336,5 +341,5 @@ Scenario: supports directives on inline fragments (https://github.com/apollograp
   """
   Then query plan
   """
-  {"kind":"QueryPlan","node":{"kind":"Fetch","serviceName":"product","variableUsages":[],"operation":"{vehicle(id:\"rav4\"){__typename ...on Car@fragmentDirective{price}...on Van{price@fieldDirective}}}"}}
+  {"kind":"QueryPlan","node":{"kind":"Fetch","serviceName":"product","variableUsages":[],"operation":"{vehicle(id:\"rav4\"){__typename ...on Car@fragmentDirective{price thing{__typename ...on Ikea{asile}}}...on Van{price@fieldDirective}}}"}}
   """

--- a/query-planner/tests/features/basic/fragments.feature
+++ b/query-planner/tests/features/basic/fragments.feature
@@ -319,3 +319,22 @@ Scenario: supports root fragments
     }
   }
   """
+
+Scenario: supports directives on inline fragments (https://github.com/apollographql/federation/issues/177)
+  Given query
+  """
+  query GetVehicle {
+    vehicle(id:"rav4") {
+      ... on Car @fragmentDirective {
+        price
+      }
+      ... on Van {
+        price @fieldDirective
+      }
+    }
+  }
+  """
+  Then query plan
+  """
+  {"kind":"QueryPlan","node":{"kind":"Fetch","serviceName":"product","variableUsages":[],"operation":"{vehicle(id:\"rav4\"){__typename ...on Car@fragmentDirective{price}...on Van{price@fieldDirective}}}"}}
+  """


### PR DESCRIPTION
As reported in #177, we lose any directives on inline fragments from the original query

## Problem

We create new scopes either when we drill into object fields, inline fragments, or fragment spreads.

When we go into object fields, we collect the entire field node, so we don't lose directives.
We do however, lose directives when we create a new scope for inline fragments and fragment spreads.

## Solution for inline fragments

This PR fixes #177 by adding in any directives we find when collecting inline fragments and adding them to the scope we create for any fields in the fragment.

When we rebuild the operation that goes to downstream services, we wrap them in inline fragments if needed, if the fields we're wrapping have optional directives on the scope they're in, we add it to the inline fragment we're creating.

## Fragment spreads

As far as I can tell, we have the same problem with fragment spreads and directives on fragment definitions because the planner unfurls any fragments. I've opened #179 for this case.


