### PR TITLE
Fix link to graph refs in quickstart

### DIFF
--- a/docs/source/quickstart-pt-2.mdx
+++ b/docs/source/quickstart-pt-2.mdx
@@ -86,7 +86,7 @@ rover subgraph publish <GRAPH_NAME> \
   --name products
 ```
 
-> Technically, you don't provide the graph's _name_, but rather its **graph ref**. [Learn more.](https://www.apollographql.com/docs/rover/essentials/#graph-refs)
+> Technically, you don't provide the graph's _name_, but rather its **graph ref**. [Learn more.](https://www.apollographql.com/docs/rover/conventions/#graph-refs)
 
 If the command is successful, you'll see output like the following:
 


### PR DESCRIPTION
In `docs/source/quickstart-pt-2.mdx`, I think the link to `graph-refs` is outdated in the following section:

`> Technically, you don't provide the graph's _name_, but rather its **graph ref**. [Learn more.](https://www.apollographql.com/docs/rover/essentials/#graph-refs)`

I think the link is now https://www.apollographql.com/docs/rover/conventions/#graph-refs 

Closes https://github.com/apollographql/federation/issues/694