### PR TITLE
Release @apollo/federation 0.21.3 (and @apollo/gateway 0.23.3)

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+## v0.21.3
+
+- No code changes, but when used with TypeScript, the generated code is now compatible with `graphql@15` (as well as previous versions).
+
 ## v0.21.2
 
 - Fix an erroneous `break` to `continue`, follow-up fix for #478 [PR #481](https://github.com/apollographql/federation/pull/481)

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation",
-  "version": "0.21.2",
+  "version": "0.21.3-alpha.0",
   "description": "Apollo Federation Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+## v0.23.3
+
+- The only change is pulling in the `graphql@15` compatibility fix in `@apollo/federation@0.21.3`.
+
 ## v0.23.2
 
 - Only changes in the similarly versioned `@apollo/federation` package.

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.23.2",
+  "version": "0.23.3-alpha.0",
   "description": "Apollo Gateway",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8075,13 +8075,10 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-      "dev": true,
-      "requires": {
-        "iterall": "^1.2.2"
-      }
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "dev": true
     },
     "graphql-extensions": {
       "version": "0.12.8",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "apollo-server-testing": "2.21.0",
     "bunyan": "1.8.14",
     "deep-freeze": "0.0.1",
-    "graphql": "14.7.0",
+    "graphql": "15.5.0",
     "graphql-tag": "2.11.0",
     "jest": "25.5.4",
     "jest-config": "25.5.4",


### PR DESCRIPTION
This is the release PR for @apollo/federation 0.21.3. It is a cherry-pick that resolves #537 by building output that is compatible with graphql@15.