### PR TITLE
Clean `unwrap()`s from `query-planner`

### DIFF
--- a/query-planner/src/context.rs
+++ b/query-planner/src/context.rs
@@ -218,10 +218,6 @@ impl<'q> QueryPlanningContext<'q> {
 
         let return_type = self.names_to_types.get(field_def.field_type.as_name());
 
-        if return_type.is_none() {
-            return vec![];
-        }
-
         if let Some(return_type) = return_type {
             if !return_type.is_composite_type() {
                 return vec![];

--- a/query-planner/src/federation.rs
+++ b/query-planner/src/federation.rs
@@ -186,6 +186,6 @@ fn as_selection_set_ref(value: &str) -> query::SelectionSet {
         .expect("failed parsing directive value as selection set")
         .definitions
         .pop()
-        .unwrap();
+        .expect("parsed selection set must have at least one definition");
     letp!(query::Definition::SelectionSet(ss) = ss => ss)
 }

--- a/query-planner/src/groups.rs
+++ b/query-planner/src/groups.rs
@@ -153,7 +153,7 @@ impl<'q> GroupForField<'q> for SerialGroupForField<'q> {
             _ => self.groups.push(FetchGroup::init(service_name)),
         }
 
-        self.groups.last_mut().unwrap()
+        self.groups.last_mut().expect("groups is not empty")
     }
 
     fn into_groups(self) -> Vec<FetchGroup<'q>> {

--- a/query-planner/src/helpers.rs
+++ b/query-planner/src/helpers.rs
@@ -63,10 +63,7 @@ pub(crate) fn build_possible_types<'a, 'q>(
                     let mut queue: VecDeque<&str> =
                         obj.implements_interfaces.iter().cloned().collect();
 
-                    while !queue.is_empty() {
-                        // get iface from queue.
-                        let iface = queue.pop_front().unwrap();
-
+                    while let Some(iface) = queue.pop_front() {
                         // associate iface with obj
                         implementing_types
                             .entry(iface)
@@ -256,7 +253,7 @@ impl<T> Head<T> for Vec<T> {
             panic!("head must be called on a non empty Vec")
         } else {
             let mut iter = self.into_iter();
-            (iter.next().unwrap(), iter.collect())
+            (iter.next().expect("self is not empty"), iter.collect())
         }
     }
 }

--- a/stargate/crates/stargate-lib/src/request_pipeline/executor.rs
+++ b/stargate/crates/stargate-lib/src/request_pipeline/executor.rs
@@ -34,7 +34,7 @@ pub async fn execute_query_plan<'req>(
     let data_lock: RwLock<Value> = RwLock::new(json!({}));
 
     if let Some(ref node) = query_plan.node {
-        execute_node(&context, node, &data_lock, &vec![]).await;
+        execute_node(&context, node, &data_lock, &[]).await;
     } else {
         unimplemented!("Introspection not supported yet");
     };
@@ -47,7 +47,7 @@ fn execute_node<'schema, 'request>(
     context: &'request ExecutionContext<'schema, 'request>,
     node: &'request PlanNode,
     results: &'request RwLock<Value>,
-    path: &'request ResponsePath,
+    path: &'request [String],
 ) -> BoxFuture<'request, ()> {
     async move {
         match node {
@@ -71,7 +71,7 @@ fn execute_node<'schema, 'request>(
                 //   }
             }
             PlanNode::Flatten(flatten_node) => {
-                let mut flattend_path = Vec::from(path.as_slice());
+                let mut flattend_path = Vec::from(path);
                 flattend_path.extend_from_slice(flatten_node.path.as_slice());
 
                 let inner_lock: RwLock<Value> = RwLock::new(json!({}));
@@ -130,7 +130,7 @@ fn execute_node<'schema, 'request>(
     .boxed()
 }
 
-fn merge_flattend_results(parent_data: &mut Value, child_data: &Value, path: &ResponsePath) {
+fn merge_flattend_results(parent_data: &mut Value, child_data: &Value, path: &[String]) {
     if path.is_empty() || child_data.is_null() {
         merge(&mut *parent_data, &child_data);
         return;
@@ -249,7 +249,7 @@ async fn execute_fetch<'schema, 'request>(
 
 fn flatten_results_at_path<'request>(
     value: &'request mut Value,
-    path: &ResponsePath,
+    path: &[String],
 ) -> &'request Value {
     if path.is_empty() || value.is_null() {
         return value;
@@ -283,7 +283,7 @@ fn flatten_results_at_path<'request>(
     }
 }
 
-fn execute_selection_set(source: &Value, selections: &SelectionSet) -> Value {
+fn execute_selection_set(source: &Value, selections: &[Selection]) -> Value {
     if source.is_null() {
         return Value::default();
     }


### PR DESCRIPTION
Started from the query-planner crate.

Only remaining `unwrap()`s are in unit tests.

(also cleaned a clippy thing)