### PR TITLE
docs: change 'Implementing services' to subgraphs

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -162,8 +162,8 @@ server.listen();
 ```
 
 That’s it! With Apollo Federation, schemas and resolvers live in your
-implementing services. The gateway serves only to plan and execute GraphQL
-operations across those implementing services.
+subgraphs. The gateway serves only to plan and execute GraphQL
+operations across those subgraphs.
 
 Now we can execute GraphQL operations against our composed schema just as if it were implemented as a single, monolithic service:
 


### PR DESCRIPTION
From: https://www.apollographql.com/docs/federation/

> Implementing services are now known as subgraphs.
> 
> If you find an outdated use of "implementing service," please submit article feedback or a pull request using the links on the right.

I changed 2 instances of 'Implementing services' to 'subgraphs'.