### PR TITLE
Change query planner API to avoid double parsing and schema building

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Re-introduce TypeScript query planner to the gateway. This change should effectively be an implementation detail - it's undergone extensive testing to ensure compatibility with current query plans. [PR #622](https://github.com/apollographql/federation/pull/622)
 - __BREAKING__ - All references to CSDL within the gateway have been updated to its latest iteration `Supergraph SDL` which is very similar in spirit, but implements the currently-being-introduced core and join specs. This includes changes to recent external API additions like the `csdl` and `experimental_updateCsdl` gateway constructor options. [PR #622](https://github.com/apollographql/federation/pull/622)
-
+- Update query planner API. With the query planner back in TypeScript, we can modify the QP API in such a way that prevents double parsing and schema building. [PR #628](https://github.com/apollographql/federation/pull/628)
 ## v0.25.1
 
 - Improved query plan execution by pruning entities which are `undefined` or didn't match specified type conditions after a prior `FetchNode` execution.  After pruning, only the remaining entities will be fetched in the dependent `FetchNode` execution.  If NO entities remain, the request will not be made.  [PR #612](https://github.com/apollographql/federation/pull/612)

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -1,20 +1,20 @@
 import { GraphQLSchema } from 'graphql';
 import gql from 'graphql-tag';
-import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
+import { buildOperationContext } from '../operationContext';
 import { astSerializer, queryPlanSerializer } from 'apollo-federation-integration-testsuite';
 import { getFederatedTestingSchema } from './execution-utils';
-import { QueryPlannerPointer } from '@apollo/query-planner';
+import { QueryPlanner } from '@apollo/query-planner';
 
 expect.addSnapshotSerializer(astSerializer);
 expect.addSnapshotSerializer(queryPlanSerializer);
 
 describe('buildQueryPlan', () => {
   let schema: GraphQLSchema;
-  let queryPlannerPointer: QueryPlannerPointer;
+  let queryPlanner: QueryPlanner;
 
   beforeEach(() => {
     expect(
-      () => ({ schema, queryPlannerPointer } = getFederatedTestingSchema()),
+      () => ({ schema, queryPlanner } = getFederatedTestingSchema()),
     ).not.toThrow();
   });
 
@@ -39,12 +39,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       }),
     );
 
@@ -83,12 +81,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -119,12 +115,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -208,12 +202,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -341,12 +333,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -385,12 +375,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -428,12 +416,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         })
       );
 
@@ -485,12 +471,10 @@ describe('buildQueryPlan', () => {
 
         const operationDocument = gql(operationString);
 
-        const queryPlan = buildQueryPlan(
+        const queryPlan = queryPlanner.buildQueryPlan(
           buildOperationContext({
             schema,
             operationDocument,
-            operationString,
-            queryPlannerPointer,
           })
         );
 
@@ -543,12 +527,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         })
       );
 
@@ -602,12 +584,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         })
       );
 
@@ -657,12 +637,10 @@ describe('buildQueryPlan', () => {
 
         const operationDocument = gql(operationString);
 
-        const queryPlan = buildQueryPlan(
+        const queryPlan = queryPlanner.buildQueryPlan(
           buildOperationContext({
             schema,
             operationDocument,
-            operationString,
-            queryPlannerPointer,
           })
         );
 
@@ -714,12 +692,10 @@ describe('buildQueryPlan', () => {
 
         const operationDocument = gql(operationString);
 
-        const queryPlan = buildQueryPlan(
+        const queryPlan = queryPlanner.buildQueryPlan(
           buildOperationContext({
             schema,
             operationDocument,
-            operationString,
-            queryPlannerPointer,
           })
         );
 
@@ -771,12 +747,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         })
       );
 
@@ -829,12 +803,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         })
       );
 
@@ -875,12 +847,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -951,12 +921,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -1008,12 +976,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -1060,12 +1026,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         }),
         { autoFragmentization: true },
       );
@@ -1185,12 +1149,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         }),
         { autoFragmentization: true },
       );
@@ -1222,12 +1184,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         }),
         { autoFragmentization: true },
       );
@@ -1270,12 +1230,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         }),
         { autoFragmentization: true },
       );
