### PR TITLE
Stop force-publishing *all* Lerna packages on each release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compile": "tsc --build tsconfig.build.json",
     "compile:clean": "tsc --build tsconfig.build.json --clean",
     "watch": "tsc --build tsconfig.build.json --watch",
-    "release:version-bump": "lerna version --force-publish=@apollo/federation,@apollo/gateway,apollo-federation-integration-testsuite",
+    "release:version-bump": "lerna version",
     "release:start-ci-publish": "node -p '`Publish (dist-tag:${process.env.APOLLO_DIST_TAG || \"latest\"})`' | git tag -F - \"publish/$(date -u '+%Y%m%d%H%M%S')\" && git push origin \"$(git describe --match='publish/*' --tags --exact-match HEAD)\"",
     "postinstall": "lerna run monorepo-prepare && npm run compile",
     "test": "jest --verbose",


### PR DESCRIPTION
Lerna, the tool we use for version management within this repository, can detect changes in sub-trees of this repository and guide the publisher through bumping versions to affected packages accordingly.

Prior to this change, we have historically paired the release versions of the `@apollo/federation` and `@apollo/gateway` packages (and `apollo-federation-integration-testsuite` has been coupled into this, though it's not a public package, rather a nececessary testing dependency within this monorepo).  We've done so by using `--force-publish` (passed to `lerna`) to say, "we don't care what specific sub-trees have changed, we just want to always publish these together".

That coupling was partially due to a couple factors:

- The original placement of these packages into the `apollo-server` repository, which leverages lock-step versioning of its so-called "integration" packages (e.g., `apollo-server-express, `apollo-server-fastify`, `apollo-server-koa`, etc.) which are meant to have mostly the same/identical public API with subtle, integration specific sub-interface differences.  However, most all of the functionality that was relevant was always changed in `apollo-server-core`.

- From a debuggability standpoint, when these packages first came out it was also perceived as convenient to market and debug them in parallel with each other.  This comes with a caveat though: Because we didn't have Lerna's `--exact` flag in place during publishing, the versions could actually drift in a user's configuration, particularly if they had run `npm update` on one of the two dependencies and the new, incoming versions still were satisfied by the caret (e.g., `^x.y.z`) versioning request of the other package.

More recently, these packages have started being published with their own, standalone changes more often than not.  A look at the CHANGELOG for both of those packages will reveal that we have been over-publishing one or the other, and usually putting "- Same as similarly versioned package in <other package>" notations in their respective changelogs.

This over publishing is somewhat unfortunate for consumers of our packages since they are sometimes having to update and check the changelog for changes that may or may not have actually happened in the package they depend on.  For example, when we publish new `@apollo/gateway` packages, implementing services (which need only rely on `@apollo/federation`), may be prompted (either by Greenkeeper, Renovate, Dependabot, or human attention to detail in `npm outdated` output) to update to the newer `@apollo/federation` package which actually has no changes.

Given that we now have separate changelogs and are free of `apollo-server`, I am proposing that we stop this lock-step versioning.  We will need to explicitly ask users for the versions of packages that they are using, but that has actually been important to do for quite some time, particularly because of the semantic version ranges that we emit into published versions!