### PR TITLE
fix(infra): Force publish wasm query planner for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compile": "tsc --build tsconfig.build.json",
     "compile:clean": "tsc --build tsconfig.build.json --clean",
     "watch": "tsc --build tsconfig.build.json --watch",
-    "release:version-bump": "lerna version",
+    "release:version-bump": "lerna version --force-publish=@apollo/query-planner-wasm",
     "release:start-ci-publish": "node -p '`Publish (dist-tag:${process.env.APOLLO_DIST_TAG || \"latest\"})`' | git tag -F - \"publish/$(date -u '+%Y%m%d%H%M%S')\" && git push origin \"$(git describe --match='publish/*' --tags --exact-match HEAD)\"",
     "postinstall": "lerna run monorepo-prepare && npm run compile",
     "test": "jest --verbose",


### PR DESCRIPTION
Admittedly, this will take us back to the dark ages of over-publishing from whence we recently came (https://github.com/apollographql/federation/pull/194), but fortunately it is with a package that's really only intended to be used internally for now.

One might recall a recent botched release (see: 0328553 004b8a1) in which the wasm package didn't get the required version bump that it needed. This is _possibly_ due to a restructuring of the repository, but my suspicion is that this runs a bit deeper and the workflow we're hoping for isn't achievable by typical uses of `lerna`.

For additional context, but likely unnecessary reading:
To elaborate a bit, we need to map changes in the _rust_ query planner into a resulting `lerna changed` entry in the `@apollo/query-planner-wasm` package (which is the artifact of changes to the rust query planner). This is proving difficult and may require some digging and creativity.

All that is to say, at the cost of over-publishing for now, there shouldn't be any more failed releases due to this issue.


<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
