### PR TITLE
`JSON.stringify()` should be called only once for the single HTTP call

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Avoid _small_ potential performamce concern/observation introduced in v0.21.0 which unnecessarily `JSON.stringify`'d the same object twice during requests to upstream subgraphs. [PR #673](https://github.com/apollographql/federation/pull/673)
 - Allow passing a function to the `introspectionHeaders` field when constructing an `ApolloGateway` instance. This allows for producing dynamic introspection headers per request. [PR #607](https://github.com/apollographql/federation/pull/607)
 
 ## v0.26.0

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -140,10 +140,10 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
     // being transmitted.  Instead, we want those to be used to indicate what
     // we're accessing (e.g. url) and what we access it with (e.g. headers).
     const { http, ...requestWithoutHttp } = request;
-    const requestBody = JSON.stringify(requestWithoutHttp);
+    const stringifiedRequestWithoutHttp = JSON.stringify(requestWithoutHttp);
     const fetchRequest = new Request(http.url, {
       ...http,
-      body: requestBody,
+      body: stringifiedRequestWithoutHttp,
     });
 
     let fetchResponse: Response | undefined;
@@ -153,7 +153,7 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
       // Use the fetcher's `Request` implementation for compatibility
       fetchResponse = await this.fetcher(http.url, {
         ...http,
-        body: requestBody
+        body: stringifiedRequestWithoutHttp,
       });
 
       if (!fetchResponse.ok) {

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -140,9 +140,10 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
     // being transmitted.  Instead, we want those to be used to indicate what
     // we're accessing (e.g. url) and what we access it with (e.g. headers).
     const { http, ...requestWithoutHttp } = request;
+    const requestBody = JSON.stringify(requestWithoutHttp);
     const fetchRequest = new Request(http.url, {
       ...http,
-      body: JSON.stringify(requestWithoutHttp),
+      body: requestBody,
     });
 
     let fetchResponse: Response | undefined;
@@ -152,7 +153,7 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
       // Use the fetcher's `Request` implementation for compatibility
       fetchResponse = await this.fetcher(http.url, {
         ...http,
-        body: JSON.stringify(requestWithoutHttp)
+        body: requestBody
       });
 
       if (!fetchResponse.ok) {


### PR DESCRIPTION
The current behavior of `RemoteGraphQLDataSource.ts` is to stringify the body twice. For the applications require to have low SLO for overhead created by the gateway it may be critical. 

We didn't measure the real impact on performance, but it'll take less effort to fix this small piece of code, instead of writing metrics/tests to analyze the performance.