### PR TITLE
chore(docs): Update documentation around delivery endpoint option

### DIFF
--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -127,10 +127,10 @@ interface GatewayConfigBase {
   fetcher?: typeof fetch;
   serviceHealthCheck?: boolean;
   /**
-   * @deprecated This configuration option shouldn't be used unless by
-   *             recommendation from Apollo staff. This behavior will be
-   *             defaulted in a future release and this option will strictly be
-   *             used as an override.
+   * Enable an upcoming mechanism for fetching a graph’s schema and
+   * configuration when using managed federation. This mechanism is currently in
+   * a preview state and should not be used in production graphs.
+   * See https://go.apollo.dev/g/supergraph-preview for details.
    */
   experimental_schemaConfigDeliveryEndpoint?: null | string;
 }


### PR DESCRIPTION
Undeprecate the option and update documentation which will (in the future) point to the supergraph preview doc.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
