### PR TITLE
Investigate not re-executing for single fetch queryplans

### DIFF
--- a/gateway-js/src/__tests__/gateway/composedSdl.test.ts
+++ b/gateway-js/src/__tests__/gateway/composedSdl.test.ts
@@ -21,7 +21,7 @@ describe('Using csdl configuration', () => {
     const server = await getCsdlGatewayServer();
 
     fetch.mockJSONResponseOnce({
-      data: { me: { id: 1, username: '@jbaxleyiii' } },
+      data: { me: { id: "1", username: '@jbaxleyiii' } },
     });
 
     const result = await server.executeOperation({

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -79,23 +79,27 @@ export async function executeQueryPlan<TContext>(
   // only explicitly requested fields are included and field ordering follows
   // the original query.
   // It is also used to allow execution of introspection queries though.
-  try {
-    ({ data } = await execute({
-      schema: operationContext.schema,
-      document: {
-        kind: Kind.DOCUMENT,
-        definitions: [
-          operationContext.operation,
-          ...Object.values(operationContext.fragments),
-        ],
-      },
-      rootValue: data,
-      variableValues: requestContext.request.variables,
-      // See also `wrapSchemaWithAliasResolver` in `gateway-js/src/index.ts`.
-      fieldResolver: defaultFieldResolverWithAliasSupport,
-    }));
-  } catch (error) {
-    return { errors: [error] };
+  if(queryPlan.node && queryPlan.node.kind != "Fetch") {
+    //Single fetch queryplan
+  } else {
+    try {
+      ({ data } = await execute({
+        schema: operationContext.schema,
+        document: {
+          kind: Kind.DOCUMENT,
+          definitions: [
+            operationContext.operation,
+            ...Object.values(operationContext.fragments),
+          ],
+        },
+        rootValue: data,
+        variableValues: requestContext.request.variables,
+        // See also `wrapSchemaWithAliasResolver` in `gateway-js/src/index.ts`.
+        fieldResolver: defaultFieldResolverWithAliasSupport,
+      }));
+    } catch (error) {
+      return { errors: [error] };
+    }
   }
 
   return errors.length === 0 ? { data } : { errors, data };

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -79,7 +79,7 @@ export async function executeQueryPlan<TContext>(
   // only explicitly requested fields are included and field ordering follows
   // the original query.
   // It is also used to allow execution of introspection queries though.
-  if(queryPlan.node && queryPlan.node.kind != "Fetch") {
+  if(queryPlan.node && queryPlan.node.kind == "Fetch") {
     //Single fetch queryplan
   } else {
     try {


### PR DESCRIPTION
There are [commented reasons](https://github.com/apollographql/federation/blob/main/gateway-js/src/executeQueryPlan.ts#L78) about why we need to re-execute, but this isn't necessarily needed for single **Fetch** query plans, meaning:

```
QueryPlan {
  Fetch(service: "search") {
      ...
  }
}
```
For "single Fetch" queryplans, the gateway is essentially forwarding the GraphQL request to a single federated GraphQL service. This is very common when migrating from a monolith to a federated architecture and the performance bump would help ease the adoption curve.

**Note**: This is to discuss the potential performance improvement from removing this step and provide a tarball to test