### PR TITLE
Improve onboarding slightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     description: "Commands to run on every Node.js environment"
     steps:
       - run:
-          # rustup must be installed prior to installing `wasm-pack`.
+          # rustup must be installed in order to use `wasm-pack`.
           # If rustup isn't already in our environment, install it.
           # On the `circleci/rust:*-node` images, it's already installed, so
           # it's marginally faster to skip this when not necessary.
@@ -30,11 +30,6 @@ commands:
                   echo 'source $HOME/.cargo/env' >> $BASH_ENV
                   # This last line here is for subsequent "run" steps.
               )
-      - run:
-          name: Install wasm-pack
-          command: |
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf |
-              sh
       - oss/install_specific_npm_version
       - checkout
       - oss/npm_clean_install_with_caching

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,22 +16,13 @@ commands:
   common_test_steps:
     description: "Commands to run on every Node.js environment"
     steps:
+      - oss/install_specific_npm_version
+      - checkout
       - run:
           # rustup must be installed in order to use `wasm-pack`.
           # If rustup isn't already in our environment, install it.
-          # On the `circleci/rust:*-node` images, it's already installed, so
-          # it's marginally faster to skip this when not necessary.
           name: Ensure / Install rustup
-          command: |
-            which rustup > /dev/null 2>&1 ||
-              (
-                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
-                  bash -s -- -y &&
-                  echo 'source $HOME/.cargo/env' >> $BASH_ENV
-                  # This last line here is for subsequent "run" steps.
-              )
-      - oss/install_specific_npm_version
-      - checkout
+          command: WRITE_BASH_ENV=t npm run rustup-install
       - oss/npm_clean_install_with_caching
       - run:
           command: npm run test:ci

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ We'll be improving this `README` as soon as possible, but to learn about Apollo 
 
 ## Contributing
 
-In order to work in this repository (even on the TypeScript code), you must have Rust installed. Specifically, install [`rustup`](https://rustup.rs/).
-
 If this project seems like something you want to which you want to contribute, first off **thank you**. We are so excited that you are excited about this project and we want to make sure contributing is a safe, fun, and fruitful experience for you. Please read our [code of conduct](https://www.apollographql.com/docs/community/code-of-conduct/) and then head on over to the [contributing guide](./CONTRIBUTING.md) to learn how to work on this project.
 
 If you ever have any problems, questions, or ideas, the maintainers of this project are:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ We'll be improving this `README` as soon as possible, but to learn about Apollo 
 
 ## Contributing
 
+In order to work in this repository (even on the TypeScript code), you must have Rust installed. Specifically, install [`rustup`](https://rustup.rs/).
+
 If this project seems like something you want to which you want to contribute, first off **thank you**. We are so excited that you are excited about this project and we want to make sure contributing is a safe, fun, and fruitful experience for you. Please read our [code of conduct](https://www.apollographql.com/docs/community/code-of-conduct/) and then head on over to the [contributing guide](./CONTRIBUTING.md) to learn how to work on this project.
 
 If you ever have any problems, questions, or ideas, the maintainers of this project are:

--- a/ensure-rustup.sh
+++ b/ensure-rustup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+if ! which rustup >/dev/null 2>&1; then
+  if [ -n "${INSTALL_RUSTUP:-}" ]; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+      bash -s -- -y
+    if [ -n "${WRITE_BASH_ENV:-}" ]; then
+      # rustup's installer will write a source line to one of a few fixed
+      # startup scripts, but to work properly on CircleCI you should write
+      # it to $BASH_ENV instead, which CircleCI sets to a temp file.
+      # shellcheck disable=SC2016
+      echo 'source $HOME/.cargo/env' >> "$BASH_ENV"
+    fi
+  else
+    echo 'rustup is not installed! Run "npm run rustup-install" to install it in your home' 1>&2
+    echo 'directory. You may need to start a new shell afterwards for the PATH change to ' 1>&2
+    echo 'take effect.' 1>&2
+    echo 1>&2
+    exit 1
+  fi
+fi

--- a/gateway-js/src/__tests__/gateway/composedSdl.test.ts
+++ b/gateway-js/src/__tests__/gateway/composedSdl.test.ts
@@ -42,5 +42,6 @@ describe('Using csdl configuration', () => {
     expect(request.body).toEqual(
       JSON.stringify({ query: '{me{id username}}', variables: {} }),
     );
+    await server.stop();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,29 @@
         "loglevel": "^1.6.1",
         "make-fetch-happen": "^8.0.0",
         "pretty-format": "^26.0.0"
+      },
+      "dependencies": {
+        "apollo-server-caching": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.3.tgz",
+          "integrity": "sha512-iMi3087iphDAI0U2iSBE9qtx9kQoMMEWr6w+LwXruBD95ek9DWyj7OeC2U/ngLjRsXM43DoBDXlu7R+uMjahrQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "@apollo/protobufjs": {
@@ -4050,14 +4073,6 @@
         "graphql-tools": "^4.0.0"
       }
     },
-    "apollo-server-caching": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.2.tgz",
-      "integrity": "sha512-HUcP3TlgRsuGgeTOn8QMbkdx0hLPXyEJehZIPrcof0ATz7j7aTPA4at7gaiFHCo8gk07DaWYGB3PFgjboXRcWQ==",
-      "requires": {
-        "lru-cache": "^5.0.0"
-      }
-    },
     "apollo-server-core": {
       "version": "2.19.2",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.19.2.tgz",
@@ -4451,6 +4466,15 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "babel-jest": {
       "version": "25.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
@@ -4633,6 +4657,57 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
+    },
+    "binary-install": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.0.1.tgz",
+      "integrity": "sha512-axr6lqB4ec/pkEOb/JMnZpfcroWv1zT48pVz1oQHG7XmGkS77vmdxmP1btuH79lWQdy9e2MVw/uW0D8siopkRg==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.0",
+        "env-paths": "^2.2.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^3.0.0",
+        "tar": "^5.0.5",
+        "universal-url": "^2.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "tar": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
+          "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.3",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.0",
+            "mkdirp": "^0.5.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "bindings": {
       "version": "1.5.0",
@@ -6911,6 +6986,32 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -7943,6 +8044,12 @@
           }
         }
       }
+    },
+    "hasurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hasurl/-/hasurl-1.0.0.tgz",
+      "integrity": "sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -11942,6 +12049,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       }
@@ -15324,6 +15432,16 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "universal-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universal-url/-/universal-url-2.0.0.tgz",
+      "integrity": "sha512-3DLtXdm/G1LQMCnPj+Aw7uDoleQttNHp2g5FnNQKR6cP6taNWS1b/Ehjjx4PVyvejKi3TJyu8iBraKM4q3JQPg==",
+      "dev": true,
+      "requires": {
+        "hasurl": "^1.0.0",
+        "whatwg-url": "^7.0.0"
+      }
+    },
     "universal-user-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
