### PR TITLE
Lock down fn/struct visibility and a round of version upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48de0a29c99c8a5068c1c5492f6e477ef1843cc5e3c53daa0191562b71950632"
+checksum = "d88ea83af46935098feec2e19a28c919b54eb3cbf0e239b330298e2e69d4b76b"
 dependencies = [
  "actix-service",
  "actix-web",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36de80175eb1f0a5c518024ce0d23646b54a23008279e090ca1848f6f1448bf4"
+checksum = "c1b12fe25e11cd9ed2ef2e428427eb6178a1b363f3f7f0dab8278572f11b2da1"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -258,7 +258,7 @@ dependencies = [
  "serde_urlencoded",
  "socket2",
  "time",
- "tinyvec",
+ "tinyvec 1.0.1",
  "url",
 ]
 
@@ -347,9 +347,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
+checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -1213,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "0.16.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617e921abc813f96a3b00958c079e7bf1e2db998f8a04f1546dd967373a418ee"
+checksum = "d3463f26c58ee98b72e4eae1a6b4c28bc3320ab69d4836b55162362c2ec63fa6"
 dependencies = [
  "console",
  "difference",
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -2256,6 +2256,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
+name = "tinyvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,7 +2416,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "tinyvec",
+ "tinyvec 0.3.4",
 ]
 
 [[package]]

--- a/query-planner-wasm/Cargo.toml
+++ b/query-planner-wasm/Cargo.toml
@@ -18,10 +18,10 @@ crate-type=["cdylib"]
 apollo-query-planner = { path = "../stargate/crates/query-planner" }
 
 # 3rd party
-wasm-bindgen = { version = "0.2.67", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.68", features = ["serde-serialize"] }
 js-sys = "0.3.45"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.18"
 serde = { version = "1.0.116", features = ["derive"] }
-serde_json = "1.0.57"
+serde_json = "1.0.58"

--- a/stargate/Cargo.toml
+++ b/stargate/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/apollographql/federation"
 apollo-stargate-lib = { path = "crates/stargate-lib" }
 
 # 3rd party
-actix-cors = "0.3.0"
-actix-web = "3.0.2"
+actix-cors = "0.4.0"
+actix-web = "3.1.0"
 futures = "0.3.5"
 env_logger = "0.7.1"

--- a/stargate/crates/graphql-parser/Cargo.toml
+++ b/stargate/crates/graphql-parser/Cargo.toml
@@ -23,5 +23,5 @@ thiserror = "1.0.20"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
-insta = "0.16.1"
+insta = "1.0.0"
 paste = "1.0.1"

--- a/stargate/crates/query-planner/Cargo.toml
+++ b/stargate/crates/query-planner/Cargo.toml
@@ -16,7 +16,7 @@ derive_builder = "0.9.0"
 lazy_static = "1.4.0"
 linked-hash-map = "0.5.3"
 serde = { version = "1.0.116", features = ["derive"] }
-serde_json = "1.0.57"
+serde_json = "1.0.58"
 
 [dev-dependencies]
 gherkin_rust = "0.8.3"

--- a/stargate/crates/query-planner/src/autofrag.rs
+++ b/stargate/crates/query-planner/src/autofrag.rs
@@ -182,10 +182,10 @@ struct Counter {
 }
 
 impl Counter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self { i: 0 }
     }
-    pub fn get_and_incr(&mut self) -> i32 {
+    pub(crate) fn get_and_incr(&mut self) -> i32 {
         let r = self.i;
         self.i += 1;
         r

--- a/stargate/crates/query-planner/src/builder.rs
+++ b/stargate/crates/query-planner/src/builder.rs
@@ -21,7 +21,7 @@ use linked_hash_map::LinkedHashMap;
 use std::collections::HashSet;
 use std::rc::Rc;
 
-pub fn build_query_plan(
+pub(crate) fn build_query_plan(
     schema: &schema::Document,
     query: &Document,
     options: QueryPlanningOptions,

--- a/stargate/crates/query-planner/src/consts.rs
+++ b/stargate/crates/query-planner/src/consts.rs
@@ -33,10 +33,10 @@ pub static MUTATION_TYPE_NAME: &str = "Mutation";
 pub static EMPTY_ARGS: Vec<(Txt<'static>, Value<'static>)> = vec![];
 pub static EMPTY_DIRECTIVES: Vec<Directive<'static>> = vec![];
 
-pub fn typename_field_def<'a>() -> &'a schema::Field<'a> {
+pub(crate) fn typename_field_def<'a>() -> &'a schema::Field<'a> {
     &*TYPENAME_SCHEMA_FIELD
 }
 
-pub fn typename_field_node<'a>() -> FieldRef<'a> {
+pub(crate) fn typename_field_node<'a>() -> FieldRef<'a> {
     (*TYPENAME_QUERY_FIELD).clone()
 }

--- a/stargate/crates/query-planner/src/context.rs
+++ b/stargate/crates/query-planner/src/context.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct QueryPlanningContext<'q> {
+pub(crate) struct QueryPlanningContext<'q> {
     pub schema: &'q schema::Document<'q>,
     pub operation: Op<'q>,
     pub fragments: HashMap<&'q str, &'q FragmentDefinition<'q>>,
@@ -24,7 +24,7 @@ pub struct QueryPlanningContext<'q> {
 }
 
 impl<'q> QueryPlanningContext<'q> {
-    pub fn new_scope_with_directives(
+    pub(crate) fn new_scope_with_directives(
         &self,
         parent_type: &'q TypeDefinition<'q>,
         enclosing_scope: Option<Rc<Scope<'q>>>,
@@ -50,7 +50,7 @@ impl<'q> QueryPlanningContext<'q> {
         })
     }
 
-    pub fn new_scope(
+    pub(crate) fn new_scope(
         &self,
         parent_type: &'q TypeDefinition<'q>,
         enclosing_scope: Option<Rc<Scope<'q>>>,
@@ -62,7 +62,7 @@ impl<'q> QueryPlanningContext<'q> {
         &self.possible_types[td.as_name()]
     }
 
-    pub fn get_variable_usages(
+    pub(crate) fn get_variable_usages(
         &self,
         selection_set: &SelectionSetRef,
     ) -> (Vec<String>, Vec<&VariableDefinition>) {
@@ -74,7 +74,7 @@ impl<'q> QueryPlanningContext<'q> {
             .unzip()
     }
 
-    pub fn type_def_for_object(
+    pub(crate) fn type_def_for_object(
         &self,
         obj: &'q schema::ObjectType<'q>,
     ) -> &'q schema::TypeDefinition<'q> {
@@ -82,13 +82,13 @@ impl<'q> QueryPlanningContext<'q> {
     }
 
     // TODO(ran)(p2)(#114) we may be able to change this return type to &str
-    pub fn get_base_service(&self, parent_type: &schema::ObjectType) -> String {
+    pub(crate) fn get_base_service(&self, parent_type: &schema::ObjectType) -> String {
         self.federation
             .service_name_for_type(parent_type)
             .expect("Cannot find federation metadata")
     }
 
-    pub fn get_owning_service(
+    pub(crate) fn get_owning_service(
         &self,
         parent_type: &schema::ObjectType,
         field_def: &schema::Field,
@@ -99,7 +99,7 @@ impl<'q> QueryPlanningContext<'q> {
     }
 
     // TODO(ran)(p2)(#114) for get_X_fields, we can calculate it once from the schema and put it in some maps or something.
-    pub fn get_key_fields<'a>(
+    pub(crate) fn get_key_fields<'a>(
         &'q self,
         parent_type: &'q TypeDefinition<'q>,
         service_name: &'a str,
@@ -148,7 +148,7 @@ impl<'q> QueryPlanningContext<'q> {
         key_fields
     }
 
-    pub fn get_required_fields<'a>(
+    pub(crate) fn get_required_fields<'a>(
         &'q self,
         parent_type: &'q TypeDefinition<'q>,
         field_def: &'q schema::Field<'q>,
@@ -164,7 +164,7 @@ impl<'q> QueryPlanningContext<'q> {
         required_fields
     }
 
-    pub fn get_provided_fields<'a>(
+    pub(crate) fn get_provided_fields<'a>(
         &'q self,
         field_def: &'q schema::Field<'q>,
         service_name: &'a str,
@@ -248,7 +248,7 @@ impl<'q> QueryPlanningContext<'q> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Scope<'q> {
+pub(crate) struct Scope<'q> {
     pub parent_type: &'q TypeDefinition<'q>,
     pub possible_types: Vec<&'q schema::ObjectType<'q>>,
     pub enclosing_scope: Option<Rc<Scope<'q>>>,
@@ -256,10 +256,10 @@ pub struct Scope<'q> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Field<'q> {
+pub(crate) struct Field<'q> {
     pub scope: Rc<Scope<'q>>,
     pub field_node: FieldRef<'q>,
     pub field_def: &'q schema::Field<'q>,
 }
 
-pub type FieldSet<'q> = Vec<Field<'q>>;
+pub(crate) type FieldSet<'q> = Vec<Field<'q>>;

--- a/stargate/crates/query-planner/src/federation.rs
+++ b/stargate/crates/query-planner/src/federation.rs
@@ -14,7 +14,7 @@ struct FederationTypeMetadata<'q> {
 }
 
 impl<'q> FederationTypeMetadata<'q> {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             is_value_type: HashMap::new(),
             keys: HashMap::new(),
@@ -31,7 +31,7 @@ struct FederationFieldMetadata<'q> {
 }
 
 impl<'q> FederationFieldMetadata<'q> {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             service_name: HashMap::new(),
             requires: HashMap::new(),
@@ -41,13 +41,13 @@ impl<'q> FederationFieldMetadata<'q> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Federation<'q> {
+pub(crate) struct Federation<'q> {
     types: FederationTypeMetadata<'q>,
     fields: FederationFieldMetadata<'q>,
 }
 
 impl<'q> Federation<'q> {
-    pub fn new(schema: &'q Document<'q>) -> Federation<'q> {
+    pub(crate) fn new(schema: &'q Document<'q>) -> Federation<'q> {
         let mut types = FederationTypeMetadata::new();
         let mut fields = FederationFieldMetadata::new();
 
@@ -132,29 +132,32 @@ impl<'q> Federation<'q> {
         Federation { types, fields }
     }
 
-    pub fn service_name_for_field<'a>(&'a self, field_def: &'q Field<'q>) -> Option<String> {
+    pub(crate) fn service_name_for_field<'a>(&'a self, field_def: &'q Field<'q>) -> Option<String> {
         self.fields.service_name.get(&field_def.position).cloned()
     }
 
-    pub fn requires<'a>(&'a self, field_def: &'q Field<'q>) -> Option<SelectionSetRef<'a>> {
+    pub(crate) fn requires<'a>(&'a self, field_def: &'q Field<'q>) -> Option<SelectionSetRef<'a>> {
         self.fields
             .requires
             .get(&field_def.position)
             .map(SelectionSetRef::from)
     }
 
-    pub fn provides<'a>(&'a self, field_def: &'q Field<'q>) -> Option<SelectionSetRef<'a>> {
+    pub(crate) fn provides<'a>(&'a self, field_def: &'q Field<'q>) -> Option<SelectionSetRef<'a>> {
         self.fields
             .provides
             .get(&field_def.position)
             .map(SelectionSetRef::from)
     }
 
-    pub fn service_name_for_type<'a>(&'a self, object_type: &'q ObjectType<'q>) -> Option<String> {
+    pub(crate) fn service_name_for_type<'a>(
+        &'a self,
+        object_type: &'q ObjectType<'q>,
+    ) -> Option<String> {
         self.types.owner.get(&object_type.position).cloned()
     }
 
-    pub fn key<'a>(
+    pub(crate) fn key<'a>(
         &'a self,
         object_type: &'q ObjectType<'q>,
         service_name: &str,
@@ -169,7 +172,7 @@ impl<'q> Federation<'q> {
             })
     }
 
-    pub fn is_value_type<'a>(&'a self, parent_type: &'q TypeDefinition<'q>) -> bool {
+    pub(crate) fn is_value_type<'a>(&'a self, parent_type: &'q TypeDefinition<'q>) -> bool {
         if let TypeDefinition::Object(object_type) = parent_type {
             self.types.is_value_type[&object_type.position]
         } else {

--- a/stargate/crates/query-planner/src/groups.rs
+++ b/stargate/crates/query-planner/src/groups.rs
@@ -7,7 +7,7 @@ use graphql_parser::schema::TypeDefinition;
 use linked_hash_map::LinkedHashMap;
 
 #[derive(Debug)]
-pub struct FetchGroup<'q> {
+pub(crate) struct FetchGroup<'q> {
     pub service_name: String,
     pub fields: FieldSet<'q>,
     // This is only for auto_fragmentization -- which is currently unimplemented
@@ -20,11 +20,11 @@ pub struct FetchGroup<'q> {
 }
 
 impl<'q> FetchGroup<'q> {
-    pub fn init(service_name: String) -> FetchGroup<'q> {
+    pub(crate) fn init(service_name: String) -> FetchGroup<'q> {
         FetchGroup::new(service_name, vec![], vec![])
     }
 
-    pub fn new(
+    pub(crate) fn new(
         service_name: String,
         merge_at: ResponsePath,
         provided_fields: Vec<&'q str>,
@@ -42,7 +42,7 @@ impl<'q> FetchGroup<'q> {
         }
     }
 
-    pub fn dependent_group_for_service<'a>(
+    pub(crate) fn dependent_group_for_service<'a>(
         &'a mut self,
         service: String,
         required_fields: FieldSet<'q>,
@@ -77,13 +77,13 @@ pub(crate) trait GroupForField<'q> {
 }
 
 // Used by split_root_fields
-pub struct ParallelGroupForField<'q> {
+pub(crate) struct ParallelGroupForField<'q> {
     context: &'q QueryPlanningContext<'q>,
     groups_map: LinkedHashMap<String, FetchGroup<'q>>,
 }
 
 impl<'q> ParallelGroupForField<'q> {
-    pub fn new(context: &'q QueryPlanningContext<'q>) -> Self {
+    pub(crate) fn new(context: &'q QueryPlanningContext<'q>) -> Self {
         Self {
             context,
             groups_map: LinkedHashMap::new(),
@@ -118,13 +118,13 @@ impl<'q> GroupForField<'q> for ParallelGroupForField<'q> {
 }
 
 // Used by split_root_fields_serially
-pub struct SerialGroupForField<'q> {
+pub(crate) struct SerialGroupForField<'q> {
     context: &'q QueryPlanningContext<'q>,
     groups: Vec<FetchGroup<'q>>,
 }
 
 impl<'q> SerialGroupForField<'q> {
-    pub fn new(context: &'q QueryPlanningContext<'q>) -> Self {
+    pub(crate) fn new(context: &'q QueryPlanningContext<'q>) -> Self {
         Self {
             context,
             groups: vec![],
@@ -162,13 +162,13 @@ impl<'q> GroupForField<'q> for SerialGroupForField<'q> {
 }
 
 // Used by split_sub_fields
-pub struct GroupForSubField<'q> {
+pub(crate) struct GroupForSubField<'q> {
     context: &'q QueryPlanningContext<'q>,
     parent_group: FetchGroup<'q>,
 }
 
 impl<'q> GroupForSubField<'q> {
-    pub fn new(context: &'q QueryPlanningContext<'q>, parent_group: FetchGroup<'q>) -> Self {
+    pub(crate) fn new(context: &'q QueryPlanningContext<'q>, parent_group: FetchGroup<'q>) -> Self {
         Self {
             context,
             parent_group,

--- a/stargate/crates/query-planner/src/helpers.rs
+++ b/stargate/crates/query-planner/src/helpers.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
 use std::iter::FromIterator;
 
-pub fn get_operations<'q>(query: &'q Document<'q>) -> Vec<Op<'q>> {
+pub(crate) fn get_operations<'q>(query: &'q Document<'q>) -> Vec<Op<'q>> {
     query
         .definitions
         .iter()
@@ -26,7 +26,7 @@ pub fn get_operations<'q>(query: &'q Document<'q>) -> Vec<Op<'q>> {
         .collect()
 }
 
-pub fn build_possible_types<'a, 'q>(
+pub(crate) fn build_possible_types<'a, 'q>(
     schema: &'q schema::Document<'q>,
     types: &'a HashMap<&'q str, &'q schema::TypeDefinition<'q>>,
 ) -> HashMap<&'q str, Vec<&'q schema::ObjectType<'q>>> {
@@ -90,7 +90,7 @@ pub fn build_possible_types<'a, 'q>(
     implementing_types
 }
 
-pub fn names_to_types<'q>(
+pub(crate) fn names_to_types<'q>(
     schema: &'q schema::Document<'q>,
 ) -> HashMap<&'q str, &'q TypeDefinition<'q>> {
     schema
@@ -104,7 +104,7 @@ pub fn names_to_types<'q>(
         .collect()
 }
 
-pub fn variable_name_to_def<'q>(
+pub(crate) fn variable_name_to_def<'q>(
     query: &'q query::Document<'q>,
 ) -> HashMap<&'q str, &'q VariableDefinition<'q>> {
     match query
@@ -124,11 +124,11 @@ pub(crate) fn pos() -> Pos {
     Pos { line: 0, column: 0 }
 }
 
-pub fn span() -> (Pos, Pos) {
+pub(crate) fn span() -> (Pos, Pos) {
     (pos(), pos())
 }
 
-pub fn merge_selection_sets<'q>(fields: Vec<FieldRef<'q>>) -> SelectionSetRef<'q> {
+pub(crate) fn merge_selection_sets<'q>(fields: Vec<FieldRef<'q>>) -> SelectionSetRef<'q> {
     fn merge_field_selection_sets(fields: Vec<SelectionRef>) -> Vec<SelectionRef> {
         let (field_nodes, fragment_nodes): (Vec<SelectionRef>, Vec<SelectionRef>) =
             fields.into_iter().partition(|s| s.is_field());
@@ -198,7 +198,7 @@ pub fn merge_selection_sets<'q>(fields: Vec<FieldRef<'q>>) -> SelectionSetRef<'q
     }
 }
 
-pub fn group_by<T, K, F>(v: Vec<T>, f: F) -> LinkedHashMap<K, Vec<T>>
+pub(crate) fn group_by<T, K, F>(v: Vec<T>, f: F) -> LinkedHashMap<K, Vec<T>>
 where
     F: Fn(&T) -> K,
     K: Hash + PartialEq + Eq,
@@ -211,7 +211,7 @@ where
 }
 
 // https://github.com/graphql/graphql-js/blob/7b3241329e1ff49fb647b043b80568f0cf9e1a7c/src/type/introspection.js#L500-L509
-pub fn is_introspection_type(name: &str) -> bool {
+pub(crate) fn is_introspection_type(name: &str) -> bool {
     name == "__Schema"
         || name == "__Directive"
         || name == "__DirectiveLocation"
@@ -222,7 +222,7 @@ pub fn is_introspection_type(name: &str) -> bool {
         || name == "__TypeKind"
 }
 
-pub fn is_not_introspection_field(selection: &SelectionRef) -> bool {
+pub(crate) fn is_not_introspection_field(selection: &SelectionRef) -> bool {
     match *selection {
         SelectionRef::FieldRef(ref field) => {
             field.name != INTROSPECTION_SCHEMA_FIELD_NAME
@@ -262,7 +262,7 @@ impl<T> Head<T> for Vec<T> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Op<'q> {
+pub(crate) struct Op<'q> {
     pub selection_set: &'q SelectionSet<'q>,
     pub kind: query::Operation,
 }

--- a/stargate/crates/query-planner/src/lib.rs
+++ b/stargate/crates/query-planner/src/lib.rs
@@ -4,7 +4,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate derive_builder;
 
-pub use crate::builder::build_query_plan;
+use crate::builder::build_query_plan;
 use crate::model::QueryPlan;
 use graphql_parser::{parse_query, parse_schema, schema, ParseError};
 use serde::{Deserialize, Serialize};

--- a/stargate/crates/query-planner/src/visitors.rs
+++ b/stargate/crates/query-planner/src/visitors.rs
@@ -6,12 +6,14 @@ use graphql_parser::query;
 use graphql_parser::query::refs::{SelectionRef, SelectionSetRef};
 use graphql_parser::query::*;
 
-pub struct VariableUsagesMap<'q> {
+pub(crate) struct VariableUsagesMap<'q> {
     variable_definitions: &'q HashMap<&'q str, &'q VariableDefinition<'q>>,
 }
 
 impl<'q> VariableUsagesMap<'q> {
-    pub fn new(variable_definitions: &'q HashMap<&'q str, &'q VariableDefinition<'q>>) -> Self {
+    pub(crate) fn new(
+        variable_definitions: &'q HashMap<&'q str, &'q VariableDefinition<'q>>,
+    ) -> Self {
         Self {
             variable_definitions,
         }

--- a/stargate/crates/stargate-lib/Cargo.toml
+++ b/stargate/crates/stargate-lib/Cargo.toml
@@ -15,9 +15,9 @@ apollo-query-planner = { path = "../query-planner" }
 graphql-parser = { path = "../graphql-parser" }
 
 # 3rd party
-async-trait = "0.1.40"
+async-trait = "0.1.41"
 futures = "0.3.5"
-serde = { version = "1.0.115", features = ["derive"] }
-serde_json = "1.0.57"
-structopt = "0.3.15"
+serde = { version = "1.0.116", features = ["derive"] }
+serde_json = "1.0.58"
+structopt = "0.3.18"
 surf = "1.0.3"

--- a/stargate/crates/stargate-lib/src/request_pipeline/executor.rs
+++ b/stargate/crates/stargate-lib/src/request_pipeline/executor.rs
@@ -281,7 +281,7 @@ fn flatten_results_at_path<'request>(
     }
 }
 
-pub fn execute_selection_set(source: &Value, selections: &SelectionSet) -> Value {
+fn execute_selection_set(source: &Value, selections: &SelectionSet) -> Value {
     if source.is_null() {
         return Value::default();
     }

--- a/stargate/crates/stargate-lib/src/utilities/deep_merge.rs
+++ b/stargate/crates/stargate-lib/src/utilities/deep_merge.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-pub fn merge(target: &mut Value, source: &Value) {
+pub(crate) fn merge(target: &mut Value, source: &Value) {
     if source.is_null() {
         return;
     }


### PR DESCRIPTION
This PR does 2 things:

## Visibility lock down

By default we wrote a lot of functions and structs as `pub` where they are really only used internally in the crate. I've changed most of them to `pub(crate)`. I did a "find & replace", compiled, fixed errors, and eventually ran tests.

## Version upgrades

Dependabot opened a few different PRs, this collates them into one.
closes #202 #203 #204 #205 #206 