### PR TITLE
Remove query-planner-wasm referenced from query-planner-js

### DIFF
--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -25,7 +25,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@apollo/query-planner-wasm": "file:../query-planner-wasm",
     "pretty-format": "^26.0.0"
   },
   "peerDependencies": {

--- a/query-planner-js/src/index.ts
+++ b/query-planner-js/src/index.ts
@@ -5,9 +5,9 @@ export * from './QueryPlan';
 import { QueryPlan } from './QueryPlan';
 
 export * from './composedSchema';
-import { buildQueryPlan, BuildQueryPlanOptions, OperationContext } from './buildQueryPlan';
+import { buildQueryPlan, buildOperationContext, BuildQueryPlanOptions, OperationContext } from './buildQueryPlan';
 import { GraphQLSchema } from 'graphql';
-export { BuildQueryPlanOptions };
+export { BuildQueryPlanOptions, buildQueryPlan, buildOperationContext };
 
 // There isn't much in this class yet, and I didn't want to make too many
 // changes at once, but since we were already storing a pointer to a


### PR DESCRIPTION
- Remove query-planner-wasm referenced from query-planner-js as it is not used in this package