@@ -1414,12 +1372,10 @@ describe('buildQueryPlan', () => {
 
     const operationDocument = gql(operationString);
 
-    const queryPlan = buildQueryPlan(
+    const queryPlan = queryPlanner.buildQueryPlan(
       buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       })
     );
 
@@ -1478,12 +1434,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         })
       );
 
@@ -1530,12 +1484,10 @@ describe('buildQueryPlan', () => {
 
       const operationDocument = gql(operationString);
 
-      const queryPlan = buildQueryPlan(
+      const queryPlan = queryPlanner.buildQueryPlan(
         buildOperationContext({
           schema,
           operationDocument,
-          operationString,
-          queryPlannerPointer,
         })
       );
 

--- a/gateway-js/src/__tests__/executeQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/executeQueryPlan.test.ts
@@ -3,12 +3,12 @@ import { addResolversToSchema, GraphQLResolverMap } from 'apollo-graphql';
 import gql from 'graphql-tag';
 import { GraphQLRequestContext } from 'apollo-server-types';
 import { AuthenticationError } from 'apollo-server-core';
-import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
+import { buildOperationContext } from '../operationContext';
 import { executeQueryPlan } from '../executeQueryPlan';
 import { LocalGraphQLDataSource } from '../datasources/LocalGraphQLDataSource';
 import { astSerializer, queryPlanSerializer } from 'apollo-federation-integration-testsuite';
 import { getFederatedTestingSchema } from './execution-utils';
-import { QueryPlannerPointer } from '@apollo/query-planner';
+import { QueryPlanner } from '@apollo/query-planner';
 
 expect.addSnapshotSerializer(astSerializer);
 expect.addSnapshotSerializer(queryPlanSerializer);
@@ -33,7 +33,7 @@ describe('executeQueryPlan', () => {
   }
 
   let schema: GraphQLSchema;
-  let queryPlannerPointer: QueryPlannerPointer;
+  let queryPlanner: QueryPlanner;
 
   beforeEach(() => {
     expect(
@@ -41,7 +41,7 @@ describe('executeQueryPlan', () => {
         ({
           serviceMap,
           schema,
-          queryPlannerPointer,
+          queryPlanner,
         } = getFederatedTestingSchema()),
     ).not.toThrow();
   });
@@ -75,11 +75,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -116,11 +114,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -180,11 +176,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -260,11 +254,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -364,11 +356,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -415,11 +405,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -491,11 +479,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -530,11 +516,9 @@ describe('executeQueryPlan', () => {
       const operationContext = buildOperationContext({
         schema,
         operationDocument,
-        operationString,
-        queryPlannerPointer,
       });
 
-      const queryPlan = buildQueryPlan(operationContext);
+      const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
       const response = await executeQueryPlan(
         queryPlan,
@@ -568,11 +552,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,
@@ -663,11 +645,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const requestContext = buildRequestContext();
     requestContext.request.variables = { first: 3 };
@@ -764,11 +744,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const requestContext = buildRequestContext();
     requestContext.request.variables = { locale: 'en-US' };
@@ -844,10 +822,8 @@ describe('executeQueryPlan', () => {
       operationDocument: gql`
         ${getIntrospectionQuery()}
       `,
-      operationString: getIntrospectionQuery(),
-      queryPlannerPointer,
     });
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,
@@ -876,11 +852,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,
@@ -922,11 +896,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,
@@ -979,11 +951,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,
@@ -1023,11 +993,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,
@@ -1080,11 +1048,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,
@@ -1131,11 +1097,9 @@ describe('executeQueryPlan', () => {
     const operationContext = buildOperationContext({
       schema,
       operationDocument,
-      operationString,
-      queryPlannerPointer,
     });
 
-    const queryPlan = buildQueryPlan(operationContext);
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
 
     const response = await executeQueryPlan(
       queryPlan,

--- a/gateway-js/src/__tests__/execution-utils.ts
+++ b/gateway-js/src/__tests__/execution-utils.ts
@@ -15,14 +15,13 @@ import {
   executeQueryPlan,
   buildOperationContext,
 } from '@apollo/gateway';
-import { buildComposedSchema, QueryPlan } from '@apollo/query-planner';
+import { buildComposedSchema, QueryPlanner, QueryPlan } from '@apollo/query-planner';
 import { LocalGraphQLDataSource } from '../datasources/LocalGraphQLDataSource';
 import { mergeDeep } from 'apollo-utilities';
 
 import { queryPlanSerializer, astSerializer } from 'apollo-federation-integration-testsuite';
 import gql from 'graphql-tag';
 import { fixtures } from 'apollo-federation-integration-testsuite';
-import { QueryPlanner } from '@apollo/query-planner';
 import { parse } from 'graphql';
 
 const prettyFormat = require('pretty-format');

--- a/gateway-js/src/__tests__/gateway/queryPlanCache.test.ts
+++ b/gateway-js/src/__tests__/gateway/queryPlanCache.test.ts
@@ -5,12 +5,9 @@ import { buildFederatedSchema } from '@apollo/federation';
 import { LocalGraphQLDataSource } from '../../datasources/LocalGraphQLDataSource';
 import { ApolloGateway } from '../../';
 import { fixtures } from 'apollo-federation-integration-testsuite';
-
+import { QueryPlanner } from '@apollo/query-planner';
 it('caches the query plan for a request', async () => {
-  const planner = require('../../buildQueryPlan');
-  const originalPlanner = planner.buildQueryPlan;
-
-  planner.buildQueryPlan = jest.fn(originalPlanner);
+  const buildQueryPlanSpy = jest.spyOn(QueryPlanner.prototype, 'buildQueryPlan');
 
   const gateway = new ApolloGateway({
     localServiceList: fixtures,
@@ -51,7 +48,7 @@ it('caches the query plan for a request', async () => {
   });
 
   expect(result.data).toEqual(secondResult.data);
-  expect(planner.buildQueryPlan).toHaveBeenCalledTimes(1);
+  expect(buildQueryPlanSpy).toHaveBeenCalledTimes(1);
 });
 
 it('supports multiple operations and operationName', async () => {

--- a/gateway-js/src/__tests__/queryPlanCucumber.test.ts
+++ b/gateway-js/src/__tests__/queryPlanCucumber.test.ts
@@ -2,8 +2,8 @@ import gql from 'graphql-tag';
 import { defineFeature, loadFeature } from 'jest-cucumber';
 import { DocumentNode } from 'graphql';
 
-import { QueryPlan } from '@apollo/query-planner';
-import { buildQueryPlan, buildOperationContext, BuildQueryPlanOptions } from '../buildQueryPlan';
+import { QueryPlan, BuildQueryPlanOptions } from '@apollo/query-planner';
+import { buildOperationContext } from '../operationContext';
 import { getFederatedTestingSchema } from './execution-utils';
 
 const buildQueryPlanFeature = loadFeature(
@@ -20,17 +20,15 @@ features.forEach((feature) => {
     feature.scenarios.forEach((scenario) => {
       test(scenario.title, async ({ given, when, then }) => {
         let operationDocument: DocumentNode;
-        let operationString: string;
         let queryPlan: QueryPlan;
         let options: BuildQueryPlanOptions = { autoFragmentization: false };
 
         // throws on composition errors
-        const { schema, queryPlannerPointer } = getFederatedTestingSchema();
+        const { schema, queryPlanner } = getFederatedTestingSchema();
 
         const givenQuery = () => {
           given(/^query$/im, (operation: string) => {
             operationDocument = gql(operation);
-            operationString = operation;
           })
         }
 
@@ -42,12 +40,10 @@ features.forEach((feature) => {
 
         const thenQueryPlanShouldBe = () => {
           then(/^query plan$/i, (expectedQueryPlan: string) => {
-            queryPlan = buildQueryPlan(
+            queryPlan = queryPlanner.buildQueryPlan(
               buildOperationContext({
                 schema,
                 operationDocument,
-                operationString,
-                queryPlannerPointer,
               }),
               options
             );

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -5,7 +5,7 @@ import { GraphQLRequestContextExecutionDidStart, Logger } from "apollo-server-ty
 import { ServiceDefinition } from "@apollo/federation";
 import { GraphQLDataSource } from './datasources/types';
 import { QueryPlan } from '@apollo/query-planner';
-import { OperationContext } from './';
+import { OperationContext } from './operationContext';
 import { ServiceMap } from './executeQueryPlan';
 
 export type ServiceEndpointDefinition = Pick<ServiceDefinition, 'name' | 'url'>;

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -14,7 +14,7 @@ import {
 import { Trace, google } from 'apollo-reporting-protobuf';
 import { defaultRootOperationNameLookup } from '@apollo/federation';
 import { GraphQLDataSource } from './datasources/types';
-import { OperationContext } from './';
+import { OperationContext } from './operationContext';
 import {
   FetchNode,
   PlanNode,

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -18,8 +18,6 @@ import {
   VariableDefinitionNode,
   DocumentNode,
   print,
-  FragmentDefinitionNode,
-  OperationDefinitionNode,
   parse,
 } from 'graphql';
 import {
@@ -29,7 +27,7 @@ import {
 } from '@apollo/federation';
 import loglevel from 'loglevel';
 
-import { buildQueryPlan, buildOperationContext } from './buildQueryPlan';
+import { buildOperationContext, OperationContext } from './operationContext';
 import {
   executeQueryPlan,
   ServiceMap,
@@ -43,7 +41,7 @@ import { getVariableValues } from 'graphql/execution/values';
 import fetcher from 'make-fetch-happen';
 import { HttpRequestCache } from './cache';
 import { fetch } from 'apollo-server-env';
-import { getQueryPlanner, QueryPlannerPointer, QueryPlan, prettyFormatQueryPlan } from '@apollo/query-planner';
+import { QueryPlanner, QueryPlan, prettyFormatQueryPlan } from '@apollo/query-planner';
 import {
   ServiceEndpointDefinition,
   Experimental_DidFailCompositionCallback,
@@ -72,16 +70,6 @@ import {
 import { loadSupergraphSdlFromStorage } from './loadSupergraphSdlFromStorage';
 import { getServiceDefinitionsFromStorage } from './legacyLoadServicesFromStorage';
 import { buildComposedSchema } from '@apollo/query-planner';
-
-type FragmentMap = { [fragmentName: string]: FragmentDefinitionNode };
-
-export type OperationContext = {
-  schema: GraphQLSchema;
-  operation: OperationDefinitionNode;
-  fragments: FragmentMap;
-  queryPlannerPointer: QueryPlannerPointer;
-  operationString: string;
-};
 
 type DataSourceMap = {
   [serviceName: string]: { url?: string; dataSource: GraphQLDataSource };
@@ -160,7 +148,7 @@ export class ApolloGateway implements GraphQLService {
   private compositionMetadata?: CompositionMetadata;
   private serviceSdlCache = new Map<string, string>();
   private warnedStates: WarnedStates = Object.create(null);
-  private queryPlannerPointer?: QueryPlannerPointer;
+  private queryPlanner?: QueryPlanner;
   private parsedSupergraphSdl?: DocumentNode;
   private fetcher: typeof fetch;
   private compositionId?: string;
@@ -367,7 +355,7 @@ export class ApolloGateway implements GraphQLService {
 
     this.maybeWarnOnConflictingConfig();
 
-    // Handles initial assignment of `this.schema`, `this.queryPlannerPointer`
+    // Handles initial assignment of `this.schema`, `this.queryPlanner`
     isStaticConfig(this.config)
       ? this.loadStatic(this.config)
       : await this.loadDynamic(unrefTimer);
@@ -404,7 +392,7 @@ export class ApolloGateway implements GraphQLService {
     this.schema = schema;
     // TODO(trevor): #580 redundant parse
     this.parsedSupergraphSdl = parse(supergraphSdl);
-    this.queryPlannerPointer = getQueryPlanner(supergraphSdl);
+    this.queryPlanner = new QueryPlanner(schema);
     this.state = { phase: 'loaded' };
   }
 
@@ -482,7 +470,7 @@ export class ApolloGateway implements GraphQLService {
       );
     } else {
       this.schema = schema;
-      this.queryPlannerPointer = getQueryPlanner(supergraphSdl);
+      this.queryPlanner = new QueryPlanner(schema);
 
       // Notify the schema listeners of the updated schema
       try {
@@ -555,7 +543,7 @@ export class ApolloGateway implements GraphQLService {
       );
     } else {
       this.schema = schema;
-      this.queryPlannerPointer = getQueryPlanner(supergraphSdl);
+      this.queryPlanner = new QueryPlanner(schema);
 
       // Notify the schema listeners of the updated schema
       try {
@@ -943,13 +931,11 @@ export class ApolloGateway implements GraphQLService {
   public executor = async <TContext>(
     requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
   ): Promise<GraphQLExecutionResult> => {
-    const { request, document, queryHash, source } = requestContext;
+    const { request, document, queryHash } = requestContext;
     const queryPlanStoreKey = queryHash + (request.operationName || '');
     const operationContext = buildOperationContext({
       schema: this.schema!,
       operationDocument: document,
-      operationString: source,
-      queryPlannerPointer: this.queryPlannerPointer!,
       operationName: request.operationName,
     });
 
@@ -970,7 +956,8 @@ export class ApolloGateway implements GraphQLService {
     }
 
     if (!queryPlan) {
-      queryPlan = buildQueryPlan(operationContext, {
+      // TODO: Can we be sure the query planner has been initialized here?
+      queryPlan = this.queryPlanner!.buildQueryPlan(operationContext, {
         autoFragmentization: Boolean(
           this.config.experimental_autoFragmentization,
         ),
@@ -1175,7 +1162,6 @@ class UnreachableCaseError extends Error {
 }
 
 export {
-  buildQueryPlan,
   executeQueryPlan,
   buildOperationContext,
   ServiceMap,

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -956,7 +956,7 @@ export class ApolloGateway implements GraphQLService {
     }
 
     if (!queryPlan) {
-      // TODO: Can we be sure the query planner has been initialized here?
+      // TODO(#631): Can we be sure the query planner has been initialized here?
       queryPlan = this.queryPlanner!.buildQueryPlan(operationContext, {
         autoFragmentization: Boolean(
           this.config.experimental_autoFragmentization,

--- a/gateway-js/src/operationContext.ts
+++ b/gateway-js/src/operationContext.ts
@@ -5,41 +5,26 @@ import {
   GraphQLSchema,
   Kind,
   OperationDefinitionNode,
-  print,
 } from 'graphql';
-import { OperationContext } from './';
-import { getQueryPlan, QueryPlan, QueryPlannerPointer } from '@apollo/query-planner';
 
-export interface BuildQueryPlanOptions {
-  autoFragmentization: boolean;
-}
+type FragmentMap = { [fragmentName: string]: FragmentDefinitionNode };
 
-export function buildQueryPlan(
-  operationContext: OperationContext,
-  options: BuildQueryPlanOptions = { autoFragmentization: false },
-): QueryPlan {
-
-  return getQueryPlan(
-    operationContext.queryPlannerPointer,
-    operationContext.operationString,
-    options
-  );
-}
+export type OperationContext = {
+  schema: GraphQLSchema;
+  operation: OperationDefinitionNode;
+  fragments: FragmentMap;
+};
 
 // Adapted from buildExecutionContext in graphql-js
 interface BuildOperationContextOptions {
   schema: GraphQLSchema;
   operationDocument: DocumentNode;
-  operationString: string;
-  queryPlannerPointer: QueryPlannerPointer;
   operationName?: string;
 };
 
 export function buildOperationContext({
   schema,
   operationDocument,
-  operationString,
-  queryPlannerPointer,
   operationName,
 }: BuildOperationContextOptions): OperationContext {
   let operation: OperationDefinitionNode | undefined;
@@ -77,23 +62,9 @@ export function buildOperationContext({
     }
   }
 
-  // In the case of multiple operations specified (operationName presence validated above),
-  // `operation` === the operation specified by `operationName`
-  const trimmedOperationString = operationCount > 1
-    ? print({
-      kind: Kind.DOCUMENT,
-      definitions: [
-        operation,
-        ...Object.values(fragments),
-      ],
-    })
-    : operationString;
-
   return {
     schema,
     operation,
     fragments,
-    queryPlannerPointer,
-    operationString: trimmedOperationString
   };
 }

--- a/query-planner-js/src/QueryPlan.ts
+++ b/query-planner-js/src/QueryPlan.ts
@@ -1,7 +1,4 @@
 import {
-  FragmentDefinitionNode,
-  GraphQLSchema,
-  OperationDefinitionNode,
   Kind,
   SelectionNode as GraphQLJSSelectionNode,
 } from 'graphql';
@@ -9,14 +6,6 @@ import prettyFormat from 'pretty-format';
 import { queryPlanSerializer, astSerializer } from './snapshotSerializers';
 
 export type ResponsePath = (string | number)[];
-
-export type FragmentMap = { [fragmentName: string]: FragmentDefinitionNode };
-
-export type OperationContext = {
-  schema: GraphQLSchema;
-  operation: OperationDefinitionNode;
-  fragments: FragmentMap;
-};
 
 export interface QueryPlan {
   kind: 'QueryPlan';

--- a/query-planner-js/src/__tests__/allFeatures.test.ts
+++ b/query-planner-js/src/__tests__/allFeatures.test.ts
@@ -3,14 +3,13 @@ import { DocumentNode, GraphQLSchema, parse, validate } from 'graphql';
 import { defineFeature, loadFeatures } from 'jest-cucumber';
 import path from 'path';
 import {
-  QueryPlan
+  QueryPlan, QueryPlanner
 } from '..';
 import {
   buildComposedSchema
 } from '../composedSchema';
 import {
   buildOperationContext,
-  buildQueryPlan,
 } from '../buildQueryPlan';
 
 // This test looks over all directories under tests/features and finds "supergraphSdl.graphql" in
@@ -36,10 +35,12 @@ for (const directory of directories) {
   features.forEach((feature) => {
     defineFeature(feature, (test) => {
       let schema: GraphQLSchema;
+      let queryPlanner: QueryPlanner;
 
       beforeAll(() => {
         const supergraphSdl = fs.readFileSync(schemaPath, 'utf8');
         schema = buildComposedSchema(parse(supergraphSdl));
+        queryPlanner = new QueryPlanner(schema);
       });
 
       feature.scenarios.forEach((scenario) => {
@@ -62,7 +63,7 @@ for (const directory of directories) {
 
           const thenQueryPlanShouldBe = () => {
             then(/^query plan$/i, (expectedQueryPlanString: string) => {
-              queryPlan = buildQueryPlan(
+              queryPlan = queryPlanner.buildQueryPlan(
                 buildOperationContext(schema, queryDocument),
               );
 

--- a/query-planner-js/src/buildQueryPlan.ts
+++ b/query-planner-js/src/buildQueryPlan.ts
@@ -46,9 +46,7 @@ import {
   SequenceNode,
   QueryPlan,
   ResponsePath,
-  OperationContext,
   trimSelectionNodes,
-  FragmentMap,
 } from './QueryPlan';
 import { getFieldDef, getResponseName } from './utilities/graphql';
 import { MultiMap } from './utilities/MultiMap';
@@ -61,6 +59,14 @@ const typenameField = {
     value: TypeNameMetaFieldDef.name,
   },
 };
+
+export type OperationContext = {
+  schema: GraphQLSchema;
+  operation: OperationDefinitionNode;
+  fragments: FragmentMap;
+};
+
+export type FragmentMap = { [fragmentName: string]: FragmentDefinitionNode };
 
 export interface BuildQueryPlanOptions {
   autoFragmentization: boolean;

--- a/query-planner-js/src/index.ts
+++ b/query-planner-js/src/index.ts
@@ -19,7 +19,7 @@ export { BuildQueryPlanOptions };
 export class QueryPlanner {
   constructor(public readonly schema: GraphQLSchema) {}
 
-  // TODO: We should change the API to avoid confusion, because
+  // TODO(#632): We should change the API to avoid confusion, because
   // taking an operationContext with a schema on it isn't consistent
   // with a QueryPlanner instance being bound to a single schema.
   buildQueryPlan(


### PR DESCRIPTION
We originally kept the same API we used for the wasm query planner, but that relied on passing in strings for the schema and operation. Since the query planner is now implemented in TypeScript again, we can avoid double parsing and schema building by passing in a composed schema and a parsed operation.

There are remaining inefficiencies in the gateway workflows that we'll want to address in follow-up PRs. In particular, the gateway still calls `buildComposedSchema` twice for every update, because it extracts the service list to perform health checks in a separate function. We also parse the supergraph SDL multiple times due to the way functions are structured. Solving this will likely require a rethinking of the way these workflows are composed, and the possible introduction of additional objects (see #580).