### PR TITLE
fix(query-planner): Avoid asking for fields of types that aren't owned

### DIFF
--- a/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
+++ b/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
@@ -1303,7 +1303,7 @@ Scenario: supports mutations with a cross-service request
               }
             ],
             "variableUsages": [],
-            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}"
           }
         },
         {
@@ -1468,7 +1468,7 @@ Scenario: supports multiple root mutations
               }
             ],
             "variableUsages": [],
-            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}"
           }
         },
         {
@@ -1626,7 +1626,7 @@ Scenario: multiple root mutations with correct service order
               }
             ],
             "variableUsages": [],
-            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}"
           }
         },
         {

--- a/query-planner-js/src/__tests__/features/basic/mutations.feature
+++ b/query-planner-js/src/__tests__/features/basic/mutations.feature
@@ -43,7 +43,7 @@ Scenario: supports mutations
               }
             ],
             "variableUsages": [],
-            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}"
           }
         },
         {
@@ -174,7 +174,7 @@ Scenario: multiple root mutations
               }
             ],
             "variableUsages": [],
-            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}"
           }
         },
         {
@@ -295,7 +295,7 @@ Scenario: multiple root mutations with correct service order
               }
             ],
             "variableUsages": [],
-            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}"
           }
         },
         {
@@ -328,4 +328,3 @@ Scenario: multiple root mutations with correct service order
     }
   }
   """
-

--- a/query-planner-js/src/buildQueryPlan.ts
+++ b/query-planner-js/src/buildQueryPlan.ts
@@ -657,9 +657,13 @@ function splitFields(
             debug.group(`For runtime parent type ${runtimeParentType}:`);
 
             const fieldDef = context.getFieldDef(
-
               runtimeParentType,
               field.fieldNode,
+            );
+
+            const owningService = context.getOwningService(
+              runtimeParentType,
+              fieldDef
             );
 
             const fieldsWithRuntimeParentType = fieldsForScope.map(field => ({
@@ -667,15 +671,17 @@ function splitFields(
               fieldDef,
             }));
 
-            group.fields.push(
-              completeField(
-                context,
-                scope.refine(runtimeParentType),
-                group,
-                path,
-                fieldsWithRuntimeParentType,
-              ),
-            );
+            if (owningService === group.serviceName) {
+              group.fields.push(
+                completeField(
+                  context,
+                  scope.refine(runtimeParentType),
+                  group,
+                  path,
+                  fieldsWithRuntimeParentType,
+                ),
+              );
+            }
             debug.groupEnd(() => `Updated fetch group: ${debugPrintGroup(group)}`);
           }
           debug.groupEnd();


### PR DESCRIPTION
When the resolved field type is shared interface and this interface is implemented in different services by types that aren't shared query planner would create queries that cause `No such type ...` errors.

### Example

Service A:
```
type Query {
  myField: MyInterface
}

type MyInterface {
  name: String
}

type MyTypeA implements MyInterface {
  name: String
}

type MyTypeB implements MyInterface {
  name: String
}
```

Service B:
```
interface MyInterface {
 name: String
}

type MyTypeC implements MyInterface {
  name: String
}
```

The query:
```
query {
  myField: {
    ...MyIntFragment
  }
}

fragment MyIntFragment on MyInterface {
  name
}
```

result in such query to service A:
```
query {
  myField {
    ...on MyTypeA { name }
    ...on MyTypeB { name }
    ...on MyTypeC { name }
  }
}
```
which cause an error
```
Unknown type "MyTypeC".
```

