### PR TITLE
fix(q-p-w): Be explicit about the `files` and rm wasm-pack artifacts.

### DIFF
--- a/query-planner-wasm/.gitignore
+++ b/query-planner-wasm/.gitignore
@@ -1,0 +1,5 @@
+# This dist/ is also ignored by the root monorepo dist/
+dist/
+
+# This is unique to this package.
+module/

--- a/query-planner-wasm/package.json
+++ b/query-planner-wasm/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build-esm": "wasm-pack build --target bundler --out-dir module --out-name index --scope apollo",
     "build-cjs": "wasm-pack build --target nodejs --out-dir dist --out-name index --scope apollo",
-    "remove-pkg-jsons": "rm module/package.json && rm dist/package.json",
-    "monorepo-prepare": "npm run build-esm && npm run build-cjs && npm run remove-pkg-jsons"
+    "remove-pkg-cruft": "rm module/package.json dist/package.json dist/.gitignore module/.gitignore dist/README.md module/README.md",
+    "monorepo-prepare": "npm run build-esm && npm run build-cjs && npm run remove-pkg-cruft"
   },
   "author": "opensource@apollographql.com",
   "license": "MIT",
@@ -26,13 +26,20 @@
     "apollo"
   ],
   "files": [
-    "dist/*",
-    "module/*"
+    "module/index_bg.wasm",
+    "module/index.js",
+    "module/index.d.ts",
+    "dist/index_bg.wasm",
+    "dist/index.js",
+    "dist/index_bg.js",
+    "dist/index.d.ts"
   ],
   "main": "dist/index.js",
   "exports": {
     "require": "./dist/index.js",
     "import": "./module/index.js"
   },
+  "module": "module/index.js",
+  "sideEffects": "false",
   "types": "dist/index.d.ts"
 }


### PR DESCRIPTION
Following up on #270, this ensures that the correct files are included in the published `@apollo/query-planner-wasm` package. 

Debugging this was frustrating, as npm has some particular rules about how it includes files and when it respects `.gitignore` vs `.npmignore` vs. the presence of both, but I'll point out that the suggestion to run `npx npm-packlist` provided at [this URL](https://docs.npmjs.com/cli/v7/commands/npm-publish#files-included-in-package) was quite helpful.

Other references, which I've certainly read many times but still come in handy:

- https://docs.npmjs.com/cli/v7/using-npm/developers#keeping-files-out-of-your-package
- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files