### PR TITLE
rust coverage: see if stable toolchain works

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         id: toolchain
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       ### BUILD CACHE SPECIFIC FOR COVERAGE ###


### PR DESCRIPTION
We were getting internal compiler errors today. Let's try not using nightly
builds?
