### PR TITLE
Use `monorepo-prepare` rather than `preinstall` script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc --build tsconfig.build.json --watch",
     "release:version-bump": "lerna version --force-publish=@apollo/federation,@apollo/gateway,apollo-federation-integration-testsuite",
     "release:start-ci-publish": "node -p '`Publish (dist-tag:${process.env.APOLLO_DIST_TAG || \"latest\"})`' | git tag -F - \"publish/$(date -u '+%Y%m%d%H%M%S')\" && git push origin \"$(git describe --match='publish/*' --tags --exact-match HEAD)\"",
-    "postinstall": "lerna run prepare && npm run compile",
+    "postinstall": "lerna run monorepo-prepare && npm run compile",
     "test": "jest --verbose",
     "test:clean": "jest --clearCache",
     "test:watch": "jest --verbose --watchAll",

--- a/query-planner-wasm/package.json
+++ b/query-planner-wasm/package.json
@@ -4,7 +4,7 @@
   "description": "Bridge code written in Rust to Javascript/Typescript, to be internally used by Apollo Gateway. This package is not meant to be independently consumed.",
   "scripts": {
     "wasm-pack": "wasm-pack build --target nodejs --out-dir dist --out-name index --scope apollo",
-    "preinstall": "npm run wasm-pack"
+    "monorepo-prepare": "npm run wasm-pack"
   },
   "author": "opensource@apollographql.com",
   "license": "MIT",


### PR DESCRIPTION
Follows-up apollographql/federation#184

This adjusts the life-cycle hook which is meant for building within the
monorepo to use the `monorepo-prepare` hook, which is only run when
installing this monorepo for local development, and is invoked by the
top-level `package.json`'s `postinstall` script in the root of the monorepo.

The other possible option here which actually makes the most sense is
`prepare`, but unfortunately, that breaks our CI pipeline right now since it
requires running it prior to the MOCK publishing that we do which generates
tarballs. See [[Failure]].

Fixes: https://github.com/apollographql/federation/issues/184

[Failure]: https://app.circleci.com/pipelines/github/apollographql/federation/219/workflows/3577e277-1e21-4d82-a76c-ad0e39b27064/jobs/549