### PR TITLE
docs fix - federation quickstart out of preview

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Federation quickstart (preview)"
+title: "Federation quickstart"
 sidebar_title: "Part 1 - Local schema composition"
 description: "Part 1 - Local schema composition"
 ---


### PR DESCRIPTION
Federation quickstart is out of preview.

Signed-off-by: Phil Prasek <prasek@gmail.com>