### PR TITLE
fix(gateway): Ignore thrown errors from `extendSchema`

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Ignore thrown errors from `extendSchema` during composition (these particular errors are already validated against and returned as composition errors) [PR #478](https://github.com/apollographql/federation/pull/478)
+
 ## v0.21.0
 
 - __BREAKING__: Drop support for Node.js 8 and Node.js 10.  This package now only targets Node.js 12+ LTS (Long-Term Support) versions, the same as `@apollo/gateway`, which first received this treatment in https://github.com/apollographql/apollo-server/pull/4031.  Node.js 8 has already lapsed from the [Node.js Foundation's LTS schedule](https://github.com/nodejs/release) and Node.js 10 (in _Maintenance LTS_ right now) is targeted to be end-of-life'd (EOL) at the end of April 2021.  [PR #311](https://github.com/apollographql/federation/pull/311)

--- a/federation-js/src/composition/__tests__/composeAndValidate.test.ts
+++ b/federation-js/src/composition/__tests__/composeAndValidate.test.ts
@@ -159,7 +159,7 @@ it('errors when a type extension has no base', () => {
   `);
 });
 
-fit("doesn't throw errors when a type is unknown, but captures them instead", () => {
+it("doesn't throw errors when a type is unknown, but captures them instead", () => {
   const serviceA = {
     typeDefs: gql`
       type Query {

--- a/federation-js/src/composition/__tests__/composeAndValidate.test.ts
+++ b/federation-js/src/composition/__tests__/composeAndValidate.test.ts
@@ -162,26 +162,38 @@ it('errors when a type extension has no base', () => {
 fit("doesn't throw errors when a type is unknown, but captures them instead", () => {
   const serviceA = {
     typeDefs: gql`
+      type Query {
+        foo: Bar!
+      }
+
       extend type Bar @key(fields: "id") {
         id: ID! @external
         thing: String
-      }
-
-      type Query {
-        foo: Bar!
       }
     `,
     name: 'serviceA',
   };
 
-  const compositionResult = composeAndValidate([
-    serviceA
-  ]);
+  const compositionResult = composeAndValidate([serviceA]);
 
   assertCompositionFailure(compositionResult);
   const { errors } = compositionResult;
-  expect(errors).toHaveLength(1);
-  expect(errors[0]).toMatchInlineSnapshot(`[Error: Unknown type: "Bar".]`);
+  expect(errors).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "code": "MISSING_ERROR",
+        "message": "Unknown type \\"Bar\\".",
+      },
+      Object {
+        "code": "EXTENSION_WITH_NO_BASE",
+        "message": "[serviceA] Bar -> \`Bar\` is an extension type, but \`Bar\` is not defined in any service",
+      },
+      Object {
+        "code": "MISSING_ERROR",
+        "message": "Type Query must define one or more fields.",
+      },
+    ]
+  `);
 });
 
 it('treats types with @extends as type extensions', () => {

--- a/federation-js/src/composition/__tests__/composeAndValidate.test.ts
+++ b/federation-js/src/composition/__tests__/composeAndValidate.test.ts
@@ -16,6 +16,7 @@ import {
   assertCompositionFailure,
   assertCompositionSuccess,
   compositionHasErrors,
+  CompositionResult,
 } from '../utils';
 
 expect.addSnapshotSerializer(astSerializer);
@@ -174,7 +175,10 @@ it("doesn't throw errors when a type is unknown, but captures them instead", () 
     name: 'serviceA',
   };
 
-  const compositionResult = composeAndValidate([serviceA]);
+  let compositionResult: CompositionResult;
+  expect(
+    () => (compositionResult = composeAndValidate([serviceA])),
+  ).not.toThrow();
 
   assertCompositionFailure(compositionResult);
   const { errors } = compositionResult;

--- a/federation-js/src/composition/compose.ts
+++ b/federation-js/src/composition/compose.ts
@@ -405,7 +405,12 @@ export function buildSchemaFromDefinitionsAndExtensions({
   };
 
   errors = validateSDL(definitionsDocument, schema, compositionRules);
-  schema = extendSchema(schema, definitionsDocument, { assumeValidSDL: true });
+
+  try {
+    schema = extendSchema(schema, definitionsDocument, {
+      assumeValidSDL: true,
+    });
+  } catch (e) {}
 
   // Extend the schema with the extension definitions (as an AST node)
   const extensionsDocument: DocumentNode = {
@@ -415,7 +420,11 @@ export function buildSchemaFromDefinitionsAndExtensions({
 
   errors.push(...validateSDL(extensionsDocument, schema, compositionRules));
 
-  schema = extendSchema(schema, extensionsDocument, { assumeValidSDL: true });
+  try {
+    schema = extendSchema(schema, extensionsDocument, {
+      assumeValidSDL: true,
+    });
+  } catch {}
 
   // Remove federation directives from the final schema
   schema = new GraphQLSchema({
@@ -514,6 +523,7 @@ export function addFederationMetadataToSchemaNodes({
       // TODO: Why don't we need to check for non-object types here
       if (isObjectType(namedType)) {
         const field = namedType.getFields()[fieldName];
+        if (!field) break;
 
         const fieldFederationMetadata: FederationField = {
           ...getFederationMetadata(field),


### PR DESCRIPTION
`extendSchema` throws errors in the case that we extend a type before it exists during composition. This should certainly result in _composition errors_ (which we have validations for), but it shouldn't cause `composeAndValidate` to throw, which is unexpected.

This change catches and discards errors thrown by `extendSchema`. The reason for discarding and not capturing the error (`Unknown type Bar.`) is that it's duplicated when we capture errors from `validateSDL` immediately after: https://github.com/apollographql/federation/blob/8f77bf41d8c5075ee1b5de6d7018a70326f39acd/federation-js/src/composition/compose.ts#L421

In the `extendSchema` code path, there is [only one `throw` case](https://github.com/graphql/graphql-js/blame/main/src/utilities/extendSchema.js#L423) (excluding an initial `assertSchema` which I'm not concerned about) and this test case exercises it. However, I'm unsure about this approach because there could be other errors thrown in the future which may be valuable or worth capturing. Open to feedback here, or possibly an alternative solution.

Bit of an unrelated tangent here, but worth mentioning:
Modifying this area of the codebase made it tempting to return as early as possible once all errors are collected and stop returning both a schema and errors (which seems like odd behavior). However, we can provide _more_ errors to the user when `compose` returns both, since `composeAndValidate` can take composition errors and append useful schema validation errors to the final set of errors provided.

It wouldn't be unreasonable at some point to stop returning both a `schema` and `errors` from `composeAndValidate`, however (this is already what we do with `composedSdl`).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
