### PR TITLE
fix(federation): differentiate field and input value names

### DIFF
--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -84,6 +84,7 @@ If Apollo Gateway encounters an error, composition fails. This document lists co
 | Code | Description |
 |---|---|
 | `VALUE_TYPE_FIELD_TYPE_MISMATCH` | Multiple implementing services define the same value type, but with mismatched fields. Value types must match across all services that define them. |
+| `VALUE_TYPE_INPUT_VALUE_MISMATCH` | Multiple implementing services define the same value type, but with mismatched input values for fields. Value types and input values for fields must match across all services that define them. |
 | `VALUE_TYPE_NO_ENTITY` | Multiple implementing services define the same value type, but at least one service assigns it a `@key`. Either remove the `@key` or convert the type to an entity and `extend` it.|
 | `VALUE_TYPE_UNION_TYPES_MISMATCH` | Multiple implementing services define the same union type, but with mismatched sets of types. Union types must match across all services that define them. |
 | `VALUE_TYPE_KIND_MISMATCH` | An implementing service defines a type with the same name and fields as a type in another service, but there is a declaration mismatch. For example, `type MyType` is invalid if another service defines `interface MyType`. |

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Fix check for value types when having fields and arguments with the same name [PR #280](https://github.com/apollographql/federation/pull/280)
+
 ## v0.20.6
 
 - No changes, but please note that `v0.20.5` was a botched release, with no update to the `@apollo/query-planner-wasm` package that was needed. If you're seeing an error similar to `This data graph is missing a valid configuration. unreachable`, please upgrade to at least this patch release.

--- a/federation-js/src/composition/__tests__/compose.test.ts
+++ b/federation-js/src/composition/__tests__/compose.test.ts
@@ -476,11 +476,11 @@ describe('composeServices', () => {
         const { schema, errors } = composeServices([serviceA, serviceB]);
         expect(schema).toBeDefined();
         expect(errors).toMatchInlineSnapshot(`
-                    Array [
-                      [GraphQLError: Field "Product.name" can only be defined once.],
-                      [GraphQLError: There can be only one type named "Product".],
-                    ]
-                `);
+          Array [
+            [GraphQLError: Field "Product.name" can only be defined once.],
+            [GraphQLError: There can be only one type named "Product".],
+          ]
+        `);
 
         const product = schema.getType('Product') as GraphQLObjectType;
 

--- a/federation-js/src/composition/validate/sdl/__tests__/uniqueFieldDefinitionNames.test.ts
+++ b/federation-js/src/composition/validate/sdl/__tests__/uniqueFieldDefinitionNames.test.ts
@@ -264,5 +264,60 @@ describe('UniqueFieldDefinitionNames', () => {
       ]);
       expect(errors).toHaveLength(0);
     });
+
+    it('object type definitions field and arguments with different type', () => {
+      const typeDefs = gql`
+        type Campaign implements Node {
+          identifier: String
+          event(identifier: String!): Event
+        }
+      `;
+
+      const [definitions] = createDocumentsForServices([
+        {
+          typeDefs,
+          name: 'serviceA',
+        },
+        {
+          typeDefs,
+          name: 'serviceB',
+        },
+      ]);
+
+      const errors = validateSDL(definitions, schema, [
+        UniqueFieldDefinitionNames,
+      ]);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  it('object type definitions order does not impact diffing', () => {
+    const [definitions] = createDocumentsForServices([
+      {
+        typeDefs: gql`
+          type Order implements Node {
+            questions(answers: OrderAnswersInput): Questions
+            fees(answers: OrderAnswersInput): Fees
+            answers: [Answer]
+          }
+        `,
+        name: 'serviceA',
+      },
+      {
+        typeDefs: gql`
+          type Order implements Node {
+            questions(answers: OrderAnswersInput): Questions
+            answers: [Answer]
+            fees(answers: OrderAnswersInput): Fees
+          }
+        `,
+        name: 'serviceB',
+      },
+    ]);
+
+    const errors = validateSDL(definitions, schema, [
+      UniqueFieldDefinitionNames,
+    ]);
+    expect(errors).toHaveLength(0);
   });
 });

--- a/federation-js/src/composition/validate/sdl/__tests__/uniqueTypeNamesWithFields.test.ts
+++ b/federation-js/src/composition/validate/sdl/__tests__/uniqueTypeNamesWithFields.test.ts
@@ -119,6 +119,40 @@ describe('UniqueTypeNamesWithFields', () => {
       `);
     });
 
