### PR TITLE
renovate: remove `force` declaration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,15 +2,6 @@
   "extends": [
     "apollo-open-source"
   ],
-  "force": {
-    "constraints": {
-      // Until we bump everything to npm@7 and make sure our
-      // tooling and contribution guides know this is expected
-      // and enforced via tooling, otherwise we could end up with
-      // flapping.
-      "node": "< 15.0.0"
-    }
-  },
   "dependencyDashboard": true,
   "packageRules": [
     // We set this to the lowest supported Node.js version to ensure we don't


### PR DESCRIPTION
We already declare the same thing in the package.json `engines` section and apparently this force declaration is no longer needed (and can in fact be harmful, as it overrides the npm declaration for package.json). The same fix was applied to apollo-server by the creator of Renovate in https://github.com/apollographql/apollo-server/pull/5020 after we reported an issue.
