### PR TITLE
gateway: Update gateway.load() to support AS2 and AS3

### DIFF
--- a/gateway-js/src/__tests__/integration/nockMocks.ts
+++ b/gateway-js/src/__tests__/integration/nockMocks.ts
@@ -6,8 +6,7 @@ import { getTestingSupergraphSdl } from '../../__tests__/execution-utils';
 import { print } from 'graphql';
 import { fixtures } from 'apollo-federation-integration-testsuite';
 
-export const graphId = 'federated-service';
-export const graphVariant = 'current';
+export const graphRef = 'federated-service@current';
 export const apiKey = 'service:federated-service:DD71EBbGmsuh-6suUVDwnA';
 const apiKeyHash = 'dd55a79d467976346d229a7b12b673ce';
 
@@ -15,8 +14,7 @@ export const mockApolloConfig = {
   apollo: {
     key: apiKey,
     keyHash: apiKeyHash,
-    graphId,
-    graphVariant,
+    graphRef,
   },
 };
 
@@ -73,7 +71,7 @@ export function mockSupergraphSdlRequest() {
   return gatewayNock(mockCloudConfigUrl).post('/', {
     query: SUPERGRAPH_SDL_QUERY,
     variables: {
-      ref: `${graphId}@${graphVariant}`,
+      ref: graphRef,
       apiKey: apiKey,
     },
   });

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -2,8 +2,7 @@ import { loadSupergraphSdlFromStorage } from '../loadSupergraphSdlFromStorage';
 import { getDefaultFetcher } from '../..';
 import {
   mockSupergraphSdlRequestSuccess,
-  graphId,
-  graphVariant,
+  graphRef,
   apiKey,
   mockCloudConfigUrl,
   mockSupergraphSdlRequest,
@@ -14,8 +13,7 @@ describe('loadSupergraphSdlFromStorage', () => {
     mockSupergraphSdlRequestSuccess();
     const fetcher = getDefaultFetcher();
     const result = await loadSupergraphSdlFromStorage({
-      graphId,
-      graphVariant,
+      graphRef,
       apiKey,
       endpoint: mockCloudConfigUrl,
       fetcher,
@@ -308,8 +306,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       const fetcher = getDefaultFetcher();
       await expect(
         loadSupergraphSdlFromStorage({
-          graphId,
-          graphVariant,
+          graphRef,
           apiKey,
           endpoint: mockCloudConfigUrl,
           fetcher,
@@ -331,8 +328,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       const fetcher = getDefaultFetcher();
       await expect(
         loadSupergraphSdlFromStorage({
-          graphId,
-          graphVariant,
+          graphRef,
           apiKey,
           endpoint: mockCloudConfigUrl,
           fetcher,
@@ -346,8 +342,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       const fetcher = getDefaultFetcher();
       await expect(
         loadSupergraphSdlFromStorage({
-          graphId,
-          graphVariant,
+          graphRef,
           apiKey,
           endpoint: mockCloudConfigUrl,
           fetcher,

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -8,7 +8,6 @@ import {
   GraphQLExecutionResult,
   Logger,
   GraphQLRequestContextExecutionDidStart,
-  ApolloConfig,
 } from 'apollo-server-types';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import {
@@ -126,7 +125,7 @@ export const SERVICE_DEFINITION_QUERY =
 
 type GatewayState =
   | { phase: 'initialized' }
-  | { phase: 'failed to load'}
+  | { phase: 'failed to load' }
   | { phase: 'loaded' }
   | { phase: 'stopping'; stoppingDonePromise: Promise<void> }
   | { phase: 'stopped' }
@@ -136,13 +135,28 @@ type GatewayState =
       doneWaiting: () => void;
     }
   | { phase: 'polling'; pollingDonePromise: Promise<void> };
+
+interface ApolloConfigFromAS3 {
+  key?: string;
+  keyHash?: string;
+  graphRef?: string;
+}
+
+interface ApolloConfigFromAS2Or3 {
+  key?: string;
+  keyHash?: string;
+  graphRef?: string;
+  graphId?: string;
+  graphVariant?: string;
+}
+
 export class ApolloGateway implements GraphQLService {
   public schema?: GraphQLSchema;
   private serviceMap: DataSourceMap = Object.create(null);
   private config: GatewayConfig;
   private logger: Logger;
   private queryPlanStore: InMemoryLRUCache<QueryPlan>;
-  private apolloConfig?: ApolloConfig;
+  private apolloConfig?: ApolloConfigFromAS3;
   private onSchemaChangeListeners = new Set<SchemaChangeCallback>();
   private serviceDefinitions: ServiceDefinition[] = [];
   private compositionMetadata?: CompositionMetadata;
@@ -306,7 +320,7 @@ export class ApolloGateway implements GraphQLService {
   }
 
   public async load(options?: {
-    apollo?: ApolloConfig;
+    apollo?: ApolloConfigFromAS2Or3;
     engine?: GraphQLServiceEngineConfig;
   }) {
     if (this.state.phase !== 'initialized') {
@@ -315,13 +329,22 @@ export class ApolloGateway implements GraphQLService {
       );
     }
     if (options?.apollo) {
-      this.apolloConfig = options.apollo;
+      const { key, keyHash, graphRef, graphId, graphVariant } = options.apollo;
+      this.apolloConfig = {
+        key,
+        keyHash,
+        graphRef:
+          graphRef ??
+          (graphId ? `${graphId}@${graphVariant ?? 'current'}` : undefined),
+      };
     } else if (options?.engine) {
       // Older version of apollo-server-core that isn't passing 'apollo' yet.
+      const { apiKeyHash, graphId, graphVariant } = options.engine;
       this.apolloConfig = {
-        keyHash: options.engine.apiKeyHash,
-        graphId: options.engine.graphId,
-        graphVariant: options.engine.graphVariant || 'current',
+        keyHash: apiKeyHash,
+        graphRef: graphId
+          ? `${graphId}@${graphVariant ?? 'current'}`
+          : undefined,
       };
     }
 
@@ -363,8 +386,8 @@ export class ApolloGateway implements GraphQLService {
     const mode = isManagedConfig(this.config) ? 'managed' : 'unmanaged';
     this.logger.info(
       `Gateway successfully loaded schema.\n\t* Mode: ${mode}${
-        this.apolloConfig && this.apolloConfig.graphId
-          ? `\n\t* Service: ${this.apolloConfig.graphId}@${this.apolloConfig.graphVariant}`
+        this.apolloConfig && this.apolloConfig.graphRef
+          ? `\n\t* Service: ${this.apolloConfig.graphRef}`
           : ''
       }`,
     );
@@ -861,7 +884,7 @@ export class ApolloGateway implements GraphQLService {
     }
 
     const canUseManagedConfig =
-      this.apolloConfig?.graphId && this.apolloConfig?.keyHash;
+      this.apolloConfig?.graphRef && this.apolloConfig?.keyHash;
     if (!canUseManagedConfig) {
       throw new Error(
         'When a manual configuration is not provided, gateway requires an Apollo ' +
@@ -877,18 +900,16 @@ export class ApolloGateway implements GraphQLService {
       !isPrecomposedManagedConfig(config)
     ) {
       return getServiceDefinitionsFromStorage({
-        graphId: this.apolloConfig!.graphId!,
+        graphRef: this.apolloConfig!.graphRef!,
         apiKeyHash: this.apolloConfig!.keyHash!,
-        graphVariant: this.apolloConfig!.graphVariant,
         federationVersion: config.federationVersion || 1,
         fetcher: this.fetcher,
       });
     }
 
     return loadSupergraphSdlFromStorage({
-      graphId: this.apolloConfig!.graphId!,
+      graphRef: this.apolloConfig!.graphRef!,
       apiKey: this.apolloConfig!.key!,
-      graphVariant: this.apolloConfig!.graphVariant,
       endpoint: this.experimental_schemaConfigDeliveryEndpoint!,
       fetcher: this.fetcher,
     });
@@ -896,7 +917,7 @@ export class ApolloGateway implements GraphQLService {
 
   private maybeWarnOnConflictingConfig() {
     const canUseManagedConfig =
-      this.apolloConfig?.graphId && this.apolloConfig?.keyHash;
+      this.apolloConfig?.graphRef && this.apolloConfig?.keyHash;
 
     // This might be a bit confusing just by reading, but `!isManagedConfig` just
     // means it's any of the other types of config. If it's any other config _and_

--- a/gateway-js/src/legacyLoadServicesFromStorage.ts
+++ b/gateway-js/src/legacyLoadServicesFromStorage.ts
@@ -98,18 +98,22 @@ function fetchApolloGcs(
 }
 
 export async function getServiceDefinitionsFromStorage({
-  graphId,
+  graphRef,
   apiKeyHash,
-  graphVariant,
   federationVersion,
   fetcher,
 }: {
-  graphId: string;
+  graphRef: string;
   apiKeyHash: string;
-  graphVariant: string;
   federationVersion: number;
   fetcher: typeof fetch;
 }): Promise<ServiceDefinitionUpdate> {
+  // The protocol for talking to GCS requires us to split the graph ref
+  // into ID and variant; sigh.
+  const at = graphRef.indexOf('@');
+  const graphId = at === -1 ? graphRef : graphRef.substring(0, at);
+  const graphVariant = at === -1 ? 'current' : graphRef.substring(at + 1);
+
   // fetch the storage secret
   const storageSecretUrl = getStorageSecretUrl(graphId, apiKeyHash);
 

--- a/gateway-js/src/loadSupergraphSdlFromStorage.ts
+++ b/gateway-js/src/loadSupergraphSdlFromStorage.ts
@@ -37,14 +37,12 @@ const { name, version } = require('../package.json');
 const fetchErrorMsg = "An error occurred while fetching your schema from Apollo: ";
 
 export async function loadSupergraphSdlFromStorage({
-  graphId,
-  graphVariant,
+  graphRef,
   apiKey,
   endpoint,
   fetcher,
 }: {
-  graphId: string;
-  graphVariant: string;
+  graphRef: string;
   apiKey: string;
   endpoint: string;
   fetcher: typeof fetch;
@@ -56,7 +54,7 @@ export async function loadSupergraphSdlFromStorage({
       body: JSON.stringify({
         query: SUPERGRAPH_SDL_QUERY,
         variables: {
-          ref: `${graphId}@${graphVariant}`,
+          ref: graphRef,
           apiKey,
         },
       }),


### PR DESCRIPTION
Starting with AS 2.25.0, gateway.load receives `graphRef` in addition to
`graphId` and `graphVariant`; `graphVariant` is declared as always
provided.

In AS3, only `graphRef` will be provided; `graphVariant` will not be
provided.

In order for this code to work with both versions, we declare a version
of ApolloConfig that could come from either ourselves, and parse it into
an internal representation based on the AS3 version.