### PR TITLE
Update federation spec for key definition

### DIFF
--- a/docs/source/federation-spec.md
+++ b/docs/source/federation-spec.md
@@ -227,8 +227,7 @@ A new field must be added to the query root called `_entities`. This field must 
 ### `@key`
 
 ```graphql
-directive @key(fields: _FieldSet!) on OBJECT
-directive @key(fields: _FieldSet!) on INTERFACE
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 ```
 
 The `@key` directive is used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface.


### PR DESCRIPTION
## Description
Update the docs to match the same definition as used above for the `@key` directive

## References
https://github.com/apollographql/federation/blob/main/docs/source/federation-spec.md#federation-schema-specification
