### PR TITLE
Fix missing fields due to loss of specific scope (fixes #396)

### DIFF
--- a/federation-integration-testsuite-js/src/fixtures/documents.ts
+++ b/federation-integration-testsuite-js/src/fixtures/documents.ts
@@ -12,13 +12,17 @@ export const typeDefs = gql`
 
   union Body = Image | Text
 
-  type Image {
+  interface NamedObject {
+    name: String!
+  }
+
+  type Image implements NamedObject {
       name: String!
       # Same as option below but the type is different
       attributes: ImageAttributes!
   }
 
-  type Text {
+  type Text implements NamedObject {
       name: String!
       # Same as option above but the type is different
       attributes: TextAttributes!

--- a/federation-js/src/service/__tests__/printFederatedSchema.test.ts
+++ b/federation-js/src/service/__tests__/printFederatedSchema.test.ts
@@ -72,7 +72,7 @@ describe('printFederatedSchema', () => {
         asile: Int
       }
 
-      type Image {
+      type Image implements NamedObject {
         name: String!
         attributes: ImageAttributes!
       }
@@ -104,6 +104,10 @@ describe('printFederatedSchema', () => {
       type Name {
         first: String
         last: String
+      }
+
+      interface NamedObject {
+        name: String!
       }
 
       type PasswordAccount @key(fields: \\"email\\") {
@@ -160,7 +164,7 @@ describe('printFederatedSchema', () => {
         number: String
       }
 
-      type Text {
+      type Text implements NamedObject {
         name: String!
         attributes: TextAttributes!
       }

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -119,7 +119,7 @@ describe('printSupergraphSdl', () => {
         asile: Int
       }
 
-      type Image {
+      type Image implements NamedObject {
         name: String!
         attributes: ImageAttributes!
       }
@@ -166,6 +166,10 @@ describe('printSupergraphSdl', () => {
       type Name {
         first: String
         last: String
+      }
+
+      interface NamedObject {
+        name: String!
       }
 
       type PasswordAccount
@@ -231,7 +235,7 @@ describe('printSupergraphSdl', () => {
         number: String @join__field(graph: ACCOUNTS)
       }
 
-      type Text {
+      type Text implements NamedObject {
         name: String!
         attributes: TextAttributes!
       }

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  _Nothing yet! Stay tuned!_
 
+## v0.27.0
+
+- Fix query plans missing fields in some situations involving nested type conditions (#396).
+
 ## v0.26.3
 
 - Update `apollo-graphql` dependency which resolves a missing dependency (`sha.js`) within that package. [PR #699](https://github.com/apollographql/federation/pull/699)

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -118,7 +118,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         asile: Int
       }
 
-      type Image {
+      type Image implements NamedObject {
         name: String!
         attributes: ImageAttributes!
       }
@@ -165,6 +165,10 @@ describe('loadSupergraphSdlFromStorage', () => {
       type Name {
         first: String
         last: String
+      }
+
+      interface NamedObject {
+        name: String!
       }
 
       type PasswordAccount
@@ -230,7 +234,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         number: String @join__field(graph: ACCOUNTS)
       }
 
-      type Text {
+      type Text implements NamedObject {
         name: String!
         attributes: TextAttributes!
       }

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  _Nothing yet! Stay tuned!_
 
+# v0.1.3
+
+- Fix query plans missing fields in some situations involving nested type conditions (#396).
+
 # v0.1.2
 
 - This change is mostly a set of follow-up changes for PR #622. Most of these changes are internal (renaming, etc.). Some noteworthy changes worth mentioning are: the splitting of entity and value type metadata types and a conversion of GraphMap to an actual `Map` (which resulted in some additional assertions). [PR #656](https://github.com/apollographql/federation/pull/656)

--- a/query-planner-js/src/QueryPlanningContext.ts
+++ b/query-planner-js/src/QueryPlanningContext.ts
@@ -1,0 +1,330 @@
+import {
+  DocumentNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  getNamedType,
+  GraphQLAbstractType,
+  GraphQLCompositeType,
+  GraphQLError,
+  GraphQLField,
+  GraphQLObjectType,
+  GraphQLSchema,
+  InlineFragmentNode,
+  isAbstractType,
+  isCompositeType,
+  Kind,
+  OperationDefinitionNode,
+  SelectionSetNode,
+  typeFromAST,
+  TypeNameMetaFieldDef,
+  VariableDefinitionNode,
+  visit
+} from "graphql";
+import { FragmentMap } from "./buildQueryPlan";
+import { getFederationMetadataForField, getFederationMetadataForType, isEntityTypeMetadata } from "./composedSchema";
+import { FieldSet, Scope } from "./FieldSet";
+import { getFieldDef } from "./utilities/graphql";
+
+const typenameField = {
+  kind: Kind.FIELD,
+  name: {
+    kind: Kind.NAME,
+    value: TypeNameMetaFieldDef.name,
+  },
+};
+
+/**
+ * Context objects used during query planning.
+ */
+export class QueryPlanningContext {
+  public internalFragments: Map<
+    string, {
+      name: string;
+      definition: FragmentDefinitionNode;
+      selectionSet: SelectionSetNode;
+    }
+  > = new Map();
+
+  public internalFragmentCount = 0;
+
+  protected variableDefinitions: {
+    [name: string]: VariableDefinitionNode;
+  };
+
+  constructor(
+    public readonly schema: GraphQLSchema,
+    public readonly operation: OperationDefinitionNode,
+    public readonly fragments: FragmentMap,
+    public readonly autoFragmentization: boolean,
+  ) {
+    this.variableDefinitions = Object.create(null);
+    visit(operation, {
+      VariableDefinition: definition => {
+        this.variableDefinitions[definition.variable.name.value] = definition;
+      },
+    });
+  }
+
+  getFieldDef(parentType: GraphQLCompositeType, fieldNode: FieldNode) {
+    const fieldName = fieldNode.name.value;
+
+    const fieldDef = getFieldDef(this.schema, parentType, fieldName);
+
+    if (!fieldDef) {
+      throw new GraphQLError(
+        `Cannot query field "${fieldNode.name.value}" on type "${String(
+          parentType,
+        )}"`,
+        fieldNode,
+      );
+    }
+
+    return fieldDef;
+  }
+
+  getPossibleTypes(
+    type: GraphQLAbstractType | GraphQLObjectType,
+  ): ReadonlyArray<GraphQLObjectType> {
+    return isAbstractType(type) ? this.schema.getPossibleTypes(type) : [type];
+  }
+
+  getVariableUsages(
+    selectionSet: SelectionSetNode,
+    fragments: Set<FragmentDefinitionNode>,
+  ) {
+    const usages: {
+      [name: string]: VariableDefinitionNode;
+    } = Object.create(null);
+
+    // Construct a document of the selection set and fragment definitions so we
+    // can visit them, adding all variable usages to the `usages` object.
+    const document: DocumentNode = {
+      kind: Kind.DOCUMENT,
+      definitions: [
+        { kind: Kind.OPERATION_DEFINITION, selectionSet, operation: 'query' },
+        ...Array.from(fragments),
+      ],
+    };
+
+    visit(document, {
+      Variable: (node) => {
+        usages[node.name.value] = this.variableDefinitions[node.name.value];
+      },
+    });
+
+    return usages;
+  }
+
+  newScope<TParent extends GraphQLCompositeType>(
+    parentType: TParent,
+    enclosingScope?: Scope<GraphQLCompositeType>,
+  ): Scope<TParent> {
+    return {
+      parentType,
+      possibleTypes: enclosingScope
+        ? this.getPossibleTypes(parentType).filter(type =>
+            enclosingScope.possibleTypes.includes(type),
+          )
+        : this.getPossibleTypes(parentType),
+      enclosingScope,
+    };
+  }
+
+  getBaseService(parentType: GraphQLObjectType): string | undefined {
+    const type = getFederationMetadataForType(parentType);
+    return (type && isEntityTypeMetadata(type)) ? type.graphName : undefined;
+  }
+
+  getOwningService(
+    parentType: GraphQLObjectType,
+    fieldDef: GraphQLField<any, any>,
+  ): string | undefined {
+    return (
+      getFederationMetadataForField(fieldDef)?.graphName ??
+      this.getBaseService(parentType)
+    );
+  }
+
+  getKeyFields({
+    parentType,
+    serviceName,
+    fetchAll = false,
+  }: {
+    parentType: GraphQLCompositeType;
+    serviceName: string;
+    fetchAll?: boolean;
+  }): FieldSet {
+    const keyFields: FieldSet = [];
+
+    keyFields.push({
+      scope: {
+        parentType,
+        possibleTypes: this.getPossibleTypes(parentType),
+      },
+      fieldNode: typenameField,
+      fieldDef: TypeNameMetaFieldDef,
+    });
+
+    for (const possibleType of this.getPossibleTypes(parentType)) {
+      const type = getFederationMetadataForType(possibleType);
+      const keys =
+        type && isEntityTypeMetadata(type)
+          ? type.keys.get(serviceName)
+          : undefined;
+
+      if (!(keys && keys.length > 0)) continue;
+
+      if (fetchAll) {
+        keyFields.push(
+          ...keys.flatMap(key =>
+            this.collectFields(this.newScope(possibleType), {
+              kind: Kind.SELECTION_SET,
+              selections: key,
+            }),
+          ),
+        );
+      } else {
+        keyFields.push(
+          ...this.collectFields(this.newScope(possibleType), {
+            kind: Kind.SELECTION_SET,
+            selections: keys[0],
+          }),
+        );
+      }
+    }
+
+    return keyFields;
+  }
+
+  getRequiredFields(
+    parentType: GraphQLCompositeType,
+    fieldDef: GraphQLField<any, any>,
+    serviceName: string,
+  ): FieldSet {
+    const requiredFields: FieldSet = [];
+
+    requiredFields.push(...this.getKeyFields({ parentType, serviceName }));
+
+    const fieldFederationMetadata = getFederationMetadataForField(fieldDef);
+    if (fieldFederationMetadata?.requires) {
+      requiredFields.push(
+        ...this.collectFields(this.newScope(parentType), {
+          kind: Kind.SELECTION_SET,
+          selections: fieldFederationMetadata.requires,
+        }),
+      );
+    }
+
+    return requiredFields;
+  }
+
+  getProvidedFields(
+    fieldDef: GraphQLField<any, any>,
+    serviceName: string,
+  ): FieldSet {
+    const returnType = getNamedType(fieldDef.type);
+    if (!isCompositeType(returnType)) return [];
+
+    const providedFields: FieldSet = [];
+
+    providedFields.push(
+      ...this.getKeyFields({
+        parentType: returnType,
+        serviceName,
+        fetchAll: true,
+      }),
+    );
+
+    const fieldFederationMetadata = getFederationMetadataForField(fieldDef);
+    if (fieldFederationMetadata?.provides) {
+      providedFields.push(
+        ...this.collectFields(this.newScope(returnType), {
+          kind: Kind.SELECTION_SET,
+          selections: fieldFederationMetadata.provides,
+        }),
+      );
+    }
+
+    return providedFields;
+  }
+
+  private getFragmentCondition(
+    scope: Scope<GraphQLCompositeType>,
+    fragment: FragmentDefinitionNode | InlineFragmentNode,
+  ): GraphQLCompositeType {
+    const typeConditionNode = fragment.typeCondition;
+    if (!typeConditionNode) return scope.parentType;
+
+    return typeFromAST(
+      this.schema,
+      typeConditionNode,
+    ) as GraphQLCompositeType;
+  }
+
+  /**
+   * Collects the top-level fields for the provided selection set into a `FieldSet`.
+   *
+   * This method does not recuse into the selection sets of the collected fields.
+   *
+   * @param scope - the scope of the provided selection set.
+   * @param selectionSet - the selection set with fields to collect.
+   * @param fields - the array to which the collected fields are added.
+   */
+  collectFields(
+    scope: Scope<GraphQLCompositeType>,
+    selectionSet: SelectionSetNode,
+    fields: FieldSet = [],
+    visitedFragmentNames: { [fragmentName: string]: boolean } = Object.create(null)
+  ): FieldSet {
+    for (const selection of selectionSet.selections) {
+      switch (selection.kind) {
+        case Kind.FIELD:
+          const fieldDef = this.getFieldDef(scope.parentType, selection);
+          fields.push({ scope, fieldNode: selection, fieldDef });
+          break;
+        case Kind.INLINE_FRAGMENT: {
+          const newScope = this.newScope(this.getFragmentCondition(scope, selection), scope);
+          if (newScope.possibleTypes.length === 0) {
+            break;
+          }
+
+          newScope.directives = selection.directives;
+
+          this.collectFields(
+            newScope,
+            selection.selectionSet,
+            fields,
+            visitedFragmentNames,
+          );
+          break;
+        }
+        case Kind.FRAGMENT_SPREAD:
+          const fragmentName = selection.name.value;
+
+          const fragment = this.fragments[fragmentName];
+          if (!fragment) {
+            continue;
+          }
+
+          const newScope = this.newScope(this.getFragmentCondition(scope, fragment), scope);
+          if (newScope.possibleTypes.length === 0) {
+            continue;
+          }
+
+          if (visitedFragmentNames[fragmentName]) {
+            continue;
+          }
+          visitedFragmentNames[fragmentName] = true;
+
+          this.collectFields(
+            newScope,
+            fragment.selectionSet,
+            fields,
+            visitedFragmentNames,
+          );
+          break;
+      }
+    }
+    return fields;
+  }
+}

