### PR TITLE
doc: Update community links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Excited about Apollo and want to make it better? We’re excited too!
 
 Apollo is a community of developers just like you, striving to create the best tools and libraries around GraphQL. We welcome anyone who wants to contribute or provide constructive feedback, no matter the age or level of experience. If you want to help but don't know where to start, let us know, and we'll find something for you.
 
-Oh, and if you haven't already, join the [Apollo Spectrum community](https://spectrum.chat/apollo).
+Oh, and if you haven't already, join the [Apollo community](https://community.apollographql.com/).
 
 Here are some ways to contribute to the project, from easiest to most difficult:
 
@@ -39,7 +39,7 @@ Improving the documentation, examples, and other open source content can be the 
 
 ### Responding to issues
 
-In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" in the [Apollo Spectrum community](https://spectrum.chat/apollo)!
+In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" in the [Apollo community](https://community.apollographql.com/)!
 
 ### Small bug fixes
 


### PR DESCRIPTION
Just clicked on one of the links to the community forum and noticed it's
hosted in another place now.

Actually, this is the message I saw there:

```
We ran into trouble loading this page  😣

You may be trying to view something that is deleted, or Spectrum is
just having a hiccup. If you think something has gone wrong, please
contact us.
```

This is just for updating the links to the community at federation repo, but, will submit an Issue to follow up on the update for the links in the documentation, which seems to be managed from /gatsby-theme-apollo