### PR TITLE
chore(gateway): Simplify startup code paths

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Simplify startup code paths. This is technically only intended to be an internal restructure, but it's substantial enough to warrant a changelog entry for observability in case of any unexpected behavioral changes. [PR #440](https://github.com/apollographql/federation/pull/440)
+
 ## v0.22.0
 
 - Include original error during creation of `GraphQLError` in `downstreamServiceError()`. [PR #309](https://github.com/apollographql/federation/pull/309)

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag';
 import {
   ApolloGateway,
-  GatewayConfig,
   Experimental_DidResolveQueryPlanCallback,
   Experimental_UpdateServiceDefinitions,
 } from '../../index';
@@ -49,7 +48,7 @@ beforeEach(() => {
 describe('lifecycle hooks', () => {
   it('uses updateServiceDefinitions override', async () => {
     const experimental_updateServiceDefinitions: Experimental_UpdateServiceDefinitions = jest.fn(
-      async (_config: GatewayConfig) => {
+      async () => {
         return { serviceDefinitions, isNewSchema: true };
       },
     );
@@ -71,7 +70,7 @@ describe('lifecycle hooks', () => {
     const experimental_didFailComposition = jest.fn();
 
     const gateway = new ApolloGateway({
-      async experimental_updateServiceDefinitions(_config: GatewayConfig) {
+      async experimental_updateServiceDefinitions() {
         return {
           serviceDefinitions: [serviceDefinitions[0]],
           compositionMetadata: {
@@ -107,9 +106,7 @@ describe('lifecycle hooks', () => {
       schemaHash: 'hash1',
     };
 
-    const update: Experimental_UpdateServiceDefinitions = async (
-      _config: GatewayConfig,
-    ) => ({
+    const update: Experimental_UpdateServiceDefinitions = async () => ({
       serviceDefinitions,
       isNewSchema: true,
       compositionMetadata: {
@@ -124,7 +121,7 @@ describe('lifecycle hooks', () => {
 
     // We want to return a different composition across two ticks, so we mock it
     // slightly differenty
-    mockUpdate.mockImplementationOnce(async (_config: GatewayConfig) => {
+    mockUpdate.mockImplementationOnce(async () => {
       const services = serviceDefinitions.filter(s => s.name !== 'books');
       return {
         serviceDefinitions: [
@@ -215,7 +212,7 @@ describe('lifecycle hooks', () => {
 
   it('registers schema change callbacks when experimental_pollInterval is set for unmanaged configs', async () => {
     const experimental_updateServiceDefinitions: Experimental_UpdateServiceDefinitions = jest.fn(
-      async (_config: GatewayConfig) => {
+      async (_config) => {
         return { serviceDefinitions, isNewSchema: true };
       },
     );

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -1,9 +1,9 @@
 import gql from 'graphql-tag';
+import { ApolloGateway } from '../..';
 import {
-  ApolloGateway,
   Experimental_DidResolveQueryPlanCallback,
   Experimental_UpdateServiceDefinitions,
-} from '../../index';
+} from '../../config';
 import {
   product,
   reviews,

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -128,14 +128,15 @@ describe('gateway startup errors', () => {
       }
     `);
 
-    expect(
-      () =>
-        new ApolloGateway({
-          localServiceList: [
-            { name: 'accounts', url: service.url, typeDefs: uncomposableSdl },
-          ],
-          logger,
-        }),
-    ).toThrowError("A valid schema couldn't be composed");
+    const gateway = new ApolloGateway({
+      localServiceList: [
+        { name: 'accounts', url: service.url, typeDefs: uncomposableSdl },
+      ],
+      logger,
+    });
+
+    expect(gateway.load()).rejects.toThrowError(
+      "A valid schema couldn't be composed",
+    );
   });
 });

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -145,8 +145,10 @@ describe('gateway startup errors', () => {
       logger,
     });
 
-    expect(gateway.load()).rejects.toThrowError(
-      "A valid schema couldn't be composed",
-    );
+    expect(gateway.load()).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "A valid schema couldn't be composed. The following composition errors were found:
+      	[accounts] User -> A @key selects id, but User.id could not be found
+      	[accounts] Account -> A @key selects id, but Account.id could not be found"
+    `);
   });
 });

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -106,6 +106,16 @@ describe('gateway configuration warnings', () => {
       ),
     );
   });
+
+  it('throws when no configuration is provided', async () => {
+    const gateway = new ApolloGateway({
+      logger,
+    });
+
+    expect(gateway.load()).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"When a manual configuration is not provided, gateway requires an Apollo configuration. See https://www.apollographql.com/docs/apollo-server/federation/managed-federation/ for more information. Manual configuration options include: \`serviceList\`, \`csdl\`, and \`experimental_updateServiceDefinitions\`."`,
+    );
+  });
 });
 
 describe('gateway startup errors', () => {

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -145,7 +145,22 @@ describe('gateway startup errors', () => {
       logger,
     });
 
-    expect(gateway.load()).rejects.toThrowErrorMatchingInlineSnapshot(`
+    // This is the ideal, but our version of Jest has a bug with printing error snapshots.
+    // See: https://github.com/facebook/jest/pull/10217 (fixed in v26.2.0)
+    //     expect(gateway.load()).rejects.toThrowErrorMatchingInlineSnapshot(`
+    //       "A valid schema couldn't be composed. The following composition errors were found:
+    //         [accounts] User -> A @key selects id, but User.id could not be found
+    //         [accounts] Account -> A @key selects id, but Account.id could not be found"
+    //     `);
+    // Instead we'll just use the regular snapshot matcher...
+    let err: any;
+    try {
+      await gateway.load();
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err.message).toMatchInlineSnapshot(`
       "A valid schema couldn't be composed. The following composition errors were found:
       	[accounts] User -> A @key selects id, but User.id could not be found
       	[accounts] Account -> A @key selects id, but Account.id could not be found"

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -1,0 +1,108 @@
+import { Logger } from 'apollo-server-types';
+import { ApolloGateway } from '../..';
+import {
+  mockSDLQuerySuccess,
+  mockStorageSecretSuccess,
+  mockCompositionConfigLinkSuccess,
+  mockCompositionConfigsSuccess,
+  mockImplementingServicesSuccess,
+  mockRawPartialSchemaSuccess,
+  apiKeyHash,
+  graphId,
+} from './nockMocks';
+import { getTestingCsdl } from '../execution-utils';
+import { MockService } from './networkRequests.test';
+
+let logger: Logger;
+
+const service: MockService = {
+  gcsDefinitionPath: 'service-definition.json',
+  partialSchemaPath: 'accounts-partial-schema.json',
+  url: 'http://localhost:4001',
+  sdl: `#graphql
+      extend type Query {
+        me: User
+        everyone: [User]
+      }
+
+      "This is my User"
+      type User @key(fields: "id") {
+        id: ID!
+        name: String
+        username: String
+      }
+    `,
+};
+
+beforeEach(() => {
+  const warn = jest.fn();
+  const debug = jest.fn();
+  const error = jest.fn();
+  const info = jest.fn();
+
+  logger = {
+    warn,
+    debug,
+    error,
+    info,
+  };
+});
+
+describe('gateway configuration warnings', () => {
+  it('warns when both csdl and studio configuration are provided', async () => {
+    const gateway = new ApolloGateway({
+      csdl: getTestingCsdl(),
+      logger,
+    });
+
+    await gateway.load({
+      apollo: { keyHash: apiKeyHash, graphId, graphVariant: 'current' },
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'A local gateway configuration is overriding a managed federation configuration.' +
+        '  To use the managed configuration, do not specify a service list or csdl locally.',
+    );
+  });
+
+  it('conflicting configurations are warned about when present', async () => {
+    mockSDLQuerySuccess(service);
+
+    const gateway = new ApolloGateway({
+      serviceList: [{ name: 'accounts', url: service.url }],
+      logger,
+    });
+
+    await gateway.load({
+      apollo: { keyHash: apiKeyHash, graphId, graphVariant: 'current' },
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /A local gateway configuration is overriding a managed federation configuration/,
+      ),
+    );
+  });
+
+  it('conflicting configurations are not warned about when absent', async () => {
+    mockStorageSecretSuccess();
+    mockCompositionConfigLinkSuccess();
+    mockCompositionConfigsSuccess([service]);
+    mockImplementingServicesSuccess(service);
+    mockRawPartialSchemaSuccess(service);
+
+    const gateway = new ApolloGateway({
+      logger,
+    });
+
+    await gateway.load({
+      apollo: { keyHash: apiKeyHash, graphId, graphVariant: 'current' },
+    });
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringMatching(
+        /A local gateway configuration is overriding a managed federation configuration/,
+      ),
+    );
+  });
+});

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -1,0 +1,159 @@
+import { GraphQLError, GraphQLSchema } from "graphql";
+import { HeadersInit } from "node-fetch";
+import { fetch } from 'apollo-server-env';
+import { GraphQLRequestContextExecutionDidStart, Logger } from "apollo-server-types";
+import { ServiceDefinition } from "@apollo/federation";
+import { GraphQLDataSource } from './datasources/types';
+import { QueryPlan, OperationContext } from './QueryPlan';
+import { ServiceMap } from './executeQueryPlan';
+import {
+  CompositionMetadata,
+} from './loadServicesFromStorage';
+
+export type ServiceEndpointDefinition = Pick<ServiceDefinition, 'name' | 'url'>;
+
+export type Experimental_DidResolveQueryPlanCallback = ({
+  queryPlan,
+  serviceMap,
+  operationContext,
+  requestContext,
+}: {
+  readonly queryPlan: QueryPlan;
+  readonly serviceMap: ServiceMap;
+  readonly operationContext: OperationContext;
+  readonly requestContext: GraphQLRequestContextExecutionDidStart<
+    Record<string, any>
+  >;
+}) => void;
+
+export type Experimental_DidFailCompositionCallback = ({
+  errors,
+  serviceList,
+  compositionMetadata,
+}: {
+  readonly errors: GraphQLError[];
+  readonly serviceList: ServiceDefinition[];
+  readonly compositionMetadata?: CompositionMetadata;
+}) => void;
+
+export interface Experimental_CompositionInfo {
+  serviceDefinitions: ServiceDefinition[];
+  schema: GraphQLSchema;
+  compositionMetadata?: CompositionMetadata;
+}
+
+export type Experimental_DidUpdateCompositionCallback = (
+  currentConfig: Experimental_CompositionInfo,
+  previousConfig?: Experimental_CompositionInfo,
+) => void;
+
+/**
+ * **Note:** It's possible for a schema to be the same (`isNewSchema: false`) when
+ * `serviceDefinitions` have changed. For example, during type migration, the
+ * composed schema may be identical but the `serviceDefinitions` would differ
+ * since a type has moved from one service to another.
+ */
+export type Experimental_UpdateServiceDefinitions = (
+  config: DynamicGatewayConfig,
+) => Promise<{
+  serviceDefinitions?: ServiceDefinition[];
+  compositionMetadata?: CompositionMetadata;
+  isNewSchema: boolean;
+}>;
+
+interface GatewayConfigBase {
+  debug?: boolean;
+  logger?: Logger;
+  // TODO: expose the query plan in a more flexible JSON format in the future
+  // and remove this config option in favor of `exposeQueryPlan`. Playground
+  // should cutover to use the new option when it's built.
+  __exposeQueryPlanExperimental?: boolean;
+  buildService?: (definition: ServiceEndpointDefinition) => GraphQLDataSource;
+
+  // experimental observability callbacks
+  experimental_didResolveQueryPlan?: Experimental_DidResolveQueryPlanCallback;
+  experimental_didFailComposition?: Experimental_DidFailCompositionCallback;
+  experimental_didUpdateComposition?: Experimental_DidUpdateCompositionCallback;
+  experimental_pollInterval?: number;
+  experimental_approximateQueryPlanStoreMiB?: number;
+  experimental_autoFragmentization?: boolean;
+  fetcher?: typeof fetch;
+  serviceHealthCheck?: boolean;
+}
+
+export interface RemoteGatewayConfig extends GatewayConfigBase {
+  serviceList: ServiceEndpointDefinition[];
+  introspectionHeaders?: HeadersInit;
+}
+
+export interface ManagedGatewayConfig extends GatewayConfigBase {
+  federationVersion?: number;
+}
+
+interface ManuallyManagedGatewayConfig extends GatewayConfigBase {
+  experimental_updateServiceDefinitions: Experimental_UpdateServiceDefinitions;
+}
+interface LocalGatewayConfig extends GatewayConfigBase {
+  localServiceList: ServiceDefinition[];
+}
+
+interface CsdlGatewayConfig extends GatewayConfigBase {
+  csdl: string;
+}
+
+export type StaticGatewayConfig = LocalGatewayConfig | CsdlGatewayConfig;
+
+type DynamicGatewayConfig =
+| ManagedGatewayConfig
+| RemoteGatewayConfig
+| ManuallyManagedGatewayConfig;
+
+export type GatewayConfig = StaticGatewayConfig | DynamicGatewayConfig;
+
+export function isLocalConfig(config: GatewayConfig): config is LocalGatewayConfig {
+  return 'localServiceList' in config;
+}
+
+export function isRemoteConfig(config: GatewayConfig): config is RemoteGatewayConfig {
+  return 'serviceList' in config;
+}
+
+export function isCsdlConfig(config: GatewayConfig): config is CsdlGatewayConfig {
+  return 'csdl' in config;
+}
+
+// A manually managed config means the user has provided a function which
+// handles providing service definitions to the gateway.
+export function isManuallyManagedConfig(
+  config: GatewayConfig,
+): config is ManuallyManagedGatewayConfig {
+  return 'experimental_updateServiceDefinitions' in config;
+}
+
+// Managed config strictly means managed by Studio
+export function isManagedConfig(
+  config: GatewayConfig,
+): config is ManagedGatewayConfig {
+  return (
+    !isRemoteConfig(config) &&
+    !isLocalConfig(config) &&
+    !isCsdlConfig(config) &&
+    !isManuallyManagedConfig(config)
+  );
+}
+
+// A static config is one which loads synchronously on start and never updates
+export function isStaticConfig(config: GatewayConfig): config is StaticGatewayConfig {
+  return isLocalConfig(config) || isCsdlConfig(config);
+}
+
+// A dynamic config is one which loads asynchronously and (can) update via polling
+export function isDynamicConfig(
+  config: GatewayConfig,
+): config is DynamicGatewayConfig {
+  return (
+    isRemoteConfig(config) ||
+    isManagedConfig(config) ||
+    isManuallyManagedConfig(config)
+  );
+}

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -200,7 +200,7 @@ export type Experimental_DidUpdateCompositionCallback = (
  * since a type has moved from one service to another.
  */
 export type Experimental_UpdateServiceDefinitions = (
-  config: GatewayConfig,
+  config: DynamicGatewayConfig,
 ) => Promise<{
   serviceDefinitions?: ServiceDefinition[];
   compositionMetadata?: CompositionMetadata;
@@ -749,7 +749,7 @@ export class ApolloGateway implements GraphQLService {
   }
 
   protected async loadServiceDefinitions(
-    config: GatewayConfig,
+    config: RemoteGatewayConfig | ManagedGatewayConfig,
   ): ReturnType<Experimental_UpdateServiceDefinitions> {
     if (isRemoteConfig(config)) {
       const serviceList = config.serviceList.map((serviceDefinition) => ({
@@ -781,8 +781,7 @@ export class ApolloGateway implements GraphQLService {
       graphId: this.apolloConfig!.graphId!,
       apiKeyHash: this.apolloConfig!.keyHash!,
       graphVariant: this.apolloConfig!.graphVariant,
-      federationVersion:
-        (config as ManagedGatewayConfig).federationVersion || 1,
+      federationVersion: config.federationVersion || 1,
       fetcher: this.fetcher,
     });
   }

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -15,7 +15,6 @@ import {
   isObjectType,
   isIntrospectionType,
   GraphQLSchema,
-  GraphQLError,
   VariableDefinitionNode,
   parse,
   visit,
@@ -46,165 +45,34 @@ import {
 import { serializeQueryPlan, QueryPlan, OperationContext, WasmPointer } from './QueryPlan';
 import { GraphQLDataSource } from './datasources/types';
 import { RemoteGraphQLDataSource } from './datasources/RemoteGraphQLDataSource';
-import { HeadersInit } from 'node-fetch';
 import { getVariableValues } from 'graphql/execution/values';
 import fetcher from 'make-fetch-happen';
 import { HttpRequestCache } from './cache';
 import { fetch } from 'apollo-server-env';
 import { getQueryPlanner } from '@apollo/query-planner-wasm';
 import { csdlToSchema } from './csdlToSchema';
-
-export type ServiceEndpointDefinition = Pick<ServiceDefinition, 'name' | 'url'>;
-
-interface GatewayConfigBase {
-  debug?: boolean;
-  logger?: Logger;
-  // TODO: expose the query plan in a more flexible JSON format in the future
-  // and remove this config option in favor of `exposeQueryPlan`. Playground
-  // should cutover to use the new option when it's built.
-  __exposeQueryPlanExperimental?: boolean;
-  buildService?: (definition: ServiceEndpointDefinition) => GraphQLDataSource;
-
-  // experimental observability callbacks
-  experimental_didResolveQueryPlan?: Experimental_DidResolveQueryPlanCallback;
-  experimental_didFailComposition?: Experimental_DidFailCompositionCallback;
-  experimental_didUpdateComposition?: Experimental_DidUpdateCompositionCallback;
-  experimental_pollInterval?: number;
-  experimental_approximateQueryPlanStoreMiB?: number;
-  experimental_autoFragmentization?: boolean;
-  fetcher?: typeof fetch;
-  serviceHealthCheck?: boolean;
-}
-
-interface RemoteGatewayConfig extends GatewayConfigBase {
-  serviceList: ServiceEndpointDefinition[];
-  introspectionHeaders?: HeadersInit;
-}
-
-interface ManagedGatewayConfig extends GatewayConfigBase {
-  federationVersion?: number;
-}
-
-interface ManuallyManagedGatewayConfig extends GatewayConfigBase {
-  experimental_updateServiceDefinitions: Experimental_UpdateServiceDefinitions;
-}
-interface LocalGatewayConfig extends GatewayConfigBase {
-  localServiceList: ServiceDefinition[];
-}
-
-interface CsdlGatewayConfig extends GatewayConfigBase {
-  csdl: string;
-}
-
-type StaticGatewayConfig = LocalGatewayConfig | CsdlGatewayConfig;
-
-type DynamicGatewayConfig =
-| ManagedGatewayConfig
-| RemoteGatewayConfig
-| ManuallyManagedGatewayConfig;
-
-export type GatewayConfig = StaticGatewayConfig | DynamicGatewayConfig;
+import {
+  ServiceEndpointDefinition,
+  Experimental_DidFailCompositionCallback,
+  Experimental_DidResolveQueryPlanCallback,
+  Experimental_DidUpdateCompositionCallback,
+  Experimental_UpdateServiceDefinitions,
+  Experimental_CompositionInfo,
+  GatewayConfig,
+  StaticGatewayConfig,
+  RemoteGatewayConfig,
+  ManagedGatewayConfig,
+  isManuallyManagedConfig,
+  isLocalConfig,
+  isRemoteConfig,
+  isManagedConfig,
+  isDynamicConfig,
+  isStaticConfig,
+} from './config';
 
 type DataSourceMap = {
   [serviceName: string]: { url?: string; dataSource: GraphQLDataSource };
 };
-
-function isLocalConfig(config: GatewayConfig): config is LocalGatewayConfig {
-  return 'localServiceList' in config;
-}
-
-function isRemoteConfig(config: GatewayConfig): config is RemoteGatewayConfig {
-  return 'serviceList' in config;
-}
-
-function isCsdlConfig(config: GatewayConfig): config is CsdlGatewayConfig {
-  return 'csdl' in config;
-}
-
-// A manually managed config means the user has provided a function which
-// handles providing service definitions to the gateway.
-function isManuallyManagedConfig(
-  config: GatewayConfig,
-): config is ManuallyManagedGatewayConfig {
-  return 'experimental_updateServiceDefinitions' in config;
-}
-
-// Managed config strictly means managed by Studio
-function isManagedConfig(
-  config: GatewayConfig,
-): config is ManagedGatewayConfig {
-  return (
-    !isRemoteConfig(config) &&
-    !isLocalConfig(config) &&
-    !isCsdlConfig(config) &&
-    !isManuallyManagedConfig(config)
-  );
-}
-
-// A static config is one which loads synchronously on start and never updates
-function isStaticConfig(
-  config: GatewayConfig,
-): config is StaticGatewayConfig {
-  return isLocalConfig(config) || isCsdlConfig(config);
-}
-
-// A dynamic config is one which loads asynchronously and (can) update via polling
-function isDynamicConfig(
-  config: GatewayConfig,
-): config is DynamicGatewayConfig {
-  return (
-    isRemoteConfig(config) ||
-    isManagedConfig(config) ||
-    isManuallyManagedConfig(config)
-  );
-}
-
-export type Experimental_DidResolveQueryPlanCallback = ({
-  queryPlan,
-  serviceMap,
-  operationContext,
-  requestContext,
-}: {
-  readonly queryPlan: QueryPlan;
-  readonly serviceMap: ServiceMap;
-  readonly operationContext: OperationContext;
-  readonly requestContext: GraphQLRequestContextExecutionDidStart<Record<string, any>>;
-}) => void;
-
-export type Experimental_DidFailCompositionCallback = ({
-  errors,
-  serviceList,
-  compositionMetadata,
-}: {
-  readonly errors: GraphQLError[];
-  readonly serviceList: ServiceDefinition[];
-  readonly compositionMetadata?: CompositionMetadata;
-}) => void;
-
-export interface Experimental_CompositionInfo {
-  serviceDefinitions: ServiceDefinition[];
-  schema: GraphQLSchema;
-  compositionMetadata?: CompositionMetadata;
-}
-
-export type Experimental_DidUpdateCompositionCallback = (
-  currentConfig: Experimental_CompositionInfo,
-  previousConfig?: Experimental_CompositionInfo,
-) => void;
-
-/**
- * **Note:** It's possible for a schema to be the same (`isNewSchema: false`) when
- * `serviceDefinitions` have changed. For example, during type migration, the
- * composed schema may be identical but the `serviceDefinitions` would differ
- * since a type has moved from one service to another.
- */
-export type Experimental_UpdateServiceDefinitions = (
-  config: DynamicGatewayConfig,
-) => Promise<{
-  serviceDefinitions?: ServiceDefinition[];
-  compositionMetadata?: CompositionMetadata;
-  isNewSchema: boolean;
-}>;
 
 type Await<T> = T extends Promise<infer U> ? U : T;
 
@@ -986,5 +854,13 @@ export {
   buildOperationContext,
   QueryPlan,
   ServiceMap,
+  Experimental_DidFailCompositionCallback,
+  Experimental_DidResolveQueryPlanCallback,
+  Experimental_DidUpdateCompositionCallback,
+  Experimental_UpdateServiceDefinitions,
+  GatewayConfig,
+  ServiceEndpointDefinition,
+  Experimental_CompositionInfo,
 };
+
 export * from './datasources';

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -395,7 +395,7 @@ export class ApolloGateway implements GraphQLService {
     if (
       isManagedConfig(this.config) &&
       this.config.experimental_pollInterval &&
-      this.config?.experimental_pollInterval < 10000
+      this.config.experimental_pollInterval < 10000
     ) {
       this.experimental_pollInterval = 10000;
       this.logger.warn(

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -101,7 +101,8 @@ export type GatewayConfig =
   | RemoteGatewayConfig
   | LocalGatewayConfig
   | ManagedGatewayConfig
-  | CsdlGatewayConfig;
+  | CsdlGatewayConfig
+  | ManuallyManagedGatewayConfig;
 
 type DataSourceMap = {
   [serviceName: string]: { url?: string; dataSource: GraphQLDataSource };

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -348,13 +348,17 @@ export class ApolloGateway implements GraphQLService {
 
   private initStaticSchema(config: LocalGatewayConfig | CsdlGatewayConfig) {
     if (isLocalConfig(config)) {
-      const { schema, composedSdl } = this.createSchema({
-        serviceList: config.localServiceList,
-      });
-
-      // TODO: test this case
-      if (!composedSdl) {
-        throw Error("A valid schema couldn't be composed.");
+      let schema: GraphQLSchema;
+      let composedSdl: string;
+      try {
+        ({ schema, composedSdl } = this.createSchema({
+          serviceList: config.localServiceList,
+        }));
+      } catch (e) {
+        throw Error(
+          "A valid schema couldn't be composed. The following errors were found:\n" +
+            e.message,
+        );
       }
 
       const queryPlannerPointer = getQueryPlanner(composedSdl);

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -97,12 +97,14 @@ interface CsdlGatewayConfig extends GatewayConfigBase {
   csdl: string;
 }
 
-export type GatewayConfig =
-  | RemoteGatewayConfig
-  | LocalGatewayConfig
-  | ManagedGatewayConfig
-  | CsdlGatewayConfig
-  | ManuallyManagedGatewayConfig;
+type StaticGatewayConfig = LocalGatewayConfig | CsdlGatewayConfig;
+
+type DynamicGatewayConfig =
+| ManagedGatewayConfig
+| RemoteGatewayConfig
+| ManuallyManagedGatewayConfig;
+
+export type GatewayConfig = StaticGatewayConfig | DynamicGatewayConfig;
 
 type DataSourceMap = {
   [serviceName: string]: { url?: string; dataSource: GraphQLDataSource };
@@ -143,14 +145,14 @@ function isManagedConfig(
 // A static config is one which loads synchronously on start and never updates
 function isStaticConfig(
   config: GatewayConfig,
-): config is LocalGatewayConfig | CsdlGatewayConfig {
+): config is StaticGatewayConfig {
   return isLocalConfig(config) || isCsdlConfig(config);
 }
 
 // A dynamic config is one which loads asynchronously and (can) update via polling
 function isDynamicConfig(
   config: GatewayConfig,
-): config is RemoteGatewayConfig | ManagedGatewayConfig {
+): config is DynamicGatewayConfig {
   return (
     isRemoteConfig(config) ||
     isManagedConfig(config) ||

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -333,14 +333,14 @@ export class ApolloGateway implements GraphQLService {
     return loglevelLogger;
   }
 
-  private initQueryPlanStore(size?: number) {
+  private initQueryPlanStore(approximateQueryPlanStoreMiB?: number) {
     return new InMemoryLRUCache<QueryPlan>({
       // Create ~about~ a 30MiB InMemoryLRUCache.  This is less than precise
       // since the technique to calculate the size of a DocumentNode is
       // only using JSON.stringify on the DocumentNode (and thus doesn't account
       // for unicode characters, etc.), but it should do a reasonable job at
       // providing a caching document store for most operations.
-      maxSize: Math.pow(2, 20) * (size || 30),
+      maxSize: Math.pow(2, 20) * (approximateQueryPlanStoreMiB || 30),
       sizeCalculator: approximateObjectSize,
     });
   }

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -21,7 +21,6 @@ import {
   visit,
   DocumentNode,
 } from 'graphql';
-import { GraphQLSchemaValidationError } from 'apollo-graphql';
 import {
   composeAndValidate,
   compositionHasErrors,
@@ -416,16 +415,7 @@ export class ApolloGateway implements GraphQLService {
       ? { serviceList: config.localServiceList }
       : { csdl: config.csdl };
 
-    let schema: GraphQLSchema;
-    let composedSdl: string;
-    try {
-      ({ schema, composedSdl } = this.createSchema(schemaConstructionOpts));
-    } catch (e) {
-      throw Error(
-        "A valid schema couldn't be composed. The following errors were found:\n" +
-          e.message,
-      );
-    }
+    const { schema, composedSdl } = this.createSchema(schemaConstructionOpts);
 
     this.schema = schema;
     this.parsedCsdl = parse(composedSdl);
@@ -613,7 +603,10 @@ export class ApolloGateway implements GraphQLService {
           }),
         });
       }
-      throw new GraphQLSchemaValidationError(errors);
+      throw Error(
+        "A valid schema couldn't be composed. The following composition errors were found:\n" +
+          errors.map(e => '\t' + e.message).join('\n'),
+      );
     } else {
       const { composedSdl } = compositionResult;
       this.createServices(serviceList);

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -774,7 +774,10 @@ export class ApolloGateway implements GraphQLService {
       this.apolloConfig?.graphId && this.apolloConfig?.keyHash;
     if (!canUseManagedConfig) {
       throw new Error(
-        'When `serviceList` is not set, an Apollo configuration must be provided. See https://www.apollographql.com/docs/apollo-server/federation/managed-federation/ for more information.',
+        'When a manual configuration is not provided, gateway requires an Apollo ' +
+        'configuration. See https://www.apollographql.com/docs/apollo-server/federation/managed-federation/ ' +
+        'for more information. Manual configuration options include: ' +
+        '`serviceList`, `csdl`, and `experimental_updateServiceDefinitions`.',
       );
     }
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -299,8 +299,6 @@ export class ApolloGateway implements GraphQLService {
       config?.experimental_didResolveQueryPlan;
     this.experimental_didFailComposition =
       config?.experimental_didFailComposition;
-    this.experimental_didFailComposition =
-      config?.experimental_didFailComposition;
     this.experimental_didUpdateComposition =
       config?.experimental_didUpdateComposition;
     this.experimental_approximateQueryPlanStoreMiB =

--- a/gateway-js/src/loadServicesFromRemoteEndpoint.ts
+++ b/gateway-js/src/loadServicesFromRemoteEndpoint.ts
@@ -2,7 +2,8 @@ import { GraphQLRequest } from 'apollo-server-types';
 import { parse } from 'graphql';
 import { Headers, HeadersInit } from 'node-fetch';
 import { GraphQLDataSource } from './datasources/types';
-import { Experimental_UpdateServiceDefinitions, SERVICE_DEFINITION_QUERY } from './';
+import { SERVICE_DEFINITION_QUERY } from './';
+import { Experimental_UpdateServiceDefinitions } from './config';
 import { ServiceDefinition } from '@apollo/federation';
 
 export async function getServiceDefinitionsFromRemoteEndpoint({

--- a/gateway-js/src/loadServicesFromStorage.ts
+++ b/gateway-js/src/loadServicesFromStorage.ts
@@ -1,6 +1,6 @@
 import { fetch } from 'apollo-server-env';
 import { parse } from 'graphql';
-import { Experimental_UpdateServiceDefinitions } from '.';
+import { Experimental_UpdateServiceDefinitions } from './config';
 
 interface LinkFileResult {
   configPath: string;


### PR DESCRIPTION
In my attempts to implement CSDL fetching for managed gateway configurations, I found the complexity of our startup code to really inhibit my progress (and in turn, I'll need to add a bit more complexity for what I'm trying to accomplish).

After thinking through what is actually happening during startup (and wanting to simplify the code paths specifically `loadServiceDefinitions`), I was able to tease out the idea of static vs. dynamic configs and isolate those code paths a bit. Static === (local || csdl) configs where the gateway never updates. 

Previously, we had `loadServiceDefinitions` overloaded to handle every type of config, but really it doesn't need to concern itself with the static cases. Those cases, I found, could actually be handled synchronously within the constructor!

The effect of these changes can be seen in the test updates that I had to make - the gateway was actually going through a full async update cycle even in the cases where that was totally unnecessary.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
