### PR TITLE
infra(ci): Adjust Windows CI job parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ executors:
   rust_windows: &rust_windows_executor
     machine:
       image: 'windows-server-2019-vs2019:stable'
-    resource_class: windows.medium
+    resource_class: windows.xlarge
     shell: powershell.exe -ExecutionPolicy Bypass
 
 # Important! When adding a new job to `jobs`, make sure to define when it
@@ -172,13 +172,17 @@ jobs:
           steps:
             - run:
                 name: Install rustup
+                environment:
+                  # Override auto-detection of RAM for Rustc install.
+                  # https://github.com/rust-lang/rustup/issues/2229#issuecomment-585855925
+                  RUSTUP_UNPACK_RAM: "21474836480"
                 command: |
                   $installer_dir = "$Env:TEMP"
                   echo "Downloading rustup"
-                  (New-Object System.Net.WebClient).DownloadFile("https://win.rustup.rs", "$installer_dir\rustup-init.exe")
+                  (New-Object System.Net.WebClient).DownloadFile("https://win.rustup.rs/x86_64", "$installer_dir\rustup-init.exe")
                   echo "Installing rustup"
                   & $installer_dir\rustup-init.exe --profile minimal --component rustfmt,clippy -y
-                  echo "Done"
+                  exit $LASTEXITCODE
             - run:
                 name: Special case for Windows because of ssh-agent
                 command: |


### PR DESCRIPTION
To overcome an error which was occurring during the "Rustup install" step
that was producing a "memory allocation of 16777216 bytes failed" error that
was ALSO NOT causing the _setup_ step to fail, this commit:

- Use the 64-bit installer rather than the 32-bit!  I would have thought
  that this on its own could have been the major root of the problem, but it
  seems like it's also paired best with the next bullet.

- Limits the amount of RAM for the _installation of Rust_ (and nothing else),
  overriding the auto-detection which seems un-reliable in this virtual env.
  https://github.com/rust-lang/rustup/issues/2229#issuecomment-585855925

- Uses a larger resource size, which actually makes the tests run faster
  anyhow.  This will use more credits but use less minutes.  I'll look at
  the numbers in a month to see what I think, but I'm not worried right now.
  (note to self: 76203c/1900m, right now, jesse)

- Prevent missed failure catch in installation via .exe file, instead opting
  for using LASTEXITCODE which seems to be a recommended way to do this when
  using EXE files.  Having the "echo" there certainly seems like it could
  have been hurting things too (since echo returns 0, but that didn't seem to
  fix it on its own).