### PR TITLE
fix(gateway): Add `Promise<T>` gneeric to fix typescript errors

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Include original error during creation of `GraphQLError` in `downstreamServiceError()`. [PR #309](https://github.com/apollographql/federation/pull/309)
 - Gateway accepts `csdl` for startup configuration, uses CSDL internally for schema object creation. [PR #278](https://github.com/apollographql/federation/pull/278)
+- Add `Promise<T>` generic type info to fix typescript errors [PR #324](https://github.com/apollographql/federation/pull/324)
 ## v0.21.4
 
 - Update version of `@apollo/federation`

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -612,7 +612,7 @@ export class ApolloGateway implements GraphQLService {
     if (this.pollingTimer) clearTimeout(this.pollingTimer);
 
     // Sleep for the specified pollInterval before kicking off another round of polling
-    await new Promise(res => {
+    await new Promise<void>(res => {
       this.pollingTimer = setTimeout(
         () => res(),
         this.experimental_pollInterval || 10000,


### PR DESCRIPTION
Library users may have typescript compile issues if they have the source files for the gateway in their project

Error from our internal project on running `tsc`

```
node_modules/@apollo/gateway/src/index.ts:527:15 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

527         () => res(),
                  ~~~~~

  node_modules/typescript/lib/lib.es2015.promise.d.ts:33:34
    33     new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'value' was not provided.
```