### PR TITLE
fix(gateway): Make `protected` fields and methods `private` (except `loadServiceDefinitions`)

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- __BREAKING__: Make all `protected` gateway fields `private`. [PR #539](https://github.com/apollographql/federation/pull/539)
+
 ## v0.23.2
 
 - Only changes in the similarly versioned `@apollo/federation` package.

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- __BREAKING__: Make all `protected` gateway fields `private`. [PR #539](https://github.com/apollographql/federation/pull/539)
+- __BREAKING__: Make all `protected` gateway fields and methods `private`. To our knowledge, we've never encouraged subclassing the `ApolloGateway` class (which is the reason why one might choose `protected` over `private` in the first place). If you currently depend on the ability to override protected members of `ApolloGateway` please let us know. [PR #539](https://github.com/apollographql/federation/pull/539)
 
 ## v0.23.2
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- __BREAKING__: Make all `protected` gateway fields and methods `private`. To our knowledge, we've never encouraged subclassing the `ApolloGateway` class (which is the reason why one might choose `protected` over `private` in the first place). If you currently depend on the ability to override protected members of `ApolloGateway` please let us know. [PR #539](https://github.com/apollographql/federation/pull/539)
+- __BREAKING__: Make all `protected` gateway fields and methods `private` (except `loadServiceDefinitions`). If you currently depend on the ability to override any of these currently `protected` members of `ApolloGateway` please let us know. [PR #539](https://github.com/apollographql/federation/pull/539)
 
 ## v0.23.2
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- __BREAKING__: Make all `protected` gateway fields and methods `private` (except `loadServiceDefinitions`). If you currently depend on the ability to override any of these currently `protected` members of `ApolloGateway` please let us know. [PR #539](https://github.com/apollographql/federation/pull/539)
+- __BREAKING__: Make all `protected` gateway fields and methods `private` (except `loadServiceDefinitions`). If you currently depend on the ability to override any of these currently `protected` members of `ApolloGateway` please let us know. For additional context on why `loadServiceDefinitions` remains `protected` (for now) please read the associated PR description and linked issue. [PR #539](https://github.com/apollographql/federation/pull/539)
 
 ## v0.23.2
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -135,10 +135,10 @@ type GatewayState =
   | { phase: 'polling'; pollingDonePromise: Promise<void> };
 export class ApolloGateway implements GraphQLService {
   public schema?: GraphQLSchema;
-  protected serviceMap: DataSourceMap = Object.create(null);
-  protected config: GatewayConfig;
+  private serviceMap: DataSourceMap = Object.create(null);
+  private config: GatewayConfig;
   private logger: Logger;
-  protected queryPlanStore: InMemoryLRUCache<QueryPlan>;
+  private queryPlanStore: InMemoryLRUCache<QueryPlan>;
   private apolloConfig?: ApolloConfig;
   private onSchemaChangeListeners = new Set<SchemaChangeCallback>();
   private serviceDefinitions: ServiceDefinition[] = [];
@@ -154,19 +154,19 @@ export class ApolloGateway implements GraphQLService {
   // Observe query plan, service info, and operation info prior to execution.
   // The information made available here will give insight into the resulting
   // query plan and the inputs that generated it.
-  protected experimental_didResolveQueryPlan?: Experimental_DidResolveQueryPlanCallback;
+  private experimental_didResolveQueryPlan?: Experimental_DidResolveQueryPlanCallback;
   // Observe composition failures and the ServiceList that caused them. This
   // enables reporting any issues that occur during composition. Implementors
   // will be interested in addressing these immediately.
-  protected experimental_didFailComposition?: Experimental_DidFailCompositionCallback;
+  private experimental_didFailComposition?: Experimental_DidFailCompositionCallback;
   // Used to communicated composition changes, and what definitions caused
   // those updates
-  protected experimental_didUpdateComposition?: Experimental_DidUpdateCompositionCallback;
+  private experimental_didUpdateComposition?: Experimental_DidUpdateCompositionCallback;
   // Used for overriding the default service list fetcher. This should return
   // an array of ServiceDefinition. *This function must be awaited.*
-  protected updateServiceDefinitions: Experimental_UpdateServiceDefinitions;
+  private updateServiceDefinitions: Experimental_UpdateServiceDefinitions;
   // how often service defs should be loaded/updated (in ms)
-  protected experimental_pollInterval?: number;
+  private experimental_pollInterval?: number;
 
   constructor(config?: GatewayConfig) {
     this.config = {
@@ -362,7 +362,7 @@ export class ApolloGateway implements GraphQLService {
     return isManagedConfig(this.config) || this.experimental_pollInterval;
   }
 
-  protected async updateComposition(): Promise<void> {
+  private async updateComposition(): Promise<void> {
     let result: Await<ReturnType<Experimental_UpdateServiceDefinitions>>;
     this.logger.debug('Checking service definitions...');
     try {
@@ -497,7 +497,7 @@ export class ApolloGateway implements GraphQLService {
     );
   }
 
-  protected createSchema(
+  private createSchema(
     input: { serviceList: ServiceDefinition[] } | { csdl: string },
   ) {
     if ('serviceList' in input) {
@@ -507,7 +507,7 @@ export class ApolloGateway implements GraphQLService {
     }
   }
 
-  protected createSchemaFromServiceList(serviceList: ServiceDefinition[]) {
+  private createSchemaFromServiceList(serviceList: ServiceDefinition[]) {
     this.logger.debug(
       `Composing schema from service list: \n${serviceList
         .map(({ name, url }) => `  ${url || 'local'}: ${name}`)
@@ -550,7 +550,7 @@ export class ApolloGateway implements GraphQLService {
     }
   }
 
-  protected serviceListFromCsdl() {
+  private serviceListFromCsdl() {
     const serviceList: Omit<ServiceDefinition, 'typeDefs'>[] = [];
 
     visit(this.parsedCsdl!, {
@@ -581,7 +581,7 @@ export class ApolloGateway implements GraphQLService {
     return serviceList;
   }
 
-  protected createSchemaFromCsdl(csdl: string) {
+  private createSchemaFromCsdl(csdl: string) {
     this.parsedCsdl = parse(csdl);
     const serviceList = this.serviceListFromCsdl();
 
@@ -712,13 +712,13 @@ export class ApolloGateway implements GraphQLService {
         });
   }
 
-  protected createServices(services: ServiceEndpointDefinition[]) {
+  private createServices(services: ServiceEndpointDefinition[]) {
     for (const serviceDef of services) {
       this.createAndCacheDataSource(serviceDef);
     }
   }
 
-  protected async loadServiceDefinitions(
+  private async loadServiceDefinitions(
     config: RemoteGatewayConfig | ManagedGatewayConfig,
   ): ReturnType<Experimental_UpdateServiceDefinitions> {
     if (isRemoteConfig(config)) {
@@ -908,7 +908,7 @@ export class ApolloGateway implements GraphQLService {
     return response;
   };
 
-  protected validateIncomingRequest<TContext>(
+  private validateIncomingRequest<TContext>(
     requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
     operationContext: OperationContext,
   ) {

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -718,7 +718,7 @@ export class ApolloGateway implements GraphQLService {
     }
   }
 
-  private async loadServiceDefinitions(
+  protected async loadServiceDefinitions(
     config: RemoteGatewayConfig | ManagedGatewayConfig,
   ): ReturnType<Experimental_UpdateServiceDefinitions> {
     if (isRemoteConfig(config)) {


### PR DESCRIPTION
Without a strong case for subclassing the gateway, keeping these fields and methods as `protected` is more confusing than useful (_is_ there a use case for subclassing?...one might ask). We don't believe so, but feel free to @ me on this PR if this breaking change voids a legitimate use case that can't be accomplished via the gateway's configuration.

Edit: a use case for `loadServiceDefinitions` to be overridden has been brought to my attention, so I'm going to leave this as `protected`. For future consideration, we may want to expose this desired capability more cleanly via the gateway's configuration.

There is _almost_ parity between the `experimental_updateServiceDefinitions` config option and overriding `loadServiceDefinitions`, however the hook doesn't allow the user to call the original implementation of `loadServiceDefinitions` (which is one existing use case that we would be breaking).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
