### PR TITLE
Update ASTNodeWithDirectives to include more nodes with directives

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
--  _Nothing yet! Stay tuned!_
+-  `ASTNodeWithDirectives` now includes all AST nodes with the `directives` field on it. 
 
 ## v0.25.0
 

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
--  `ASTNodeWithDirectives` now includes all AST nodes with the `directives` field on it. 
+-  `ASTNodeWithDirectives` now includes all AST nodes with the `directives` field on it. [PR #755](https://github.com/apollographql/federation/pull/755)
 
 ## v0.25.0
 

--- a/federation-js/src/composition/utils.ts
+++ b/federation-js/src/composition/utils.ts
@@ -31,10 +31,6 @@ import {
   OperationTypeNode,
   isDirective,
   isNamedType,
-  EnumValueDefinitionNode,
-  SchemaDefinitionNode,
-  ExecutableDefinitionNode,
-  TypeSystemExtensionNode,
   stripIgnoredCharacters,
 } from 'graphql';
 import {
@@ -46,7 +42,7 @@ import {
   FederationField,
   ServiceDefinition,
 } from './types';
-import federationDirectives from '../directives';
+import federationDirectives, { ASTNodeWithDirectives } from '../directives';
 import { assert, isNotNullOrUndefined } from '../utilities';
 
 export function isStringValueNode(node: any): node is StringValueNode {
@@ -70,14 +66,7 @@ export function mapFieldNamesToServiceName<Node extends { name: NameNode }>(
 
 export function findDirectivesOnNode(
   node: Maybe<
-    | FieldDefinitionNode
-    | InputValueDefinitionNode
-    | EnumValueDefinitionNode
-    | SchemaDefinitionNode
-    | ExecutableDefinitionNode
-    | SelectionNode
-    | TypeDefinitionNode
-    | TypeSystemExtensionNode
+    ASTNodeWithDirectives
   >,
   directiveName: string,
 ) {
@@ -108,14 +97,7 @@ export function printFieldSet(selections: readonly SelectionNode[]): string {
  */
 export function findSelectionSetOnNode(
   node: Maybe<
-    | FieldDefinitionNode
-    | InputValueDefinitionNode
-    | EnumValueDefinitionNode
-    | SchemaDefinitionNode
-    | ExecutableDefinitionNode
-    | SelectionNode
-    | TypeDefinitionNode
-    | TypeSystemExtensionNode
+    ASTNodeWithDirectives
   >,
   directiveName: string,
   printedSelectionSet: string,

--- a/federation-js/src/directives.ts
+++ b/federation-js/src/directives.ts
@@ -7,18 +7,13 @@ import {
   isInputObjectType,
   GraphQLInputObjectType,
   DirectiveNode,
-  ScalarTypeDefinitionNode,
-  ObjectTypeDefinitionNode,
-  InterfaceTypeDefinitionNode,
-  UnionTypeDefinitionNode,
-  EnumTypeDefinitionNode,
-  ScalarTypeExtensionNode,
-  ObjectTypeExtensionNode,
-  InterfaceTypeExtensionNode,
-  UnionTypeExtensionNode,
-  EnumTypeExtensionNode,
   GraphQLField,
   FieldDefinitionNode,
+  InputValueDefinitionNode,
+  SchemaDefinitionNode,
+  TypeSystemExtensionNode,
+  TypeDefinitionNode,
+  ExecutableDefinitionNode,
 } from 'graphql';
 
 export const KeyDirective = new GraphQLDirective({
@@ -72,17 +67,12 @@ export const federationDirectives = [
 export default federationDirectives;
 
 export type ASTNodeWithDirectives =
-  | ScalarTypeDefinitionNode
-  | ObjectTypeDefinitionNode
-  | InterfaceTypeDefinitionNode
-  | UnionTypeDefinitionNode
-  | EnumTypeDefinitionNode
-  | ScalarTypeExtensionNode
-  | ObjectTypeExtensionNode
-  | InterfaceTypeExtensionNode
-  | UnionTypeExtensionNode
-  | EnumTypeExtensionNode
-  | FieldDefinitionNode;
+  | FieldDefinitionNode
+  | InputValueDefinitionNode
+  | ExecutableDefinitionNode
+  | SchemaDefinitionNode
+  | TypeDefinitionNode
+  | TypeSystemExtensionNode;
 
 // | GraphQLField<any, any>
 export type GraphQLNamedTypeWithDirectives = Exclude<


### PR DESCRIPTION
This PR
- updated ASTNodeWithDirectives to include all nodes with directives ([TypeDefinitionNode](https://github.com/graphql/graphql-js/blob/main/src/language/ast.d.ts#L473) is a union of all types with `directives`, [TypeSystemExtensionNode](https://github.com/graphql/graphql-js/blob/main/src/language/ast.d.ts#L578) is a union of [all](https://github.com/graphql/graphql-js/blob/main/src/language/ast.d.ts#L589) [nodes](https://github.com/graphql/graphql-js/blob/main/src/language/ast.d.ts#L580) with directives, [InputValueDefinitionNode](https://github.com/graphql/graphql-js/blob/main/src/language/ast.d.ts#L509) has directives, [ExecutableDefinitionNode](https://github.com/graphql/graphql-js/blob/main/src/language/ast.d.ts#L223) is a union of nodes with directives.
