### PR TITLE
Fix plan querying a subgraph with an interface it doesn't know due to directives

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  _Nothing yet! Stay tuned!_
 
+## v0.28.1
+
+- Fix plan querying a subgraph with an interface it doesn't know due to directives ([#801](https://github.com/apollographql/federation/issues/801)).
+
 ## v0.28.0
 
 - Expand the range of supported `node` versions in the package's `engines` specifier to include the now-tested Node.js `16`. [PR #713](https://github.com/apollographql/federation/pull/713)

--- a/gateway-js/src/__tests__/integration/scope.test.ts
+++ b/gateway-js/src/__tests__/integration/scope.test.ts
@@ -1,0 +1,568 @@
+import gql from 'graphql-tag';
+import { execute } from '../execution-utils';
+
+import {
+  astSerializer,
+  queryPlanSerializer,
+} from 'apollo-federation-integration-testsuite';
+
+expect.addSnapshotSerializer(astSerializer);
+expect.addSnapshotSerializer(queryPlanSerializer);
+
+describe('scope', () => {
+  it("doesn't wrap inline fragments with the supertype when @include is used", async () => {
+    const query = `#graphql
+    query GetProducts {
+      topProducts {
+        name
+        ... on Shoe @include(if: true) {
+          rating
+        }
+        ... on Car {
+          rating
+        }
+      }
+    }
+  `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'products',
+        typeDefs: gql`
+          extend type Query {
+            topProducts: [Product]
+          }
+
+          interface Product {
+            name: String
+          }
+
+          type Shoe implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+
+          type Car implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Shoe @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+
+          extend type Car @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Car {
+                  name
+                  __typename
+                  upc
+                }
+                ... on Shoe {
+                  name
+                }
+                ... on Shoe @include(if: true) {
+                  __typename
+                  upc
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Shoe {
+                  __typename
+                  upc
+                }
+                ... on Car {
+                  __typename
+                  upc
+                }
+              } =>
+              {
+                ... on Shoe @include(if: true) {
+                  rating
+                }
+                ... on Car {
+                  rating
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it("doesn't merge conditions on the same type when one has a @include", async () => {
+    const query = `#graphql
+    query GetProducts {
+      topProducts {
+        name
+        ... on Shoe {
+          reviewsCount
+        }
+        ... on Shoe @include(if: true) {
+          rating
+        }
+        ... on Car {
+          rating
+        }
+      }
+    }
+  `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'products',
+        typeDefs: gql`
+          extend type Query {
+            topProducts: [Product]
+          }
+
+          interface Product {
+            name: String
+          }
+
+          type Shoe implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+
+          type Car implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Shoe @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+            reviewsCount: Int
+          }
+
+          extend type Car @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Car {
+                  name
+                  __typename
+                  upc
+                }
+                ... on Shoe {
+                  name
+                  __typename
+                  upc
+                }
+                ... on Shoe @include(if: true) {
+                  __typename
+                  upc
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Shoe {
+                  __typename
+                  upc
+                }
+                ... on Shoe {
+                  __typename
+                  upc
+                }
+                ... on Car {
+                  __typename
+                  upc
+                }
+              } =>
+              {
+                ... on Shoe {
+                  reviewsCount
+                }
+                ... on Shoe @include(if: true) {
+                  rating
+                }
+                ... on Car {
+                  rating
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it("doesn't merge conditions on the same type when one has a @include even for the same selected field", async () => {
+    const query = `#graphql
+    query GetProducts {
+      topProducts {
+        name
+        ... on Shoe {
+          rating
+        }
+        ... on Shoe @include(if: true) {
+          rating
+        }
+        ... on Car {
+          rating
+        }
+      }
+    }
+  `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'products',
+        typeDefs: gql`
+          extend type Query {
+            topProducts: [Product]
+          }
+
+          interface Product {
+            name: String
+          }
+
+          type Shoe implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+
+          type Car implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Shoe @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+            reviewsCount: Int
+          }
+
+          extend type Car @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Car {
+                  name
+                  __typename
+                  upc
+                }
+                ... on Shoe {
+                  name
+                  __typename
+                  upc
+                }
+                ... on Shoe @include(if: true) {
+                  __typename
+                  upc
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Shoe {
+                  __typename
+                  upc
+                }
+                ... on Shoe {
+                  __typename
+                  upc
+                }
+                ... on Car {
+                  __typename
+                  upc
+                }
+              } =>
+              {
+                ... on Shoe {
+                  rating
+                }
+                ... on Shoe @include(if: true) {
+                  rating
+                }
+                ... on Car {
+                  rating
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it("merges nested conditions when possible", async () => {
+    const query = `#graphql
+    query GetProducts {
+      topProducts {
+        name
+        ... on Shoe @include(if: true) {
+          ... on Shoe {
+            rating
+          }
+        }
+        ... on Car {
+          rating
+        }
+      }
+    }
+  `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'products',
+        typeDefs: gql`
+          extend type Query {
+            topProducts: [Product]
+          }
+
+          interface Product {
+            name: String
+          }
+
+          type Shoe implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+
+          type Car implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Shoe @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+
+          extend type Car @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Car {
+                  name
+                  __typename
+                  upc
+                }
+                ... on Shoe {
+                  name
+                }
+                ... on Shoe @include(if: true) {
+                  __typename
+                  upc
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Shoe {
+                  __typename
+                  upc
+                }
+                ... on Car {
+                  __typename
+                  upc
+                }
+              } =>
+              {
+                ... on Shoe @include(if: true) {
+                  rating
+                }
+                ... on Car {
+                  rating
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it("doesn't merge nested conditions when both have directives", async () => {
+    const query = `#graphql
+    query GetProducts {
+      topProducts {
+        name
+        ... on Shoe @include(if: true) {
+          ... on Shoe @skip(if: true) {
+            rating
+          }
+        }
+        ... on Car {
+          rating
+        }
+      }
+    }
+  `;
+
+    const { queryPlan, errors } = await execute({ query }, [
+      {
+        name: 'products',
+        typeDefs: gql`
+          extend type Query {
+            topProducts: [Product]
+          }
+
+          interface Product {
+            name: String
+          }
+
+          type Shoe implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+
+          type Car implements Product @key(fields: "upc") {
+            upc: String
+            name: String
+          }
+        `,
+      },
+      {
+        name: 'reviews',
+        typeDefs: gql`
+          extend type Shoe @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+
+          extend type Car @key(fields: "upc") {
+            upc: String @external
+            rating: Int
+          }
+        `,
+      },
+    ]);
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "products") {
+            {
+              topProducts {
+                __typename
+                ... on Car {
+                  name
+                  __typename
+                  upc
+                }
+                ... on Shoe {
+                  name
+                }
+                ... on Shoe @include(if: true) {
+                  ... on Shoe @skip(if: true) {
+                    __typename
+                    upc
+                  }
+                }
+              }
+            }
+          },
+          Flatten(path: "topProducts.@") {
+            Fetch(service: "reviews") {
+              {
+                ... on Shoe {
+                  ... on Shoe {
+                    __typename
+                    upc
+                  }
+                }
+                ... on Car {
+                  __typename
+                  upc
+                }
+              } =>
+              {
+                ... on Shoe @include(if: true) {
+                  ... on Shoe @skip(if: true) {
+                    rating
+                  }
+                }
+                ... on Car {
+                  rating
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  _Nothing yet! Stay tuned!_
 
+# v0.2.1
+
+- Fix plan querying a subgraph with an interface it doesn't know due to directives ([#801](https://github.com/apollographql/federation/issues/801)).
+
 # v0.2.0
 
 - Expand the range of supported `node` versions in the package's `engines` specifier to include the now-tested Node.js `16`. [PR #713](https://github.com/apollographql/federation/pull/713)

--- a/query-planner-js/src/Scope.ts
+++ b/query-planner-js/src/Scope.ts
@@ -91,10 +91,6 @@ export class Scope {
     if (directives && directives.length == 0) {
       directives = undefined;
     }
-    // If we have directives, we always want to preserve the condition so as to preserve that directive.
-    if (directives) {
-      return new Scope(this.context, type, directives, this);
-    }
     // Scope always preserve the immediate parent type, but if the new type is already the parent one
     // and we have not directives to preserve, simply return the existing scope.
     if (!directives && type === this.parentType) {


### PR DESCRIPTION
The commit message has more details, but this was due to a faulty condition in the code committed by #652 that I mistakenly forgot to remove when doing some change during the development of that PR. 

More precisely, early version of that PR was not always preserving the innermost condition of a scope (so technically `Scope.refine` was sometimes ignoring the newly added condition) and so the condition was avoid this when we had a directive to avoid incorrectly dropping said directive. But the whole behaviour was wrong and was changed to always preserve the innermost condition, which made that particular condition not only unneeded but actually harmful. Tl;dr, the patch simple remove the leftover condition. 