### PR TITLE
ci: Windows images already have nvm installed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,9 +185,6 @@ jobs:
                 keys:
                   - rust-target-v1-windows-{{ checksum "Cargo.lock" }}
             - run:
-                name: Install nvm (with choco)
-                command: choco install nvm
-            - run:
                 name: Install desired Node.js version with nvm
                 command: |
                   nvm install ${Env:NODE_VERSION}


### PR DESCRIPTION
The motivation for this was that Chocolatey was down and thus `choco install nvm` was failing because of a 503 error.  Upon giving it a bit more thought, I found that the Windows CircleCI images already had Chocolatey installed and that the version was actively maintained enough (and that nvm windows doesn't release new versions all that often, anyhow) to be used for the relatively simple lift of installing a specific Node.js version.