### PR TITLE
Key selects a field on a value type

### DIFF
--- a/federation-js/src/composition/validate/preComposition/__tests__/keyFieldsMissingExternal.test.ts
+++ b/federation-js/src/composition/validate/preComposition/__tests__/keyFieldsMissingExternal.test.ts
@@ -178,4 +178,28 @@ describe('keyFieldsMissingExternal', () => {
       ]
     `);
   });
+
+
+  it('nested key selection set on a value type', () => {
+    const serviceA = {
+      typeDefs: gql`
+          extend type Car @key(fields: "model { name kit { upc } }") {
+              model: Model! @external
+          }
+
+          type Model {
+              name: String!
+              kit: Kit
+          }
+
+          type Kit {
+              upc: String!
+          }
+      `,
+      name: 'serviceA',
+    };
+
+    const warnings = validateKeyFieldsMissingExternal(serviceA);
+    expect(warnings).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
I'm trying to understand why @key fieldSet can not reference a field on a value type? In other words, why is below not allowed?

```
          extend type Car @key(fields: "model { name kit { upc } }") {
              model: Model! @external
          }
          type Model {
              name: String!
              kit: Kit
          }
          type Kit {
              upc: String!
          }
```

I added a test that fails validation to reproduce.