### PR TITLE
Take subtypes into account when matching type conditions to extract representations

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
--  _Nothing yet! Stay tuned!_
+-  Take subtypes into account when matching type conditions to extract representations. [PR #804](https://github.com/apollographql/federation/pull/804)
 
 ## v0.28.0
 

--- a/gateway-js/src/__tests__/executeQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/executeQueryPlan.test.ts
@@ -1118,4 +1118,64 @@ describe('executeQueryPlan', () => {
       }
     `);
   });
+
+  it(`can execute queries with @include on inline fragment with extension field`, async () => {
+    const operationString = `#graphql
+      query {
+        topProducts(first: 5) {
+          ... on Book @include(if: true) {
+            price
+            inStock
+          }
+          ... on Furniture {
+            price
+            inStock
+          }
+        }
+      }
+    `;
+
+    const operationDocument = gql(operationString);
+
+    const operationContext = buildOperationContext({
+      schema,
+      operationDocument,
+    });
+
+    const queryPlan = queryPlanner.buildQueryPlan(operationContext);
+
+    const response = await executeQueryPlan(
+      queryPlan,
+      serviceMap,
+      buildRequestContext(),
+      operationContext,
+    );
+
+    expect(response.data).toMatchInlineSnapshot(`
+      Object {
+        "topProducts": Array [
+          Object {
+            "inStock": true,
+            "price": "899",
+          },
+          Object {
+            "inStock": false,
+            "price": "1299",
+          },
+          Object {
+            "inStock": true,
+            "price": "54",
+          },
+          Object {
+            "inStock": true,
+            "price": "39",
+          },
+          Object {
+            "inStock": false,
+            "price": "29",
+          },
+        ],
+      }
+    `);
+  });
 });

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -10,6 +10,8 @@ import {
   TypeNameMetaFieldDef,
   GraphQLFieldResolver,
   GraphQLFormattedError,
+  isAbstractType,
+  GraphQLSchema,
 } from 'graphql';
 import { Trace, google } from 'apollo-reporting-protobuf';
 import { defaultRootOperationNameLookup } from '@apollo/federation';
@@ -247,7 +249,11 @@ async function executeFetch<TContext>(
     const representationToEntity: number[] = [];
 
     entities.forEach((entity, index) => {
-      const representation = executeSelectionSet(entity, requires);
+      const representation = executeSelectionSet(
+        context.operationContext,
+        entity,
+        requires,
+      );
       if (representation && representation[TypeNameMetaFieldDef.name]) {
         representations.push(representation);
         representationToEntity.push(index);
@@ -401,6 +407,7 @@ async function executeFetch<TContext>(
  * @param selectionSet
  */
 function executeSelectionSet(
+  operationContext: OperationContext,
   source: Record<string, any> | null,
   selections: QueryPlanSelectionNode[],
 ): Record<string, any> | null {
@@ -424,10 +431,13 @@ function executeSelectionSet(
         }
         if (Array.isArray(source[responseName])) {
           result[responseName] = source[responseName].map((value: any) =>
-            selections ? executeSelectionSet(value, selections) : value,
+            selections
+              ? executeSelectionSet(operationContext, value, selections)
+              : value,
           );
         } else if (selections) {
           result[responseName] = executeSelectionSet(
+            operationContext,
             source[responseName],
             selections,
           );
@@ -441,10 +451,10 @@ function executeSelectionSet(
         const typename = source && source['__typename'];
         if (!typename) continue;
 
-        if (typename === selection.typeCondition) {
+        if (doesTypeConditionMatch(operationContext.schema, selection.typeCondition, typename)) {
           deepMerge(
             result,
-            executeSelectionSet(source, selection.selections),
+            executeSelectionSet(operationContext, source, selection.selections),
           );
         }
         break;
@@ -452,6 +462,32 @@ function executeSelectionSet(
   }
 
   return result;
+}
+
+function doesTypeConditionMatch(
+  schema: GraphQLSchema,
+  typeCondition: string,
+  typename: string,
+): boolean {
+  if (typeCondition === typename) {
+    return true;
+  }
+
+  const type = schema.getType(typename);
+  if (!type) {
+    return false;
+  }
+
+  const conditionalType = schema.getType(typeCondition);
+  if (!conditionalType) {
+    return false;
+  }
+
+  if (isAbstractType(conditionalType)) {
+    return schema.isSubType(conditionalType, type);
+  }
+
+  return false;
 }
 
 function flattenResultsAtPath(value: any, path: ResponsePath): any {


### PR DESCRIPTION
The `executeSelectionSet` function in `executeQueryPlan.ts`, which is used to extract field values from a result object to build up representations to send to a subgraph, only looked for exact matches of the `__typename` to the type condition on an inline fragment. This wasn't an issue before, because the query plans we generated always contained an inline fragment per requested object type, never an abstract type condition.

Recent changes in the way we handle scope surfaced this issue however, because it would sometimes wrap things in an additional inline fragment for a parent interface type (this has since been fixed in https://github.com/apollographql/federation/pull/805). 

Although that means the issue won't arise for now, we do expect to make other changes that would require support for abstract type conditions (avoiding exploding types when they share an interface with a `@key` directive).