### PR TITLE
jest: remove `diagnostics: false`

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -15,8 +15,7 @@ module.exports = {
     clearMocks: true,
     globals: {
       "ts-jest": {
-        tsconfig: "<rootDir>/tsconfig.test.json",
-        diagnostics: false
+        tsconfig: "<rootDir>/tsconfig.test.json"
       }
     }
 };


### PR DESCRIPTION
In #453 @martijnwalraven noted that `diagnostics` was still set to false (which
allows `jest` to run tests even if typechecking fails) with errors logged. It
seems like perhaps the errors in question have been fixed since then, as
tests pass with `diagnostics: false` removed.
