### PR TITLE
fix(gateway): Address typings issue for `getDefaultFetcher`

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- Enable gateway to fetch CSDL / cloud config in managed mode. This feature is currently opt-in only and should have no effect for existing use cases. After some testing, this behavior will become the default (and should be nearly transparent / non-breaking for users when we do so). It's unintended for users to start using this feature for now unless instructed by Apollo to do so. [PR #458](https://github.com/apollographql/federation/pull/458) 
+- Enable gateway to fetch CSDL / cloud config in managed mode. This feature is currently opt-in only and should have no effect for existing use cases. After some testing, this behavior will become the default (and should be nearly transparent / non-breaking for users when we do so). It's unintended for users to start using this feature for now unless instructed by Apollo to do so. [PR #458](https://github.com/apollographql/federation/pull/458)
+- __FIX__: Fix typings of `getDefaultFetcher`, which in turn fixes the regression of `make-fetch-happen` types not being included in the gateway's compiled `index.d.ts` file. [PR #585](https://github.com/apollographql/federation/pull/585)
 
 ## v0.24.4
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -5,7 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Enable gateway to fetch CSDL / cloud config in managed mode. This feature is currently opt-in only and should have no effect for existing use cases. After some testing, this behavior will become the default (and should be nearly transparent / non-breaking for users when we do so). It's unintended for users to start using this feature for now unless instructed by Apollo to do so. [PR #458](https://github.com/apollographql/federation/pull/458)
-- __FIX__: Fix typings of `getDefaultFetcher`, which in turn fixes the regression of `make-fetch-happen` types not being included in the gateway's compiled `index.d.ts` file. [PR #585](https://github.com/apollographql/federation/pull/585)
+- __FIX__: followup to #458. Fix typings of `getDefaultFetcher` - `make-fetch-happen` types were not being included in the gateway's compiled `index.d.ts` file. [PR #585](https://github.com/apollographql/federation/pull/585)
 
 ## v0.24.4
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -43,7 +43,7 @@ import { getServiceDefinitionsFromRemoteEndpoint } from './loadServicesFromRemot
 import { GraphQLDataSource } from './datasources/types';
 import { RemoteGraphQLDataSource } from './datasources/RemoteGraphQLDataSource';
 import { getVariableValues } from 'graphql/execution/values';
-import fetcher, { Fetcher } from 'make-fetch-happen';
+import fetcher from 'make-fetch-happen';
 import { HttpRequestCache } from './cache';
 import { fetch } from 'apollo-server-env';
 import { getQueryPlanner, QueryPlannerPointer, QueryPlan, prettyFormatQueryPlan } from '@apollo/query-planner';
@@ -99,7 +99,7 @@ type WarnedStates = {
   remoteWithLocalConfig?: boolean;
 };
 
-export function getDefaultFetcher(): Fetcher {
+export function getDefaultFetcher() {
   const { name, version } = require('../package.json');
   return fetcher.defaults({
     cacheManager: new HttpRequestCache(),


### PR DESCRIPTION
The `Fetcher` type isn't quite right here (it's augmented with `.defaults()` later in its exported life, which is more applicable to our use case.

More importantly, the compiled types lose the following important line in `index.d.ts`
`/// <reference path="../src/make-fetch-happen.d.ts" />`
...when the `Fetcher` type (or `typeof fetcher`) is used to declare the return type of `getDefaultFetcher`.

For now, leaving this off is more correct and inferrable by TS anyhow.