@@ -15537,6 +15655,15 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "wasm-pack": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.9.1.tgz",
+      "integrity": "sha512-866+5UIdASabHMVU+M1azbn8tN1g6kLDoL5qvzVYep2hCYicKCgD/Y1LD0yOB3xMDdi+OD51WYNNBGH1NNF23g==",
+      "dev": true,
+      "requires": {
+        "binary-install": "0.0.1"
       }
     },
     "wcwidth": {
@@ -15888,7 +16015,8 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
     "watch": "tsc --build tsconfig.build.json --watch",
     "release:version-bump": "lerna version --force-publish=@apollo/query-planner-wasm",
     "release:start-ci-publish": "node -p '`Publish (dist-tag:${process.env.APOLLO_DIST_TAG || \"latest\"})`' | git tag -F - \"publish/$(date -u '+%Y%m%d%H%M%S')\" && git push origin \"$(git describe --match='publish/*' --tags --exact-match HEAD)\"",
-    "postinstall": "lerna run monorepo-prepare --stream && npm run compile",
+    "postinstall": "npm run rustup-ensure && lerna run monorepo-prepare --stream && npm run compile",
     "test": "jest --verbose",
     "test:clean": "jest --clearCache",
     "test:watch": "jest --verbose --watchAll",
     "testonly": "npm test",
     "test:ci": "npm run coverage -- --ci --maxWorkers=2  --reporters=default --reporters=jest-junit",
     "coverage": "npm test -- --coverage",
-    "coverage:upload": "codecov"
+    "coverage:upload": "codecov",
+    "rustup-install": "INSTALL_RUSTUP=true ./ensure-rustup.sh",
+    "rustup-ensure": "INSTALL_RUSTUP= ./ensure-rustup.sh"
   },
   "engines": {
     "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@apollographql/apollo-tools": "0.4.8",
     "@apollo/federation": "file:federation-js",
     "@apollo/gateway": "file:gateway-js",
     "@apollo/query-planner-wasm": "file:query-planner-wasm",
+    "@apollographql/apollo-tools": "0.4.8",
     "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
   },
   "devDependencies": {
@@ -50,13 +50,14 @@
     "jest-config": "25.5.4",
     "jest-cucumber": "2.0.13",
     "jest-junit": "10.0.0",
-    "log4js": "6.3.0",
     "lerna": "3.22.1",
+    "log4js": "6.3.0",
     "nock": "13.0.4",
     "node-fetch": "2.6.1",
     "prettier": "2.1.1",
     "ts-jest": "26.3.0",
     "typescript": "3.9.7",
+    "wasm-pack": "^0.9.1",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
   },

--- a/query-planner-wasm/README.md
+++ b/query-planner-wasm/README.md
@@ -3,12 +3,11 @@
 ## How to make this work
 
 ```shell script
-curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 cd query-planner-wasm
-wasm-pack build -t nodejs --scope apollo
+npx wasm-pack build -t nodejs --scope apollo
 ```
 
 ## How to test:
 ```shell script
-wasm-pack test --node
+npx wasm-pack test --node
 ```


### PR DESCRIPTION
- Fail quickly on `npm install` if `rustup` is not installed. Provide a script to easily
  install it. Use the script in CircleCI too.
- Install wasm-pack via npm instead of via README. This means we're pinning
  a specific wasm-pack version too. The CircleCI tasks rely on this; the GitHub
  actions which are more Rust-focused still manually install wasm-pack.
- Make Jest tests not print "A worker process has failed to exit gracefully and
  has been force exited" by properly cleaning one test up. This will make it
  easier to test gateway lifecycle properties.