+    it('object type definitions (non-identical, field input value types with type mismatch)', () => {
+      const [definitions] = createDocumentsForServices([
+        {
+          typeDefs: gql`
+            type Person {
+              age(relative: Boolean!): Int
+            }
+          `,
+          name: 'serviceA',
+        },
+        {
+          typeDefs: gql`
+            type Person {
+              age(relative: Boolean): Int
+            }
+          `,
+          name: 'serviceB',
+        },
+      ]);
+
+      const errors = validateSDL(definitions, schema, [
+        UniqueTypeNamesWithFields,
+      ]);
+      expect(errors).toHaveLength(1);
+      expect(errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "code": "VALUE_TYPE_INPUT_VALUE_MISMATCH",
+            "message": "[serviceA] Person -> A field's input type (\`relative\`) was defined differently in different services. \`serviceA\` and \`serviceB\` define \`relative\` as a Boolean! and Boolean respectively. In order to define \`Person\` in multiple places, the input values and their types must be identical.",
+          },
+        ]
+      `);
+    });
+
     it('object type definitions (overlapping fields, but non-value types)', () => {
       const [definitions] = createDocumentsForServices([
         {

--- a/federation-js/src/composition/validate/sdl/uniqueFieldDefinitionNames.ts
+++ b/federation-js/src/composition/validate/sdl/uniqueFieldDefinitionNames.ts
@@ -148,13 +148,23 @@ export function UniqueFieldDefinitionNames(
       valueTypeFromSchema || possibleValueTypes[node.name.value];
 
     if (duplicateTypeNode) {
-      const { fields } = diffTypeNodes(node, duplicateTypeNode);
+      const { fields, inputValues } = diffTypeNodes(node, duplicateTypeNode);
 
       // This is the condition required for a *near* value type. At this point, we know the
       // parent type names are the same. We know the field names are the same if either:
       // 1) the field has no entry in the fields diff (they're identical), or
       // 2) the field's diff entry is an array of length 2 (both nodes have the field, but the field types are different)
       if (Object.values(fields).every(diffEntry => diffEntry.length === 2)) {
+        return false;
+      }
+
+      // not all types might have input values, we only want to check the diff if there's any
+      const inputValuesTypes = Object.values(inputValues);
+
+      if (
+        inputValuesTypes.length > 0 &&
+        inputValuesTypes.every((diffEntry) => diffEntry.length === 2)
+      ) {
         return false;
       }
     } else {


### PR DESCRIPTION
This only contains the test at the moment :)

I found a bug where I had at type like this:

```graphql

type Campaign implements Node {
  id: ID!
  identifier: String
  event(identifier: String!): Event
}
```

in two services, and apollo was still complaining about the types being different.

Turns out that the diff is comparing the field `identifier` with the argument `identifier`,
and they have different types.

So, I've added a test for that. I suspect we might have a similar issue with different fields 
having the same argument but with different type. I might add a test for that later :)

EDIT: not sure why the tests didn't fail here

```
Summary of all failing tests
 FAIL  federation-js/src/composition/validate/sdl/__tests__/uniqueFieldDefinitionNames.test.ts (5.973s)
  ● UniqueFieldDefinitionNames › permits duplicate field names for › object type definitions field and arguments with different type

    expect(received).toHaveLength(expected)

    Expected length: 0
    Received length: 2
    Received array:  [[GraphQLError: Field "Campaign.identifier" can only be defined once.], [GraphQLError: Field "Campaign.event" can only be defined once.]]

      288 |         UniqueFieldDefinitionNames,
      289 |       ]);
    > 290 |       expect(errors).toHaveLength(0);
          |                      ^
      291 |     });
      292 |   });
      293 | });

      at Object.<anonymous> (src/composition/validate/sdl/__tests__/uniqueFieldDefinitionNames.test.ts:290:22)
```

Ah, the tests were not running: https://github.com/apollographql/federation/pull/281