### PR TITLE
feat: Support `make-fetch-happen` fetcher when communicating with services

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+## v0.21.0
+- Add support for custom fetcher such as `make-fetch-happen` other than default (node-fetch) used for communicating with downstream services
 
 ## v0.20.4
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,9 +6,6 @@
 
 - When using a custom `fetcher` on a `RemoteGraphQLDataSource`, use that fetcher's `Request` initialization in order to satisfy and of its own implementation details.  This is necessary, for example, when using `make-fetch-happen`. [PR #188](https://github.com/apollographql/federation/pull/188) [Issue #191](https://github.com/apollographql/federation/issues/191)
 
-## v0.21.0
-- Add support for custom fetcher such as `make-fetch-happen` other than default (node-fetch) used for communicating with downstream services
-
 ## v0.20.4
 
 - Adjust a `preinstall` script which was only intended to be executed by the monorepo tool-chain, not merely by installing the `@apollo/gateway` package as a dependency in another project. [PR #185](https://github.com/apollographql/federation/pull/185) [Issue #184](https://github.com/apollographql/federation/issues/184)

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- When using a custom `fetcher` on a `RemoteGraphQLDataSource`, use that fetcher's `Request` initialization in order to satisfy and of its own implementation details.  This is necessary, for example, when using `make-fetch-happen`. [PR #188](https://github.com/apollographql/federation/pull/188) [Issue #191](https://github.com/apollographql/federation/issues/191)
+
 ## v0.21.0
 - Add support for custom fetcher such as `make-fetch-happen` other than default (node-fetch) used for communicating with downstream services
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.20.4",
+  "version": "0.21.0",
   "description": "Apollo Gateway",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/gateway-js/src/__mocks__/make-fetch-happen-fetcher.ts
+++ b/gateway-js/src/__mocks__/make-fetch-happen-fetcher.ts
@@ -1,0 +1,51 @@
+/// <reference types="jest" />
+
+import {
+  fetch,
+  Response,
+  BodyInit,
+  Headers,
+  HeadersInit
+} from 'apollo-server-env';
+
+import fetcher from 'make-fetch-happen';
+
+interface MakeFetchHappenMock extends jest.Mock<typeof fetch> {
+  mockResponseOnce(data?: any, headers?: HeadersInit, status?: number): this;
+  mockJSONResponseOnce(data?: object, headers?: HeadersInit): this;
+}
+
+const mockMakeFetchHappen = jest.fn<typeof fetch>(fetcher) as MakeFetchHappenMock;
+
+mockMakeFetchHappen.mockResponseOnce = (
+  data?: BodyInit,
+  headers?: Headers,
+  status: number = 200,
+) => {
+  return mockMakeFetchHappen.mockImplementationOnce(async () => {
+    return new Response(data, {
+      status,
+      headers,
+    });
+  });
+};
+
+mockMakeFetchHappen.mockJSONResponseOnce = (
+  data = {},
+  headers?: Headers,
+  status?: number,
+) => {
+  return mockMakeFetchHappen.mockResponseOnce(
+    JSON.stringify(data),
+    Object.assign({ 'Content-Type': 'application/json' }, headers),
+    status,
+  );
+};
+
+const makeFetchMock = {
+  makeFetchHappenFetcher: mockMakeFetchHappen,
+};
+
+jest.doMock('make-fetch-happen', () => makeFetchMock);
+
+export = makeFetchMock;

--- a/gateway-js/src/__tests__/gateway/buildService.test.ts
+++ b/gateway-js/src/__tests__/gateway/buildService.test.ts
@@ -77,8 +77,7 @@ it('correctly passes the context from ApolloServer to datasources', async () => 
   });
 
   expect(fetch).toBeCalledTimes(1);
