### PR TITLE
Configure VS Code to use the local TypeScript version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "editor.wordWrapColumn": 80,
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
-    "typescript.tsdk": "./node_modules/typescript/lib"
-  }
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
 }


### PR DESCRIPTION
The `typescript.tsdk` setting had inadvertently been moved inside the `[typescript]` block, which is not supported and thus meant it was ignored.

This also enables the new `typescript.enablePromptUseWorkspaceTsdk` setting to prompt switching to the local TypeScript version (see https://code.visualstudio.com/updates/v1_45#_prompt-users-to-switch-to-the-workspace-version-of-typescript).