### PR TITLE
gateway(RemoteGraphQLDataSource): Only calculate hash for APQ when enabled

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -5,6 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Allow passing a function to the `introspectionHeaders` field when constructing an `ApolloGateway` instance. This allows for producing dynamic introspection headers per request. [PR #607](https://github.com/apollographql/federation/pull/607)
+- Will no longer calculate the automated persisted query (APQ) hash when `apq` is not set to `true` on the `RemoteGraphQLDataSource`. [PR #672](https://github.com/apollographql/federation/pull/672)
 
 ## v0.26.0
 

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -78,10 +78,6 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
       throw new Error("Missing query");
     }
 
-    const apqHash = createSHA('sha256')
-       .update(request.query)
-       .digest('hex');
-
     const { query, ...requestWithoutQuery } = request;
 
     const respond = (response: GraphQLResponse, request: GraphQLRequest) =>
@@ -90,6 +86,10 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
         : response;
 
     if (this.apq) {
+      const apqHash = createSHA('sha256')
+        .update(request.query)
+        .digest('hex');
+
       // Take the original extensions and extend them with
       // the necessary "extensions" for APQ handshaking.
       requestWithoutQuery.extensions = {


### PR DESCRIPTION
This guards the calculation of the APQ (Automated Persisted Queries) hash (a SHA-256; a Crypto function) within the (existing) conditional that toggles whether or not APQ is desired to be used when communicating with the upstream GraphQL service.  No need to pay that cost when APQ is not enabled!