### PR TITLE
Support multiple gateways in the same process

### DIFF
--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -43,7 +43,7 @@ import { getVariableValues } from 'graphql/execution/values';
 import fetcher from 'make-fetch-happen';
 import { HttpRequestCache } from './cache';
 import { fetch } from 'apollo-server-env';
-import { getQueryPlanner } from '@apollo/query-planner-wasm';
+import { getQueryPlanner, updatePlannerSchema } from '@apollo/query-planner-wasm';
 
 export type ServiceEndpointDefinition = Pick<ServiceDefinition, 'name' | 'url'>;
 
@@ -417,7 +417,11 @@ export class ApolloGateway implements GraphQLService {
       )
     } else {
       this.schema = schema;
-      this.queryPlannerPointer = getQueryPlanner(composedSdl);
+      if (this.queryPlannerPointer != null) {
+        updatePlannerSchema(this.queryPlannerPointer, composedSdl)
+      } else {
+        this.queryPlannerPointer = getQueryPlanner(composedSdl);
+      }
 
       // Notify the schema listeners of the updated schema
       try {


### PR DESCRIPTION
This PR makes it so that getting a query planner creates a new planner every time and never overrides the global instance.
However, because ApolloGateway can roll over its schema on the fly, we've added a new function named `updatePlannerSchema` that overrides a specific planner.

I opted for the simplest solution that solves the problem described in #210 , without having to manage memory from JS and implementing complex freeing/reference counting.

This hopefully fixes #210 
This implementation is suggested instead of #226 to keep things simple.

This PR also moves away from using raw pointers, to using an index to an array. That was a good suggestion in #226 as well.

@jaredly Can you verify this works for you? As far as I could tell, this solves the problem, and I've used the test you wrote in #226 (thanks for that!). I'd like to get confirmation from you before I merge. Thanks!
