### PR TITLE
gateway: stop using apollo-server-testing

### DIFF
--- a/gateway-js/src/__tests__/gateway/buildService.test.ts
+++ b/gateway-js/src/__tests__/gateway/buildService.test.ts
@@ -1,6 +1,4 @@
-import gql from 'graphql-tag';
 import { fetch } from '../../__mocks__/apollo-server-env';
-import { createTestClient } from 'apollo-server-testing';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 
 import { RemoteGraphQLDataSource } from '../../datasources/RemoteGraphQLDataSource';
@@ -55,9 +53,7 @@ it('correctly passes the context from ApolloServer to datasources', async () => 
     }),
   });
 
-  const call = createTestClient(server);
-
-  const query = gql`
+  const query = `#graphql
     {
       me {
         username
@@ -67,7 +63,7 @@ it('correctly passes the context from ApolloServer to datasources', async () => 
 
   fetch.mockJSONResponseOnce({ data: { me: { username: '@jbaxleyiii' } } });
 
-  const result = await call.query({
+  const result = await server.executeOperation({
     query,
   });
 

--- a/gateway-js/src/__tests__/gateway/queryPlanCache.test.ts
+++ b/gateway-js/src/__tests__/gateway/queryPlanCache.test.ts
@@ -1,5 +1,4 @@
 import gql from 'graphql-tag';
-import { createTestClient } from 'apollo-server-testing';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 import { buildFederatedSchema } from '@apollo/federation';
 
@@ -26,9 +25,8 @@ it('caches the query plan for a request', async () => {
   const server = new ApolloServer({ schema, executor });
 
   const upc = '1';
-  const call = createTestClient(server);
 
-  const query = gql`
+  const query = `#graphql
     query GetProduct($upc: String!) {
       product(upc: $upc) {
         name
@@ -36,7 +34,7 @@ it('caches the query plan for a request', async () => {
     }
   `;
 
-  const result = await call.query({
+  const result = await server.executeOperation({
     query,
     variables: { upc },
   });
@@ -47,7 +45,7 @@ it('caches the query plan for a request', async () => {
     },
   });
 
-  const secondResult = await call.query({
+  const secondResult = await server.executeOperation({
     query,
     variables: { upc },
   });
@@ -187,8 +185,6 @@ it('does not corrupt cached queryplan data across requests', async () => {
 
   const server = new ApolloServer({ schema, executor });
 
-  const call = createTestClient(server);
-
   const query1 = `#graphql
     query UserFavoriteColor {
       user {
@@ -206,13 +202,13 @@ it('does not corrupt cached queryplan data across requests', async () => {
     }
   `;
 
-  const result1 = await call.query({
+  const result1 = await server.executeOperation({
     query: query1,
   });
-  const result2 = await call.query({
+  const result2 = await server.executeOperation({
     query: query2,
   });
-  const result3 = await call.query({
+  const result3 = await server.executeOperation({
     query: query1,
   });
 

--- a/gateway-js/src/__tests__/integration/aliases.test.ts
+++ b/gateway-js/src/__tests__/integration/aliases.test.ts
@@ -1,6 +1,4 @@
 import { execute } from '../execution-utils';
-// FIXME: remove this when GraphQLExtensions is removed
-import { createTestClient } from 'apollo-server-testing';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 import { buildFederatedSchema } from '@apollo/federation';
 import { LocalGraphQLDataSource } from '../../datasources/LocalGraphQLDataSource';
@@ -156,9 +154,8 @@ it('supports aliases when using ApolloServer', async () => {
   const server = new ApolloServer({ schema, executor });
 
   const upc = '1';
-  const { query } = createTestClient(server);
 
-  const result = await query({
+  const result = await server.executeOperation({
     query: `#graphql
       query GetProduct($upc: String!) {
         product(upc: $upc) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,15 +4026,6 @@
         "apollo-server-types": "^0.6.3"
       }
     },
-    "apollo-server-testing": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-testing/-/apollo-server-testing-2.21.0.tgz",
-      "integrity": "sha512-8XYYT/fibBzdB4Fbidqp5kSdCKV6PhnJdZSO/I/kcLS9EuKUlGw3j0S2eN4ofAFpaTmPSNkYDzXcvcfiZli8CA==",
-      "dev": true,
-      "requires": {
-        "apollo-server-core": "^2.21.0"
-      }
-    },
     "apollo-server-types": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.3.tgz",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "apollo-link-http": "1.5.17",
     "apollo-server": "2.21.1",
     "apollo-server-env": "3.0.0",
-    "apollo-server-testing": "2.21.0",
     "bunyan": "1.8.15",
     "deep-freeze": "0.0.1",
     "graphql": "15.5.0",


### PR DESCRIPTION
I've been making the assertion in various issues on `apollo-server` that I don't
feel like `apollo-server-testing` has much value over using the
`executeOperation` method (which was added to AS as part of implementing
`apollo-server-testing`) directly. I figured it was worth trying out my
suggestion over on this repo (esp when I noticed #553 upgrading
`apollo-server-testing`). My opinion is that the version without
`createTestClient` is more clear in these particular tests in that adding an
intermediate `call` object only serves to obfuscate.

The one nice thing that `createTestClient` does is allow you to pass an AST
rather than a string for the operation. We could change `executeOperation` to
support this directly too, though in this case just changing the tests to not
create AST nodes was easy enough.