-  expect(fetch).toHaveFetched({
-    url: 'https://api.example.com/foo',
+  expect(fetch).toHaveFetched('https://api.example.com/foo', {
     body: {
       query: `{me{username}}`,
       variables: {},
@@ -125,8 +124,7 @@ it('makes enhanced introspection request using datasource', async () => {
 
   expect(fetch).toBeCalledTimes(1);
 
-  expect(fetch).toHaveFetched({
-    url: 'https://api.example.com/override',
+  expect(fetch).toHaveFetched('https://api.example.com/override', {
     body: {
       query: SERVICE_DEFINITION_QUERY,
     },
@@ -171,8 +169,7 @@ it('customizes request on a per-service basis', async () => {
 
   expect(fetch).toBeCalledTimes(3);
 
-  expect(fetch).toHaveFetched({
-    url: 'https://api.example.com/one',
+  expect(fetch).toHaveFetched('https://api.example.com/one', {
     body: {
       query: `query __ApolloGetServiceDefinition__ { _service { sdl } }`,
     },
@@ -181,8 +178,7 @@ it('customizes request on a per-service basis', async () => {
     },
   });
 
-  expect(fetch).toHaveFetched({
-    url: 'https://api.example.com/two',
+  expect(fetch).toHaveFetched('https://api.example.com/two', {
     body: {
       query: `query __ApolloGetServiceDefinition__ { _service { sdl } }`,
     },
@@ -191,8 +187,7 @@ it('customizes request on a per-service basis', async () => {
     },
   });
 
-  expect(fetch).toHaveFetched({
-    url: 'https://api.example.com/three',
+  expect(fetch).toHaveFetched('https://api.example.com/three', {
     body: {
       query: `query __ApolloGetServiceDefinition__ { _service { sdl } }`,
     },

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -149,7 +149,12 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
 
     try {
       // Use our local `fetcher` to allow for fetch injection
-      fetchResponse = await this.fetcher(fetchRequest);
+      // Adding support for custom fetcher such as 'make-fetch-happen' other than default (node fetch);
+      // for it, we need the Request to be constructed by the fetcher's own Request class
+      fetchResponse = await this.fetcher(http.url, {
+        ...http,
+        body: JSON.stringify(requestWithoutHttp)
+      });
 
       if (!fetchResponse.ok) {
         throw await this.errorFromResponse(fetchResponse);

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -149,8 +149,7 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
 
     try {
       // Use our local `fetcher` to allow for fetch injection
-      // Adding support for custom fetcher such as 'make-fetch-happen' other than default (node fetch);
-      // for it, we need the Request to be constructed by the fetcher's own Request class
+      // Use the fetcher's `Request` implementation for compatibility
       fetchResponse = await this.fetcher(http.url, {
         ...http,
         body: JSON.stringify(requestWithoutHttp)

--- a/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -1,4 +1,5 @@
 import { fetch } from '__mocks__/apollo-server-env';
+import { makeFetchHappenFetcher} from '__mocks__/make-fetch-happen-fetcher';
 
 import {
   ApolloError,
@@ -31,9 +32,8 @@ describe('constructing requests', () => {
 
       expect(data).toEqual({ me: 'james' });
       expect(fetch).toBeCalledTimes(1);
-      expect(fetch).toHaveFetched({
-        url: 'https://api.example.com/foo',
-        body: { query: '{ me { name } }' },
+      expect(fetch).toHaveFetched('https://api.example.com/foo', {
+        body: { query: '{ me { name } }' }
       });
     });
 
@@ -55,8 +55,7 @@ describe('constructing requests', () => {
 
       expect(data).toEqual({ me: 'james' });
       expect(fetch).toBeCalledTimes(1);
-      expect(fetch).toHaveFetched({
-        url: 'https://api.example.com/foo',
+      expect(fetch).toHaveFetched('https://api.example.com/foo', {
         body: { query: '{ me { name } }', variables: { id: '1' } },
       });
     });
@@ -101,8 +100,7 @@ describe('constructing requests', () => {
 
         expect(data).toEqual({ me: 'james' });
         expect(fetch).toBeCalledTimes(2);
-        expect(fetch).toHaveFetchedNth(1, {
-          url: 'https://api.example.com/foo',
+        expect(fetch).toHaveFetchedNth(1, 'https://api.example.com/foo', {
           body: {
             extensions: {
               persistedQuery: {
@@ -112,8 +110,7 @@ describe('constructing requests', () => {
             }
           },
         });
-        expect(fetch).toHaveFetchedNth(2, {
-          url: 'https://api.example.com/foo',
+        expect(fetch).toHaveFetchedNth(2, 'https://api.example.com/foo', {
           body: {
             query,
             extensions: {
@@ -145,8 +142,7 @@ describe('constructing requests', () => {
 
         expect(data).toEqual({ me: 'james' });
         expect(fetch).toBeCalledTimes(2);
-        expect(fetch).toHaveFetchedNth(1, {
-          url: 'https://api.example.com/foo',
+        expect(fetch).toHaveFetchedNth(1, 'https://api.example.com/foo', {
           body: {
             variables: { id: '1' },
             extensions: {
@@ -157,9 +153,7 @@ describe('constructing requests', () => {
             }
           },
         });
-
-        expect(fetch).toHaveFetchedNth(2, {
-          url: 'https://api.example.com/foo',
+        expect(fetch).toHaveFetchedNth(2, 'https://api.example.com/foo', {
           body: {
             query,
             variables: { id: '1' },
@@ -190,9 +184,8 @@ describe('constructing requests', () => {
 
         expect(data).toEqual({ me: 'james' });
         expect(fetch).toBeCalledTimes(1);
-        expect(fetch).toHaveFetched({
-          url: 'https://api.example.com/foo',
-          body: {
+        expect(fetch).toHaveFetched('https://api.example.com/foo', {
+            body: {
             extensions: {
               persistedQuery: {
                 version: 1,
@@ -221,8 +214,7 @@ describe('constructing requests', () => {
 
         expect(data).toEqual({ me: 'james' });
         expect(fetch).toBeCalledTimes(1);
-        expect(fetch).toHaveFetched({
-          url: 'https://api.example.com/foo',
+        expect(fetch).toHaveFetched('https://api.example.com/foo', {
           body: {
             variables: { id: '1' },
             extensions: {
@@ -259,6 +251,24 @@ describe('fetcher', () => {
 
   });
 
+  it('supports a custom fetcher such `make-fetch-happen` other than default node fetch', async () => {
+    const injectedFetch = makeFetchHappenFetcher.mockJSONResponseOnce({ data: { me: 'james' } });
+    const DataSource = new RemoteGraphQLDataSource({
+      url: 'https://api.example.com/foo',
+      fetcher: injectedFetch,
+    });
+
+    const { data } = await DataSource.process({
+      request: {
+        query: '{ me { name } }',
+        variables: { id: '1' },
+      },
+      context: {},
+    });
+
+    expect(injectedFetch).toHaveBeenCalled();
+    expect(data).toEqual({ me: 'james' });
+  })
 });
 
 describe('willSendRequest', () => {
@@ -281,8 +291,7 @@ describe('willSendRequest', () => {
     });
 
     expect(data).toEqual({ me: 'james' });
-    expect(fetch).toHaveFetched({
-      url: 'https://api.example.com/foo',
+    expect(fetch).toHaveFetched('https://api.example.com/foo', {
       body: {
         query: '{ me { name } }',
         variables: JSON.stringify({ id: '1' }),
@@ -309,8 +318,7 @@ describe('willSendRequest', () => {
     });
 
     expect(data).toEqual({ me: 'james' });
-    expect(fetch).toHaveFetched({
-      url: 'https://api.example.com/foo',
+    expect(fetch).toHaveFetched('https://api.example.com/foo', {
       body: {
         query: '{ me { name } }',
         variables: { id: '1' },

--- a/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -251,8 +251,9 @@ describe('fetcher', () => {
 
   });
 
-  it('supports a custom fetcher such `make-fetch-happen` other than default node fetch', async () => {
-    const injectedFetch = makeFetchHappenFetcher.mockJSONResponseOnce({ data: { me: 'james' } });
+  it('supports a custom fetcher, like `make-fetch-happen`', async () => {
+    const injectedFetch =
+      makeFetchHappenFetcher.mockJSONResponseOnce({ data: { me: 'james' } });
     const DataSource = new RemoteGraphQLDataSource({
       url: 'https://api.example.com/foo',
       fetcher: injectedFetch,


### PR DESCRIPTION
The custom fetcher that the RemoteGraphQLDataSource accepts doesn't currently support make fetch happen fetcher. This PR is to add support for the same i.e add support for passing make fetch happen fetcher (any other custom fetcher other than node ) to downstream services which is required for use cases where we want to provide fetcher other than node-fetch in order to leverage functionalities provided by them. 
To specifically speak of the concerned use case, our organisation wants to use a fetcher where we can configure default request options such as timeout and make fetch happen fetcher exactly fits our requirement. But with the existing codebase, passing that custom fetcher doesn't work correctly. (I debugged a lot and found the ultimate cause - which is we need the Request to be constructed by the fetcher's own Request class instead of node fetch's Request class as done currently) Hence, these are the proposed changes along with previous tests fixed and new tests added. Please look into the changes, it will really help us unblock and move forward with using Apollo gateway in production. Also, let me know if any other changes are required, I'll be happy to accommodate.

P.S. This to me feels as bug cum feature, let me know what should be correct category and I'll update the version and CHANGEME accordingly.

Thanks a ton!
Bhoomika Panwar

Closes #193 
Closes #191 