### PR TITLE
[BUGFIX] reservedField validation rule should also check root type extensions

### DIFF
--- a/federation-js/src/composition/validate/preComposition/__tests__/reservedFieldUsed.test.ts
+++ b/federation-js/src/composition/validate/preComposition/__tests__/reservedFieldUsed.test.ts
@@ -54,6 +54,37 @@ describe('reservedFieldUsed', () => {
     `);
   });
 
+  it('warns when _service or _entities is used on an extension of query', () => {
+    const serviceA = {
+      typeDefs: gql`
+        extend type Query {
+          product: Product
+          _service: String!
+          _entities: String!
+        }
+
+        type Product {
+          sku: String
+        }
+      `,
+      name: 'serviceA',
+    };
+
+    const warnings = validateReservedFieldUsed(serviceA);
+    expect(warnings).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "RESERVED_FIELD_USED",
+          "message": "[serviceA] Query._service -> _service is a field reserved for federation and can't be used at the Query root.",
+        },
+        Object {
+          "code": "RESERVED_FIELD_USED",
+          "message": "[serviceA] Query._entities -> _entities is a field reserved for federation and can't be used at the Query root.",
+        },
+      ]
+    `);
+  });
+
   it('warns when _service or _entities is used in a schema extension', () => {
     const schemaDefinition = {
       typeDefs: gql`

--- a/federation-js/src/composition/validate/preComposition/reservedFieldUsed.ts
+++ b/federation-js/src/composition/validate/preComposition/reservedFieldUsed.ts
@@ -1,5 +1,5 @@
-import { GraphQLError, visit } from 'graphql';
-import { ServiceDefinition } from '../../types';
+import { GraphQLError, visit, ObjectTypeExtensionNode, ObjectTypeDefinitionNode} from 'graphql';
+import {ServiceDefinition} from '../../types';
 import {
   logServiceAndType,
   errorWithCode,
@@ -26,23 +26,30 @@ export const reservedFieldUsed = ({
   });
 
   visit(typeDefs, {
+    ObjectTypeExtension(node) {
+      checkForReservedField(node);
+    },
     ObjectTypeDefinition(node) {
-      if (node.name.value === rootQueryName && node.fields) {
-        for (const field of node.fields) {
-          const { value: fieldName } = field.name;
-          if (reservedRootFields.includes(fieldName)) {
-            errors.push(
-              errorWithCode(
-                'RESERVED_FIELD_USED',
-                logServiceAndType(serviceName, rootQueryName, fieldName) +
-                  `${fieldName} is a field reserved for federation and can\'t be used at the Query root.`,
-              ),
-            );
-          }
-        }
-      }
+      checkForReservedField(node)
     },
   });
+
+  function checkForReservedField(node: ObjectTypeExtensionNode | ObjectTypeDefinitionNode) {
+    if (node.name.value === rootQueryName && node.fields) {
+      for (const field of node.fields) {
+        const {value: fieldName} = field.name;
+        if (reservedRootFields.includes(fieldName)) {
+          errors.push(
+              errorWithCode(
+                  'RESERVED_FIELD_USED',
+                  logServiceAndType(serviceName, rootQueryName, fieldName) +
+                  `${fieldName} is a field reserved for federation and can\'t be used at the Query root.`,
+              ),
+          );
+        }
+      }
+    }
+  }
 
   return errors;
 };


### PR DESCRIPTION
Today, the `reservedField` preComposition rule only checks for type definitions,  and the written test in this PR proves the rule passes if a federated service defines the `__service` field on a Query extension.

Since the composition logic [converts all Query types from all federated services into extensions](https://github.com/apollographql/federation/blob/4494ef420946c89b6e308ed879be1b40786a3c9f/federation-js/src/composition/normalize.ts#L165), this rule effectively will always pass.

The fix consists of checking type extensions as well as type definitions.