### PR TITLE
infra(ci): Adjust npm installation strategy in Rust containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,11 @@ jobs:
                 command: |
                   sudo npm install --global npm@${NPM_VERSION}
             - run:
-                name: Debug output of Node.js and npm versions
-                command: |
-                  echo 'Node.js version:'
-                  node --version
-                  echo 'npm version:'
-                  npm --version
+                name: Assert Node.js version
+                command: test "$(node --version)" = "v${NODE_VERSION}"
+            - run:
+                name: Assert npm version
+                command: test "$(npm --version)" = "${NPM_VERSION}"
             - run: npm clean-install
             - rust/test:
                 # This is prefixed in the orb with 'cargo-'
@@ -150,12 +149,11 @@ jobs:
                   nvm alias default $NODE_VERSION
                   npm install --global npm@${NPM_VERSION}
             - run:
-                name: Debug output of Node.js and npm versions
-                command: |
-                  echo 'Node.js version:'
-                  node --version
-                  echo 'npm version:'
-                  npm --version
+                name: Assert Node.js version
+                command: test "$(node --version)" = "v${NODE_VERSION}"
+            - run:
+                name: Assert npm version
+                command: test "$(npm --version)" = "${NPM_VERSION}"
             - run: npm clean-install
             - rust/test:
                 # This is prefixed in the orb with 'cargo-'
@@ -214,12 +212,13 @@ jobs:
                   }
                   npm-orig install --global "npm@${Env:NPM_VERSION}"
             - run:
-                name: Debug output of Node.js and npm versions
+                name: Assert Node.js version
                 command: |
-                  echo 'Node.js version:'
-                  node --version
-                  echo 'npm version:'
-                  npm --version
+                  if ((node --version) -Ne "v${Env:NODE_VERSION}") { exit 1 }
+            - run:
+                name: Assert npm version
+                command: |
+                  if ((npm --version) -Ne "${Env:NPM_VERSION}") { exit 1 }
             - run: npm clean-install
             - rust/test:
                 # This is prefixed in the orb with 'cargo-'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
                   node --version
                   echo 'npm version:'
                   npm --version
-            - run: npm install
+            - run: npm clean-install
             - rust/test:
                 # This is prefixed in the orb with 'cargo-'
                 cache_version: v2-macos
@@ -156,7 +156,7 @@ jobs:
                   node --version
                   echo 'npm version:'
                   npm --version
-            - run: npm install
+            - run: npm clean-install
             - rust/test:
                 # This is prefixed in the orb with 'cargo-'
                 cache_version: v2-linux
@@ -220,7 +220,7 @@ jobs:
                   node --version
                   echo 'npm version:'
                   npm --version
-            - run: npm install
+            - run: npm clean-install
             - rust/test:
                 # This is prefixed in the orb with 'cargo-'
                 cache_version: v2-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,8 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     environment:
-      # Because it's QUITE difficult to change the npm version on Windows,
-      # we'll use the version of npm that comes with this version of Node.js
-      # These versions can be found at https://nodejs.org/en/download/releases/.
       NODE_VERSION: 14.16.1
+      NPM_VERSION: 6.14.13
     steps:
       - checkout
       - when:
@@ -109,6 +107,10 @@ jobs:
                 name: Installing Node.js with a .pkg.
                 command: |
                   curl "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.pkg" > "$HOME/Downloads/node.pkg" && sudo installer -store -pkg "$HOME/Downloads/node.pkg" -target "/"
+            - run:
+                name: Install specific version of npm
+                command: |
+                  sudo npm install --global npm@${NPM_VERSION}
             - run:
                 name: Debug output of Node.js and npm versions
                 command: |
@@ -141,7 +143,12 @@ jobs:
                 name: Install nvm
                 command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
             - run: echo '. ~/.nvm/nvm.sh' >> $BASH_ENV
-            - run: nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
+            - run:
+                name: Install desired Node.js version
+                command: |
+                  nvm install $NODE_VERSION
+                  nvm alias default $NODE_VERSION
+                  npm install --global npm@${NPM_VERSION}
             - run:
                 name: Debug output of Node.js and npm versions
                 command: |
@@ -189,6 +196,23 @@ jobs:
                 command: |
                   nvm install ${Env:NODE_VERSION}
                   nvm on
+            - run:
+                # https://github.com/coreybutler/nvm-windows/issues/300
+                # Have to move the command out of the way because it can't
+                # overwrite itself otherwise.   This is madness, but apparently
+                # accepted.  Other things I tried: using yarn to install npm,
+                # using http://npm.im/npm-windows-upgrade and even shouting.
+                name: Install specific version of npm in a crazy Windows way
+                command: |
+                  $node_dir = (get-item (get-command npm).source).directory.fullname
+                  foreach ($cmd in @("npm", "npx")) {
+                    foreach ($ext in @(".ps1", ".cmd", "")) {
+                      if (Test-Path "$node_dir/$cmd$ext") {
+                        rename-item -path (join-path -path $node_dir -childpath "$cmd$ext") "${cmd}-orig${ext}"
+                      }
+                    }
+                  }
+                  npm-orig install --global "npm@${Env:NPM_VERSION}"
             - run:
                 name: Debug output of Node.js and npm versions
                 command: |


### PR DESCRIPTION
This is a follow-up on https://github.com/apollographql/federation/issues/540
but also what I found to be a valuable precursor to an impending upgrade to
npm@7 for this monorepo.  Essentially, this brings some durability to the
npm version that we expect to be installed in the containers, rather than
leveraging the version that ships with a version of Node.js and allows those
to move forward separately.  For example, using Node.js 14 within the Rust
containers seems prudent but that still ships with npm 6.  When we upgrade
the repository to npm 7, that version will no longer be suitable for the
`package-lock.json` that will be checked into this repository, but we
probably don't want to make the version of Node.js that runs in that
container Node.js 16 for a few more months when it reaches LTS.

Generally speaking, this seems useful to have separated to spare a future
person from having to unravel any complexities that I went through in
accomplishing this.  (I could very much see this logic living in a CircleCI
Orb elsewhere and I may take on that initiative eventually but it's a
heavier lift right now.)

Thusly, I'm opening this as a pre-req for an upcoming upgrade to `npm@7` that
can live on its own and still add value.