### PR TITLE
Consolidate downstreamServiceError() args

### DIFF
--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -456,23 +456,23 @@ function downstreamServiceError(
   query: string,
   variables?: Record<string, any>,
 ) {
-  const {
+  let {
     message,
-    extensions: originalExtensions,
+    extensions,
     path,
   } = originalError
 
   if (!message) {
     message = `Error while fetching subquery from service "${serviceName}"`;
   }
-  const extensions = {
+  extensions = {
     code: 'DOWNSTREAM_SERVICE_ERROR',
     // XXX The presence of a serviceName in extensions is used to
     // determine if this error should be captured for metrics reporting.
     serviceName,
     query,
     variables,
-    ...originalExtensions,
+    ...extensions,
   };
   return new GraphQLError(
     message,


### PR DESCRIPTION
Now that we are passing the whole `originalError` to the `downstreamServiceError()` function, we no longer need to pass in `originalError.message`, etc. 

This change consolidates the arguments for `downstreamServiceError()` which is only used in a single place in this file and is not exported so the change shouldn't cause any compatibility issues.
