### PR TITLE
fix: Dependency issues introduced by changes to underlying tooling packages

### DIFF
--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -21,7 +21,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "apollo-graphql": "^0.9.0",
+    "apollo-graphql": "^0.9.2",
     "graphql-tag": "^2.10.4"
   }
 }

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- Remove lingering `core-js` polyfill imports, they're no longer needed and their presence is problematic since `core-js` isn't defined as a dependency within the package. Update `apollo-graphql` dependency which resolves a missing dependency (`sha.js`) within that package. [PR #699](https://github.com/apollographql/federation/pull/699)
+- Remove lingering `core-js` polyfill imports, they're no longer needed (since `@apollo/gateway@0.15.0` dropped support for <= Node.js v10) and their presence is problematic since `core-js` isn't defined as a dependency within the package. Update `apollo-graphql` dependency which resolves a missing dependency (`sha.js`) within that package. [PR #699](https://github.com/apollographql/federation/pull/699)
 
 ## v0.23.1
 

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
--  _Nothing yet! Stay tuned!_
+- Remove lingering `core-js` polyfill imports, they're no longer needed and their presence is problematic since `core-js` isn't defined as a dependency within the package. Update `apollo-graphql` dependency which resolves a missing dependency (`sha.js`) within that package. [PR #699](https://github.com/apollographql/federation/pull/699)
 
 ## v0.23.1
 

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "apollo-graphql": "^0.9.0",
+    "apollo-graphql": "^0.9.2",
     "lodash.xorby": "^4.7.0"
   },
   "peerDependencies": {

--- a/federation-js/src/index.ts
+++ b/federation-js/src/index.ts
@@ -1,5 +1,2 @@
-import "core-js/features/array/flat";
-import "core-js/features/array/flat-map";
-
 export * from './composition';
 export * from './service';

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
--  _Nothing yet! Stay tuned!_
+- Update `apollo-graphql` dependency which resolves a missing dependency (`sha.js`) within that package. [PR #699](https://github.com/apollographql/federation/pull/699)
 
 ## v0.26.2
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -28,7 +28,7 @@
     "@apollo/federation": "file:../federation-js",
     "@apollo/query-planner": "file:../query-planner-js",
     "@types/node-fetch": "2.5.10",
-    "apollo-graphql": "^0.9.0",
+    "apollo-graphql": "^0.9.2",
     "apollo-reporting-protobuf": "^0.6.0",
     "apollo-server-caching": "^0.6.0",
     "apollo-server-core": "^2.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "@apollo/federation": {
       "version": "file:federation-js",
       "requires": {
-        "apollo-graphql": "^0.9.0",
+        "apollo-graphql": "^0.9.2",
         "lodash.xorby": "^4.7.0"
       },
       "dependencies": {
@@ -27,7 +27,7 @@
         "@apollo/federation": "file:federation-js",
         "@apollo/query-planner": "file:query-planner-js",
         "@types/node-fetch": "2.5.10",
-        "apollo-graphql": "^0.9.0",
+        "apollo-graphql": "^0.9.2",
         "apollo-reporting-protobuf": "^0.6.0",
         "apollo-server-caching": "^0.6.0",
         "apollo-server-core": "^2.23.0",
@@ -6774,7 +6774,7 @@
     "apollo-federation-integration-testsuite": {
       "version": "file:federation-integration-testsuite-js",
       "requires": {
-        "apollo-graphql": "^0.9.0",
+        "apollo-graphql": "^0.9.2",
         "graphql-tag": "^2.10.4"
       },
       "dependencies": {


### PR DESCRIPTION
I believe this was only needed for compatibility with old versions of Node and hasn't been required since #311. That PR removed the explicit dependency on `core-js` from `federation-js/package.json`, but didn't remove this import, which breaks build scenarios that are more strict about dependency declaration.

Update `apollo-graphql` to `latest`, which includes a dependency fix for a missing package `sha.js` which was previously required transitively (revealing the bug that it was missing all along). https://github.com/apollographql/apollo-tooling/pull/2283

Fixes #692.
Fixes #693.