### PR TITLE
Resolve typo in gateway.mdx

### DIFF
--- a/docs/source/gateway.mdx
+++ b/docs/source/gateway.mdx
@@ -21,7 +21,7 @@ First, let's install the necessary packages:
 npm install @apollo/gateway apollo-server graphql
 ```
 
-The `@apollo/gateway` package includes the [`ApolloGateway` class](/api/apollo-gateway/). To configure Apollo Sever to act as a gateway, you pass an instance of `ApolloGateway` to the `ApolloServer` constructor, like so:
+The `@apollo/gateway` package includes the [`ApolloGateway` class](/api/apollo-gateway/). To configure Apollo Server to act as a gateway, you pass an instance of `ApolloGateway` to the `ApolloServer` constructor, like so:
 
 ```js
 const { ApolloServer } = require('apollo-server');


### PR DESCRIPTION
Simple typo resolution in the documentation page for the gateway.
