### PR TITLE
chore(federation)!: Drop support for Node.js 8 and Node.js 10.

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- __BREAKING__: Drop support for Node.js 8 and Node.js 10.  This package now only targets Node.js 12+ LTS (Long-Term Support) versions, the same as `@apollo/gateway`, which first received this treatment in https://github.com/apollographql/apollo-server/pull/4031.  Node.js 8 has already lapsed from the [Node.js Foundation's LTS schedule](https://github.com/nodejs/release) and Node.js 10 (in _Maintenance LTS_ right now) is targeted to be end-of-life'd (EOL) at the end of April 2021.  [PR #TODO](https://github.com/apollographql/federation/pull/TODO)
 - Export `GraphQLSchemaModule` type. [PR #293](https://github.com/apollographql/federation/pull/293)
 
 ## v0.20.7

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- __BREAKING__: Drop support for Node.js 8 and Node.js 10.  This package now only targets Node.js 12+ LTS (Long-Term Support) versions, the same as `@apollo/gateway`, which first received this treatment in https://github.com/apollographql/apollo-server/pull/4031.  Node.js 8 has already lapsed from the [Node.js Foundation's LTS schedule](https://github.com/nodejs/release) and Node.js 10 (in _Maintenance LTS_ right now) is targeted to be end-of-life'd (EOL) at the end of April 2021.  [PR #TODO](https://github.com/apollographql/federation/pull/TODO)
+- __BREAKING__: Drop support for Node.js 8 and Node.js 10.  This package now only targets Node.js 12+ LTS (Long-Term Support) versions, the same as `@apollo/gateway`, which first received this treatment in https://github.com/apollographql/apollo-server/pull/4031.  Node.js 8 has already lapsed from the [Node.js Foundation's LTS schedule](https://github.com/nodejs/release) and Node.js 10 (in _Maintenance LTS_ right now) is targeted to be end-of-life'd (EOL) at the end of April 2021.  [PR #311](https://github.com/apollographql/federation/pull/311)
 - Export `GraphQLSchemaModule` type. [PR #293](https://github.com/apollographql/federation/pull/293)
 
 ## v0.20.7

--- a/federation-js/jest.config.js
+++ b/federation-js/jest.config.js
@@ -1,18 +1,9 @@
 const config = require('../jest.config.base');
 
-const NODE_MAJOR_VERSION = parseInt(
-  process.versions.node.split('.', 1)[0],
-  10
-);
-
 const additionalConfig = {
-  setupFiles: [
-    'core-js/features/array/flat',
-    'core-js/features/array/flat-map',
-  ],
   testPathIgnorePatterns: [
     ...config.testPathIgnorePatterns,
-    ...NODE_MAJOR_VERSION === 6 ? ["<rootDir>"] : []
+    ...[]
   ]
 };
 

--- a/federation-js/jest.config.js
+++ b/federation-js/jest.config.js
@@ -1,10 +1,5 @@
 const config = require('../jest.config.base');
 
-const additionalConfig = {
-  testPathIgnorePatterns: [
-    ...config.testPathIgnorePatterns,
-    ...[]
-  ]
-};
+const additionalConfig = {};
 
 module.exports = Object.assign(Object.create(null), config, additionalConfig);

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -17,14 +17,13 @@
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=8"
+    "node": ">=12.13.0 <15.0"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
     "apollo-graphql": "^0.6.0",
-    "core-js": "^3.4.0",
     "lodash.xorby": "^4.7.0"
   },
   "peerDependencies": {

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "apollo-graphql": "^0.6.0",
-    "apollo-server-env": "^2.4.5",
     "core-js": "^3.4.0",
     "lodash.xorby": "^4.7.0"
   },

--- a/federation-js/src/composition/compose.ts
+++ b/federation-js/src/composition/compose.ts
@@ -1,4 +1,3 @@
-import 'apollo-server-env';
 import {
   GraphQLSchema,
   extendSchema,

--- a/federation-js/src/composition/utils.ts
+++ b/federation-js/src/composition/utils.ts
@@ -1,4 +1,3 @@
-import 'apollo-server-env';
 import {
   InterfaceTypeExtensionNode,
   FieldDefinitionNode,

--- a/federation-js/src/composition/validate/postComposition/executableDirectivesIdentical.ts
+++ b/federation-js/src/composition/validate/postComposition/executableDirectivesIdentical.ts
@@ -1,4 +1,3 @@
-import 'apollo-server-env';
 import { GraphQLError, isSpecifiedDirective, print } from 'graphql';
 import {
   errorWithCode,

--- a/federation-js/src/composition/validate/postComposition/executableDirectivesInAllServices.ts
+++ b/federation-js/src/composition/validate/postComposition/executableDirectivesInAllServices.ts
@@ -1,4 +1,3 @@
-import 'apollo-server-env';
 import { GraphQLError, isSpecifiedDirective } from 'graphql';
 import {
   errorWithCode,

--- a/federation-js/src/composition/validate/postComposition/externalMissingOnBase.ts
+++ b/federation-js/src/composition/validate/postComposition/externalMissingOnBase.ts
@@ -1,4 +1,3 @@
-import 'apollo-server-env';
 import { isObjectType, GraphQLError } from 'graphql';
 import { logServiceAndType, errorWithCode, getFederationMetadata } from '../../utils';
 import { PostCompositionValidator } from '.';

--- a/federation-js/src/service/buildFederatedSchema.ts
+++ b/federation-js/src/service/buildFederatedSchema.ts
@@ -21,8 +21,6 @@ import { serviceField, entitiesField, EntityType } from '../types';
 
 import { printSchema } from './printFederatedSchema';
 
-import 'apollo-server-env';
-
 type LegacySchemaModule = {
   typeDefs: DocumentNode | DocumentNode[];
   resolvers?: GraphQLResolverMap<any>;

--- a/federation-js/tsconfig.json
+++ b/federation-js/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist",
-    "lib": ["es2017", "es2019.array", "esnext.asynciterable"],
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__"],

--- a/gateway-js/tsconfig.json
+++ b/gateway-js/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.base",
   "compilerOptions": {
-    "target": "es2019",
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "version": "file:federation-js",
       "requires": {
         "apollo-graphql": "^0.6.0",
-        "core-js": "^3.4.0",
         "lodash.xorby": "^4.7.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "version": "file:federation-js",
       "requires": {
         "apollo-graphql": "^0.6.0",
-        "apollo-server-env": "^2.4.5",
         "core-js": "^3.4.0",
         "lodash.xorby": "^4.7.0"
       }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "es2016",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -16,7 +16,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2017", "esnext.asynciterable"],
+    "lib": ["es2019", "esnext.asynciterable"],
     "types": ["node"],
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.test.base.json
+++ b/tsconfig.test.base.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["es2017", "es2019.array", "esnext.asynciterable"],
     "types": ["node", "jest", "apollo-server-env/dist/global"],
     "paths": {
       "__mocks__/*" : ["__mocks__/*"],


### PR DESCRIPTION
BREAKING CHANGE: This PR drops support for versions of Node.js prior to v12 that were still supported in the `@apollo/federation` package, leaving only support for Node.js 12+ LTS ([Long-Term Support](https://github.com/nodejs/release)) versions.

This aligns the supported versions of `@apollo/federation` with those supported by `@apollo/gateway`, which first received this treatment in https://github.com/apollographql/apollo-server/pull/4031 for performance gains.  Conversely to the motivation for that PR, performance gains are NOT expected from this change for the `@apollo/federation` package since it's not invoked per-request and has limited runtime computational cycles.

Aside from the impending end-of-life (EOL) cycle for Node.js 10 that is coming in April 2021, and dropping support for Node.js 8 which lapsed at the end of 2019, the motivating reason for releasing this change now is to remove the need for the `@apollo/federation` package to continue to leverage `apollo-server-env`, which brings globally-loaded polyfills from `core-js` and a `fetch` polyfill in Node.js environments that causes additional struggles when trying to package the `@apollo/federation` with bundling tools like Webpack or Rollup.

If this change proves to be problematic for any users of `@apollo/federation`, I'm happy to reconsider this and possibly revert it until the end of April 2021 (again, when Node.js 10 is completely end-of-life), but I would strongly suggest that users update their Node.js runtimes to a newer version of Node.js prior to that time, as once it is end-of-life'd continuing to support old Node.js versions won't continue to be an option.