### PR TITLE
Move composition into a worker to avoid blocking the event loop

### DIFF
--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -28,6 +28,7 @@
     "@apollo/federation": "file:../federation-js",
     "@apollo/query-planner-wasm": "file:../query-planner-wasm",
     "@types/node-fetch": "2.5.4",
+    "@types/node": "^12.13.0",
     "apollo-graphql": "^0.6.0",
     "apollo-reporting-protobuf": "^0.6.0",
     "apollo-server-caching": "^0.5.2",

--- a/gateway-js/src/compose-worker.ts
+++ b/gateway-js/src/compose-worker.ts
@@ -8,7 +8,7 @@ if (isMainThread) {
     (see https://nodejs.org/api/worker_threads.html)`)
 }
 
-export type WorkerServiceDefinition = Omit<ServiceDefinition, 'type{Defs'> & { typeDefs: string };
+export type WorkerServiceDefinition = Omit<ServiceDefinition, 'typeDefs'> & { typeDefs: string };
 export type WorkerCompositionResult = Omit<ReturnType<typeof composeAndValidate>, 'schema'>
 
 const result: WorkerCompositionResult = composeAndValidate(

--- a/gateway-js/src/compose-worker.ts
+++ b/gateway-js/src/compose-worker.ts
@@ -1,0 +1,23 @@
+import { isMainThread, parentPort, workerData } from 'worker_threads';
+import { parse } from 'graphql';
+import { composeAndValidate } from '@apollo/federation';
+import type { ServiceDefinition } from '@apollo/federation';
+
+if (isMainThread) {
+  throw new Error(`compose-worker must be called as a Worker
+    (see https://nodejs.org/api/worker_threads.html)`)
+}
+
+export type WorkerServiceDefinition = Omit<ServiceDefinition, 'type{Defs'> & { typeDefs: string };
+export type WorkerCompositionResult = Omit<ReturnType<typeof composeAndValidate>, 'schema'>
+
+const result: WorkerCompositionResult = composeAndValidate(
+  workerData.map((def: WorkerServiceDefinition) => ({
+    ...def,
+    typeDefs: parse(def.typeDefs)
+  }))
+);
+
+delete (result as any).schema;
+
+parentPort?.postMessage(result)

--- a/gateway-js/src/compose.ts
+++ b/gateway-js/src/compose.ts
@@ -13,7 +13,6 @@ export default async (serviceList: ServiceDefinition[]): Promise<Result> => {
     name, url,
     typeDefs: print(typeDefs),
   }))
-  // console.log(require('util').inspect(workerData, {depth: null}))
   return new Promise((resolve, reject) => {
     const worker = new Worker(WORKER_SCRIPT, { workerData });
     worker.on('message', done);

--- a/gateway-js/src/compose.ts
+++ b/gateway-js/src/compose.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'path';
+import { Worker } from 'worker_threads';
+import { buildSchema, GraphQLError, print } from 'graphql';
+import type { composeAndValidate, ComposedGraphQLSchema, ServiceDefinition } from '@apollo/federation';
+import type { WorkerCompositionResult } from './compose-worker';
+
+const WORKER_SCRIPT = resolve(__dirname, '..', 'dist', 'compose-worker.js');
+
+type Result = ReturnType<typeof composeAndValidate>;
+
+export default async (serviceList: ServiceDefinition[]): Promise<Result> => {
+  const workerData = serviceList.map(({ name, url, typeDefs }) => ({
+    name, url,
+    typeDefs: print(typeDefs),
+  }))
+  // console.log(require('util').inspect(workerData, {depth: null}))
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(WORKER_SCRIPT, { workerData });
+    worker.on('message', done);
+    worker.on('error', reject);
+    worker.on('exit', (code) => {
+      if (code !== 0)
+        reject(new Error(`Worker stopped with exit code ${code}`));
+    });
+
+    function done(result: WorkerCompositionResult) {
+      // We lose prototypes when getting results back from the worker; rehydrate them here.
+      resolve({
+        schema: result.errors.length
+          ? null as unknown as ComposedGraphQLSchema
+          : Object.assign(buildSchema(result.composedSdl!), { extensions: { serviceList } }),
+        warnings: [], // deprecated
+        errors: result.errors.map(({ message, nodes, source, positions, path, originalError, extensions }) =>
+          new GraphQLError(message, nodes, source, positions, path, originalError, extensions)
+        ),
+        composedSdl: result.composedSdl,
+      })
+    }
+  });
+}
+