--- a/query-planner-js/src/QueryPlanningContext.ts
+++ b/query-planner-js/src/QueryPlanningContext.ts
@@ -278,7 +278,6 @@ export class QueryPlanningContext {
     scope: Scope,
     selectionSet: SelectionSetNode,
     fields: FieldSet = [],
-    visitedFragmentNames: { [fragmentName: string]: boolean } = Object.create(null)
   ): FieldSet {
     for (const selection of selectionSet.selections) {
       switch (selection.kind) {
@@ -289,7 +288,7 @@ export class QueryPlanningContext {
         case Kind.INLINE_FRAGMENT: {
           const newScope = this.scopeForFragment(scope, selection, selection.directives);
           if (newScope) {
-            this.collectFields(newScope, selection.selectionSet, fields, visitedFragmentNames);
+            this.collectFields(newScope, selection.selectionSet, fields);
           }
           break;
         }
@@ -301,14 +300,9 @@ export class QueryPlanningContext {
             continue;
           }
 
-          if (visitedFragmentNames[fragmentName]) {
-            continue;
-          }
-          visitedFragmentNames[fragmentName] = true;
-
           const newScope = this.scopeForFragment(scope, fragment, selection.directives);
           if (newScope) {
-            this.collectFields(newScope, fragment.selectionSet, fields, visitedFragmentNames);
+            this.collectFields(newScope, fragment.selectionSet, fields);
           }
           break;
       }

--- a/query-planner-js/src/Scope.ts
+++ b/query-planner-js/src/Scope.ts
@@ -1,0 +1,259 @@
+import { DirectiveNode, GraphQLCompositeType, GraphQLObjectType, isTypeSubTypeOf, ValueNode } from "graphql";
+import { QueryPlanningContext } from "./QueryPlanningContext";
+
+/**
+ * A chain of type conditions leading to a particular point within an object.
+ *
+ * For instance, for a query like:
+ * ```
+ * {
+ *   v {
+ *     f1
+ *     ... on X {
+ *       f2
+ *       ... on Y @myDirective {
+ *         f3
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ * and assuming the type of field `v` is `V`, then the scope for `f1` would be just type `V`,
+ * while the one for `f2` is the chain `X <- V` and the one for `f3` is the chain `Y <- X <- V`.
+ *
+ * Mainly, the scope contains enough information to 1) to compute the set of possible runtime
+ * type an object can have at a given point in the query (@see `possibleRuntimeTypes`) and
+ * 2) recreate minimal type conditions to obtain that set of possible runtimes.
+ *
+ * Additionally, the scope keep track of any directive that is applied on one of the type
+ * condition it represents. So in the example below, the scope will aslo track that for
+ * reaching `f3` there is a `@myDirective` directive on the `Y` condition.
+ *
+ * Do note that scope attempts to be "minimal" in that they eschew unecessary conditions. For
+ * example, in query:
+ * ```
+ * {
+ *   v {
+ *     ... on X {
+ *       ... on V {
+ *         f
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ * still assuming that `v` is of type `V` and assuming that X is a subtype of V, the scope for field
+ * `f` will simply be `V <- X` (instead of `V <- X <- V`) as the outermost `... on V` condition adds
+ * nothing (but scope always preserve the most inner type condition as for a field, this is the type
+ * in which the field is defined). Additionally, if type `X` happens to a _super type_ of `V`, the
+ * scope for `f` would simply be `V`.
+ */
+export class Scope {
+  private cachedRuntimeTypes?: readonly GraphQLObjectType[];
+  private cachedIdentityKey: string | undefined = undefined;
+
+  private constructor(
+    private readonly context: QueryPlanningContext,
+
+    /** The innermost type of this scope. */
+    public readonly parentType: GraphQLCompositeType,
+    /** Directives associated to `parentType`. */
+    public readonly directives?: readonly DirectiveNode[],
+    /** Then enclosing scope, that is the next scope in the chain. */
+    public readonly enclosing?: Scope
+  ) {
+  }
+
+  /**
+   * Creates a new scope given a top-level type.
+   *
+   * @param context - the query planning context in which this scope is created.
+   * @param parentType - the top-level (and only) type of the created scope.
+   * @returns the newly created scope.
+   */
+  static create(context: QueryPlanningContext, parentType: GraphQLCompositeType) {
+    return new Scope(context, parentType, undefined, undefined);
+  }
+
+  /**
+   * Refines this scope by (maybe) adding the provide type (with the optional provided directives).
+   *
+   * @param type - the new type to refine this scope with.
+   * @param directives - optional directives for `type` condition.
+   * @returns a scope corresponding to restrictive this scope with the `type`. This may return
+   * this scope (be a no-op) if `directives` is undefined/null/empty and `type` is a super type of
+   * one of the existing type in this scope. Otherwise (if either `directives` is non empty or
+   * `type` genuinely restricts the existing types in this scope), a new scope with `type`
+   * as first link in the scope chain.
+   */
+  refine(type: GraphQLCompositeType, directives?: readonly DirectiveNode[]) : Scope {
+    // Always treat the absence of directives as "undefined" to make is simpler.
+    if (directives && directives.length == 0) {
+      directives = undefined;
+    }
+    // If we have directives, we always want to preserve the condition so as to preserve that directive.
+    if (directives) {
+      return new Scope(this.context, type, directives, this);
+    }
+    // Scope always preserve the immediate parent type, but if the new type is already the parent one
+    // and we have not directives to preserve, simply return the existing scope.
+    if (!directives && type === this.parentType) {
+      return this;
+    }
+    return new Scope(this.context, type, directives, Scope.pruneRefinedTypes(this, type));
+  }
+
+  private static pruneRefinedTypes(
+    toPrune: Scope | undefined,
+    refiningType: GraphQLCompositeType
+  ) : Scope | undefined {
+    if (!toPrune) {
+      return undefined;
+    }
+    if (!toPrune.directives && isTypeSubTypeOf(toPrune.context.schema, refiningType, toPrune.parentType)) {
+      // The newly added type is a subtype of the current "link", and the current link has no directives,
+      // so it's not useful anymore. Skip it, and check if we can prune further.
+      return Scope.pruneRefinedTypes(toPrune.enclosing, refiningType);
+    }
+    return new Scope(
+      toPrune.context,
+      toPrune.parentType,
+      toPrune.directives,
+      Scope.pruneRefinedTypes(toPrune.enclosing, refiningType)
+    );
+  }
+
+  /**
+   *  Whether this scope is restricting the possible runtime types of the provided type.
+   */
+  isStrictlyRefining(type: GraphQLCompositeType) : boolean {
+    // This scope will refine the provided type, unless that provided type is a subtype of all
+    // the type in the chain.
+    let scope: Scope | undefined = this;
+    while (scope) {
+      if (scope.parentType !== type && isTypeSubTypeOf(this.context.schema, scope.parentType, type)) {
+        return true;
+      }
+      scope = scope.enclosing;
+    }
+    return false;
+  }
+
+  private computePossibleRuntimeTypes() : readonly GraphQLObjectType[] {
+    // The possible runtime types is the intersection of all the possible types of each condition in scope.
+    let possibleTypes = this.context.getPossibleTypes(this.parentType);
+    let nextScope = this.enclosing;
+    while (nextScope) {
+      let enclosingPossibleTypes = this.context.getPossibleTypes(nextScope.parentType);
+      possibleTypes = possibleTypes.filter(t => enclosingPossibleTypes.includes(t));
+      nextScope = nextScope.enclosing;
+    }
+    return possibleTypes;
+  }
+
+  /**
+   * Computes the set of object types that an object within this scope can have at runtime.
+   */
+  possibleRuntimeTypes() : readonly GraphQLObjectType[] {
+    if (!this.cachedRuntimeTypes) {
+      this.cachedRuntimeTypes = this.computePossibleRuntimeTypes();
+    }
+    return this.cachedRuntimeTypes;
+  }
+
+  private static valueIdentityKey(value: ValueNode) : string {
+    // We distinguish different value types though a leading character with a single quote (so the int 3 has key "i'3") to
+    // avoid conflicts.
+    switch (value.kind) {
+      case 'Variable':
+        return value.name.value;
+      case 'IntValue':
+        return "i'" + value.value;
+      case 'FloatValue':
+        return "f'" + value.value;
+      case 'EnumValue':
+        return "e'" + value.value;
+      case 'StringValue':
+        // Using stringfy to enclose in double quotes (so that we don't have issues with, say, strings within
+        // lists) _and_ getting proper escape of double quotes within the string.
+        return `s'${JSON.stringify(value.value)}`;
+      case 'BooleanValue':
+        return "b'" + String(value.value);
+      case 'NullValue':
+        return "<null>";
+      case 'ListValue':
+        return "[" + value.values.map(this.valueIdentityKey).join('-') + "]";
+      case 'ObjectValue':
+        const fields = value.fields.map(f => f.name.value + '-' + this.valueIdentityKey(f.value));
+        fields.sort(); // Field order is not semantically significant in graphQL.
+        return "{" + fields.join('-') + "}";
+    }
+  }
+
+  private static directiveIdentityKey(directive: DirectiveNode) : string {
+    const argsKeys = directive.arguments
+      ? directive.arguments.map(arg => arg.name.value + '-' + Scope.valueIdentityKey(arg.value))
+      : [];
+    argsKeys.sort(); // Argument order is not semantically significant in graphQL.
+    return `${directive.name.value}-${argsKeys.join('-')}`;
+  }
+
+  private static directivesIdentityKey(directives: readonly DirectiveNode[]) : string {
+    const keys = directives.map(d => Scope.directiveIdentityKey(d));
+    // We sort the directives keys as we don't want the order application of directives to matter
+    // in the equality. In other words, we want:
+    //   ... on X @foo @bar
+    // to be the same as:
+    //   ... on X @bar @foo
+    keys.sort();
+    return keys.join('-');
+  }
+
+  private computeIdentityKey(): string {
+      const directivesKey = this.directives ? Scope.directivesIdentityKey(this.directives) : "";
+      const enclosingKey = this.enclosing ? this.enclosing.computeIdentityKey() : "";
+      return `${this.parentType}-${directivesKey}-${enclosingKey}`;
+  }
+
+  /**
+   * A string value that uniquely identify the scope.
+   *
+   * The "identity key" of 2 scope objects can be tested for equality to decide if 2 scopes are equal. This exists
+   * so that scopes can be (kind of) used as map keys: javacript maps always only use reference equality for objects
+   * when used as key, so using this string allows to effectively get value equality.
+   *
+   * Note that the main property this method must ensure is that if 2 scopes have the same `identityKey()`, then they
+   * are semantically equivalent (their treatment by the query planner is undistiguishable). If 2 scopes are
+   * semantically equivalent, they should generally have a the same `identityKey()` but this is less important (a
+   * case breaking this would only lead to slightly less efficient query plans than necessary) and we haven't spent
+   * tremendous times ensuring this was absolutely always the case.
+   *
+   * @returns a string uniquely identifying this scope.
+   */
+  public identityKey() : string {
+    if (!this.cachedIdentityKey) {
+      this.cachedIdentityKey = this.computeIdentityKey();
+    }
+    return this.cachedIdentityKey;
+  }
+
+  /**
+   * Provides a string representation of this scope suitable for debugging.
+   *
+   * The format looks like '<A @x @y <B>>' where 'A' is the scope 'parentType', '<B>' is the 'enclosing' scope
+   * and '@x @y' the potential directives.
+   *
+   * @return a string representation of the scope.
+   */
+  debugPrint() : string {
+    let enclosingStr = '';
+    if (this.enclosing) {
+      enclosingStr = ' ' + this.enclosing.debugPrint();
+    }
+    let directiveStr = '';
+    if (this.directives) {
+      directiveStr = this.directives.map(d => ' @' + d.name.value).join(' ');
+    }
+    return`<${this.parentType}${directiveStr}${enclosingStr}>`;
+  }
+}

--- a/query-planner-js/src/buildQueryPlan.ts
+++ b/query-planner-js/src/buildQueryPlan.ts
@@ -817,7 +817,6 @@ export function collectSubfields(
   fields: FieldSet,
 ): FieldSet {
   let subfields: FieldSet = [];
-  const visitedFragmentNames = Object.create(null);
 
   for (const field of fields) {
     const selectionSet = field.fieldNode.selectionSet;
@@ -827,7 +826,6 @@ export function collectSubfields(
         Scope.create(context, returnType),
         selectionSet,
         subfields,
-        visitedFragmentNames,
       );
     }
   }


### PR DESCRIPTION
This PR fixes #396.

It includes:
- the test originally posted on apollographql/apollo-server#4281 and later migrated to #172. I did took the liberty to slightly amend that commit because 1) it wasn't compiling anymore and 2) it was including the same test twice (so I changed one of the version to use inline fragments instead of name ones to improve coverage).
- the main fix for the loss of scope (see commit message for details).
- the previous fix actually only fix one of the 2 added tests: the one with named fragments (the original one from #396) still fails due to the planner ignore repeated named fragments when it shouldn't. The 3rd commit fixes this (more details in commit message).
- the last commit is a minor optional cleanup (see commit message).