### PR TITLE
Add missing typing support to make-fetch-happen.d.ts

### DIFF
--- a/gateway-js/src/make-fetch-happen.d.ts
+++ b/gateway-js/src/make-fetch-happen.d.ts
@@ -33,6 +33,10 @@ declare module 'make-fetch-happen' {
           randomize?: boolean;
         };
     onRetry?(): void;
+    cert?: string;
+    key?: string;
+    proxy?: string;
+    noProxy?: string;
   }
 
   export interface CacheManager {


### PR DESCRIPTION
Add `cert`, `key`, `proxy` and `noProxy` options to `make-fetch-happen` typings to support internal security requirements around custom certs
