### PR TITLE
Fix duplicate fetches in query plans [js]

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v0.27.0
 
 - Fix query plans missing fields in some situations involving nested type conditions (#396).
+- Fix duplicate fetches in query plans [PR #671](https://github.com/apollographql/federation/pull/671).
 
 ## v0.26.3
 

--- a/gateway-js/src/__tests__/integration/abstract-types.test.ts
+++ b/gateway-js/src/__tests__/integration/abstract-types.test.ts
@@ -828,3 +828,917 @@ describe('unions', () => {
   //   expect(queryPlan).toCallService('books');
   // });
 });
+
+describe("doesn't result in duplicate fetches", () => {
+  it("when exploding types", async () => {
+    const query = `#graphql
+      query {
+        topProducts {
+          name
+          price
+          reviews {
+            author {
+              name
+              username
+            }
+            body
+            id
+          }
+        }
+      }
+    `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'accounts',
+        typeDefs: gql`
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+            username: String
+          }
+        `,
+      },
+      {
+        name: 'products',
+        typeDefs: gql`
+          type Book implements Product @key(fields: "isbn") {
+            isbn: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type TV implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type Computer implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type Furniture implements Product @key(fields: "sku") {
+            sku: String!
+            name: String
+            price: Int
+            weight: Int
+          }
+          interface Product {
+            name: String
+            price: Int
+          }
+          extend type Query {
+            topProducts: [Product]
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Book implements Product @key(fields: "isbn") {
+            isbn: String! @external
+            reviews: [Review]
+          }
+          extend type TV implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Computer implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Furniture implements Product @key(fields: "sku") {
+            sku: String! @external
+            reviews: [Review]
+          }
+          extend interface Product {
+            reviews: [Review]
+          }
+          type Review @key(fields: "id") {
+            id: ID!
+            body: String
+            author: User @provides(fields: "username")
+            product: Product
+          }
+          extend type User @key(fields: "id") {
+            id: ID! @external
+            username: String @external
+            reviews: [Review]
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Book {
+                  name
+                  price
+                  __typename
+                  isbn
+                }
+                ... on Computer {
+                  name
+                  price
+                  __typename
+                  id
+                }
+                ... on Furniture {
+                  name
+                  price
+                  __typename
+                  sku
+                }
+                ... on TV {
+                  name
+                  price
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Book {
+                  __typename
+                  isbn
+                }
+                ... on Computer {
+                  __typename
+                  id
+                }
+                ... on Furniture {
+                  __typename
+                  sku
+                }
+                ... on TV {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Book {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on Computer {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on Furniture {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on TV {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+              }
+            },
+          },
+          Flatten(path: "topProducts.@.reviews.@.author") {
+            Fetch(service: "accounts") {
+              {
+                ... on User {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on User {
+                  name
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+it("when including the same nested fields under different type conditions", async () => {
+    const query = `#graphql
+      query {
+        topProducts {
+          ... on Book {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+          ... on TV {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'accounts',
+        typeDefs: gql`
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+            username: String
+          }
+        `,
+      },
+      {
+        name: 'products',
+        typeDefs: gql`
+          type Book implements Product @key(fields: "isbn") {
+            isbn: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type TV implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type Computer implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type Furniture implements Product @key(fields: "sku") {
+            sku: String!
+            name: String
+            price: Int
+            weight: Int
+          }
+          interface Product {
+            name: String
+            price: Int
+          }
+          extend type Query {
+            topProducts: [Product]
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Book implements Product @key(fields: "isbn") {
+            isbn: String! @external
+            reviews: [Review]
+          }
+          extend type TV implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Computer implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Furniture implements Product @key(fields: "sku") {
+            sku: String! @external
+            reviews: [Review]
+          }
+          extend interface Product {
+            reviews: [Review]
+          }
+          type Review @key(fields: "id") {
+            id: ID!
+            body: String
+            author: User @provides(fields: "username")
+            product: Product
+          }
+          extend type User @key(fields: "id") {
+            id: ID! @external
+            username: String @external
+            reviews: [Review]
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Book {
+                  name
+                  price
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  name
+                  price
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Book {
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Book {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on TV {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+              }
+            },
+          },
+          Flatten(path: "topProducts.@.reviews.@.author") {
+            Fetch(service: "accounts") {
+              {
+                ... on User {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on User {
+                  name
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+it('when including multiple nested fields to the same service under different type conditions', async () => {
+  const query = `#graphql
+    query {
+      topProducts {
+        ... on Book {
+          name
+          price
+          reviews {
+            author {
+              name
+              username
+            }
+            editor {
+              name
+              username
+            }
+            body
+            id
+          }
+        }
+        ... on TV {
+          name
+          price
+          reviews {
+            author {
+              name
+              username
+            }
+            editor {
+              name
+              username
+            }
+            body
+            id
+          }
+        }
+      }
+    }
+  `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'accounts',
+        typeDefs: gql`
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+            username: String
+          }
+        `,
+      },
+      {
+        name: 'products',
+        typeDefs: gql`
+          type Book implements Product @key(fields: "isbn") {
+            isbn: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type TV implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type Computer implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type Furniture implements Product @key(fields: "sku") {
+            sku: String!
+            name: String
+            price: Int
+            weight: Int
+          }
+          interface Product {
+            name: String
+            price: Int
+          }
+          extend type Query {
+            topProducts: [Product]
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Book implements Product @key(fields: "isbn") {
+            isbn: String! @external
+            reviews: [Review]
+          }
+          extend type TV implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Computer implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend type Furniture implements Product @key(fields: "sku") {
+            sku: String! @external
+            reviews: [Review]
+          }
+          extend interface Product {
+            reviews: [Review]
+          }
+          type Review @key(fields: "id") {
+            id: ID!
+            body: String
+            author: User @provides(fields: "username")
+            editor: User @provides(fields: "username")
+            product: Product
+          }
+          extend type User @key(fields: "id") {
+            id: ID! @external
+            username: String @external
+            reviews: [Review]
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Book {
+                  name
+                  price
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  name
+                  price
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Book {
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Book {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    editor {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+                ... on TV {
+                  reviews {
+                    author {
+                      __typename
+                      id
+                      username
+                    }
+                    editor {
+                      __typename
+                      id
+                      username
+                    }
+                    body
+                    id
+                  }
+                }
+              }
+            },
+          },
+          Parallel {
+            Flatten(path: "topProducts.@.reviews.@.author") {
+              Fetch(service: "accounts") {
+                {
+                  ... on User {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on User {
+                    name
+                  }
+                }
+              },
+            },
+            Flatten(path: "topProducts.@.reviews.@.editor") {
+              Fetch(service: "accounts") {
+                {
+                  ... on User {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on User {
+                    name
+                  }
+                }
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  // This test case describes a situation that isn't fixed by the deduplication
+  // workaround. It is here to remind us to look into this, but it doesn't
+  // actually test for the failing behavior so the test still succeeds.
+  //
+  // In cases where different possible types live in different
+  // services, you can't just merge the dependent fetches because they don't
+  // have the same parent. What you want here is to have these dependent fetches
+  // execute separately, but only take the objects fetched by its parent as input.
+  // The problem currently is that these fetches act on on the same path, so
+  // depending on the timing either one (or both) will end up fetching the same
+  // data just fetched by the other.
+  //
+  // To make this more concrete, in this case that means we'll fetch all of the
+  // reviews and authors twice.
+  //
+  // Solving this requires us to filter on the types of response objects as
+  // opposed to just collecting all objects in the path.
+it("when including the same nested fields under different type conditions that are split between services", async () => {
+    const query = `#graphql
+      query {
+        topProducts {
+          ... on Book {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+          ... on TV {
+            name
+            price
+            reviews {
+              author {
+                name
+                username
+              }
+              body
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'accounts',
+        typeDefs: gql`
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+            username: String
+          }
+        `,
+      },
+      {
+        name: 'products',
+        typeDefs: gql`
+          type Book implements Product @key(fields: "isbn") {
+            isbn: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          type TV implements Product @key(fields: "id") {
+            id: String!
+            title: String
+            year: Int
+            name: String
+            price: Int
+          }
+          interface Product {
+            name: String
+            price: Int
+          }
+          extend type Query {
+            topProducts: [Product]
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type TV implements Product @key(fields: "id") {
+            id: String! @external
+            reviews: [Review]
+          }
+          extend interface Product {
+            reviews: [Review]
+          }
+          type Review @key(fields: "id") {
+            id: ID!
+            body: String
+            author: User @provides(fields: "username")
+            product: Product
+          }
+          extend type User @key(fields: "id") {
+            id: ID! @external
+            username: String @external
+            reviews: [Review]
+          }
+        `,
+      },
+      {
+        name: 'books',
+        typeDefs: gql`
+          extend type Book @key(fields: "isbn") {
+            isbn: String! @external
+            reviews: [Review]
+          }
+          extend type Review @key(fields: "id") {
+            id: ID! @external
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Book {
+                  name
+                  price
+                  __typename
+                  isbn
+                }
+                ... on TV {
+                  name
+                  price
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Parallel {
+            Sequence {
+              Flatten(path: "topProducts.@") {
+                Fetch(service: "books") {
+                  {
+                    ... on Book {
+                      __typename
+                      isbn
+                    }
+                  } =>
+                  {
+                    ... on Book {
+                      reviews {
+                        __typename
+                        id
+                      }
+                    }
+                  }
+                },
+              },
+              Flatten(path: "topProducts.@.reviews.@") {
+                Fetch(service: "reviews") {
+                  {
+                    ... on Review {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Review {
+                      author {
+                        __typename
+                        id
+                        username
+                      }
+                      body
+                    }
+                  }
+                },
+              },
+              Flatten(path: "topProducts.@.reviews.@.author") {
+                Fetch(service: "accounts") {
+                  {
+                    ... on User {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on User {
+                      name
+                    }
+                  }
+                },
+              },
+            },
+            Sequence {
+              Flatten(path: "topProducts.@") {
+                Fetch(service: "reviews") {
+                  {
+                    ... on TV {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on TV {
+                      reviews {
+                        author {
+                          __typename
+                          id
+                          username
+                        }
+                        body
+                        id
+                      }
+                    }
+                  }
+                },
+              },
+              Flatten(path: "topProducts.@.reviews.@.author") {
+                Fetch(service: "accounts") {
+                  {
+                    ... on User {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on User {
+                      name
+                    }
+                  }
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6245,6 +6245,12 @@
       "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
       "dev": true
     },
+    "@types/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==",
+      "dev": true
+    },
     "@types/deep-freeze": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/deep-freeze/-/deep-freeze-0.1.2.tgz",
@@ -7123,6 +7129,11 @@
       "integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -7334,6 +7345,14 @@
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
       "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
       "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -7866,7 +7885,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -9246,6 +9264,46 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
+      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "es-get-iterator": "^1.1.1",
+        "get-intrinsic": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -9628,6 +9686,28 @@
         "object.assign": "^4.1.0",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "es-to-primitive": {
@@ -10316,6 +10396,11 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -10491,7 +10576,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -11469,8 +11553,7 @@
     "has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-flag": {
       "version": "4.0.0",
@@ -11953,6 +12036,14 @@
         }
       }
     },
+    "is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -11962,8 +12053,7 @@
     "is-bigint": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
-      "dev": true
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -11978,7 +12068,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
       "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0"
       }
@@ -12130,6 +12219,11 @@
         }
       }
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -12139,8 +12233,7 @@
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -12151,8 +12244,7 @@
     "is-number-object": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-      "dev": true
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-obj": {
       "version": "1.0.1",
@@ -12222,6 +12314,11 @@
         "is-unc-path": "^1.0.0"
       }
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
     "is-ssh": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
@@ -12240,8 +12337,7 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -12258,6 +12354,98 @@
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "is-typedarray": {
@@ -12303,6 +12491,16 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -14932,6 +15130,15 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -15880,6 +16087,15 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -16643,6 +16859,23 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -17761,7 +17994,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
       "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.0",
@@ -18160,7 +18392,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -18169,11 +18400,116 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
   "dependencies": {
     "@apollo/federation": "file:federation-js",
     "@apollo/gateway": "file:gateway-js",
-    "@apollo/query-planner": "file:query-planner-js",
     "@apollo/harmonizer": "file:harmonizer",
     "@apollographql/apollo-tools": "0.4.14",
-    "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
+    "@apollo/query-planner": "file:query-planner-js",
+    "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js",
+    "deep-equal": "^2.0.5"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "1.21.4",
@@ -43,6 +44,7 @@
     "@rollup/plugin-commonjs": "18.0.0",
     "@rollup/plugin-node-resolve": "11.2.1",
     "@types/bunyan": "1.8.6",
+    "@types/deep-equal": "^1.0.1",
     "@types/deep-freeze": "0.1.2",
     "@types/jest": "26.0.22",
     "@types/lodash.xorby": "4.7.6",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -9,6 +9,7 @@
 # v0.1.3
 
 - Fix query plans missing fields in some situations involving nested type conditions (#396).
+- Fix duplicate fetches in query plans [PR #671](https://github.com/apollographql/federation/pull/671).
 
 # v0.1.2
 


### PR DESCRIPTION
Fixes #399 and #294.

(This replaces #579, which fixed the same issue in the Rust query planner.)

The issue fixed by this PR requires a bit of unpacking. The visible result is that in some cases, the query plan will contain duplicate fetches to the same underlying service. For this query, for example:

```
query {
  topProducts {
    name
    price
    reviews {
      body
      author {
        name
      }
    }
  }
}
```

We end up fetching the names of authors as many times as there are different types of products. (It isn’t just that we fetch the authors of the reviews of each product type separately, but we literally execute the same query with the same representations, so all authors for all products, multiple times.)

In the case above, this is triggered as a consequence of type explosion, but it is a separate issue and also occurs in other cases where we manually include duplicate nested fields under multiple type conditions.

This query, for example, will also contain as many fetches for authors as there are type conditions (so two fetches here):

```
query {
  topProducts {
    name
    price
    ... on Book {
      reviews {
        body
        author {
          name
        }
      }
    }
    ... on Video {
      reviews {
        body
        author {
          name
        }
      }
    }
  }
}
```

The underlying cause is that we don't merge dependent fetch groups from subfields. In this case, we’ll create separate fetch groups for `{ name }` nested under the different type conditions, and even though these operate on the same path and fetch data from the same service, they are treated as separate fetches (that all have the same path however, which is why they take the same representations as input).

This PR attempts to solve this by manually merging nested fetch groups whenever they are compatible. That fixes the issue in most cases, but there are more complicated situations it doesn't address and that will require more substantial changes to the query planner and execution.

In particular, when possible types are spread over multiple services, it will not be possible to merge nested fetch groups from subfields because these should actually result in separate fetches. What you don't want however, is for those fetches to operate on the same objects just fetched by the other, but since representations taken as input are collected by path, there is no way to differentiate between these.

I believe solving this latter problem requires additional capabilities in the query plan (which is something we’ve talked about before). The most straightforward way to fix this seems to be a `TypeCondition` node in the query plan, which filters input representations based on their type.
