### PR TITLE
Enable GET method for APQ requests.

### DIFF
--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -99,6 +99,12 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
         ? this.didReceiveResponse({ response, request, context })
         : response;
 
+    const httpRequest = request.http;
+
+    if (!httpRequest) {
+        throw new Error("Missing http on GraphQL request");
+    }
+
     if (this.apq) {
       // Take the original extensions and extend them with
       // the necessary "extensions" for APQ handshaking.
@@ -126,17 +132,17 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
           );
         }
 
-        requestWithoutQuery.http = {
-          method: "GET",
-          url: optimisticPersistedQueryUrl,
-          headers,
-        };
+        const optimisticApqHttpGet = { ...httpRequest };
+        optimisticApqHttpGet.method = "GET";
+        optimisticApqHttpGet.url = optimisticPersistedQueryUrl;
+
+        requestWithoutQuery.http = optimisticApqHttpGet;
       } else {
-        requestWithoutQuery.http = {
-          method: "POST",
-          url: this.url,
-          headers,
-        };
+        const optimisticApqHttpPost = { ...httpRequest };
+        optimisticApqHttpPost.method = "GET";
+        optimisticApqHttpPost.url = this.url;
+
+        requestWithoutQuery.http = optimisticApqHttpPost;
       }
 
       const apqOptimisticResponse = await this.sendRequest(
@@ -177,17 +183,17 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
           );
         }
 
-        requestWithQuery.http = {
-          method: "GET",
-            url: persistedQueryUrlWithQuery,
-            headers,
-        };
+        const apqWithQueryHttpGet = { ...httpRequest };
+        apqWithQueryHttpGet.method = "GET";
+        apqWithQueryHttpGet.url = persistedQueryUrlWithQuery;
+
+        requestWithQuery.http = apqWithQueryHttpGet;
       } else {
-        requestWithQuery.http = {
-          method: "POST",
-            url: this.url,
-            headers,
-        };
+        const queryHttpPost = { ...httpRequest };
+        queryHttpPost.method = "POST";
+        queryHttpPost.url = this.url;
+
+        requestWithQuery.http = queryHttpPost;
       }
 
       const response = await this.sendRequest(requestWithQuery, context);

--- a/gateway-js/src/utilities/http.ts
+++ b/gateway-js/src/utilities/http.ts
@@ -1,0 +1,71 @@
+import { GraphQLRequest, VariableValues } from "apollo-server-core";
+
+function serializeFetchParameter(p: VariableValues, label: string) {
+  let serialized;
+  try {
+      serialized = JSON.stringify(p);
+  } catch (e) {
+      const parseError = new Error(
+          `Network request failed. ${label} is not serializable: ${e.message}`
+      );
+      throw parseError;
+  }
+  return serialized;
+};
+
+export function rewriteURIForGET(chosenURI: string, request: GraphQLRequest) {
+  // Implement the standard HTTP GET serialization, plus 'extensions'. Note
+  // the extra level of JSON serialization!
+  const queryParams: string[] = [];
+  const addQueryParam = (key: string, value: string) => {
+      queryParams.push(`${key}=${encodeURIComponent(value)}`);
+  };
+
+  if (request.query) {
+      addQueryParam("query", request.query);
+  }
+  if (request.operationName) {
+      addQueryParam("operationName", request.operationName);
+  }
+  if (request.variables) {
+      let serializedVariables;
+      try {
+          serializedVariables = serializeFetchParameter(
+              request.variables,
+              "Variables map"
+          );
+      } catch (parseError) {
+          return { parseError };
+      }
+      addQueryParam("variables", serializedVariables);
+  }
+  if (request.extensions) {
+      let serializedExtensions;
+      try {
+          serializedExtensions = serializeFetchParameter(
+              request.extensions,
+              "Extensions map"
+          );
+      } catch (parseError) {
+          return { parseError };
+      }
+      addQueryParam("extensions", serializedExtensions);
+  }
+  // Reconstruct the URI with added query params.
+  //     This assumes that the URI is well-formed and that it doesn't
+  //     already contain any of these query params. We could instead use the
+  //     URL API and take a polyfill (whatwg-url@6) for older browsers that
+  //     don't support URLSearchParams. Note that some browsers (and
+  //     versions of whatwg-url) support URL but not URLSearchParams!
+  let fragment = "";
+  let preFragment = chosenURI;
+  const fragmentStart = chosenURI.indexOf("#");
+  if (fragmentStart !== -1) {
+      fragment = chosenURI.substr(fragmentStart);
+      preFragment = chosenURI.substr(0, fragmentStart);
+  }
+  const queryParamsPrefix = preFragment.indexOf("?") === -1 ? "?" : "&";
+  const newURI =
+      preFragment + queryParamsPrefix + queryParams.join("&") + fragment;
+  return { newURI };
+}


### PR DESCRIPTION
This provides support for CDNs that cannot cache responses for POST.

(Solves #183)

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

Our CDN (AWS CloudFront) does not support caching responses for POST requests. Before federation this functionality was supported by apollo-link-persisted-queries, but a migration to federation means our caching between gateway and microservice no longer works and our services are overwhelmed with requests causing us to be rate limited by 3rd parties.

I have modified the RemoteGraphQLDataSource to support sending requests in the GET form. The default configuration maintains the existing functionality of using POST.

The rewriteURIForGET function also exists in apollo-client [here](https://github.com/apollographql/apollo-client/blob/d470c964db46728d8a5dfc63990859c550fa1656/src/link/http/rewriteURIForGET.ts). I think gateway should not depend on the apollo-client package so not sure where the best place would be for this code to live, maybe there should be an HTTP-specific package shared by client and gateway.

This seems to be our final blocker from getting off of schema stitching and onto federation, so it would be great to get this change into the Apollo packages and allow us to move forward. 🚀 