### PR TITLE
Typecheck tests before running them

### DIFF
--- a/gateway-js/src/__tests__/gateway/reporting.test.ts
+++ b/gateway-js/src/__tests__/gateway/reporting.test.ts
@@ -10,7 +10,7 @@ import { createHttpLink } from 'apollo-link-http';
 import fetch from 'node-fetch';
 import { ApolloGateway } from '../..';
 import { Plugin, Config, Refs } from 'pretty-format';
-import { Report } from 'apollo-reporting-protobuf';
+import { Report, Trace } from 'apollo-reporting-protobuf';
 import { fixtures } from 'apollo-federation-integration-testsuite';
 
 // TODO: We should fix this another way, but for now adding this
@@ -18,7 +18,7 @@ import { fixtures } from 'apollo-federation-integration-testsuite';
 // due to us not dependeing on `dom` (or `webworker`) types.
 declare global {
   interface WindowOrWorkerGlobalScope {
-    fetch: typeof import('apollo-server-env')['fetch']
+    fetch: typeof import('apollo-server-env')['fetch'];
   }
 }
 
@@ -130,9 +130,11 @@ describe('reporting', () => {
         key: 'service:foo:bar',
         graphVariant: 'current',
       },
-      plugins: [ApolloServerPluginUsageReporting({
-        sendReportsImmediately: true,
-      })],
+      plugins: [
+        ApolloServerPluginUsageReporting({
+          sendReportsImmediately: true,
+        }),
+      ],
     });
     ({ url: gatewayUrl } = await gatewayServer.listen({ port: 0 }));
   });
