### PR TITLE
A few query planner metadata tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,7 +159,6 @@
     "@apollo/query-planner": {
       "version": "file:query-planner-js",
       "requires": {
-        "@apollo/query-planner-wasm": "file:query-planner-wasm",
         "pretty-format": "^26.0.0"
       }
     },

--- a/query-planner-js/README.md
+++ b/query-planner-js/README.md
@@ -1,0 +1,3 @@
+# `@apollo/query-planner`
+
+This package is an internal implementation detail of `@apollo/gateway`. Its API is not intended to be stable for other uses.

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -25,7 +25,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@apollo/query-planner-wasm": "file:../query-planner-wasm",
     "pretty-format": "^26.0.0"
   },
   "peerDependencies": {

--- a/query-planner-js/src/index.ts
+++ b/query-planner-js/src/index.ts
@@ -5,9 +5,14 @@ export * from './QueryPlan';
 import { QueryPlan } from './QueryPlan';
 
 export * from './composedSchema';
-import { buildQueryPlan, BuildQueryPlanOptions, OperationContext } from './buildQueryPlan';
+import {
+  buildQueryPlan,
+  BuildQueryPlanOptions,
+  buildOperationContext,
+  OperationContext,
+} from './buildQueryPlan';
 import { GraphQLSchema } from 'graphql';
-export { BuildQueryPlanOptions };
+export { BuildQueryPlanOptions, buildOperationContext };
 
 // There isn't much in this class yet, and I didn't want to make too many
 // changes at once, but since we were already storing a pointer to a

--- a/query-planner-wasm/package.json
+++ b/query-planner-wasm/package.json
@@ -6,7 +6,7 @@
     "build-esm": "wasm-pack build --target bundler --out-dir module --out-name index --scope apollo",
     "build-cjs": "wasm-pack build --target nodejs --out-dir dist --out-name index --scope apollo",
     "remove-pkg-cruft": "rm module/package.json dist/package.json dist/.gitignore module/.gitignore dist/README.md module/README.md",
-    "_monorepo-prepare": "npm run build-esm && npm run build-cjs && npm run remove-pkg-cruft"
+    "monorepo-prepare": "npm run build-esm && npm run build-cjs && npm run remove-pkg-cruft"
   },
   "author": "opensource@apollographql.com",
   "license": "MIT",


### PR DESCRIPTION
- `@apollo/query-planner` does not need to depend on
  `@apollo/query-planner-wasm`

- `@apollo/query-planner-wasm` needs its `monorepo-prepare` script in order to
  not publish an empty package. (So oops, we published v0.2.5 as an empty
  package, and even though the other packages don't actually use its code any
  more, the previous bullet meant that installing the latest `@apollo/gateway`
  would (via `@apollo/query-planner`) install the empty
  `@apollo/query-planner-wasm`... hope you weren't using it directly in your app
  too!)

- Add a README to `@apollo/query-planner`.

- By popular demand, export `buildOperationContext` from
  `@apollo/query-planner`.

Once we publish a non-broken `@apollo/query-planner-wasm` as the latest version,
we can start removing it complete from the repo, but we do want to get one last
good release out.