--- a/gateway-js/src/compose.ts
+++ b/gateway-js/src/compose.ts
@@ -18,7 +18,7 @@ export default async (serviceList: ServiceDefinition[]): Promise<Result> => {
     const worker = new Worker(WORKER_SCRIPT, { workerData });
     worker.on('message', done);
     worker.on('error', reject);
-    worker.on('exit', (code) => {
+    worker.on('exit', (code: number) => {
       if (code !== 0)
         reject(new Error(`Worker stopped with exit code ${code}`));
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,15 +17,124 @@
       "requires": {
         "@apollo/federation": "file:federation-js",
         "@apollo/query-planner-wasm": "file:query-planner-wasm",
+        "@types/node": "^12.13.0",
         "@types/node-fetch": "2.5.4",
         "apollo-graphql": "^0.6.0",
         "apollo-reporting-protobuf": "^0.6.0",
         "apollo-server-caching": "^0.5.2",
+        "apollo-server-core": "^2.19.0",
         "apollo-server-env": "^2.4.5",
         "apollo-server-errors": "^2.4.2",
+        "apollo-server-types": "^0.6.1",
         "loglevel": "^1.6.1",
         "make-fetch-happen": "^8.0.0",
         "pretty-format": "^26.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.19.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
+          "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw=="
+        },
+        "apollo-cache-control": {
+          "version": "0.11.5",
+          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.5.tgz",
+          "integrity": "sha512-jvarfQhwDRazpOsmkt5Pd7qGFrtbL70zMbUZGqDhJSYpfqI672f7bXXc7O3vtpbD3qnS3XTBvK2kspX/Bdo0IA==",
+          "requires": {
+            "apollo-server-env": "^2.4.5",
+            "apollo-server-plugin-base": "^0.10.3"
+          }
+        },
+        "apollo-server-core": {
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.19.1.tgz",
+          "integrity": "sha512-5EVmcY8Ij7Ywwu+Ze4VaUhZBcxl8t5ztcSatJrKMd4HYlEHyaNGBV2itfpyqAthxfdMbGKqlpeCHmTGSqDcNpA==",
+          "requires": {
+            "@apollographql/apollo-tools": "^0.4.3",
+            "@apollographql/graphql-playground-html": "1.6.26",
+            "@types/graphql-upload": "^8.0.0",
+            "@types/ws": "^7.0.0",
+            "apollo-cache-control": "^0.11.5",
+            "apollo-datasource": "^0.7.2",
+            "apollo-graphql": "^0.6.0",
+            "apollo-reporting-protobuf": "^0.6.2",
+            "apollo-server-caching": "^0.5.2",
+            "apollo-server-env": "^2.4.5",
+            "apollo-server-errors": "^2.4.2",
+            "apollo-server-plugin-base": "^0.10.3",
+            "apollo-server-types": "^0.6.2",
+            "apollo-tracing": "^0.12.1",
+            "async-retry": "^1.2.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graphql-extensions": "^0.12.7",
+            "graphql-tag": "^2.9.2",
+            "graphql-tools": "^4.0.0",
+            "graphql-upload": "^8.0.2",
+            "loglevel": "^1.6.7",
+            "lru-cache": "^5.0.0",
+            "sha.js": "^2.4.11",
+            "subscriptions-transport-ws": "^0.9.11",
+            "uuid": "^8.0.0",
+            "ws": "^6.0.0"
+          },
+          "dependencies": {
+            "apollo-reporting-protobuf": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.2.tgz",
+              "integrity": "sha512-WJTJxLM+MRHNUxt1RTl4zD0HrLdH44F2mDzMweBj1yHL0kSt8I1WwoiF/wiGVSpnG48LZrBegCaOJeuVbJTbtw==",
+              "requires": {
+                "@apollo/protobufjs": "^1.0.3"
+              }
+            }
+          }
+        },
+        "apollo-server-plugin-base": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.3.tgz",
+          "integrity": "sha512-NCLOsk9Jsd8oLvefkQvROdMDQvnHnzbzz3MPCqEYjCOEv0YBM8T77D0wCwbcViDS2M5p0W6un2ub9s/vU71f7Q==",
+          "requires": {
+            "apollo-server-types": "^0.6.2"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.2.tgz",
+          "integrity": "sha512-LgSKgAStiDzpUSLYwJoAmy0W8nkxx/ExMmgEPgEYVi6dKPkUmtu561J970PhGdYH+D79ke3g87D+plkUkgfnlQ==",
+          "requires": {
+            "apollo-reporting-protobuf": "^0.6.2",
+            "apollo-server-caching": "^0.5.2",
+            "apollo-server-env": "^2.4.5"
+          },
+          "dependencies": {
+            "apollo-reporting-protobuf": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.2.tgz",
+              "integrity": "sha512-WJTJxLM+MRHNUxt1RTl4zD0HrLdH44F2mDzMweBj1yHL0kSt8I1WwoiF/wiGVSpnG48LZrBegCaOJeuVbJTbtw==",
+              "requires": {
+                "@apollo/protobufjs": "^1.0.3"
+              }
+            }
+          }
+        },
+        "apollo-tracing": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.12.1.tgz",
+          "integrity": "sha512-qdkUjW+pOaidGOSITypeYE288y28HkPmGNpUtyQSOeTxgqXHtQX3TDWiOJ2SmrLH08xdSwfvz9o5KrTq4PdISg==",
+          "requires": {
+            "apollo-server-env": "^2.4.5",
+            "apollo-server-plugin-base": "^0.10.3"
+          }
+        },
+        "graphql-extensions": {
+          "version": "0.12.7",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.7.tgz",
+          "integrity": "sha512-yc9qOmEmWVZNkux9m0eCiHdtYSwNZRHkFhgfKfDn4u/gpsJolft1iyMUADnG/eytiRW0CGZFBpZjHkJhpginuQ==",
+          "requires": {
+            "@apollographql/apollo-tools": "^0.4.3",
+            "apollo-server-env": "^2.4.5",
+            "apollo-server-types": "^0.6.2"
+          }
+        }
       }
     },
     "@apollo/protobufjs": {
@@ -70,7 +179,6 @@
       "version": "1.6.26",
       "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz",
       "integrity": "sha512-XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==",
-      "dev": true,
       "requires": {
         "xss": "^1.0.6"
       }
@@ -3355,7 +3463,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3405,7 +3512,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -3420,7 +3526,6 @@
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3428,14 +3533,12 @@
     "@types/content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==",
-      "dev": true
+      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
     },
     "@types/cookies": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
       "integrity": "sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -3456,7 +3559,6 @@
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
       "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -3468,7 +3570,6 @@
       "version": "4.17.12",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
       "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3479,7 +3580,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
       "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3507,7 +3607,6 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.4.tgz",
       "integrity": "sha512-0TRyJD2o8vbkmJF8InppFcPVcXKk+Rvlg/xvpHBIndSJYpmDWfmtx/ZAtl4f3jR2vfarpTqYgj8MZuJssSoU7Q==",
