### PR TITLE
chore(ci): Adjust caching and macos gnu-tar exception

### DIFF
--- a/.github/workflows/rust-slow-test.yml
+++ b/.github/workflows/rust-slow-test.yml
@@ -80,6 +80,8 @@ jobs:
           key: ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+            ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-
+            ${{ matrix.build }}-${{ env.cache-name }}-
 
       - name: Cache npm
         uses: actions/cache@v2

--- a/.github/workflows/rust-slow-test.yml
+++ b/.github/workflows/rust-slow-test.yml
@@ -78,6 +78,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache npm
         uses: actions/cache@v2
@@ -88,6 +90,7 @@ jobs:
           path: ~/.npm
           key: ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
+            ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
             ${{ matrix.build }}-${{ env.cache-name }}-
             ${{ matrix.build }}-
 

--- a/.github/workflows/rust-slow-test.yml
+++ b/.github/workflows/rust-slow-test.yml
@@ -58,13 +58,6 @@ jobs:
         with:
           node-version: '14'
 
-      # NB: We install gnu-tar because BSD tar is buggy on Github's macos machines. https://github.com/actions/cache/issues/403
-      - name: Install GNU tar (Macos)
-        if: matrix.build == 'macos'
-        run: |
-          brew install gnu-tar
-          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-
       ### BUILD CACHE ###
       - name: Cache cargo registry, target, index
         uses: actions/cache@v2

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -77,6 +77,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache npm
         uses: actions/cache@v2
@@ -87,6 +89,7 @@ jobs:
           path: ~/.npm
           key: ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
+            ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
             ${{ matrix.build }}-${{ env.cache-name }}-
             ${{ matrix.build }}-
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -93,7 +93,6 @@ jobs:
           restore-keys: |
             ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
             ${{ matrix.build }}-${{ env.cache-name }}-
-            ${{ matrix.build }}-
 
       ### UP FROM HERE TO "Checkout Code" is  uniform in rust-test.yml, rust-slow-test.yml, and lint.yml!
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -79,6 +79,8 @@ jobs:
           key: ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+            ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-
+            ${{ matrix.build }}-${{ env.cache-name }}-
 
       - name: Cache npm
         uses: actions/cache@v2

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -57,13 +57,6 @@ jobs:
         with:
           node-version: '14'
 
-      # NB: We install gnu-tar because BSD tar is buggy on Github's macos machines. https://github.com/actions/cache/issues/403
-      - name: Install GNU tar (Macos)
-        if: matrix.build == 'macos'
-        run: |
-          brew install gnu-tar
-          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-
       ### BUILD CACHE ###
       - name: Cache cargo registry, target, index
         uses: actions/cache@v2


### PR DESCRIPTION
Currently, #625 (which this PR is targeted to merge into) is exhibiting failures on the macOS builds that are suggesting that crates are unavailable.  There were similar failures last week on another PR: https://github.com/apollographql/federation/pull/608#issuecomment-807952569.

According to https://github.com/actions-rs/cargo/issues/111, these failures could be related to a special-cased/exceptional `gnu-tar` installation that was meant to solve a _different_ shortcoming which is no longer necessary in `v2` of `actions/cache`, which we are already using — rendering this exception unnecessary, in theory.

This PR makes a couple changes to the CI scripts.