### PR TITLE
gateway-js: Add onSchemaLoadOrUpdate() method to register listeners for schema loads/updates and give them the core supergraph SDL

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -5,7 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Fixes bug where one `onSchemaChange` listener throwing would prevent other `onSchemaChange` listeners from being notified. [PR #738](https://github.com/apollographql/federation/pull/738)
-- Adds `onSchemaLoadOrUpdate` method to register listeners for schema load and updates, and to receive both the API schema and the core supergraph SDL. `onSchemaChange` has been deprecated in favor of this method. [PR #738](https://github.com/apollographql/federation/pull/738)
+- Adds `onSchemaLoadOrUpdate` method to register listeners for schema load and updates, and to receive both the API schema and the core supergraph SDL. `onSchemaChange` has been deprecated in favor of this method. Note that `onSchemaChange` listeners are not notified when loading schemas from static gateway configurations, while `onSchemaLoadOrUpdate` listeners are notified. [PR #738](https://github.com/apollographql/federation/pull/738)
 
 ## v0.34.0
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- Fixes bug where one `onSchemaChange` listener throwing would prevent other `onSchemaChange` listeners from being notified. [PR #738](https://github.com/apollographql/federation/pull/738)
+- Adds `onSchemaLoadOrUpdate` method to register listeners for schema load and updates, and to receive both the API schema and the core supergraph SDL. `onSchemaChange` has been deprecated in favor of this method. [PR #738](https://github.com/apollographql/federation/pull/738)
 
 ## v0.34.0
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -174,8 +174,12 @@ export class ApolloGateway implements GraphQLService {
   private logger: Logger;
   private queryPlanStore: InMemoryLRUCache<QueryPlan>;
   private apolloConfig?: ApolloConfigFromAS3;
-  private onSchemaChangeListeners = new Set<
-    (schema: GraphQLSchema, supergraphSdl: string) => void
+  private onSchemaChangeListeners = new Set<(schema: GraphQLSchema) => void>();
+  private onSchemaLoadOrUpdateListeners = new Set<
+    (schemaContext: {
+      apiSchema: GraphQLSchema;
+      coreSupergraphSdl: string;
+    }) => void
   >();
   private serviceDefinitions: ServiceDefinition[] = [];
   private compositionMetadata?: CompositionMetadata;
@@ -436,7 +440,7 @@ export class ApolloGateway implements GraphQLService {
         : this.createSchemaFromSupergraphSdl(config.supergraphSdl));
       // TODO(trevor): #580 redundant parse
       this.parsedSupergraphSdl = parse(supergraphSdl);
-      this.updateWithSchemaAndNotify(schema, supergraphSdl);
+      this.updateWithSchemaAndNotify(schema, supergraphSdl, true);
     } catch (e) {
       this.state = { phase: 'failed to load' };
       throw e;
@@ -603,23 +607,43 @@ export class ApolloGateway implements GraphQLService {
 
   private updateWithSchemaAndNotify(
     coreSchema: GraphQLSchema,
-    supergraphSdl: string,
+    coreSupergraphSdl: string,
+    // Once we remove the deprecated onSchemaChange() method, we can remove this.
+    legacyDontNotifyOnSchemaChangeListeners: boolean = false,
   ): void {
     this.schema = toAPISchema(coreSchema);
     this.queryPlanner = new QueryPlanner(coreSchema);
 
-    // Notify the schema listeners of the updated schema
-    try {
-      this.onSchemaChangeListeners.forEach((listener) =>
-        listener(this.schema!, supergraphSdl),
-      );
-    } catch (e) {
-      this.logger.error(
-        "An error was thrown from an 'onSchemaChange' listener. " +
-          'The schema will still update: ' +
-          ((e && e.message) || e),
-      );
+    // Notify onSchemaChange listeners of the updated schema
+    if (!legacyDontNotifyOnSchemaChangeListeners) {
+      this.onSchemaChangeListeners.forEach((listener) => {
+        try {
+          listener(this.schema!);
+        } catch (e) {
+          this.logger.error(
+            "An error was thrown from an 'onSchemaChange' listener. " +
+              'The schema will still update: ' +
+              ((e && e.message) || e),
+          );
+        }
+      });
     }
+
+    // Notify onSchemaLoadOrUpdate listeners of the updated schema
+    this.onSchemaLoadOrUpdateListeners.forEach((listener) => {
+      try {
+        listener({
+          apiSchema: this.schema!,
+          coreSupergraphSdl,
+        });
+      } catch (e) {
+        this.logger.error(
+          "An error was thrown from an 'onSchemaLoadOrUpdate' listener. " +
+            'The schema will still update: ' +
+            ((e && e.message) || e),
+        );
+      }
+    });
   }
 
   private async maybePerformServiceHealthCheck(update: CompositionUpdate) {
@@ -761,13 +785,29 @@ export class ApolloGateway implements GraphQLService {
     };
   }
 
+  /**
+   * @deprecated Please use `onSchemaLoadOrUpdate` instead.
+   */
   public onSchemaChange(
-    callback: (schema: GraphQLSchema, supergraphSdl: string) => void,
+    callback: (schema: GraphQLSchema) => void,
   ): Unsubscriber {
     this.onSchemaChangeListeners.add(callback);
 
     return () => {
       this.onSchemaChangeListeners.delete(callback);
+    };
+  }
+
+  public onSchemaLoadOrUpdate(
+    callback: (schemaContext: {
+      apiSchema: GraphQLSchema;
+      coreSupergraphSdl: string;
+    }) => void,
+  ): Unsubscriber {
+    this.onSchemaLoadOrUpdateListeners.add(callback);
+
+    return () => {
+      this.onSchemaLoadOrUpdateListeners.delete(callback);
     };
   }
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -1,7 +1,4 @@
-import {
-  GraphQLService,
-  Unsubscriber,
-} from 'apollo-server-core';
+import { GraphQLService, Unsubscriber } from 'apollo-server-core';
 import {
   GraphQLExecutionResult,
   Logger,
@@ -38,7 +35,12 @@ import { getVariableValues } from 'graphql/execution/values';
 import fetcher from 'make-fetch-happen';
 import { HttpRequestCache } from './cache';
 import { fetch } from 'apollo-server-env';
-import { QueryPlanner, QueryPlan, prettyFormatQueryPlan, toAPISchema } from '@apollo/query-planner';
+import {
+  QueryPlanner,
+  QueryPlan,
+  prettyFormatQueryPlan,
+  toAPISchema,
+} from '@apollo/query-planner';
 import {
   ServiceEndpointDefinition,
   Experimental_DidFailCompositionCallback,
@@ -68,8 +70,8 @@ import {
 import { loadSupergraphSdlFromStorage } from './loadSupergraphSdlFromStorage';
 import { getServiceDefinitionsFromStorage } from './legacyLoadServicesFromStorage';
 import { buildComposedSchema } from '@apollo/query-planner';
-import { SpanStatusCode } from "@opentelemetry/api";
-import { OpenTelemetrySpanNames, tracer } from "./utilities/opentelemetry";
+import { SpanStatusCode } from '@opentelemetry/api';
+import { OpenTelemetrySpanNames, tracer } from './utilities/opentelemetry';
 
 type DataSourceMap = {
   [serviceName: string]: { url?: string; dataSource: GraphQLDataSource };
@@ -111,12 +113,12 @@ export function getDefaultFetcher() {
 /**
  * TODO(trevor:cloudconfig): Stop exporting this
  * @deprecated This will be removed in a future version of @apollo/gateway
-*/
+ */
 export const getDefaultGcsFetcher = getDefaultFetcher;
 /**
  * TODO(trevor:cloudconfig): Stop exporting this
  * @deprecated This will be removed in a future version of @apollo/gateway
-*/
+ */
 export const GCS_RETRY_COUNT = 5;
 
 export const HEALTH_CHECK_QUERY =
@@ -163,8 +165,7 @@ interface GraphQLServiceEngineConfig {
   apiKeyHash: string;
   graphId: string;
   graphVariant?: string;
-};
-
+}
 
 export class ApolloGateway implements GraphQLService {
   public schema?: GraphQLSchema;
@@ -173,7 +174,9 @@ export class ApolloGateway implements GraphQLService {
   private logger: Logger;
   private queryPlanStore: InMemoryLRUCache<QueryPlan>;
   private apolloConfig?: ApolloConfigFromAS3;
-  private onSchemaChangeListeners = new Set<(schema: GraphQLSchema, supergraphSdl: string) => void>();
+  private onSchemaChangeListeners = new Set<
+    (schema: GraphQLSchema, supergraphSdl: string) => void
+  >();
   private serviceDefinitions: ServiceDefinition[] = [];
   private compositionMetadata?: CompositionMetadata;
   private serviceSdlCache = new Map<string, string>();
@@ -251,9 +254,11 @@ export class ApolloGateway implements GraphQLService {
     if (isManuallyManagedConfig(this.config)) {
       // Use the provided updater function if provided by the user, else default
       if ('experimental_updateSupergraphSdl' in this.config) {
-        this.updateServiceDefinitions = this.config.experimental_updateSupergraphSdl;
+        this.updateServiceDefinitions =
+          this.config.experimental_updateSupergraphSdl;
       } else if ('experimental_updateServiceDefinitions' in this.config) {
-        this.updateServiceDefinitions = this.config.experimental_updateServiceDefinitions;
+        this.updateServiceDefinitions =
+          this.config.experimental_updateServiceDefinitions;
       } else {
         throw Error(
           'Programming error: unexpected manual configuration provided',
@@ -536,7 +541,9 @@ export class ApolloGateway implements GraphQLService {
     }
   }
 
-  private async updateWithSupergraphSdl(result: SupergraphSdlUpdate): Promise<void> {
+  private async updateWithSupergraphSdl(
+    result: SupergraphSdlUpdate,
+  ): Promise<void> {
     if (result.id === this.compositionId) {
       this.logger.debug('No change in composition since last check.');
       return;
@@ -564,7 +571,9 @@ export class ApolloGateway implements GraphQLService {
 
     if (this.queryPlanStore) this.queryPlanStore.flush();
 
-    const { schema, supergraphSdl } = this.createSchemaFromSupergraphSdl(result.supergraphSdl);
+    const { schema, supergraphSdl } = this.createSchemaFromSupergraphSdl(
+      result.supergraphSdl,
+    );
 
     if (!supergraphSdl) {
       this.logger.error(
@@ -592,18 +601,21 @@ export class ApolloGateway implements GraphQLService {
     }
   }
 
-  private updateWithSchemaAndNotify(coreSchema: GraphQLSchema, supergraphSdl: string): void {
+  private updateWithSchemaAndNotify(
+    coreSchema: GraphQLSchema,
+    supergraphSdl: string,
+  ): void {
     this.schema = toAPISchema(coreSchema);
     this.queryPlanner = new QueryPlanner(coreSchema);
 
     // Notify the schema listeners of the updated schema
     try {
       this.onSchemaChangeListeners.forEach((listener) =>
-          listener(this.schema!, supergraphSdl),
+        listener(this.schema!, supergraphSdl),
       );
     } catch (e) {
       this.logger.error(
-          "An error was thrown from an 'onSchemaChange' listener. " +
+        "An error was thrown from an 'onSchemaChange' listener. " +
           'The schema will still update: ' +
           ((e && e.message) || e),
       );
@@ -717,7 +729,9 @@ export class ApolloGateway implements GraphQLService {
     }
   }
 
-  private serviceListFromSupergraphSdl(supergraphSdl: DocumentNode): Omit<ServiceDefinition, 'typeDefs'>[] {
+  private serviceListFromSupergraphSdl(
+    supergraphSdl: DocumentNode,
+  ): Omit<ServiceDefinition, 'typeDefs'>[] {
     const schema = buildComposedSchema(supergraphSdl);
     return this.serviceListFromComposedSchema(schema);
   }
@@ -747,7 +761,9 @@ export class ApolloGateway implements GraphQLService {
     };
   }
 
-  public onSchemaChange(callback: (schema: GraphQLSchema, supergraphSdl: string) => void): Unsubscriber {
+  public onSchemaChange(
+    callback: (schema: GraphQLSchema, supergraphSdl: string) => void,
+  ): Unsubscriber {
     this.onSchemaChangeListeners.add(callback);
 
     return () => {
@@ -958,184 +974,182 @@ export class ApolloGateway implements GraphQLService {
   public executor = async <TContext>(
     requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
   ): Promise<GraphQLExecutionResult> => {
-    return tracer.startActiveSpan(OpenTelemetrySpanNames.REQUEST, async span => {
-      try {
-        const {request, document, queryHash} = requestContext;
-        const queryPlanStoreKey = queryHash + (request.operationName || '');
-        const operationContext = buildOperationContext({
-          schema: this.schema!,
-          operationDocument: document,
-          operationName: request.operationName,
-        });
-
-
-        // No need to build a query plan if we know the request is invalid beforehand
-        // In the future, this should be controlled by the requestPipeline
-        const validationErrors = this.validateIncomingRequest(
-            requestContext,
-            operationContext,
-        );
-
-        if (validationErrors.length > 0) {
-          span.setStatus({ code:SpanStatusCode.ERROR });
-          return {errors: validationErrors};
-        }
-
-        let queryPlan: QueryPlan | undefined;
-        if (this.queryPlanStore) {
-          queryPlan = await this.queryPlanStore.get(queryPlanStoreKey);
-        }
-
-        if (!queryPlan) {
-          queryPlan = tracer.startActiveSpan(OpenTelemetrySpanNames.PLAN, span => {
-            try {
-              // TODO(#631): Can we be sure the query planner has been initialized here?
-              return this.queryPlanner!.buildQueryPlan(operationContext, {
-                autoFragmentization: Boolean(
-                    this.config.experimental_autoFragmentization,
-                ),
-              });
-            }
-            catch (err) {
-              span.setStatus({ code:SpanStatusCode.ERROR });
-              throw err;
-            }
-            finally {
-              span.end();
-            }
+    return tracer.startActiveSpan(
+      OpenTelemetrySpanNames.REQUEST,
+      async (span) => {
+        try {
+          const { request, document, queryHash } = requestContext;
+          const queryPlanStoreKey = queryHash + (request.operationName || '');
+          const operationContext = buildOperationContext({
+            schema: this.schema!,
+            operationDocument: document,
+            operationName: request.operationName,
           });
 
-          if (this.queryPlanStore) {
-            // The underlying cache store behind the `documentStore` returns a
-            // `Promise` which is resolved (or rejected), eventually, based on the
-            // success or failure (respectively) of the cache save attempt.  While
-            // it's certainly possible to `await` this `Promise`, we don't care about
-            // whether or not it's successful at this point.  We'll instead proceed
-            // to serve the rest of the request and just hope that this works out.
-            // If it doesn't work, the next request will have another opportunity to
-            // try again.  Errors will surface as warnings, as appropriate.
-            //
-            // While it shouldn't normally be necessary to wrap this `Promise` in a
-            // `Promise.resolve` invocation, it seems that the underlying cache store
-            // is returning a non-native `Promise` (e.g. Bluebird, etc.).
-            Promise.resolve(
-                this.queryPlanStore.set(queryPlanStoreKey, queryPlan),
-            ).catch((err) =>
-                this.logger.warn(
-                    'Could not store queryPlan' + ((err && err.message) || err),
-                ),
-            );
-          }
-        }
+          // No need to build a query plan if we know the request is invalid beforehand
+          // In the future, this should be controlled by the requestPipeline
+          const validationErrors = this.validateIncomingRequest(
+            requestContext,
+            operationContext,
+          );
 
-        const serviceMap: ServiceMap = Object.entries(this.serviceMap).reduce(
-            (serviceDataSources, [serviceName, {dataSource}]) => {
+          if (validationErrors.length > 0) {
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            return { errors: validationErrors };
+          }
+
+          let queryPlan: QueryPlan | undefined;
+          if (this.queryPlanStore) {
+            queryPlan = await this.queryPlanStore.get(queryPlanStoreKey);
+          }
+
+          if (!queryPlan) {
+            queryPlan = tracer.startActiveSpan(
+              OpenTelemetrySpanNames.PLAN,
+              (span) => {
+                try {
+                  // TODO(#631): Can we be sure the query planner has been initialized here?
+                  return this.queryPlanner!.buildQueryPlan(operationContext, {
+                    autoFragmentization: Boolean(
+                      this.config.experimental_autoFragmentization,
+                    ),
+                  });
+                } catch (err) {
+                  span.setStatus({ code: SpanStatusCode.ERROR });
+                  throw err;
+                } finally {
+                  span.end();
+                }
+              },
+            );
+
+            if (this.queryPlanStore) {
+              // The underlying cache store behind the `documentStore` returns a
+              // `Promise` which is resolved (or rejected), eventually, based on the
+              // success or failure (respectively) of the cache save attempt.  While
+              // it's certainly possible to `await` this `Promise`, we don't care about
+              // whether or not it's successful at this point.  We'll instead proceed
+              // to serve the rest of the request and just hope that this works out.
+              // If it doesn't work, the next request will have another opportunity to
+              // try again.  Errors will surface as warnings, as appropriate.
+              //
+              // While it shouldn't normally be necessary to wrap this `Promise` in a
+              // `Promise.resolve` invocation, it seems that the underlying cache store
+              // is returning a non-native `Promise` (e.g. Bluebird, etc.).
+              Promise.resolve(
+                this.queryPlanStore.set(queryPlanStoreKey, queryPlan),
+              ).catch((err) =>
+                this.logger.warn(
+                  'Could not store queryPlan' + ((err && err.message) || err),
+                ),
+              );
+            }
+          }
+
+          const serviceMap: ServiceMap = Object.entries(this.serviceMap).reduce(
+            (serviceDataSources, [serviceName, { dataSource }]) => {
               serviceDataSources[serviceName] = dataSource;
               return serviceDataSources;
             },
             Object.create(null) as ServiceMap,
-        );
+          );
 
-        if (this.experimental_didResolveQueryPlan) {
-          this.experimental_didResolveQueryPlan({
+          if (this.experimental_didResolveQueryPlan) {
+            this.experimental_didResolveQueryPlan({
+              queryPlan,
+              serviceMap,
+              requestContext,
+              operationContext,
+            });
+          }
+
+          const response = await executeQueryPlan<TContext>(
             queryPlan,
             serviceMap,
             requestContext,
             operationContext,
-          });
-        }
+          );
 
-        const response = await executeQueryPlan<TContext>(
-            queryPlan,
-            serviceMap,
-            requestContext,
-            operationContext,
-        );
-
-        const shouldShowQueryPlan =
+          const shouldShowQueryPlan =
             this.config.__exposeQueryPlanExperimental &&
             request.http &&
             request.http.headers &&
             request.http.headers.get('Apollo-Query-Plan-Experimental');
 
-        // We only want to serialize the query plan if we're going to use it, which is
-        // in two cases:
-        // 1) non-empty query plan and config.debug === true
-        // 2) non-empty query plan and shouldShowQueryPlan === true
-        const serializedQueryPlan =
+          // We only want to serialize the query plan if we're going to use it, which is
+          // in two cases:
+          // 1) non-empty query plan and config.debug === true
+          // 2) non-empty query plan and shouldShowQueryPlan === true
+          const serializedQueryPlan =
             queryPlan.node && (this.config.debug || shouldShowQueryPlan)
-                ? // FIXME: I disabled printing the query plan because this lead to a
-                  // circular dependency between the `@apollo/gateway` and
-                  // `apollo-federation-integration-testsuite` packages.
-                  // We should either solve that or switch Playground to
-                  // the JSON serialization format.
+              ? // FIXME: I disabled printing the query plan because this lead to a
+                // circular dependency between the `@apollo/gateway` and
+                // `apollo-federation-integration-testsuite` packages.
+                // We should either solve that or switch Playground to
+                // the JSON serialization format.
                 prettyFormatQueryPlan(queryPlan)
-                : null;
+              : null;
 
-        if (this.config.debug && serializedQueryPlan) {
-          this.logger.debug(serializedQueryPlan);
-        }
+          if (this.config.debug && serializedQueryPlan) {
+            this.logger.debug(serializedQueryPlan);
+          }
 
-        if (shouldShowQueryPlan) {
-          // TODO: expose the query plan in a more flexible JSON format in the future
-          // and rename this to `queryPlan`. Playground should cutover to use the new
-          // option once we've built a way to print that representation.
+          if (shouldShowQueryPlan) {
+            // TODO: expose the query plan in a more flexible JSON format in the future
+            // and rename this to `queryPlan`. Playground should cutover to use the new
+            // option once we've built a way to print that representation.
 
-          // In the case that `serializedQueryPlan` is null (on introspection), we
-          // still want to respond to Playground with something truthy since it depends
-          // on this to decide that query plans are supported by this gateway.
-          response.extensions = {
-            __queryPlanExperimental: serializedQueryPlan || true,
-          };
+            // In the case that `serializedQueryPlan` is null (on introspection), we
+            // still want to respond to Playground with something truthy since it depends
+            // on this to decide that query plans are supported by this gateway.
+            response.extensions = {
+              __queryPlanExperimental: serializedQueryPlan || true,
+            };
+          }
+          if (response.errors) {
+            span.setStatus({ code: SpanStatusCode.ERROR });
+          }
+          return response;
+        } catch (err) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+          throw err;
+        } finally {
+          span.end();
         }
-        if(response.errors) {
-          span.setStatus({ code:SpanStatusCode.ERROR });
-        }
-        return response;
-      }
-      catch (err) {
-        span.setStatus({ code:SpanStatusCode.ERROR });
-        throw err;
-      }
-      finally {
-        span.end();
-      }
-    });
+      },
+    );
   };
 
   private validateIncomingRequest<TContext>(
     requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
     operationContext: OperationContext,
   ) {
-    return tracer.startActiveSpan(OpenTelemetrySpanNames.VALIDATE, span => {
+    return tracer.startActiveSpan(OpenTelemetrySpanNames.VALIDATE, (span) => {
       try {
         // casting out of `readonly`
         const variableDefinitions = operationContext.operation
-            .variableDefinitions as VariableDefinitionNode[] | undefined;
+          .variableDefinitions as VariableDefinitionNode[] | undefined;
 
         if (!variableDefinitions) return [];
 
-        const {errors} = getVariableValues(
-            operationContext.schema,
-            variableDefinitions,
-            requestContext.request.variables || {},
+        const { errors } = getVariableValues(
+          operationContext.schema,
+          variableDefinitions,
+          requestContext.request.variables || {},
         );
 
-        if(errors) {
-          span.setStatus({ code:SpanStatusCode.ERROR });
+        if (errors) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
         }
         return errors || [];
-      }
-      catch (err) {
-        span.setStatus({ code:SpanStatusCode.ERROR });
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR });
         throw err;
-      }
-      finally {
+      } finally {
         span.end();
       }
     });
   }
-
 
   // Stops all processes involved with the gateway (for now, just background
   // schema polling). Can be called multiple times safely. Once it (async)

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -510,8 +510,6 @@ export class ApolloGateway implements GraphQLService {
     this.compositionMetadata = result.compositionMetadata;
     this.serviceDefinitions = result.serviceDefinitions;
 
-    if (this.queryPlanStore) this.queryPlanStore.flush();
-
     const { schema, supergraphSdl } = this.createSchemaFromServiceList(
       result.serviceDefinitions,
     );
@@ -573,8 +571,6 @@ export class ApolloGateway implements GraphQLService {
     this.compositionId = result.id;
     this.parsedSupergraphSdl = parsedSupergraphSdl;
 
-    if (this.queryPlanStore) this.queryPlanStore.flush();
-
     const { schema, supergraphSdl } = this.createSchemaFromSupergraphSdl(
       result.supergraphSdl,
     );
@@ -611,6 +607,7 @@ export class ApolloGateway implements GraphQLService {
     // Once we remove the deprecated onSchemaChange() method, we can remove this.
     legacyDontNotifyOnSchemaChangeListeners: boolean = false,
   ): void {
+    if (this.queryPlanStore) this.queryPlanStore.flush();
     this.schema = toAPISchema(coreSchema);
     this.queryPlanner = new QueryPlanner(coreSchema);
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -601,6 +601,9 @@ export class ApolloGateway implements GraphQLService {
     }
   }
 
+  // TODO: We should consolidate "schema derived data" state as we've done in Apollo Server to
+  //       ensure we do not forget to update some of that state, and to avoid scenarios where
+  //       concurrently executing code sees partially-updated state.
   private updateWithSchemaAndNotify(
     coreSchema: GraphQLSchema,
     coreSupergraphSdl: string,


### PR DESCRIPTION
For gateway schema reporting, we would like to know the (core) supergraph SDL when the schema is loaded or updates. To that end, this PR:
- Adds a new public method `onSchemaLoadOrUpdate()` that registers listeners for schema loads/updates.
  - Unlike `onSchemaChange()`, this method ensures listeners are called during initial schema load.
    - Specifically, `onSchemaChange()` would not notify listeners when the schema is loaded via `loadStatic()`, but `onSchemaLoadOrUpdate()` does notify.
  - Unlike `onSchemaChange()`, this method provides listeners with both the API schema and the core supergraph SDL.
  - Unlike `onSchemaChange()`, this method provides listeners data via properties on a single argument object instead of multiple arguments.
- Deprecates `onSchemaChange()` in favor of `onSchemaLoadOrUpdate()`.
- Factors out some common logic into `updateWithSchemaAndNotify()`.
- Changes the notification process to notify all listeners even when one throws (previously, any listener throwing would prevent other listeners from being notified).
- Runs prettier on `gateway-js/src/index.ts`.
- Updates the `gateway-js/CHANGELOG.md`.