### PR TITLE
External interface resolution across services

### DIFF
--- a/stargate/crates/query-planner/tests/features/external-field/csdl.graphql
+++ b/stargate/crates/query-planner/tests/features/external-field/csdl.graphql
@@ -1,0 +1,48 @@
+schema
+@graph(name: "nodes", url: "https://node.api.com")
+@graph(nameL: "accounts", url: "https://accounts.com")
+@composedGraph(version: 1)
+{
+    query: Query
+
+}
+
+# Nodes
+
+type Query {
+    node(id: ID!): Node @resolve(graph: "nodes")
+}
+
+interface Node 
+@owner(graph: "nodes")
+{
+    id: ID! @external
+    createdAt: String! @external
+}
+
+
+extend type User implements Node 
+@owner(graph: "nodes")    
+@key(fields: "{id}", graph: "nodes")
+{
+    id: ID! @external
+    createdAt: String! @external
+}
+
+## Accounts
+interface Node
+@owner(graph: "accounts")
+{
+  id: ID!
+  createdAt: String!
+}
+
+type User implements Node
+@owner(graph: "accounts")
+@key(fields: "{id}", graph: "accounts")
+{
+    id: ID!
+    createdAt: String!
+    name: String
+    username: String
+}

--- a/stargate/crates/query-planner/tests/features/external-field/resolution.feature
+++ b/stargate/crates/query-planner/tests/features/external-field/resolution.feature
@@ -1,0 +1,104 @@
+Feature: Query Planning > Interface service resolution
+
+Scenario: should resolve externalised interface fields from differenct services with a concrete type query
+  Given query
+    """
+    query {
+      node(id: "User:1") {
+        ... on User {
+            __typename
+            id
+            createdAt
+            }
+        } 
+    }
+    """
+  Then query plan
+    """
+    {
+        "kind": "QueryPlan",
+        "node": {
+            "kind": "Sequence",
+            "nodes": [
+                {
+                    "kind": "Fetch",
+                    "serviceName": "nodes",
+                    "variableUsages": [],
+                    "operation":"{node(id:\"User:1\"){__typename ...on User{__typename id}}}"
+                },
+                {
+                    "kind": "Flatten",
+                    "path": ["node"],
+                    "node": {
+                        "kind": "Fetch",
+                        "serviceName": "accounts",
+                        "requires": [
+                            {
+                                "kind": "InlineFragment",
+                                "typeCondition": "User",
+                                "selections": [
+                                    {"kind": "Field", "name": "__typename" },
+                                    {"kind": "Field", "name": "id"}
+                                ]
+                            }
+                        ],
+                        "variableUsages": [],
+                        "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{id createdAt}}}"
+                    }
+                }
+            ]
+        }
+    }
+    """
+
+
+Scenario: should resolve externalised interface fields from differenct services with an interface type query
+  Given query
+    """
+    query {
+      node(id: "User:1") {
+        ... on Node {
+            __typename
+            id
+            createdAt
+            }
+        } 
+    }
+    """
+  Then query plan
+    """
+    {
+        "kind": "QueryPlan",
+        "node": {
+            "kind": "Sequence",
+            "nodes": [
+                {
+                    "kind": "Fetch",
+                    "serviceName": "nodes",
+                    "variableUsages": [],
+                    "operation":"{node(id:\"User:1\"){__typename ...on User{__typename id}}}"
+                },
+                {
+                    "kind": "Flatten",
+                    "path": ["node"],
+                    "node": {
+                        "kind": "Fetch",
+                        "serviceName": "accounts",
+                        "requires": [
+                            {
+                                "kind": "InlineFragment",
+                                "typeCondition": "User",
+                                "selections": [
+                                    {"kind": "Field", "name": "__typename" },
+                                    {"kind": "Field", "name": "id"}
+                                ]
+                            }
+                        ],
+                        "variableUsages": [],
+                        "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{id createdAt}}}"
+                    }
+                }
+            ]
+        }
+    }
+    """


### PR DESCRIPTION
## Motivation

Following Jordan's issue described [here](https://github.com/apollographql/federation/issues/156) in which certain kinds of interface queries are not properly resolved across services, we seek to understand why. We start here at the lowest level, the query planner.

## Approach
We added a test case to the query planner Rust crate which [fails for us when using the federation package](https://github.com/apollographql/federation/issues/156), translating our SDL into the domain understood by the planner. Two cases were added, one concrete type which should work as expected, and one abstract interface type which we expect to fail

## Outcome
Both tests pass with enough annotation on the `csdl.graphql` file. This implies that the issue could be higher up somewhere - perhaps at the layer that generates the annotations.

![tenor (38)](https://user-images.githubusercontent.com/5721314/96424612-d77d4100-11f2-11eb-85f0-6bd774389b7a.gif)
