### PR TITLE
infra: alter GH Actions caching technique for Rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
   # `oss` is a local reference to the package.  The source for Apollo Orbs can
   # be found at http://github.com/apollographql/CircleCI-Orbs/.
   # We could use Renovate to bump this version via PR, but that's not set up now.
-  oss: apollo/oss-ci-cd-tooling@0.0.15
+  oss: apollo/oss-ci-cd-tooling@0.0.16
 
 commands:
   # These are the steps used for each version of Node which we're testing

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,19 +56,25 @@ jobs:
         with:
           node-version: '14'
 
-      ### BUILD CACHE ###
-      - name: Cache Cargo registry, target, index
+      - name: Cache Cargo registry
         uses: actions/cache@v2
-        id: cache-cargo-v3
         env:
-          cache-name: cache-cargo-v3
+          cache-name: cache-cargo-registry
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/bin
-            ~/.cargo/git
-            target
-          key: ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          path: ~/.cargo/registry
+          key: ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.build }}-${{ env.cache-name }}-
+
+      - name: Cache Cargo index
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-cargo-index
+        with:
+          path: ~/.cargo/git
+          key: ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.build }}-${{ env.cache-name }}-
 
       ### UP FROM HERE TO "Checkout Code" is  uniform in rust-test.yml, rust-slow-test.yml, and lint.yml!
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -52,24 +52,25 @@ jobs:
         with:
           node-version: '14'
 
-      ### BUILD CACHE ###
-      - name: Cache cargo registry, target, index
+      - name: Cache Cargo registry
         uses: actions/cache@v2
-        id: cache-cargo-v3
         env:
-          cache-name: cache-cargo-v3
+          cache-name: cache-cargo-registry
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/bin
-            ~/.cargo/git
-            target
-          key: ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          path: ~/.cargo/registry
+          key: ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
-            ${{ matrix.build }}-${{ env.cache-name }}-${{ steps.toolchain.outputs.rustc_hash }}-
             ${{ matrix.build }}-${{ env.cache-name }}-
-            ${{ matrix.build }}-
+
+      - name: Cache Cargo index
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-cargo-index
+        with:
+          path: ~/.cargo/git
+          key: ${{ matrix.build }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.build }}-${{ env.cache-name }}-
 
       - name: Cache npm
         uses: actions/cache@v2


### PR DESCRIPTION
This choses a technique that is employed in the `rover` repository and doesn't cache the `target` directory in an effort to absolve ourselves from the odd caching circumstances which are causing build failures on the various branches subsequent invocations of their CI workflows.
