### PR TITLE
buildQueryPlan: FragmentMap can map to undefined

### DIFF
--- a/query-planner-js/src/buildQueryPlan.ts
+++ b/query-planner-js/src/buildQueryPlan.ts
@@ -66,7 +66,9 @@ export type OperationContext = {
   fragments: FragmentMap;
 };
 
-export type FragmentMap = { [fragmentName: string]: FragmentDefinitionNode };
+export type FragmentMap = {
+  [fragmentName: string]: FragmentDefinitionNode | undefined;
+};
 
 export interface BuildQueryPlanOptions {
   autoFragmentization: boolean;


### PR DESCRIPTION
The previous type implied that literally any fragment name can be used to retrieve a fragment from a fragment map. Typically, GraphQL documents contain a finite number of fragments.

The only code that reads from it happened to check the value for truthiness, but this wasn't enforced by the type system.
