### PR TITLE
Setup CircleCI/Lerna/npm to compile and publish `@apollo/query-planner-wasm`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,25 @@ commands:
   common_test_steps:
     description: "Commands to run on every Node.js environment"
     steps:
+      - run:
+          # rustup must be installed prior to installing `wasm-pack`.
+          # If rustup isn't already in our environment, install it.
+          # On the `circleci/rust:*-node` images, it's already installed, so
+          # it's marginally faster to skip this when not necessary.
+          name: Ensure / Install rustup
+          command: |
+            which rustup > /dev/null 2>&1 ||
+              (
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+                  bash -s -- -y &&
+                  echo 'source $HOME/.cargo/env' >> $BASH_ENV
+                  # This last line here is for subsequent "run" steps.
+              )
+      - run:
+          name: Install wasm-pack
+          command: |
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf |
+              sh
       - oss/install_specific_npm_version
       - checkout
       - oss/npm_clean_install_with_caching

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "query-planner-wasm"
-version = "0.0.4"
+version = "0.0.0-DO.NOT.CHANGE"
 dependencies = [
  "apollo-query-planner",
  "js-sys",

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollo/federation": "file:../federation-js",
-    "@apollo/query-planner-wasm": "0.0.4",
+    "@apollo/query-planner-wasm": "file:../query-planner-wasm",
     "@types/node-fetch": "2.5.4",
     "apollo-engine-reporting-protobuf": "^0.5.2",
     "apollo-graphql": "^0.6.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,10 @@
 {
-  "packages": ["federation-js", "federation-integration-testsuite-js", "gateway-js"],
+  "packages": [
+    "federation-js",
+    "federation-integration-testsuite-js",
+    "gateway-js",
+    "query-planner-wasm"
+  ],
   "version": "independent",
   "command": {
     "version": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "version": "file:gateway-js",
       "requires": {
         "@apollo/federation": "file:federation-js",
-        "@apollo/query-planner-wasm": "0.0.4",
+        "@apollo/query-planner-wasm": "file:query-planner-wasm",
         "@types/node-fetch": "2.5.4",
         "apollo-engine-reporting-protobuf": "^0.5.2",
         "apollo-graphql": "^0.6.0",
@@ -73,9 +73,7 @@
       }
     },
     "@apollo/query-planner-wasm": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner-wasm/-/query-planner-wasm-0.0.4.tgz",
-      "integrity": "sha512-umCWFC+PXptXsAkeFbA8TIVEFdFhru6Bj4wvhv0zrATYGlENrgrOavHC1+3GITMDDRZb4TQjfWPCaY3yE9gUpw=="
+      "version": "file:query-planner-wasm"
     },
     "@apollographql/apollo-tools": {
       "version": "0.4.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": "github:apollographql/federation",
   "scripts": {
-    "clean": "git clean -dfqX -- ./node_modules **/{dist,node_modules}/ ./*/tsconfig*tsbuildinfo",
+    "clean": "git clean -dfqX -- ./target ./node_modules **/{dist,node_modules}/ ./*/tsconfig*tsbuildinfo",
     "compile": "tsc --build tsconfig.build.json",
     "compile:clean": "tsc --build tsconfig.build.json --clean",
     "watch": "tsc --build tsconfig.build.json --watch",
@@ -26,6 +26,7 @@
     "@apollographql/apollo-tools": "0.4.8",
     "@apollo/federation": "file:federation-js",
     "@apollo/gateway": "file:gateway-js",
+    "@apollo/query-planner-wasm": "file:query-planner-wasm",
     "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
   },
   "devDependencies": {

--- a/query-planner-wasm/Cargo.toml
+++ b/query-planner-wasm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "query-planner-wasm" # this ends up being the name in the published npm package.
-version = "0.0.4"
+version = "0.0.0-DO.NOT.CHANGE" # The version is managed in the package.json, by Lerna.
+private = true
 authors = ["Apollo <opensource@apollographql.com>"]
 homepage = "https://github.com/apollographql/federation"
 description = "Bridge code written in Rust to Javascript/Typescript, to be internally used by Apollo Gateway. This package is not meant to be independently consumed."

--- a/query-planner-wasm/package.json
+++ b/query-planner-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner-wasm",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Bridge code written in Rust to Javascript/Typescript, to be internally used by Apollo Gateway. This package is not meant to be independently consumed.",
   "scripts": {
     "wasm-pack": "wasm-pack build --target nodejs --out-dir dist --out-name index --scope apollo",

--- a/query-planner-wasm/package.json
+++ b/query-planner-wasm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@apollo/query-planner-wasm",
+  "version": "0.0.3",
+  "description": "Bridge code written in Rust to Javascript/Typescript, to be internally used by Apollo Gateway. This package is not meant to be independently consumed.",
+  "scripts": {
+    "wasm-pack": "wasm-pack build --target nodejs --out-dir dist --out-name index --scope apollo",
+    "preinstall": "npm run wasm-pack"
+  },
+  "author": "opensource@apollographql.com",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apollographql/federation.git",
+    "directory": "query-planner-wasm/"
+  },
+  "bugs": {
+    "url": "https://github.com/apollographql/federation/issues"
+  },
+  "homepage": "https://github.com/apollographql/federation#readme",
+  "keywords": [
+    "GraphQL",
+    "rust",
+    "wasm",
+    "apollo"
+  ],
+  "files": [
+    "dist/index_bg.wasm",
+    "dist/index.js",
+    "dist/index_bg.js",
+    "dist/index.d.ts"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
+}


### PR DESCRIPTION
This allows us to compile and depend upon the local version of the WASM query planner package and get the tarballs that are packed with the right version.  Additionally, this allows Lerna to handle the version bumping and publishing for `@apollo/query-planner-wasm`, since it is uniquely positioned to do that best in a monorepo orchestration that involves multiple npm packages with relative `file:` dependencies on each other and coupled with our existing needs for Lerna and publishing workflows we have built.

Technically speaking, this relieves the `Cargo.toml` from its responsibility of managing the `version` and shifts that responsibility to `lerna` and other npm-specific tooling we have connected to that.  In fact, this change completely eliminates the need for the `wasm-pack` generated `package.json` that is derived from the Cargo.toml (and rendered into the "out-dir", previously `pkg/`).

While I would believe that there are some advanced `wasm-pack` cases where this above change might be undesirable, for now, the constraint incurred by that transposition is unblocking in other ways.  For example, rather than necessitating parallel metadata support in the `Cargo.toml` for every `package.json` property (think about npm specific properties like "labels", "bugs", "private"), we can simply change our `package.json` as we see fit.

I am claiming that this side-stepping of version control defined within `Cargo.toml` is acceptable since we do not have any intention of publishing the `query-planner-wasm` package to crates.io on its own.  Instead, we will continue to publish the `wasm-pack`'d-from-this-crate `@apollo/query-planner-wasm` package directly to npm's registry.  To reflect that desire, I've marked the `query-planner-wasm` package as "private" using the `private = true` property in its `Cargo.toml`.

In theory, this change could de-stabilize the work that `wasm-pack` does and that's worth calling out.  For example, by not allowing it to generate the `files` property (which indicates which artifacts are emitted into the `npm pack`'d bundle), we might be not allowing it to add other (Future?  Unexpected?) important emitted files.  I've instead put those `files` directly into the new `package.json` source of truth, along with other appropriate properties, like `types` and `main`.  The largest risk here - based on our intended use of the package - seems to be relevant only if we were to rename the host Crate.  To demitigate that risk, I've explicitly wired up the `package.json` with `--out-dir` and `--out-file` flags to ensure that it always emits `index`-prefixed files.  Furthermore, they are now emitted into the `dist` directory, to be parallel with all our other npm package patterns which do the same.

I will note that, `wasm-pack` may address some of the work-arounds here in the future, but best I can tell, they will be roughly compatible with what we're doing here.  I am basing this outstanding issues, PRs, RFCs and documentation on the `wasm-pack` project, referenced below.

Ref: https://rustwasm.github.io/rfcs/008-npm-dependencies.html#unresolved-questions (See last section)
Ref: https://rustwasm.github.io/docs/wasm-pack/commands/build.html#extra-options (See footnote)
Ref: https://github.com/rustwasm/wasm-pack/issues/606
Ref: https://github.com/rustwasm/wasm-pack/issues/840