@@ -206,7 +208,7 @@ describe('reporting', () => {
     const statsReportKey = '# -\n{me{name{first last}}topProducts{name}}';
     expect(Object.keys(report.tracesPerQuery)).toStrictEqual([statsReportKey]);
     expect(report.tracesPerQuery[statsReportKey]!.trace!.length).toBe(1);
-    const trace = report.tracesPerQuery[statsReportKey]!.trace![0]!;
+    const trace = report.tracesPerQuery[statsReportKey]!.trace![0]! as Trace;
     // In the gateway, the root trace is just an empty node (unless there are errors).
     expect(trace.root!.child).toStrictEqual([]);
     // The query plan has (among other things) a fetch against 'accounts' and a
@@ -230,7 +232,10 @@ describe('reporting', () => {
 
     expect(report).toMatchInlineSnapshot(`
       Object {
-        "endTime": null,
+        "endTime": Object {
+          "nanos": 123000000,
+          "seconds": "1562203363",
+        },
         "header": "<HEADER>",
         "tracesPerQuery": Object {
           "# -

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,6 @@
       "requires": {
         "apollo-graphql": "^0.9.2",
         "lodash.xorby": "^4.7.0"
-      },
-      "dependencies": {
-        "apollo-graphql": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.2.tgz",
-          "integrity": "sha512-+c/vqC2LPq3e5kO7MfBxDDiljzLog/THZr9Pd46HVaKAhHUxFL0rJEbT17VhjdOoZGWFWLYG7x9hiN6EQD1xZQ==",
-          "requires": {
-            "core-js-pure": "^3.10.2",
-            "lodash.sortby": "^4.7.0",
-            "sha.js": "^2.4.11"
-          }
-        }
       }
     },
     "@apollo/gateway": {
@@ -88,38 +76,6 @@
             }
           }
         },
-        "apollo-env": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.6.tgz",
-          "integrity": "sha512-hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==",
-          "requires": {
-            "@types/node-fetch": "2.5.7",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          },
-          "dependencies": {
-            "@types/node-fetch": {
-              "version": "2.5.7",
-              "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-              "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-              "requires": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-              }
-            }
-          }
-        },
-        "apollo-graphql": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.2.tgz",
-          "integrity": "sha512-+c/vqC2LPq3e5kO7MfBxDDiljzLog/THZr9Pd46HVaKAhHUxFL0rJEbT17VhjdOoZGWFWLYG7x9hiN6EQD1xZQ==",
-          "requires": {
-            "core-js-pure": "^3.10.2",
-            "lodash.sortby": "^4.7.0",
-            "sha.js": "^2.4.11"
-          }
-        },
         "apollo-reporting-protobuf": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.7.0.tgz",
@@ -135,86 +91,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "apollo-server-core": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.23.0.tgz",
-          "integrity": "sha512-3/a4LPgRADc8CdT/nRh7W0CAqQv3Q4DJvakWQgKqGSqDEb/0u4IBynYjlQKuPBi4wwKdeK2Hb1wiQLl+zu4StQ==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "@apollographql/graphql-playground-html": "1.6.27",
-            "@apollographql/graphql-upload-8-fork": "^8.1.3",
-            "@josephg/resolvable": "^1.0.0",
-            "@types/ws": "^7.0.0",
-            "apollo-cache-control": "^0.12.0",
-            "apollo-datasource": "^0.8.0",
-            "apollo-graphql": "^0.6.0",
-            "apollo-reporting-protobuf": "^0.6.2",
-            "apollo-server-caching": "^0.6.0",
-            "apollo-server-env": "^3.0.0",
-            "apollo-server-errors": "^2.5.0",
-            "apollo-server-plugin-base": "^0.11.0",
-            "apollo-server-types": "^0.7.0",
-            "apollo-tracing": "^0.13.0",
-            "async-retry": "^1.2.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-extensions": "^0.13.0",
-            "graphql-tag": "^2.11.0",
-            "graphql-tools": "^4.0.8",
-            "loglevel": "^1.6.7",
-            "lru-cache": "^6.0.0",
-            "sha.js": "^2.4.11",
-            "subscriptions-transport-ws": "^0.9.11",
-            "uuid": "^8.0.0",
-            "ws": "^6.0.0"
-          },
-          "dependencies": {
-            "apollo-graphql": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.6.1.tgz",
-              "integrity": "sha512-ZRXAV+k+hboCVS+FW86FW/QgnDR7gm/xMUwJPGXEbV53OLGuQQdIT0NCYK7AzzVkCfsbb7NJ3mmEclkZY9uuxQ==",
-              "requires": {
-                "apollo-env": "^0.6.6",
-                "lodash.sortby": "^4.7.0"
-              }
-            },
-            "apollo-reporting-protobuf": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.2.tgz",
-              "integrity": "sha512-WJTJxLM+MRHNUxt1RTl4zD0HrLdH44F2mDzMweBj1yHL0kSt8I1WwoiF/wiGVSpnG48LZrBegCaOJeuVbJTbtw==",
-              "requires": {
-                "@apollo/protobufjs": "^1.0.3"
-              }
-            },
-            "apollo-server-caching": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.6.0.tgz",
-              "integrity": "sha512-SfjKaccrhRzUQ8TAke9FrYppp4pZV3Rp8KCs+4Ox3kGtbco68acRPJkiYYtSVc4idR8XNAUOOVfAEZVNHdZQKQ==",
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "apollo-server-errors": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-              "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA=="
-            },
-            "apollo-server-types": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.7.0.tgz",
-              "integrity": "sha512-pJ6ri2N4xJ+e2PUUPHeCNpMDzHUagJyn0DDZGQmXDz6aoMlSd4B2KUvK81hHyHkw3wHk9clgcpfM9hKqbfZweA==",
-              "requires": {
-                "apollo-reporting-protobuf": "^0.6.2",
-                "apollo-server-caching": "^0.6.0",
-                "apollo-server-env": "^3.0.0"
-              }
-            }
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-          "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA=="
         },
         "apollo-server-types": {
           "version": "0.8.0",
@@ -245,33 +121,6 @@
       "version": "file:harmonizer",
       "requires": {
         "@apollo/federation": "file:federation-js"
-      }
-    },
-    "@apollo/protobufjs": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.5.tgz",
-      "integrity": "sha512-ZtyaBH1icCgqwIGb3zrtopV2D5Q8yxibkJzlaViM08eOhTQc7rACdYu0pfORFfhllvdMZ3aq69vifYHszY4gNA==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
-          "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
-        }
       }
     },
     "@apollo/query-planner": {
@@ -2860,24 +2709,6 @@
             "tslib": "~2.2.0"
           }
         },
-        "change-case-all": {
-          "version": "1.0.14",
-          "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
-          "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
-          "dev": true,
-          "requires": {
-            "change-case": "^4.1.2",
-            "is-lower-case": "^2.0.2",
-            "is-upper-case": "^2.0.2",
-            "lower-case": "^2.0.2",
-            "lower-case-first": "^2.0.2",
-            "sponge-case": "^1.0.1",
-            "swap-case": "^2.0.2",
-            "title-case": "^3.0.3",
-            "upper-case": "^2.0.2",
-            "upper-case-first": "^2.0.2"
-          }
-        },
         "cli-cursor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3130,42 +2961,6 @@
             "import-from": "3.0.0",
             "lodash": "~4.17.20",
             "tslib": "~2.2.0"
-          }
-        },
-        "@graphql-codegen/visitor-plugin-common": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.20.0.tgz",
-          "integrity": "sha512-AYrpy8NA3DpvhDLqYGerQRv44S+YAMPKtwT8x9GNVjzP0gVfmqi3gG1bDWbP5sm6kOZKvDC0kTxGePuBSZerxw==",
-          "dev": true,
-          "requires": {
-            "@graphql-codegen/plugin-helpers": "^1.18.5",
-            "@graphql-tools/optimize": "^1.0.1",
-            "@graphql-tools/relay-operation-optimizer": "^6",
-            "array.prototype.flatmap": "^1.2.4",
-            "auto-bind": "~4.0.0",
-            "change-case-all": "1.0.14",
-            "dependency-graph": "^0.11.0",
-            "graphql-tag": "^2.11.0",
-            "parse-filepath": "^1.0.2",
-            "tslib": "~2.2.0"
-          }
-        },
-        "change-case-all": {
-          "version": "1.0.14",
-          "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
-          "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
-          "dev": true,
-          "requires": {
-            "change-case": "^4.1.2",
-            "is-lower-case": "^2.0.2",
-            "is-upper-case": "^2.0.2",
-            "lower-case": "^2.0.2",
-            "lower-case-first": "^2.0.2",
-            "sponge-case": "^1.0.1",
-            "swap-case": "^2.0.2",
-            "title-case": "^3.0.3",
-            "upper-case": "^2.0.2",
-            "upper-case-first": "^2.0.2"
           }
         },
         "tslib": {
@@ -6801,48 +6596,17 @@
         "picomatch": "^2.0.4"
       }
     },
-    "apollo-cache-control": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.12.0.tgz",
-      "integrity": "sha512-kClF5rfAm159Nboul1LxA+l58Tjz0M8L1GUknEMpZt0UHhILLAn3BfcG3ToX4TbNoR9M57kKMUcbPWLdy3Up7w==",
-      "requires": {
-        "apollo-server-env": "^3.0.0",
-        "apollo-server-plugin-base": "^0.11.0"
-      }
-    },
-    "apollo-datasource": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.8.0.tgz",
-      "integrity": "sha512-gXgsGVLuejLc138z/2jUjPAzadDQxWbcLJyBgaQsg5BaXJNkv5uW/NjiSPk00cK51hyZrb0Xx8a+L+wPk2qIBA==",
-      "requires": {
-        "apollo-server-caching": "^0.6.0",
-        "apollo-server-env": "^3.0.0"
-      }
-    },
     "apollo-federation-integration-testsuite": {
       "version": "file:federation-integration-testsuite-js",
       "requires": {
         "apollo-graphql": "^0.9.2",
         "graphql-tag": "^2.10.4"
-      },
-      "dependencies": {
-        "apollo-graphql": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.2.tgz",
-          "integrity": "sha512-+c/vqC2LPq3e5kO7MfBxDDiljzLog/THZr9Pd46HVaKAhHUxFL0rJEbT17VhjdOoZGWFWLYG7x9hiN6EQD1xZQ==",
-          "requires": {
-            "core-js-pure": "^3.10.2",
-            "lodash.sortby": "^4.7.0",
-            "sha.js": "^2.4.11"
-          }
-        }
       }
     },
     "apollo-graphql": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.2.tgz",
       "integrity": "sha512-+c/vqC2LPq3e5kO7MfBxDDiljzLog/THZr9Pd46HVaKAhHUxFL0rJEbT17VhjdOoZGWFWLYG7x9hiN6EQD1xZQ==",
-      "dev": true,
       "requires": {
         "core-js-pure": "^3.10.2",
         "lodash.sortby": "^4.7.0",
@@ -6882,14 +6646,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "apollo-reporting-protobuf": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.2.tgz",
-      "integrity": "sha512-WJTJxLM+MRHNUxt1RTl4zD0HrLdH44F2mDzMweBj1yHL0kSt8I1WwoiF/wiGVSpnG48LZrBegCaOJeuVbJTbtw==",
-      "requires": {
-        "@apollo/protobufjs": "^1.0.3"
-      }
-    },
     "apollo-server": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.24.0.tgz",
@@ -6904,34 +6660,10 @@
         "stoppable": "^1.1.0"
       }
     },
-    "apollo-server-caching": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.6.0.tgz",
-      "integrity": "sha512-SfjKaccrhRzUQ8TAke9FrYppp4pZV3Rp8KCs+4Ox3kGtbco68acRPJkiYYtSVc4idR8XNAUOOVfAEZVNHdZQKQ==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
-      }
-    },
     "apollo-server-core": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.24.0.tgz",
       "integrity": "sha512-uW7gykPzhin9fLgSvciN8tX7098mHnUM79W3+fWfK5J415JidIqW9O+JhYmEPo6BCgosu0cKSdYe7NB+FP4lFQ==",
-      "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "^0.5.0",
         "@apollographql/graphql-playground-html": "1.6.27",
@@ -6965,7 +6697,6 @@
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
           "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-          "dev": true,
           "requires": {
             "@protobufjs/aspromise": "^1.1.2",
             "@protobufjs/base64": "^1.1.2",
@@ -6985,14 +6716,12 @@
         "@types/node": {
           "version": "10.17.59",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-          "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg==",
-          "dev": true
+          "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
         },
         "apollo-cache-control": {
           "version": "0.13.0",
           "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.13.0.tgz",
           "integrity": "sha512-ImUXwVc/8K9QA3mQiKbKw8bOS4lMNL4DoP4hldIx+gwna8dgh3gBChgxW5guMOhcvH/55ximS7ZNWUglFmQY4Q==",
-          "dev": true,
           "requires": {
             "apollo-server-env": "^3.1.0",
             "apollo-server-plugin-base": "^0.12.0"
@@ -7002,7 +6731,6 @@
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.9.0.tgz",
           "integrity": "sha512-y8H99NExU1Sk4TvcaUxTdzfq2SZo6uSj5dyh75XSQvbpH6gdAXIW9MaBcvlNC7n0cVPsidHmOcHOWxJ/pTXGjA==",
-          "dev": true,
           "requires": {
             "apollo-server-caching": "^0.7.0",
             "apollo-server-env": "^3.1.0"
@@ -7012,7 +6740,6 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.7.0.tgz",
           "integrity": "sha512-PC+zDqPPJcseemqmvUEqFiDi45pz6UaPWt6czgmrrbcQ+9VWp6IEkm08V5xBKk7V1WGUw19YwiJ7kqXpcgVNyw==",
-          "dev": true,
           "requires": {
             "@apollo/protobufjs": "1.2.2"
           }
@@ -7021,26 +6748,14 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
           "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "apollo-server-env": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
-          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
-          "dev": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "util.promisify": "^1.0.0"
           }
         },
         "apollo-server-plugin-base": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.12.0.tgz",
           "integrity": "sha512-jnNIztYz34ImE7off0t9LwseGCR/J0H1wlbiBGvdXvQY+ZiMfVF2oF8KdSAPxG2vT6scvWP4GFS/FsZcOyP1Xw==",
-          "dev": true,
           "requires": {
             "apollo-server-types": "^0.8.0"
           }
@@ -7049,7 +6764,6 @@
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.8.0.tgz",
           "integrity": "sha512-adHJnHbRV2kWUY0VQY1M2KpSdGfm+4mX4w+2lROPExqOnkyTI7CGfpJCdEwYMKrIn3aH8HIcOH0SnpWRet6TNw==",
-          "dev": true,
           "requires": {
             "apollo-reporting-protobuf": "^0.7.0",
             "apollo-server-caching": "^0.7.0",
@@ -7060,7 +6774,6 @@
           "version": "0.14.0",
           "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.14.0.tgz",
           "integrity": "sha512-KH4mOoicZ2CQkEYVuNP9avJth59LwNqku3fKZ4S0UYE1RfxzIoLLsEyuY8MuJEgNdtKKfkX5G5Kn5Rp4LCJ4RQ==",
-          "dev": true,
           "requires": {
             "apollo-server-env": "^3.1.0",
             "apollo-server-plugin-base": "^0.12.0"
@@ -7070,7 +6783,6 @@
           "version": "0.14.0",
           "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.14.0.tgz",
           "integrity": "sha512-DFtD8G+6rSj/Xhtb0IPh4A/sB/qcSEm9MTS221ESCx+axrsME92wGEsr7ihVjn1/tEEIy+9V5lUQOH/dHkCb0A==",
-          "dev": true,
           "requires": {
             "@apollographql/apollo-tools": "^0.5.0",
             "apollo-server-env": "^3.1.0",
@@ -7081,7 +6793,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -7089,8 +6800,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -7106,8 +6816,7 @@
     "apollo-server-errors": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==",
-      "dev": true
+      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA=="
     },
     "apollo-server-express": {
       "version": "2.24.0",
@@ -7192,16 +6901,6 @@
             "lru-cache": "^6.0.0"
           }
         },
-        "apollo-server-env": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
-          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
-          "dev": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "util.promisify": "^1.0.0"
-          }
-        },
         "apollo-server-types": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.8.0.tgz",
@@ -7228,33 +6927,6 @@
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
-      }
-    },
-    "apollo-server-plugin-base": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.11.0.tgz",
-      "integrity": "sha512-Du68x0XCyQ6EWlgoL9Z+1s8fJfXgY131QbKP7ao617StQPzwB0aGCwxBDfcMt1A75VXf4TkvV1rdUH5YeJFlhQ==",
-      "requires": {
-        "apollo-server-types": "^0.7.0"
-      }
-    },
-    "apollo-server-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.7.0.tgz",
-      "integrity": "sha512-pJ6ri2N4xJ+e2PUUPHeCNpMDzHUagJyn0DDZGQmXDz6aoMlSd4B2KUvK81hHyHkw3wHk9clgcpfM9hKqbfZweA==",
-      "requires": {
-        "apollo-reporting-protobuf": "^0.6.2",
-        "apollo-server-caching": "^0.6.0",
-        "apollo-server-env": "^3.0.0"
-      }
-    },
-    "apollo-tracing": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.13.0.tgz",
-      "integrity": "sha512-28z4T+XfLQ6t696usU0nTFDxVN8BfF3o74d2p/zsT4eu1OuoyoDOEmVJqdInmVRpyTJK0tDEOjkIuDJJHZftog==",
-      "requires": {
-        "apollo-server-env": "^3.0.0",
-        "apollo-server-plugin-base": "^0.11.0"
       }
     },
     "apollo-utilities": {
@@ -11587,37 +11259,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
           "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
-        }
-      }
-    },
-    "graphql-extensions": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.13.0.tgz",
-      "integrity": "sha512-Bb7E97nvfX4gtrIdZ/i5YFlqOd6MGzrw8ED+t4wQVraYje6NQ+8P8MHMOV2WZLfbW8zsNTx8NdnnlbsdH5siag==",
-      "requires": {
-        "@apollographql/apollo-tools": "^0.4.3",
-        "apollo-server-env": "^3.0.0",
-        "apollo-server-types": "^0.7.0"
-      },
-      "dependencies": {
-        "@apollographql/apollo-tools": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.14.tgz",
-          "integrity": "sha512-oTTq9G3rC47H/xd6MEtLgpbXNUbsu0WpclJ5RjSARJvUd7jKwmwUABr9g1EG68tK7pCdCRU93QL3WQT0XWhDcw==",
-          "requires": {
-            "apollo-env": "^0.9.2"
-          }
-        },
-        "apollo-env": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.9.2.tgz",
-          "integrity": "sha512-YUai2qCVenzOr3v1K1Ad/cUqLqvIQxIWjjAWDU0Q00VjegHxjIOyamdpcYkACCIkrb0Kthj4Slql4+d5ZXyeXQ==",
-          "requires": {
-            "@types/node-fetch": "2.5.10",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "npm run compile && tsc --build tsconfig.json --watch",
     "release:version-bump": "lerna version",
     "release:start-ci-publish": "node -p '`Publish (dist-tag:${process.env.APOLLO_DIST_TAG || \"latest\"})`' | git tag -F - \"publish/$(date -u '+%Y%m%d%H%M%S')\" && git push origin \"$(git describe --match='publish/*' --tags --exact-match HEAD)\"",
-    "pretest": "npm run compile",
+    "pretest": "npm run compile && tsc --build tsconfig.test.json",
     "postinstall": "lerna run monorepo-prepare --stream && npm run compile",
     "test": "jest --verbose",
     "test:clean": "jest --clearCache",


### PR DESCRIPTION
Something like this was intended to be part of #453. Because we have
`diagnostics: false` in jest.config.base.js, typechecking failures in
ts-jest don't actually stop the tests from running successfully; this
change makes us typecheck the tests before we run them. (If you really
want to run tests that don't typecheck you can run `npx jest` directly.)

As part of this, fix a typechecking failure caused by the upgrade in
PR #716 and run `npm dedup` to fix another typechecking failure. The `npm dedup`
itself causes a snapshot to need to be updated (as the snapshot was created by
some code that was still running a nested apollo-server 2.23).

We may want to consider finding a way to be comfortable removing
`diagnostics: false` instead as in #661, but we'll need to fix #662 before
we can do that.
