### PR TITLE
fix(buildFederatedSchema): Export `GraphQLSchemaModule` type

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Export `GraphQLSchemaModule` type.
+
 ## v0.20.6
 
 - No changes, but please note that `v0.20.5` was a botched release, with no update to the `@apollo/query-planner-wasm` package that was needed. If you're seeing an error similar to `This data graph is missing a valid configuration. unreachable`, please upgrade to at least this patch release.

--- a/federation-js/src/service/buildFederatedSchema.ts
+++ b/federation-js/src/service/buildFederatedSchema.ts
@@ -28,6 +28,8 @@ type LegacySchemaModule = {
   resolvers?: GraphQLResolverMap<any>;
 };
 
+export { GraphQLSchemaModule };
+
 export function buildFederatedSchema(
   modulesOrSDL:
     | (GraphQLSchemaModule | DocumentNode)[]


### PR DESCRIPTION
We have a big app that uses `@apollo/federation` and we have several modules defined separately, with their own tests etc. in their folders. Each module exports `const module: GraphQLSchemaModule = { typeDefs, resolvers }` which are then glued together and passed to `buildFederatedSchema`.

However currently the `GraphQLSchemaModule` must be imported from `apollo-graphql` which is a dependency of `@apollo/federation` and we see little need in adding that as a direct dependency of our app.

This however triggers such an eslint warning for us:

![image](https://user-images.githubusercontent.com/1862580/100739670-b144e680-33d7-11eb-91dc-6e76943e6cbc.png)

Which is annoying as we have to ignore it all over the files. ( `// eslint-disable-next-line import/no-extraneous-dependencies `)

As `GraphQLSchemaModule` is type definition of an argument of `buildFederatedSchema`, it belongs to the public API of `@apollo/federation`, and this is why I think it should be exported by the `@apollo/federation` itself.

Thus, the PR.