### PR TITLE
GH Action: Install wasm-pack only if not available.

### DIFF
--- a/.github/workflows/rust-slow-test.yml
+++ b/.github/workflows/rust-slow-test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install wasm-pack (unix)
         if: matrix.build != 'windows'
         shell: bash
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -f
+        run: which wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Install wasm-pack (windows)
         if: matrix.build == 'windows'

--- a/.github/workflows/rust-slow-test.yml
+++ b/.github/workflows/rust-slow-test.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Install wasm-pack (unix)
         if: matrix.build != 'windows'
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        shell: bash
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -f
 
       - name: Install wasm-pack (windows)
         if: matrix.build == 'windows'

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -110,7 +110,8 @@ jobs:
 
       # Install wasm-pack
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        shell: bash
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -f
 
       ### RUN TESTS ###
       - name: Test (cargo test)

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -111,7 +111,7 @@ jobs:
       # Install wasm-pack
       - name: Install wasm-pack
         shell: bash
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -f
+        run: which wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       ### RUN TESTS ###
       - name: Test (cargo test)


### PR DESCRIPTION
Installing wasm-pack [fails](https://github.com/rustwasm/wasm-pack/blob/173a05bd829bc499533c3967a2b980dc6069ce19/src/installer.rs#L96-L103) if it's already installed. This change checks if `wasm-pack` exists already, and installs it otherwise.