### PR TITLE
Implementation of @internal directive

### DIFF
--- a/federation-js/src/composition/compose.ts
+++ b/federation-js/src/composition/compose.ts
@@ -431,7 +431,7 @@ export function buildSchemaFromDefinitionsAndExtensions({
   schema = new GraphQLSchema({
     ...schema.toConfig(),
     directives: [
-      ...schema.getDirectives().filter(x => !isFederationDirective(x)),
+      ...schema.getDirectives().filter(x => !isFederationDirective(x) || x.name === 'internal'),
     ],
   });
 

--- a/federation-js/src/directives.ts
+++ b/federation-js/src/directives.ts
@@ -41,6 +41,11 @@ export const ExternalDirective = new GraphQLDirective({
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
 });
 
+export const InternalDirective = new GraphQLDirective({
+  name: 'internal',
+  locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
+});
+
 export const RequiresDirective = new GraphQLDirective({
   name: 'requires',
   locations: [DirectiveLocation.FIELD_DEFINITION],
@@ -65,6 +70,7 @@ export const federationDirectives = [
   KeyDirective,
   ExtendsDirective,
   ExternalDirective,
+  InternalDirective,
   RequiresDirective,
   ProvidesDirective,
 ];

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -43,6 +43,8 @@ describe('printSupergraphSdl', () => {
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
+      directive @internal on OBJECT | FIELD_DEFINITION
+
       directive @stream on FIELD
 
       directive @transform(from: String!) on FIELD

--- a/federation-js/src/service/printSupergraphSdl.ts
+++ b/federation-js/src/service/printSupergraphSdl.ts
@@ -94,7 +94,7 @@ export function printSupergraphSdl(
 
   return printFilteredSchema(
     schema,
-    (n) => !isSpecifiedDirective(n),
+    (n) => !isSpecifiedDirective(n) || n.name === 'internal',
     isDefinedType,
     context,
     options,
@@ -430,8 +430,13 @@ function printJoinFieldDirectives(
   }
 
   printed += directiveArgs.join(', ');
+  printed += ')'
 
-  return (printed += ')');
+  if(field.astNode?.directives?.some(directive => directive.name.value === 'internal')){
+    printed += " @internal"
+  }
+
+  return printed;
 }
 
 // Core change: `onNewLine` is a formatting nice-to-have for printing

--- a/gateway-js/src/__tests__/gateway/internalFields.test.ts
+++ b/gateway-js/src/__tests__/gateway/internalFields.test.ts
@@ -1,0 +1,33 @@
+import { fetch } from '../../__mocks__/apollo-server-env';
+import { RemoteGraphQLDataSource } from '../../datasources/RemoteGraphQLDataSource';
+import { ApolloGateway } from '../../';
+
+beforeEach(() => {
+  fetch.mockReset();
+});
+
+it('removed fields marked as @internal', async () => {
+  fetch.mockJSONResponseOnce({
+    data: {
+      _service: {
+        sdl: `extend type Query { thing: String, thing2: String @internal }`,
+      },
+    },
+  });
+
+  const buildServiceSpy = jest.fn(() => {
+    return new RemoteGraphQLDataSource({
+      url: 'https://api.example.com/foo',
+    });
+  });
+
+  const gateway = new ApolloGateway({
+    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo' }],
+    buildService: buildServiceSpy,
+  });
+
+  const { schema } = await gateway.load();
+
+  expect(schema.getQueryType()?.getFields().thing).toBeTruthy();
+  expect(schema.getQueryType()?.getFields().thing2).toBeFalsy();
+});

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -42,6 +42,8 @@ describe('loadSupergraphSdlFromStorage', () => {
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
+      directive @internal on OBJECT | FIELD_DEFINITION
+
       directive @stream on FIELD
 
       directive @transform(from: String!) on FIELD

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -70,6 +70,7 @@ import {
 import { loadSupergraphSdlFromStorage } from './loadSupergraphSdlFromStorage';
 import { getServiceDefinitionsFromStorage } from './legacyLoadServicesFromStorage';
 import { buildComposedSchema } from '@apollo/query-planner';
+import { removeInternalFields } from './utilities/removeInternalFields';
 
 type DataSourceMap = {
   [serviceName: string]: { url?: string; dataSource: GraphQLDataSource };
@@ -369,8 +370,11 @@ export class ApolloGateway implements GraphQLService {
       }`,
     );
 
+    // TODO: @internal
+    const publicSchema = removeInternalFields(this.schema!);
+
     return {
-      schema: this.schema!,
+      schema: publicSchema,
       executor: this.executor,
     };
   }
@@ -472,10 +476,12 @@ export class ApolloGateway implements GraphQLService {
       this.schema = schema;
       this.queryPlanner = new QueryPlanner(schema);
 
+      const publicSchema = removeInternalFields(this.schema);
+
       // Notify the schema listeners of the updated schema
       try {
         this.onSchemaChangeListeners.forEach((listener) =>
-          listener(this.schema!),
+          listener(publicSchema),
         );
       } catch (e) {
         this.logger.error(
@@ -545,10 +551,12 @@ export class ApolloGateway implements GraphQLService {
       this.schema = schema;
       this.queryPlanner = new QueryPlanner(schema);
 
+      const publicSchema = removeInternalFields(this.schema);
+
       // Notify the schema listeners of the updated schema
       try {
         this.onSchemaChangeListeners.forEach((listener) =>
-          listener(this.schema!),
+          listener(publicSchema),
         );
       } catch (e) {
         this.logger.error(

--- a/gateway-js/src/utilities/removeInternalFields.ts
+++ b/gateway-js/src/utilities/removeInternalFields.ts
@@ -1,0 +1,34 @@
+import { transformSchema } from 'apollo-graphql';
+import {
+  isObjectType,
+  GraphQLSchema,
+  GraphQLObjectType
+} from 'graphql';
+
+export function removeInternalFields(schema: GraphQLSchema) {
+  const newSchema =  transformSchema(schema, type => {
+    if (isObjectType(type)) {
+      const config = type.toConfig();
+
+      const fields = Object.keys(config.fields).reduce((fieldsObject, fieldName) => {
+        const field = config.fields[fieldName];
+
+        if(field.astNode?.directives?.some(directive => directive.name.value === 'internal')){
+          return fieldsObject;
+        }
+
+        return {...fieldsObject, [fieldName]: field}
+      },{})
+
+      return new GraphQLObjectType({...config, fields});
+    }
+    return undefined;
+  });
+
+  const config = newSchema.toConfig();
+
+  return new GraphQLSchema({
+    ...config,
+    directives: config.directives.filter(directive => directive.name !== 'internal')
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,7 @@
     "@apollo/query-planner": {
       "version": "file:query-planner-js",
       "requires": {
+        "chalk": "^4.1.0",
         "pretty-format": "^26.0.0"
       }
     },


### PR DESCRIPTION
# What
In #371, there is a proposal to add a `@internal` directive to allow for fields that are available internally to the graph but are not exposed externally to consumers through the Gateway schema.

A previous PR removed these fields during the compose process but it was pointed out by @trevor-scheer that the approach would break Gateway functionality such as `@requires`.

This PR looks to solve this by removing the `@internal` fields during the `gateway.load` process and `onSchemaChange` event. This means that Gateway will has access to the full schema but Apollo Server exposes a schema that does not contain these fields.

# Example


```graphql
# Schema Definition
extend type Query {
   myNormalField: String
   myInternalField: String @internal
}
```

```graphql
# Exposed Schema
type Query {
   myNormalField: String
}
```

# Caveats and Unresolved Items
- I haven't finished adding tests, comments, docs, etc. I wanted to submit this to get some feedback and make sure this is something Apollo is still interested in before spending a huge amount of time
- There are some failing rust tests that I would need to fix
- The `@internal` directive as added to the `SupergraphSdl` so that it is maintained when the schema is composed and validated in Gateway but it is removed before the schema is provided to Apollo Server
- This is my first deep dive into the federation code so this approach may be naive.
- Hoping for some feedback if this is something the Apollo team is interested in moving forward