-      "dev": true,
       "requires": {
         "@types/express": "*",
         "@types/fs-capacitor": "*",
@@ -3518,22 +3617,19 @@
         "graphql": {
           "version": "15.3.0",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
-          "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
-          "dev": true
+          "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
         }
       }
     },
     "@types/http-assert": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
-      "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==",
-      "dev": true
+      "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ=="
     },
     "@types/http-errors": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
-      "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==",
-      "dev": true
+      "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -3615,14 +3711,12 @@
     "@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
-      "dev": true
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.4.tgz",
       "integrity": "sha512-Etqs0kdqbuAsNr5k6mlZQelpZKVwMu9WPRHVVTLnceZlhr0pYmblRNJbCgoCMzKWWePldydU0AYEOX4Q9fnGUQ==",
-      "dev": true,
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -3638,7 +3732,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "dev": true,
       "requires": {
         "@types/koa": "*"
       }
@@ -3672,8 +3765,7 @@
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
-      "dev": true
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -3697,9 +3789,9 @@
       }
     },
     "@types/node": {
-      "version": "8.10.62",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.62.tgz",
-      "integrity": "sha512-76fupxOYVxk36kb7O/6KtrAPZ9jnSK3+qisAX4tQMEuGNdlvl7ycwatlHqjoE6jHfVtXFM3pCrCixZOidc5cuw=="
+      "version": "12.19.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
+      "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw=="
     },
     "@types/node-fetch": {
       "version": "2.5.4",
@@ -3724,20 +3816,17 @@
     "@types/qs": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
-      "dev": true
+      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-      "dev": true
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
       "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
-      "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -3753,7 +3842,6 @@
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
       "integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3775,7 +3863,6 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
       "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -3953,7 +4040,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.2.tgz",
       "integrity": "sha512-ibnW+s4BMp4K2AgzLEtvzkjg7dJgCaw9M5b5N0YKNmeRZRnl/I/qBTQae648FsRKgMwTbRQIvBhQ0URUFAqFOw==",
-      "dev": true,
       "requires": {
         "apollo-server-caching": "^0.5.2",
         "apollo-server-env": "^2.4.5"
@@ -4001,7 +4087,6 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
       "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "dev": true,
       "requires": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
@@ -4200,7 +4285,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
       "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "dev": true,
       "requires": {
         "@wry/equality": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4356,14 +4440,12 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-retry": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
       "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
-      "dev": true,
       "requires": {
         "retry": "0.12.0"
       }
@@ -4503,8 +4585,7 @@
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -4759,7 +4840,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-      "dev": true,
       "requires": {
         "dicer": "0.3.0"
       }
@@ -5150,8 +5230,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "compare-func": {
       "version": "2.0.0",
@@ -5770,8 +5849,7 @@
     "cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
-      "dev": true
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssom": {
       "version": "0.4.4",
@@ -5997,8 +6075,7 @@
     "deprecated-decorator": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
-      "dev": true
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -6038,7 +6115,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dev": true,
       "requires": {
         "streamsearch": "0.1.2"
       }
@@ -6276,8 +6352,7 @@
     "eventemitter3": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -6740,8 +6815,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6921,8 +6995,7 @@
     "fs-capacitor": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
-      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==",
-      "dev": true
+      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -7757,7 +7830,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
       "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
-      "dev": true,
       "requires": {
         "apollo-link": "^1.2.14",
         "apollo-utilities": "^1.0.1",
@@ -7769,8 +7841,7 @@
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -7778,7 +7849,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
       "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
-      "dev": true,
       "requires": {
         "busboy": "^0.3.1",
         "fs-capacitor": "^2.0.4",
@@ -7933,7 +8003,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
       "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -8576,8 +8645,7 @@
     "iterall": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jest": {
       "version": "25.5.4",
@@ -12829,8 +12897,7 @@
     "object-path": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=",
-      "dev": true
+      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -13777,8 +13844,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rfdc": {
       "version": "1.1.4",
@@ -14121,8 +14187,7 @@
     "setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -14526,8 +14591,7 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -14582,8 +14646,7 @@
     "streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "dev": true
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-length": {
       "version": "3.1.0",
@@ -14715,7 +14778,6 @@
       "version": "0.9.18",
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.18.tgz",
       "integrity": "sha512-tztzcBTNoEbuErsVQpTN2xUNN/efAZXyCyL5m3x4t6SKrEiTL2N8SaKWBFWM4u56pL79ULif3zjyeq+oV+nOaA==",
-      "dev": true,
       "requires": {
         "backo2": "^1.0.2",
         "eventemitter3": "^3.1.0",
@@ -14728,7 +14790,6 @@
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -14756,8 +14817,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -14997,8 +15057,7 @@
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
       "version": "3.0.1",
@@ -15042,7 +15101,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
       "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -15179,8 +15237,7 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -15425,8 +15482,7 @@
     "uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-      "dev": true
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "v8-to-istanbul": {
       "version": "4.1.4",
@@ -15815,7 +15871,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
       "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
       }
@@ -15842,7 +15897,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
       "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
-      "dev": true,
       "requires": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"
@@ -15897,14 +15951,12 @@
     "zen-observable": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
       "version": "0.8.21",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
       "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coverage:upload": "codecov"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "dependencies": {
     "@apollographql/apollo-tools": "0.4.8",
@@ -34,7 +34,7 @@
     "@types/lodash.xorby": "4.7.6",
     "@types/loglevel": "1.5.4",
     "@types/nock": "10.0.3",
-    "@types/node": "8.10.62",
+    "@types/node": "^12.13.0",
     "@types/node-fetch": "2.5.4",
     "apollo-link": "1.2.14",
     "apollo-link-http": "1.5.17",


### PR DESCRIPTION
Composition is not fast. Composition also happens on the main thread. This means that while not-fast composition is happening, the gateway isn't serving, and isn't responding to health checks. The former means downtime; the latter could mean a particularly aggressive watchdog comes along and kills the process.

This PR does not make composition faster. Instead, it moves it into a worker, which at least unblocks the event loop, allowing your gateway to keep serving (and health checking) while composition is occurring.