### PR TITLE
Fix duplicate fetches in query plans

### DIFF
--- a/gateway-js/src/__tests__/integration/abstract-types.test.ts
+++ b/gateway-js/src/__tests__/integration/abstract-types.test.ts
@@ -1524,12 +1524,24 @@ it('when including multiple nested fields to the same service under different ty
     `);
   });
 
-  // This test case is more subtle, because you actually want to fetch the reviews (and the authors of reviews)
-  // of books and TVs separately. The problem here is that these fetches act on on the same path,
-  // so depending on the timing of the fetches, they either both fetch all reviews or all authors, or only the
-  // second one will perform duplicate fetches. Solving this requires us to filter on the types of response
-  // objects as opposed to just collecting everything in a path.
-it.skip("when including the same nested fields under different type conditions that are split between services", async () => {
+  // This test case describes a situation that isn't fixed by the deduplication
+  // workaround. It is here to remind us to look into this, but it doesn't
+  // actually test for the failing behavior so the test still succeeds.
+  //
+  // In cases where different possible types live in different
+  // services, you can't just merge the dependent fetches because they don't
+  // have the same parent. What you want here is to have these dependent fetches
+  // execute separately, but only take the objects fetched by its parent as input.
+  // The problem currently is that these fetches act on on the same path, so
+  // depending on the timing either one (or both) will end up fetching the same
+  // data just fetched by the other.
+  //
+  // To make this more concrete, in this case that means we'll fetch all of the
+  // reviews and authors twice.
+  //
+  // Solving this requires us to filter on the types of response objects as
+  // opposed to just collecting all objects in the path.
+it("when including the same nested fields under different type conditions that are split between services", async () => {
     const query = `#graphql
       query {
         topProducts {

--- a/gateway-js/src/__tests__/integration/abstract-types.test.ts
+++ b/gateway-js/src/__tests__/integration/abstract-types.test.ts
@@ -828,3 +828,696 @@ describe('unions', () => {
   //   expect(queryPlan).toCallService('books');
   // });
 });
+
+describe("doesn't result in duplicate fetches", () => {
+  it("when exploding types", async () => {
+    const query = `#graphql
+      query {
+        topProducts {
+          name
+          price
+          reviews {
+            author {
+              name
+              username
+            }
+            body
+            id
+          }
+        }
+      }
+    `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'accounts',
+        typeDefs: gql`
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+            username: String
+          }
+        `,
+      },
+      {
+        name: 'products',
+        typeDefs: gql`
+          type Book implements Product @key(fields: "isbn") {
+            isbn: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          type TV implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          type Computer implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          type Furniture implements Product @key(fields: "sku") {
+            sku: String!
+            name: String
+            price: Int
+            weight: Int
+          }
+
+          interface Product {
+            name: String
+            price: Int
+          }
+
+          extend type Query {
+            topProducts: [Product]
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Book implements Product @key(fields: "isbn") {
+            isbn: String! @external
+            reviews: [Review]
+          }
+
+          extend type TV implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Computer implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+
+          extend type Furniture implements Product @key(fields: "sku") {
+            sku: String! @external
+            reviews: [Review]
+          }
+
+          extend interface Product {
+            reviews: [Review]
+          }
+
+          type Review @key(fields: "id") {
+            id: ID!
+            body: String
+            author: User @provides(fields: "username")
+            product: Product
+          }
+
+          extend type User @key(fields: "id") {
+            id: ID! @external
+            username: String @external
+            reviews: [Review]
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Book {
+                  name
+                  price
+                  __typename
+                  isbn
+                }
+                ... on Computer {
+                  name
+                  price
+                  __typename
+                  id
+                }
+                ... on Furniture {
+                  name
+                  price
+                  __typename
+                  sku
+                }
+                ... on TV {
+                  name
+                  price
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Book {
+                  __typename
+                  isbn
+                }
+                ... on Computer {
+                  __typename
+                  id
+                }
+                ... on Furniture {
+                  __typename
+                  sku
+                }
+                ... on TV {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Book {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on Computer {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on Furniture {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on TV {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+              }
+            },
+          },
+          Flatten(path: "topProducts.@.reviews.@.author") {
+            Fetch(service: "accounts") {
+              {
+                ... on User {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on User {
+                  name
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+it("when including the same nested fields under different type conditions", async () => {
+    const query = `#graphql
+      query {
+        topProducts {
+          ... on Book {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+          ... on TV {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'accounts',
+        typeDefs: gql`
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+            username: String
+          }
+        `,
+      },
+      {
+        name: 'products',
+        typeDefs: gql`
+          type Book implements Product @key(fields: "isbn") {
+            isbn: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          type TV implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          type Computer implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          type Furniture implements Product @key(fields: "sku") {
+            sku: String!
+            name: String
+            price: Int
+            weight: Int
+          }
+
+          interface Product {
+            name: String
+            price: Int
+          }
+
+          extend type Query {
+            topProducts: [Product]
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Book implements Product @key(fields: "isbn") {
+            isbn: String! @external
+            reviews: [Review]
+          }
+
+          extend type TV implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Computer implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+
+          extend type Furniture implements Product @key(fields: "sku") {
+            sku: String! @external
+            reviews: [Review]
+          }
+
+          extend interface Product {
+            reviews: [Review]
+          }
+
+          type Review @key(fields: "id") {
+            id: ID!
+            body: String
+            author: User @provides(fields: "username")
+            product: Product
+          }
+
+          extend type User @key(fields: "id") {
+            id: ID! @external
+            username: String @external
+            reviews: [Review]
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Book {
+                  name
+                  price
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  name
+                  price
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Book {
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Book {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on TV {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+              }
+            },
+          },
+          Flatten(path: "topProducts.@.reviews.@.author") {
+            Fetch(service: "accounts") {
+              {
+                ... on User {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on User {
+                  name
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  // This test case is more subtle, because you actually want to fetch the reviews (and the authors of reviews)
+  // of books and TVs separately. The problem here is that these fetches act on on the same path,
+  // so depending on the timing of the fetches, they either both fetch all reviews or all authors, or only the
+  // second one will perform duplicate fetches. Solving this requires us to filter on the types of response
+  // objects as opposed to just collecting everything in a path.
+it.skip("when including the same nested fields under different type conditions that are split between services", async () => {
+    const query = `#graphql
+      query {
+        topProducts {
+          ... on Book {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+          ... on TV {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'accounts',
+        typeDefs: gql`
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+            username: String
+          }
+        `,
+      },
+      {
+        name: 'products',
+        typeDefs: gql`
+          type Book implements Product @key(fields: "isbn") {
+            isbn: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          type TV implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+
+          interface Product {
+            name: String
+            price: Int
+          }
+
+          extend type Query {
+            topProducts: [Product]
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type TV implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+
+          extend interface Product {
+            reviews: [Review]
+          }
+
+          type Review @key(fields: "id") {
+            id: ID!
+            body: String
+            author: User @provides(fields: "username")
+            product: Product
+          }
+
+          extend type User @key(fields: "id") {
+            id: ID! @external
+            username: String @external
+            reviews: [Review]
+          }
+        `,
+      },
+      {
+        name: 'books',
+        typeDefs: gql`
+          extend type Book @key(fields: "isbn") {
+            isbn: String! @external
+            reviews: [Review]
+          }
+
+          extend type Review @key(fields: "id") {
+            id: ID! @external
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Book {
+                  name
+                  price
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  name
+                  price
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Parallel {
+            Sequence {
+              Flatten(path: "topProducts.@") {
+                Fetch(service: "books") {
+                  {
+                    ... on Book {
+                      __typename
+                      isbn
+                    }
+                  } =>
+                  {
+                    ... on Book {
+                      reviews {
+                        __typename
+                        id
+                      }
+                    }
+                  }
+                },
+              },
+              Flatten(path: "topProducts.@.reviews.@") {
+                Fetch(service: "reviews") {
+                  {
+                    ... on Review {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Review {
+                      author {
+                        __typename
+                        id
+                        username
+                      }
+                      body
+                    }
+                  }
+                },
+              },
+              Flatten(path: "topProducts.@.reviews.@.author") {
+                Fetch(service: "accounts") {
+                  {
+                    ... on User {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on User {
+                      name
+                    }
+                  }
+                },
+              },
+            },
+            Sequence {
+              Flatten(path: "topProducts.@") {
+                Fetch(service: "reviews") {
+                  {
+                    ... on TV {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on TV {
+                      reviews {
+                        author {
+                          __typename
+                          id
+                          username
+                        }
+                        body
+                        id
+                      }
+                    }
+                  }
+                },
+              },
+              Flatten(path: "topProducts.@.reviews.@.author") {
+                Fetch(service: "accounts") {
+                  {
+                    ... on User {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on User {
+                      name
+                    }
+                  }
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -415,7 +415,10 @@ fn complete_field<'a, 'q: 'a>(
             for mut sub_group in sub_group_dependent_groups {
                 let existing_dependent_group = parent_group.other_dependent_groups
                     .iter_mut()
-                    .find(| x| x.service_name == sub_group.service_name);
+                    .find(| x| 
+                        x.service_name == sub_group.service_name &&
+                        x.merge_at == sub_group.merge_at
+                    );
 
                 match existing_dependent_group {
                     Some(existing_dependent_group) => {

--- a/query-planner/src/builder.rs
+++ b/query-planner/src/builder.rs
@@ -413,16 +413,16 @@ fn complete_field<'a, 'q: 'a>(
             };
 
             for mut sub_group in sub_group_dependent_groups {
-                let existing_dependent_group = parent_group.other_dependent_groups
-                    .iter_mut()
-                    .find(| x| 
-                        x.service_name == sub_group.service_name &&
-                        x.merge_at == sub_group.merge_at
-                    );
+                let existing_dependent_group =
+                    parent_group.other_dependent_groups.iter_mut().find(|x| {
+                        x.service_name == sub_group.service_name && x.merge_at == sub_group.merge_at
+                    });
 
                 match existing_dependent_group {
                     Some(existing_dependent_group) => {
-                        existing_dependent_group.fields.append(&mut sub_group.fields);
+                        existing_dependent_group
+                            .fields
+                            .append(&mut sub_group.fields);
                     }
                     None => {
                         parent_group.other_dependent_groups.push(sub_group);


### PR DESCRIPTION
Fixes #399 and #294.

The issue fixed by this PR requires a bit of unpacking. The visible result is that in some cases, the query plan will contain duplicate fetches to the same underlying service. For this query, for example:

```
query {
  topProducts {
    name
    price
    reviews {
      body
      author {
        name
      }
    }
  }
}
```

We end up fetching the names of authors as many times as there are different types of products. (It isn’t just that we fetch the authors of the reviews of each product type separately, but we literally execute the same query with the same representations, so all authors for all products, multiple times.)

In the case above, this is triggered as a consequence of type explosion, but it is a separate issue and also occurs in other cases where we manually include duplicate nested fields under multiple type conditions.

This query, for example, will also contain as many fetches for authors as there are type conditions (so two fetches here):

```
query {
  topProducts {
    name
    price
    ... on Book {
      reviews {
        body
        author {
          name
        }
      }
    }
    ... on Video {
      reviews {
        body
        author {
          name
        }
      }
    }
  }
}
```

The underlying cause is that we don't merge dependent fetch groups from subfields. In this case, we’ll create separate fetch groups for `{ name }` nested under the different type conditions, and even though these operate on the same path and fetch data from the same service, they are treated as separate fetches (that all have the same path however, which is why they take the same representations as input).

This PR attempts to solve this by manually merging nested fetch groups whenever they are compatible. That fixes the issue in most cases, but there are more complicated situations it doesn't address and that will require more substantial changes to the query planner and execution.

In particular, when possible types are spread over multiple services, it will not be possible to merge nested fetch groups from subfields because these should actually result in separate fetches. What you don't want however, is for those fetches to operate on the same objects just fetched by the other, but since representations taken as input are collected by path, there is no way to differentiate between these.

I believe solving this latter problem requires additional capabilities in the query plan (which is something we’ve talked about before). The most straightforward way to fix this seems to be a `TypeCondition` node in the query plan, which filters input representations based on their type.
