### PR TITLE
Alternative GraphQL schema abstraction

### DIFF
--- a/core-js/jest.config.js
+++ b/core-js/jest.config.js
@@ -1,0 +1,7 @@
+const baseConfig = require('../jest.config.base');
+
+/** @typedef {import('ts-jest/dist/types')} */
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  ...baseConfig
+};

--- a/core-js/package.json
+++ b/core-js/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/apollographql/federation.git",
     "directory": "core-js/"
   },
+  "scripts": {
+    "test": "jest"
+  },
   "keywords": [
     "graphql",
     "federation",
@@ -18,6 +21,10 @@
   "license": "MIT",
   "engines": {
     "node": ">=12.13.0 <17.0"
+  },
+  "dependencies": {
+    "@types/jest": "^26.0.23",
+    "deep-equal": "^2.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/core-js/package.json
+++ b/core-js/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@apollo/core",
+  "version": "0.1.0",
+  "description": "Apollo Federation core utilities",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apollographql/federation.git",
+    "directory": "core-js/"
+  },
+  "keywords": [
+    "graphql",
+    "federation",
+    "apollo"
+  ],
+  "author": "Apollo <opensource@apollographql.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=12.13.0 <17.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "graphql": "^14.5.0 || ^15.0.0"
+  }
+}

--- a/core-js/package.json
+++ b/core-js/package.json
@@ -24,12 +24,15 @@
   },
   "dependencies": {
     "@types/jest": "^26.0.23",
-    "deep-equal": "^2.0.5"
+    "js-levenshtein": "^1.1.6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
     "graphql": "^14.5.0 || ^15.0.0"
+  },
+  "devDependencies": {
+    "@types/js-levenshtein": "^1.1.0"
   }
 }

--- a/core-js/src/__tests__/definitions.test.ts
+++ b/core-js/src/__tests__/definitions.test.ts
@@ -4,8 +4,8 @@ import {
   Type,
   DirectiveDefinition,
   InterfaceType,
-  SchemaElement,
-  EnumType
+  EnumType,
+  SchemaElement
 } from '../../dist/definitions';
 import { printSchema } from '../../dist/print';
 import { buildSchema } from '../../dist/buildSchema';
@@ -63,7 +63,7 @@ expect.extend({
   },
 
   toHaveDirective(element: SchemaElement<any, any>, definition: DirectiveDefinition, args?: Map<string, any>) {
-    const directives = element.appliedDirective(definition as any);
+    const directives = element.appliedDirectivesOf(definition);
     if (directives.length == 0) {
       return {
         message: () => `Cannot find directive @${definition} applied to element ${element} (whose applied directives are [${element.appliedDirectives.join(', ')}]`,
@@ -224,7 +224,7 @@ test('removal of all inacessible elements of a schema', () => {
   `, federationBuiltIns);
 
   for (const element of schema.allSchemaElement()) {
-    if (element.appliedDirective(schema.directive('inaccessible')!).length > 0) {
+    if (element.appliedDirectivesOf(schema.directive('inaccessible')!).length > 0) {
       element.remove();
     }
   }
@@ -424,6 +424,10 @@ interface Product {
   const product = schema.type('Product');
   expectInterfaceType(product);
   expect(product.field('description')!.description).toBe(longComment);
+
+  const directive = schema.directive('Important')!;
+  if (directive.repeatable === false)
+    product.appliedDirectivesOf(directive);
 
   expect(printSchema(schema)).toBe(sdl);
 });

--- a/core-js/src/__tests__/definitions.test.ts
+++ b/core-js/src/__tests__/definitions.test.ts
@@ -1,0 +1,238 @@
+import {
+  AnyGraphQLDocument,
+  AnyObjectType,
+  AnySchemaElement,
+  AnyType,
+  GraphQLDocument,
+  MutableGraphQLDocument,
+  MutableObjectType,
+  MutableType,
+  ObjectType,
+  Type
+} from '../../dist/definitions';
+import {
+  printDocument
+} from '../../dist/print';
+
+function expectObjectType(type: Type | MutableType | undefined): asserts type is ObjectType | MutableObjectType {
+  expect(type).toBeDefined();
+  expect(type!.kind).toBe('ObjectType');
+}
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveField(name: string, type?: AnyType): R;
+      toHaveDirective(name: string, args?: Map<string, any>): R;
+    }
+  }
+}
+
+expect.extend({
+  toHaveField(parentType: AnyObjectType, name: string, type?: AnyType) {
+    const field = parentType.field(name);
+    if (!field) {
+      return {
+        message: () => `Cannot find field '${name}' in Object Type ${parentType} with fields [${[...parentType.fields.keys()]}]`,
+        pass: false
+      };
+    }
+    if (field.name != name) {
+      return {
+        message: () => `Type ${parentType} has a field linked to name ${name} but that field name is actually ${field.name}`,
+        pass: false
+      };
+    }
+    if (type && field.type() != type) {
+      return {
+        message: () => `Expected field ${parentType}.${name} to have type ${type} but got type ${field.type()}`,
+        pass: false
+      };
+    }
+    return {
+      message: () => `Expected ${parentType} not to have field ${name} but it does (${field})`,
+      pass: true
+    }
+  },
+
+  toHaveDirective(element: AnySchemaElement, name: string, args?: Map<string, any>) {
+    const directives = element.appliedDirective(name);
+    if (directives.length == 0) {
+      return {
+        message: () => `Cannot find directive @${name} applied to element ${element} (whose applied directives are [${element.appliedDirectives().join(', ')}]`,
+        pass: false
+      };
+    }
+    if (!args) {
+      return {
+        message: () => `Expected directive @${name} to not be applied to ${element} but it is`,
+        pass: true
+      };
+    }
+
+    for (const directive of directives) {
+      if (directive.matchArguments(args)) {
+        return {
+          // Not 100% certain that message is correct but I don't think it's going to be used ...
+          message: () => `Expected directive ${directive.name} applied to ${element} to have arguments ${args} but got ${directive.arguments}`,
+          pass: true
+        };
+      }
+    }
+    return {
+      message: () => `Element ${element} has application of directive @${name} but not with the requested arguments. Got applications: [${directives.join(', ')}]`,
+      pass: false
+    }
+  }
+});
+
+test('building a simple mutable document programatically and converting to immutable', () => {
+  const mutDoc = MutableGraphQLDocument.empty();
+  const mutQueryType = mutDoc.schema.setRoot('query', mutDoc.addObjectType('Query'));
+  const mutTypeA = mutDoc.addObjectType('A');
+  mutQueryType.addField('a', mutTypeA);
+  mutTypeA.addField('q', mutQueryType);
+  mutTypeA.applyDirective('inaccessible');
+  mutTypeA.applyDirective('key', new Map([['fields', 'a']]));
+
+  // Sanity check
+  expect(mutQueryType).toHaveField('a', mutTypeA);
+  expect(mutTypeA).toHaveField('q', mutQueryType);
+  expect(mutTypeA).toHaveDirective('inaccessible');
+  expect(mutTypeA).toHaveDirective('key', new Map([['fields', 'a']]));
+
+  const doc = mutDoc.toImmutable();
+  const queryType = doc.type('Query'); 
+  const typeA = doc.type('A'); 
+  expect(queryType).toBe(doc.schema.root('query'));
+  expectObjectType(queryType);
+  expectObjectType(typeA);
+  expect(queryType).toHaveField('a', typeA);
+  expect(typeA).toHaveField('q', queryType);
+  expect(typeA).toHaveDirective('inaccessible');
+  expect(typeA).toHaveDirective('key', new Map([['fields', 'a']]));
+});
+
+function parseAndValidateTestDocument<Doc extends AnyGraphQLDocument>(parser: (source: string) => Doc): Doc {
+  const sdl =
+`schema {
+  query: MyQuery
+}
+
+type A {
+  f1(x: Int @inaccessible): String
+  f2: String @inaccessible
+}
+
+type MyQuery {
+  a: A
+  b: Int
+}`;
+  const doc = parser(sdl);
+
+  const queryType = doc.type('MyQuery')!;
+  const typeA = doc.type('A')!;
+  expectObjectType(queryType);
+  expectObjectType(typeA);
+  expect(doc.schema.root('query')).toBe(queryType);
+  expect(queryType).toHaveField('a', typeA);
+  const f2 = typeA.field('f2');
+  expect(f2).toHaveDirective('inaccessible');
+  expect(printDocument(doc)).toBe(sdl);
+  return doc;
+}
+
+
+test('parse immutable document', () => {
+  parseAndValidateTestDocument(GraphQLDocument.parse);
+});
+
+test('parse mutable document and modify', () => {
+  const doc = parseAndValidateTestDocument(MutableGraphQLDocument.parse);
+  const typeA = doc.type('A');
+  expectObjectType(typeA);
+  expect(typeA).toHaveField('f1');
+  typeA.field('f1')!.remove();
+  expect(typeA).not.toHaveField('f1');
+});
+
+test('removal of all directives of a document', () => {
+  const doc = MutableGraphQLDocument.parse(`
+    schema @foo {
+      query: Query
+    }
+
+    type Query {
+      a(id: String @bar): A @inaccessible
+    }
+
+    type A {
+      a1: String @foo
+      a2: [Int]
+    }
+
+    type B @foo {
+      b: String @bar
+    }
+
+    union U @foobar = A | B
+  `);
+
+  for (const element of doc.allSchemaElement()) {
+    element.appliedDirectives().forEach(d => d.remove());
+  }
+
+  expect(printDocument(doc)).toBe(
+`type A {
+  a1: String
+  a2: [Int]
+}
+
+type B {
+  b: String
+}
+
+type Query {
+  a(id: String): A
+}
+
+union U = A | B`);
+});
+
+test('removal of all inacessible elements of a document', () => {
+  const doc = MutableGraphQLDocument.parse(`
+    schema @foo {
+      query: Query
+    }
+
+    type Query {
+      a(id: String @bar, arg: Int @inaccessible): A
+    }
+
+    type A {
+      a1: String @inaccessible
+      a2: [Int]
+    }
+
+    type B @inaccessible {
+      b: String @bar
+    }
+
+    union U @inaccessible = A | B
+  `);
+
+  for (const element of doc.allSchemaElement()) {
+    if (element.appliedDirective('inaccessible').length > 0) {
+      element.remove();
+    }
+  }
+
+  expect(printDocument(doc)).toBe(
+`type A {
+  a2: [Int]
+}
+
+type Query {
+  a(id: String @bar): A
+}`);
+});

--- a/core-js/src/__tests__/definitions.test.ts
+++ b/core-js/src/__tests__/definitions.test.ts
@@ -30,7 +30,7 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       toHaveField(name: string, type?: Type): R;
-      toHaveDirective(directive: DirectiveDefinition, args?: Map<string, any>): R;
+      toHaveDirective(directive: DirectiveDefinition, args?: Record<string, any>): R;
     }
   }
 }
@@ -62,7 +62,7 @@ expect.extend({
     }
   },
 
-  toHaveDirective(element: SchemaElement<any, any>, definition: DirectiveDefinition, args?: Map<string, any>) {
+  toHaveDirective(element: SchemaElement<any, any>, definition: DirectiveDefinition, args?: Record<string, any>) {
     const directives = element.appliedDirectivesOf(definition);
     if (directives.length == 0) {
       return {
@@ -81,7 +81,7 @@ expect.extend({
       if (directive.matchArguments(args)) {
         return {
           // Not 100% certain that message is correct but I don't think it's going to be used ...
-          message: () => `Expected directive ${directive.name} applied to ${element} to have arguments ${args} but got ${directive.arguments}`,
+          message: () => `Expected directive ${directive.name} applied to ${element} to have arguments ${JSON.stringify(args)} but got ${JSON.stringify(directive.arguments)}`,
           pass: true
         };
       }
@@ -103,13 +103,13 @@ test('building a simple schema programatically', () => {
   queryType.addField('a', typeA);
   typeA.addField('q', queryType);
   typeA.applyDirective(inaccessible);
-  typeA.applyDirective(key, new Map([['fields', 'a']]));
+  typeA.applyDirective(key, { fields: 'a'});
 
   expect(queryType).toBe(schema.schemaDefinition.root('query'));
   expect(queryType).toHaveField('a', typeA);
   expect(typeA).toHaveField('q', queryType);
   expect(typeA).toHaveDirective(inaccessible);
-  expect(typeA).toHaveDirective(key, new Map([['fields', 'a']]));
+  expect(typeA).toHaveDirective(key, { fields: 'a'});
 });
 
 

--- a/core-js/src/buildSchema.ts
+++ b/core-js/src/buildSchema.ts
@@ -136,12 +136,12 @@ function buildSchemaDefinitionInner(schemaNode: SchemaDefinitionNode, schemaDefi
   for (const opTypeNode of schemaNode.operationTypes) {
     schemaDefinition.setRoot(opTypeNode.operation, opTypeNode.type.name.value, opTypeNode);
   }
-  schemaDefinition.source = schemaNode;
+  schemaDefinition.sourceAST = schemaNode;
   schemaDefinition.description = schemaNode.description?.value;
   buildAppliedDirectives(schemaNode, schemaDefinition);
 }
 
-function buildAppliedDirectives(elementNode: NodeWithDirectives, element: SchemaElement<any, any>) {
+function buildAppliedDirectives(elementNode: NodeWithDirectives, element: SchemaElement<any>) {
   for (const directive of elementNode.directives ?? []) {
     element.applyDirective(directive.name.value, buildArgs(directive), directive)
   }
@@ -188,7 +188,7 @@ function buildNamedTypeInner(definitionNode: DefinitionNode & NodeWithDirectives
   }
   buildAppliedDirectives(definitionNode, type);
   type.description = definitionNode.description?.value;
-  type.source = definitionNode;
+  type.sourceAST = definitionNode;
 }
 
 function buildFieldDefinitionInner(fieldNode: FieldDefinitionNode, field: FieldDefinition<any>) {
@@ -199,7 +199,7 @@ function buildFieldDefinitionInner(fieldNode: FieldDefinitionNode, field: FieldD
   }
   buildAppliedDirectives(fieldNode, field);
   field.description = fieldNode.description?.value;
-  field.source = fieldNode;
+  field.sourceAST = fieldNode;
 }
 
 export function ensureOutputType(type: Type, node: TypeNode): OutputType {
@@ -239,7 +239,7 @@ function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: 
   arg.defaultValue = buildValue(inputNode.defaultValue);
   buildAppliedDirectives(inputNode, arg);
   arg.description = inputNode.description?.value;
-  arg.source = inputNode;
+  arg.sourceAST = inputNode;
 }
 
 function buildInputFieldDefinitionInner(fieldNode: InputValueDefinitionNode, field: InputFieldDefinition) {
@@ -247,7 +247,7 @@ function buildInputFieldDefinitionInner(fieldNode: InputValueDefinitionNode, fie
   field.type = ensureInputType(type, fieldNode.type);
   buildAppliedDirectives(fieldNode, field);
   field.description = fieldNode.description?.value;
-  field.source = fieldNode;
+  field.sourceAST = fieldNode;
 }
 
 function buildDirectiveDefinitionInner(directiveNode: DirectiveDefinitionNode, directive: DirectiveDefinition) {
@@ -258,5 +258,5 @@ function buildDirectiveDefinitionInner(directiveNode: DirectiveDefinitionNode, d
   const locations = directiveNode.locations.map(({ value }) => value as DirectiveLocationEnum);
   directive.addLocations(...locations);
   directive.description = directiveNode.description?.value;
-  directive.source = directiveNode;
+  directive.sourceAST = directiveNode;
 }

--- a/core-js/src/buildSchema.ts
+++ b/core-js/src/buildSchema.ts
@@ -147,10 +147,10 @@ function buildAppliedDirectives(elementNode: NodeWithDirectives, element: Schema
   }
 }
 
-function buildArgs(argumentsNode: NodeWithArguments): Map<string, any> {
-  const args = new Map();
+function buildArgs(argumentsNode: NodeWithArguments): Record<string, any> {
+  const args = Object.create(null);
   for (const argNode of argumentsNode.arguments ?? []) {
-    args.set(argNode.name.value, buildValue(argNode.value));
+    args[argNode.name.value] = buildValue(argNode.value);
   }
   return args;
 }

--- a/core-js/src/buildSchema.ts
+++ b/core-js/src/buildSchema.ts
@@ -63,7 +63,7 @@ export function buildSchema(source: string | Source, builtIns: BuiltIns = graphQ
 
 export function buildSchemaFromAST(documentNode: DocumentNode, builtIns: BuiltIns = graphQLBuiltIns): Schema {
   const schema = new Schema(builtIns);
-  // We do a first path to add all empty types and directives definition. This ensure any reference on one of
+  // We do a first pass to add all empty types and directives definition. This ensure any reference on one of
   // those can be resolved in the 2nd pass, regardless of the order of the definitions in the AST.
   buildNamedTypeAndDirectivesShallow(documentNode, schema);
   for (const definitionNode of documentNode.definitions) {

--- a/core-js/src/buildSchema.ts
+++ b/core-js/src/buildSchema.ts
@@ -1,0 +1,252 @@
+import {
+  DefinitionNode,
+  DirectiveDefinitionNode,
+  DirectiveLocationEnum,
+  DirectiveNode,
+  DocumentNode,
+  FieldDefinitionNode,
+  GraphQLError,
+  InputValueDefinitionNode,
+  parse,
+  SchemaDefinitionNode,
+  Source,
+  TypeNode,
+  valueFromASTUntyped,
+  ValueNode,
+  NamedTypeNode,
+  ArgumentNode
+} from "graphql";
+import {
+  BuiltIns,
+  Schema,
+  graphQLBuiltIns,
+  newNamedType,
+  NamedTypeKind,
+  NamedType,
+  SchemaDefinition,
+  SchemaElement,
+  ObjectType,
+  InterfaceType,
+  FieldDefinition,
+  Type,
+  ListType,
+  OutputType,
+  isOutputType,
+  isInputType,
+  InputType,
+  NonNullType,
+  ArgumentDefinition,
+  InputFieldDefinition,
+  DirectiveDefinition,
+  UnionType,
+  InputObjectType,
+  EnumType
+} from "./definitions";
+
+function buildValue(value?: ValueNode): any {
+  // TODO: Should we rewrite a version of valueFromAST instead of using valueFromASTUntyped? Afaict, what we're missing out on is
+  // 1) coercions, which concretely, means:
+  //   - for enums, we get strings
+  //   - for int, we don't get the validation that it should be a 32bit value.
+  //   - for ID, which accepts strings and int, we don't get int converted to string.
+  //   - for floats, we get either int or float, we don't get int converted to float.
+  //   - we don't get any custom coercion (but neither is buildSchema in graphQL-js anyway).
+  // 2) type validation. 
+  return value ? valueFromASTUntyped(value) : undefined;
+}
+
+export function buildSchema(source: string | Source, builtIns: BuiltIns = graphQLBuiltIns): Schema {
+  return buildSchemaFromAST(parse(source), builtIns);
+}
+
+export function buildSchemaFromAST(documentNode: DocumentNode, builtIns: BuiltIns = graphQLBuiltIns): Schema {
+  const schema = new Schema(builtIns);
+  // We do a first path to add all empty types and directives definition. This ensure any reference on one of
+  // those can be resolved in the 2nd pass, regardless of the order of the definitions in the AST.
+  buildNamedTypeAndDirectivesShallow(documentNode, schema);
+  for (const definitionNode of documentNode.definitions) {
+    switch (definitionNode.kind) {
+      case 'OperationDefinition':
+      case 'FragmentDefinition':
+        throw new GraphQLError("Invalid executable definition found while building schema", definitionNode);
+      case 'SchemaDefinition':
+        buildSchemaDefinitionInner(definitionNode, schema.schemaDefinition);
+        break;
+      case 'ScalarTypeDefinition':
+      case 'ObjectTypeDefinition':
+      case 'InterfaceTypeDefinition':
+      case 'UnionTypeDefinition':
+      case 'EnumTypeDefinition':
+      case 'InputObjectTypeDefinition':
+        buildNamedTypeInner(definitionNode, schema.type(definitionNode.name.value)!);
+        break;
+      case 'DirectiveDefinition':
+        buildDirectiveDefinitionInner(definitionNode, schema.directive(definitionNode.name.value)!);
+        break;
+      case 'SchemaExtension':
+      case 'ScalarTypeExtension':
+      case 'ObjectTypeExtension':
+      case 'InterfaceTypeExtension':
+      case 'UnionTypeExtension':
+      case 'EnumTypeExtension':
+      case 'InputObjectTypeExtension':
+        throw new Error("Extensions are a TODO");
+    }
+  }
+  return schema;
+}
+
+function buildNamedTypeAndDirectivesShallow(documentNode: DocumentNode, schema: Schema) {
+  for (const definitionNode of documentNode.definitions) {
+    switch (definitionNode.kind) {
+      case 'ScalarTypeDefinition':
+      case 'ObjectTypeDefinition':
+      case 'InterfaceTypeDefinition':
+      case 'UnionTypeDefinition':
+      case 'EnumTypeDefinition':
+      case 'InputObjectTypeDefinition':
+        schema.addType(newNamedType(withoutTrailingDefinition(definitionNode.kind), definitionNode.name.value));
+        break;
+      case 'DirectiveDefinition':
+        schema.addDirectiveDefinition(definitionNode.name.value);
+        break;
+    }
+  }
+}
+
+type NodeWithDirectives = {directives?: ReadonlyArray<DirectiveNode>};
+type NodeWithArguments = {arguments?: ReadonlyArray<ArgumentNode>};
+
+function withoutTrailingDefinition(str: string): NamedTypeKind {
+  return str.slice(0, str.length - 'Definition'.length) as NamedTypeKind;
+}
+
+function getReferencedType(node: NamedTypeNode, schema: Schema): NamedType {
+  const type = schema.type(node.name.value);
+  if (!type) {
+    throw new GraphQLError(`Unknown type ${node.name.value}`, node);
+  }
+  return type;
+}
+
+function buildSchemaDefinitionInner(schemaNode: SchemaDefinitionNode, schemaDefinition: SchemaDefinition) {
+  schemaDefinition.source = schemaNode;
+  buildAppliedDirectives(schemaNode, schemaDefinition);
+  for (const opTypeNode of schemaNode.operationTypes) {
+    schemaDefinition.setRoot(opTypeNode.operation, opTypeNode.type.name.value, opTypeNode);
+  }
+}
+
+function buildAppliedDirectives(elementNode: NodeWithDirectives, element: SchemaElement<any, any>) {
+  for (const directive of elementNode.directives ?? []) {
+    element.applyDirective(directive.name.value, buildArgs(directive), directive)
+  }
+}
+
+function buildArgs(argumentsNode: NodeWithArguments): Map<string, any> {
+  const args = new Map();
+  for (const argNode of argumentsNode.arguments ?? []) {
+    args.set(argNode.name.value, buildValue(argNode.value));
+  }
+  return args;
+}
+
+function buildNamedTypeInner(definitionNode: DefinitionNode & NodeWithDirectives, type: NamedType) {
+  switch (definitionNode.kind) {
+    case 'ObjectTypeDefinition':
+    case 'InterfaceTypeDefinition':
+      const fieldBasedType = type as ObjectType | InterfaceType;
+      for (const fieldNode of definitionNode.fields ?? []) {
+        buildFieldDefinitionInner(fieldNode, fieldBasedType.addField(fieldNode.name.value));
+      }
+      for (const itfNode of definitionNode.interfaces ?? []) {
+        fieldBasedType.addImplementedInterface(itfNode.name.value, itfNode);
+      }
+      break;
+    case 'UnionTypeDefinition':
+      const unionType = type as UnionType;
+      for (const namedType of definitionNode.types ?? []) {
+        unionType.addType(namedType.name.value, namedType);
+      }
+      break;
+    case 'EnumTypeDefinition':
+      const enumType = type as EnumType;
+      for (const enumVal of definitionNode.values ?? []) {
+        enumType.addValue(enumVal.name.value);
+      }
+      break;
+    case 'InputObjectTypeDefinition':
+      const inputObjectType = type as InputObjectType;
+      for (const fieldNode of definitionNode.fields ?? []) {
+        buildInputFieldDefinitionInner(fieldNode, inputObjectType.addField(fieldNode.name.value));
+      }
+      break;
+  }
+  buildAppliedDirectives(definitionNode, type);
+  type.source = definitionNode;
+}
+
+function buildFieldDefinitionInner(fieldNode: FieldDefinitionNode, field: FieldDefinition<any>) {
+  const type = buildWrapperTypeOrTypeRef(fieldNode.type, field.schema()!);
+  field.type = ensureOutputType(type, fieldNode.type);
+  for (const inputValueDef of fieldNode.arguments ?? []) {
+    buildArgumentDefinitionInner(inputValueDef, field.addArgument(inputValueDef.name.value));
+  }
+  buildAppliedDirectives(fieldNode, field);
+  field.source = fieldNode;
+}
+
+export function ensureOutputType(type: Type, node: TypeNode): OutputType {
+  if (isOutputType(type)) {
+    return type;
+  } else {
+    throw new GraphQLError(`Expected ${type} to be an output type`, node);
+  }
+}
+
+export function ensureInputType(type: Type, node: TypeNode): InputType {
+  if (isInputType(type)) {
+    return type;
+  } else {
+    throw new GraphQLError(`Expected ${type} to be an input type`, node);
+  }
+}
+
+function buildWrapperTypeOrTypeRef(typeNode: TypeNode, schema: Schema): Type {
+  switch (typeNode.kind) {
+    case 'ListType':
+      return new ListType(buildWrapperTypeOrTypeRef(typeNode.type, schema));
+    case 'NonNullType':
+      const wrapped = buildWrapperTypeOrTypeRef(typeNode.type, schema);
+      if (wrapped.kind == 'NonNullType') {
+        throw new GraphQLError(`Cannot apply the non-null operator (!) twice to the same type`, typeNode);
+      }
+      return new NonNullType(wrapped);
+    default:
+      return getReferencedType(typeNode, schema);
+  }
+}
+
+function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: ArgumentDefinition<any>) {
+  const type = buildWrapperTypeOrTypeRef(inputNode.type, arg.schema()!);
+  arg.type = ensureInputType(type, inputNode.type);
+  buildAppliedDirectives(inputNode, arg);
+  arg.source = inputNode;
+}
+
+function buildInputFieldDefinitionInner(fieldNode: InputValueDefinitionNode, field: InputFieldDefinition) {
+  const type = buildWrapperTypeOrTypeRef(fieldNode.type, field.schema()!);
+  field.type = ensureInputType(type, fieldNode.type);
+  buildAppliedDirectives(fieldNode, field);
+  field.source = fieldNode;
+}
+
+function buildDirectiveDefinitionInner(directiveNode: DirectiveDefinitionNode, directive: DirectiveDefinition) {
+  for (const inputValueDef of directiveNode.arguments ?? []) {
+    buildArgumentDefinitionInner(inputValueDef, directive.addArgument(inputValueDef.name.value));
+  }
+  directive.repeatable = directiveNode.repeatable;
+  const locations = directiveNode.locations.map(({ value }) => value as DirectiveLocationEnum);
+  directive.addLocations(...locations);
+  directive.source = directiveNode;
+}

--- a/core-js/src/buildSchema.ts
+++ b/core-js/src/buildSchema.ts
@@ -276,7 +276,7 @@ function buildFieldDefinitionInner(fieldNode: FieldDefinitionNode, field: FieldD
   field.sourceAST = fieldNode;
 }
 
-export function ensureOutputType(type: Type, node: TypeNode): OutputType {
+function ensureOutputType(type: Type, node: TypeNode): OutputType {
   if (isOutputType(type)) {
     return type;
   } else {
@@ -284,7 +284,7 @@ export function ensureOutputType(type: Type, node: TypeNode): OutputType {
   }
 }
 
-export function ensureInputType(type: Type, node: TypeNode): InputType {
+function ensureInputType(type: Type, node: TypeNode): InputType {
   if (isInputType(type)) {
     return type;
   } else {

--- a/core-js/src/buildSchema.ts
+++ b/core-js/src/buildSchema.ts
@@ -319,6 +319,7 @@ function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: 
 function buildInputFieldDefinitionInner(fieldNode: InputValueDefinitionNode, field: InputFieldDefinition) {
   const type = buildWrapperTypeOrTypeRef(fieldNode.type, field.schema()!);
   field.type = ensureInputType(type, fieldNode.type);
+  field.defaultValue = buildValue(fieldNode.defaultValue);
   buildAppliedDirectives(fieldNode, field);
   field.description = fieldNode.description?.value;
   field.sourceAST = fieldNode;

--- a/core-js/src/definitions.ts
+++ b/core-js/src/definitions.ts
@@ -1,0 +1,1561 @@
+import {
+  ASTNode,
+  DefinitionNode,
+  DirectiveDefinitionNode,
+  DirectiveNode,
+  DocumentNode,
+  FieldDefinitionNode,
+  GraphQLError,
+  InputValueDefinitionNode,
+  parse,
+  SchemaDefinitionNode,
+  Source,
+  TypeNode,
+  valueFromASTUntyped,
+  ValueNode
+} from "graphql";
+import { assert } from "./utils";
+import deepEqual from 'deep-equal';
+
+export type QueryRoot = 'query';
+export type MutationRoot = 'mutation';
+export type SubscriptionRoot = 'subscription';
+export type SchemaRoot = QueryRoot | MutationRoot | SubscriptionRoot;
+
+export function defaultRootTypeName(root: SchemaRoot) {
+  return root.charAt(0).toUpperCase() + root.slice(1);
+}
+
+type ImmutableWorld = {
+  detached: never,
+  document: GraphQLDocument,
+  schema: Schema,
+  schemaElement: SchemaElement,
+  type: Type,
+  namedType: NamedType,
+  objectType: ObjectType,
+  scalarType: ScalarType,
+  unionType: UnionType,
+  inputObjectType: InputObjectType,
+  inputType: InputType,
+  outputType: OutputType,
+  wrapperType: WrapperType,
+  listType: ListType<any>,
+  fieldDefinition: FieldDefinition,
+  fieldArgumentDefinition: ArgumentDefinition<FieldDefinition>,
+  inputFieldDefinition: InputFieldDefinition,
+  directiveDefinition: DirectiveDefinition,
+  directiveArgumentDefinition: ArgumentDefinition<DirectiveDefinition>,
+  directive: Directive
+}
+
+type MutableWorld = {
+  detached: undefined,
+  document: MutableGraphQLDocument,
+  schema: MutableSchema,
+  schemaElement: MutableSchemaElement,
+  type: MutableType,
+  namedType: MutableNamedType,
+  objectType: MutableObjectType,
+  scalarType: MutableScalarType,
+  unionType: MutableUnionType,
+  inputObjectType: MutableInputObjectType,
+  inputType: MutableInputType,
+  outputType: MutableOutputType,
+  wrapperType: MutableWrapperType,
+  listType: MutableListType<any>,
+  fieldDefinition: MutableFieldDefinition,
+  fieldArgumentDefinition: MutableArgumentDefinition<MutableFieldDefinition>,
+  inputFieldDefinition: MutableInputFieldDefinition,
+  directiveDefinition: MutableDirectiveDefinition
+  directiveArgumentDefinition: MutableArgumentDefinition<MutableDirectiveDefinition>,
+  directive: MutableDirective
+}
+
+type World = ImmutableWorld | MutableWorld;
+
+export type Type = InputType | OutputType;
+export type NamedType = ScalarType | ObjectType | UnionType | InputObjectType;
+export type OutputType = ScalarType | ObjectType | UnionType | ListType<any>;
+export type InputType = ScalarType | InputObjectType;
+export type WrapperType = ListType<any>;
+
+export type MutableType = MutableOutputType | MutableInputType;
+export type MutableNamedType = MutableScalarType | MutableObjectType | MutableUnionType | MutableInputObjectType;
+export type MutableOutputType = MutableScalarType | MutableObjectType | MutableUnionType | MutableListType<any>;
+export type MutableInputType = MutableScalarType | MutableInputObjectType;
+export type MutableWrapperType = MutableListType<any>;
+
+// Those exists to make it a bit easier to write code that work on both mutable and immutable variants, if one so wishes.
+export type AnyGraphQLDocument = GraphQLDocument | MutableGraphQLDocument;
+export type AnySchemaElement = SchemaElement | MutableSchemaElement;
+export type AnyType = AnyOutputType | AnyInputType;
+export type AnyNamedType = AnyScalarType | AnyObjectType | AnyUnionType | AnyInputObjectType;
+export type AnyOutputType = AnyScalarType | AnyObjectType | AnyUnionType | AnyListType;
+export type AnyInputType = AnyScalarType | AnyInputObjectType;
+export type AnyWrapperType = AnyListType;
+export type AnyScalarType = ScalarType | MutableScalarType;
+export type AnyObjectType = ObjectType | MutableObjectType;
+export type AnyUnionType = UnionType | MutableUnionType;
+export type AnyInputObjectType = InputObjectType | MutableInputObjectType;
+export type AnyListType = ListType<any> | MutableListType<any>;
+
+export type AnySchema = Schema | MutableSchema;
+export type AnyDirectiveDefinition = DirectiveDefinition | MutableDirectiveDefinition;
+export type AnyDirective = Directive | MutableDirective;
+export type AnyFieldDefinition = FieldDefinition | MutableFieldDefinition;
+export type AnyInputFieldDefinition = InputFieldDefinition | MutableInputFieldDefinition;
+export type AnyFieldArgumentDefinition = ArgumentDefinition<FieldDefinition> | MutableArgumentDefinition<MutableFieldDefinition>;
+export type AnyDirectiveArgumentDefinition = ArgumentDefinition<DirectiveDefinition> | MutableArgumentDefinition<MutableDirectiveDefinition>;
+export type AnyArgumentDefinition = AnyFieldDefinition | AnyDirectiveDefinition;
+
+const builtInTypes = [ 'Int', 'Float', 'String', 'Boolean', 'ID' ];
+const builtInDirectives = [ 'include', 'skip', 'deprecated', 'specifiedBy' ];
+
+export function isNamedType<W extends World>(type: W['type']): type is W['namedType'] {
+  return type instanceof BaseNamedType;
+}
+
+export function isWrapperType<W extends World>(type: W['type']): type is W['wrapperType'] {
+  return type.kind == 'ListType';
+}
+
+export function isBuiltInType<W extends World>(type: W['namedType']): boolean {
+  return builtInTypes.includes(type.name);
+}
+
+export function isBuiltInDirective<W extends World>(directive: W['directiveDefinition']): boolean {
+  return builtInDirectives.includes(directive.name);
+}
+
+export interface Named {
+  readonly name: string;
+}
+
+function valueToString(v: any): string {
+  return JSON.stringify(v);
+}
+
+function valueEquals(a: any, b: any): boolean {
+  return deepEqual(a, b);
+}
+
+// TODO: make most of those a field since they are essentially a "property" of the element (document() excluded maybe).
+export interface SchemaElement<W extends World = ImmutableWorld> {
+  coordinate(): string;
+  document(): W['document'] | W['detached'];
+  parent(): W['schemaElement'] | W['document'] | W['detached'];
+  source(): ASTNode | undefined;
+  appliedDirectives(): readonly W['directive'][];
+  appliedDirective(name: string): W['directive'][];
+}
+
+export interface MutableSchemaElement extends SchemaElement<MutableWorld> {
+  remove(): MutableSchemaElement[];
+}
+
+abstract class BaseElement<P extends W['schemaElement']  | W['document'], W extends World> implements SchemaElement<W> {
+  protected readonly _appliedDirectives: W['directive'][] = [];
+
+  constructor(
+    protected _parent: P | W['detached'],
+    protected _source?: ASTNode
+  ) {}
+
+  abstract coordinate(): string;
+
+  document(): W['document'] | W['detached'] {
+    if (this._parent == undefined) {
+      return undefined;
+    } else if ('kind' in this._parent && this._parent.kind == 'Document') {
+      return this._parent as W['document'];
+    } else {
+      return (this._parent as W['schemaElement']).document();
+    }
+  }
+
+  parent(): P | W['detached'] {
+    return this._parent;
+  }
+
+  setParent(parent: P) {
+    assert(!this._parent, "Cannot set parent of a non-detached element");
+    this._parent = parent;
+  }
+
+  source(): ASTNode | undefined {
+    return this._source;
+  }
+
+  appliedDirectives(): readonly W['directive'][] {
+    return this._appliedDirectives;
+  }
+
+  appliedDirective(name: string): W['directive'][] {
+    return this._appliedDirectives.filter(d => d.name == name);
+  }
+
+  protected addAppliedDirective(directive: W['directive']): W['directive'] {
+    // TODO: should we dedup directives applications with the same arguments?
+    // TODO: also, should we reject directive applications for directives that are not declared (maybe do so in the Directive ctor
+    // and add a link to the definition)? 
+    this._appliedDirectives.push(directive);
+    return directive;
+  }
+
+  protected removeTypeReference(_: W['namedType']): void {
+  }
+}
+
+abstract class BaseNamedElement<P extends W['schemaElement']  | W['document'], W extends World> extends BaseElement<P, W> implements Named {
+  constructor(
+    readonly name: string,
+    parent: P | W['detached'],
+    source?: ASTNode
+  ) {
+    super(parent, source);
+  }
+}
+
+abstract class BaseNamedType<W extends World> extends BaseNamedElement<W['document'], W> {
+  protected readonly _referencers: Set<W['schemaElement']> = new Set();
+
+  protected constructor(
+    name: string,
+    document: W['document'] | W['detached'],
+    source?: ASTNode
+  ) {
+    super(name, document, source);
+  }
+
+  coordinate(): string {
+    return this.name;
+  }
+
+  *allChildrenElements(): Generator<W['schemaElement'], void, undefined> {
+    // Overriden by those types that do have chidrens
+  }
+
+  private addReferencer(referencer: W['schemaElement']) {
+    assert(referencer, 'Referencer should exists');
+    this._referencers.add(referencer);
+  }
+
+  toString(): string {
+    return this.name;
+  }
+}
+
+class BaseGraphQLDocument<W extends World> {
+  private _schema: W['schema'] | undefined = undefined;
+  protected readonly builtInTypes: Map<string, W['scalarType']> = new Map();
+  protected readonly typesMap: Map<string, W['namedType']> = new Map();
+  protected readonly directivesMap: Map<string, W['directiveDefinition'] & W['schemaElement']> = new Map();
+
+  protected constructor() {}
+
+  kind: 'Document' = 'Document';
+
+  // Used only through cheating the type system.
+  private setSchema(schema: W['schema']) {
+    this._schema = schema;
+  }
+
+  private setBuiltIn(name: string, type: W['scalarType']) {
+    this.builtInTypes.set(name, type);
+  }
+
+  get schema(): W['schema'] {
+    assert(this._schema, "Badly constructor document; doesn't have a schema");
+    return this._schema;
+  }
+
+  /**
+   * A map of all the types defined on this document _excluding_ the built-in types.
+   */
+  get types(): ReadonlyMap<string, W['namedType']> {
+    return this.typesMap;
+  }
+
+  /**
+   * The type of the provide name in this document if one is defined or if it is the name of a built-in.
+   */
+  type(name: string): W['namedType'] | undefined {
+    const type = this.typesMap.get(name);
+    return type ? type : this.builtInTypes.get(name);
+  }
+
+  intType(): W['scalarType'] {
+    return this.builtInTypes.get('Int')!;
+  }
+
+  floatType(): W['scalarType'] {
+    return this.builtInTypes.get('Float')!;
+  }
+
+  stringType(): W['scalarType'] {
+    return this.builtInTypes.get('String')!;
+  }
+
+  booleanType(): W['scalarType'] {
+    return this.builtInTypes.get('Boolean')!;
+  }
+
+  idType(): W['scalarType'] {
+    return this.builtInTypes.get('ID')!;
+  }
+
+  get directives(): ReadonlyMap<string, W['directiveDefinition'] & W['schemaElement']> {
+    return this.directivesMap;
+  }
+
+  directive(name: string): W['directiveDefinition'] | undefined {
+    return this.directivesMap.get(name);
+  }
+
+  *allSchemaElement(): Generator<W['schemaElement'], void, undefined> {
+    if (this._schema) {
+      yield this._schema;
+    }
+    for (const type of this.types.values()) {
+      yield type;
+      yield* type.allChildrenElements();
+    }
+    for (const directive of this.directives.values()) {
+      yield directive;
+      yield* directive.arguments().values();
+    }
+  }
+}
+
+export class GraphQLDocument extends BaseGraphQLDocument<ImmutableWorld> {
+  // Note that because typescript typesystem is structural, we need GraphQLDocument to some incompatible
+  // properties in GraphQLDocument that are not in MutableGraphQLDocument (not having MutableGraphQLDocument be a subclass
+  // of GraphQLDocument is not sufficient). This is the why of the 'mutable' field (the `toMutable` property
+  // also achieve this in practice, but we could want to add a toMutable() to MutableGraphQLDocument (that
+  // just return `this`) for some reason, so the field is a bit clearer/safer).
+  mutable: false = false;
+
+  static parse(source: string | Source): GraphQLDocument {
+    return buildDocumentInternal(parse(source), Ctors.immutable);
+  }
+
+  toMutable(): MutableGraphQLDocument {
+    return copy(this, Ctors.mutable);
+  }
+}
+
+export class MutableGraphQLDocument extends BaseGraphQLDocument<MutableWorld> {
+  mutable: true = true;
+
+  static empty(): MutableGraphQLDocument {
+    return Ctors.mutable.addSchema(Ctors.mutable.document());
+  }
+
+  static parse(source: string | Source): MutableGraphQLDocument {
+    return buildDocumentInternal(parse(source), Ctors.mutable);
+  }
+
+  private ensureTypeNotFound(name: string) {
+    if (this.type(name)) {
+      throw new GraphQLError(`Type ${name} already exists in this document`);
+    }
+  }
+
+  private addOrGetType(name: string, kind: string, adder: (n: string) => MutableNamedType) {
+    // Note: we don't use `this.type(name)` so that `addOrGetScalarType` always throws when called
+    // with the name of a scalar type.
+    const existing = this.typesMap.get(name);
+    if (existing) {
+      if (existing.kind == kind) {
+        return existing;
+      }
+      throw new GraphQLError(`Type ${name} already exists and is not an ${kind} (it is a ${existing.kind})`);
+    }
+    return adder(name);
+  }
+
+  private addType<T extends MutableNamedType>(name: string, ctor: (n: string) => T): T {
+    this.ensureTypeNotFound(name);
+    const newType = ctor(name);
+    this.typesMap.set(newType.name, newType);
+    return newType;
+  }
+
+  addOrGetObjectType(name: string): MutableObjectType {
+    return this.addOrGetType(name, 'ObjectType', n => this.addObjectType(n)) as MutableObjectType;
+  }
+
+  addObjectType(name: string): MutableObjectType {
+    return this.addType(name, n => Ctors.mutable.createObjectType(n, this));
+  }
+
+  addOrGetScalarType(name: string): MutableScalarType {
+    return this.addOrGetType(name, 'ScalarType', n => this.addScalarType(n)) as MutableScalarType;
+  }
+
+  addScalarType(name: string): MutableScalarType {
+    if (this.builtInTypes.has(name)) {
+      throw new GraphQLError(`Cannot add scalar type of name ${name} as it is a built-in type`);
+    }
+    return this.addType(name, n => Ctors.mutable.createScalarType(n, this));
+  }
+
+  addDirective(directive: MutableDirectiveDefinition) {
+    this.directivesMap.set(directive.name, directive);
+  }
+
+  toImmutable(): GraphQLDocument {
+    return copy(this, Ctors.immutable);
+  }
+}
+
+export class Schema<W extends World = ImmutableWorld> extends BaseElement<W['document'], W>  {
+  protected readonly rootsMap: Map<SchemaRoot, W['objectType']> = new Map();
+
+  protected constructor(
+    parent: W['document'] | W['detached'],
+    source?: ASTNode
+  ) {
+    super(parent, source);
+  }
+
+  coordinate(): string {
+    return '';
+  }
+
+  kind: 'Schema' = 'Schema';
+
+  get roots(): ReadonlyMap<SchemaRoot, W['objectType']> {
+    return this.rootsMap;
+  }
+
+  root(rootType: SchemaRoot): W['objectType'] | undefined {
+    return this.rootsMap.get(rootType);
+  }
+
+  protected removeTypeReference(toRemove: W['namedType']): void {
+    for (const [root, type] of this.rootsMap) {
+      if (type == toRemove) {
+        this.rootsMap.delete(root);
+      }
+    }
+  }
+
+  toString() {
+    return `schema[${[...this.rootsMap.keys()].join(', ')}]`;
+  }
+}
+
+export class MutableSchema extends Schema<MutableWorld> implements MutableSchemaElement {
+  setRoot(rootType: SchemaRoot, objectType: MutableObjectType): MutableObjectType {
+    if (objectType.document() != this.document()) {
+      const attachement = objectType.document() ? 'attached to another document' : 'detached';
+      throw new GraphQLError(`Cannot use provided type ${objectType} for ${rootType} as it is not attached to this document (it is ${attachement})`);
+    }
+    this.rootsMap.set(rootType, objectType);
+    return objectType;
+  }
+
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  remove(): MutableSchemaElement[] {
+    throw new Error('TODO');
+  }
+}
+
+export class ScalarType<W extends World = ImmutableWorld> extends BaseNamedType<W> {
+  kind: 'ScalarType' = 'ScalarType';
+
+  protected removeTypeReference(_: W['namedType']): void {
+    assert(false, "Scalar types can never reference other types");
+  }
+}
+
+export class MutableScalarType extends ScalarType<MutableWorld> implements MutableSchemaElement {
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    if (builtInTypes.includes(this.name)) {
+      throw Error(`Cannot apply directive to built-in type ${this.name}`);
+    }
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  /**
+   * Removes this type definition from its parent document.
+   *
+   * After calling this method, this type will be "detached": it wil have no parent, document, fields,
+   * values, directives, etc...
+   *
+   * Note that it is always allowed to remove a type, but this may make a valid document
+   * invalid, and in particular any element that references this type will, after this call, have an undefined
+   * reference.
+   *
+   * @returns an array of all the elements in the document of this type (before the removal) that were
+   * referening this type (and have thus now an undefined reference).
+   */
+  remove(): MutableSchemaElement[] {
+    if (!this._parent) {
+      return [];
+    }
+    removeTypeDefinition(this, this._parent);
+    this._parent = undefined;
+    for (const directive of this._appliedDirectives) {
+      directive.remove();
+    }
+    const toReturn = [... this._referencers].map(r => {
+      BaseElement.prototype['removeTypeReference'].call(r, this);
+      return r;
+    });
+    this._referencers.clear();
+    return toReturn;
+  }
+}
+
+export class ObjectType<W extends World = ImmutableWorld> extends BaseNamedType<W> {
+  protected readonly fieldsMap: Map<string, W['fieldDefinition']> = new Map();
+
+  protected constructor(
+    name: string,
+    document: W['document'] | undefined,
+    source?: ASTNode
+  ) {
+    super(name, document, source);
+  }
+
+  kind: 'ObjectType' = 'ObjectType';
+
+  get fields(): ReadonlyMap<string, W['fieldDefinition']> {
+    return this.fieldsMap;
+  }
+
+  field(name: string): W['fieldDefinition'] | undefined {
+    return this.fieldsMap.get(name);
+  }
+
+  *allChildrenElements(): Generator<W['schemaElement'], void, undefined> {
+    for (const field of this.fieldsMap.values()) {
+      yield field;
+      yield* field.arguments().values();
+    }
+  }
+
+  protected removeTypeReference(_: W['namedType']): void {
+    assert(false, "Object types can never reference other types directly (their field does)");
+  }
+}
+
+export class MutableObjectType extends ObjectType<MutableWorld> implements MutableSchemaElement {
+  addField(name: string, type: MutableOutputType): MutableFieldDefinition {
+    if (this.field(name)) {
+      throw new GraphQLError(`Field ${name} already exists in type ${this} (${this.field(name)})`);
+    }
+    if (type.document() != this.document()) {
+      const attachement = type.document() ? 'attached to another document' : 'detached';
+      throw new GraphQLError(`Cannot use provided type ${type} as it is not attached to this document (it is ${attachement})`);
+    }
+    const field = Ctors.mutable.createFieldDefinition(name, this, type);
+    this.fieldsMap.set(name, field);
+    return field;
+  }
+
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  /**
+   * Removes this type definition from its parent document.
+   *
+   * After calling this method, this type will be "detached": it wil have no parent, document, fields,
+   * values, directives, etc...
+   *
+   * Note that it is always allowed to remove a type, but this may make a valid document
+   * invalid, and in particular any element that references this type will, after this call, have an undefined
+   * reference.
+   *
+   * @returns an array of all the elements in the document of this type (before the removal) that were
+   * referening this type (and have thus now an undefined reference).
+   */
+  remove(): MutableSchemaElement[] {
+    if (!this._parent) {
+      return [];
+    }
+    removeTypeDefinition(this, this._parent);
+    this._parent = undefined;
+    for (const directive of this._appliedDirectives) {
+      directive.remove();
+    }
+    for (const field of this.fieldsMap.values()) {
+      field.remove();
+    }
+    const toReturn = [... this._referencers].map(r => {
+      BaseElement.prototype['removeTypeReference'].call(r, this);
+      return r;
+    });
+    this._referencers.clear();
+    return toReturn;
+  }
+}
+
+export class UnionType<W extends World = ImmutableWorld> extends BaseNamedType<W> {
+  protected readonly typesList: W['objectType'][] = [];
+
+  protected constructor(
+    name: string,
+    document: W['document'] | W['detached'],
+    source?: ASTNode
+  ) {
+    super(name, document, source);
+  }
+
+  kind: 'UnionType' = 'UnionType';
+
+  get types(): readonly W['objectType'][] {
+    return this.typesList;
+  }
+
+  protected removeTypeReference(type: W['namedType']): void {
+    const index = this.typesList.indexOf(type as W['objectType']);
+    if (index >= 0) {
+    this.typesList.splice(index, 1);
+    }
+  }
+}
+
+export class MutableUnionType extends UnionType<MutableWorld> implements MutableSchemaElement {
+  addType(type: MutableObjectType): void {
+    if (type.document() != this.document()) {
+      const attachement = type.document() ? 'attached to another document' : 'detached';
+      throw new GraphQLError(`Cannot add provided type ${type} to union ${this} as it is not attached to this document (it is ${attachement})`);
+    }
+    if (!this.typesList.includes(type)) {
+      this.typesList.push(type);
+    }
+  }
+
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  /**
+   * Removes this type definition from its parent document.
+   *
+   * After calling this method, this type will be "detached": it wil have no parent, document, fields,
+   * values, directives, etc...
+   *
+   * Note that it is always allowed to remove a type, but this may make a valid document
+   * invalid, and in particular any element that references this type will, after this call, have an undefined
+   * reference.
+   *
+   * @returns an array of all the elements in the document of this type (before the removal) that were
+   * referening this type (and have thus now an undefined reference).
+   */
+  remove(): MutableSchemaElement[] {
+    if (!this._parent) {
+      return [];
+    }
+    removeTypeDefinition(this, this._parent);
+    this._parent = undefined;
+    for (const directive of this._appliedDirectives) {
+      directive.remove();
+    }
+    this.typesList.splice(0, this.typesList.length);
+    const toReturn = [... this._referencers].map(r => {
+      BaseElement.prototype['removeTypeReference'].call(r, this);
+      return r;
+    });
+    this._referencers.clear();
+    return toReturn;
+  }
+}
+
+export class InputObjectType<W extends World = ImmutableWorld> extends BaseNamedType<W> {
+  protected readonly fieldsMap: Map<string, W['inputFieldDefinition']> = new Map();
+
+  protected constructor(
+    name: string,
+    document: W['document'] | undefined,
+    source?: ASTNode
+  ) {
+    super(name, document, source);
+  }
+
+  kind: 'InputObjectType' = 'InputObjectType';
+
+  get fields(): ReadonlyMap<string, W['inputFieldDefinition']> {
+    return this.fieldsMap;
+  }
+
+  field(name: string): W['inputFieldDefinition'] | undefined {
+    return this.fieldsMap.get(name);
+  }
+
+  *allChildrenElements(): Generator<W['schemaElement'], void, undefined> {
+    yield* this.fieldsMap.values();
+  }
+
+  protected removeTypeReference(_: W['namedType']): void {
+    assert(false, "Input object types can never reference other types directly (their field does)");
+  }
+}
+
+export class MutableInputObjectType extends InputObjectType<MutableWorld> implements MutableSchemaElement {
+  addField(name: string, type: MutableInputType): MutableInputFieldDefinition {
+    if (this.field(name)) {
+      throw new GraphQLError(`Field ${name} already exists in type ${this} (${this.field(name)})`);
+    }
+    if (type.document() != this.document()) {
+      const attachement = type.document() ? 'attached to another document' : 'detached';
+      throw new GraphQLError(`Cannot use provided type ${type} as it is not attached to this document (it is ${attachement})`);
+    }
+    const field = Ctors.mutable.createInputFieldDefinition(name, this, type);
+    this.fieldsMap.set(name, field);
+    return field;
+  }
+
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  /**
+   * Removes this type definition from its parent document.
+   *
+   * After calling this method, this type will be "detached": it wil have no parent, document, fields,
+   * values, directives, etc...
+   *
+   * Note that it is always allowed to remove a type, but this may make a valid document
+   * invalid, and in particular any element that references this type will, after this call, have an undefined
+   * reference.
+   *
+   * @returns an array of all the elements in the document of this type (before the removal) that were
+   * referening this type (and have thus now an undefined reference).
+   */
+  remove(): MutableSchemaElement[] {
+    if (!this._parent) {
+      return [];
+    }
+    removeTypeDefinition(this, this._parent);
+    this._parent = undefined;
+    for (const directive of this._appliedDirectives) {
+      directive.remove();
+    }
+    for (const field of this.fieldsMap.values()) {
+      field.remove();
+    }
+    const toReturn = [... this._referencers].map(r => {
+      BaseElement.prototype['removeTypeReference'].call(r, this);
+      return r;
+    });
+    this._referencers.clear();
+    return toReturn;
+  }
+}
+
+export class ListType<T extends W['type'], W extends World = ImmutableWorld> {
+  protected constructor(protected _type: T) {}
+
+  kind: 'ListType' = 'ListType';
+
+  document(): W['document'] {
+    return this.baseType().document() as W['document'];
+  }
+
+  ofType(): T {
+    return this._type;
+  }
+
+  baseType(): W['namedType'] {
+    return isWrapperType(this._type) ? this._type.baseType() : this._type as W['namedType'];
+  }
+
+  toString(): string {
+    return `[${this.ofType()}]`;
+  }
+}
+
+export class MutableListType<T extends MutableType> extends ListType<T, MutableWorld> {}
+
+export class FieldDefinition<W extends World = ImmutableWorld> extends BaseNamedElement<W['objectType'], W> {
+  protected readonly _args: Map<string, W['fieldArgumentDefinition']> = new Map();
+
+  protected constructor(
+    name: string,
+    parent: W['objectType'] | W['detached'],
+    protected _type: W['outputType'] | W['detached'],
+    source?: ASTNode
+  ) {
+    super(name, parent, source);
+  }
+
+  kind: 'FieldDefinition' = 'FieldDefinition';
+
+  coordinate(): string {
+    const parent = this.parent();
+    return `${parent == undefined ? '<detached>' : parent.coordinate()}.${this.name}`;
+  }
+
+  type(): W['outputType'] | W['detached'] {
+    return this._type;
+  }
+
+  arguments(): ReadonlyMap<string, W['fieldArgumentDefinition']> {
+    return this._args;
+  }
+
+  argument(name: string): W['fieldArgumentDefinition'] | undefined {
+    return this._args.get(name);
+  }
+
+  protected removeTypeReference(type: W['namedType']): void {
+    if (this._type == type) {
+      this._type = undefined;
+    }
+  }
+
+  toString(): string {
+    const args = this._args.size == 0
+      ? "" 
+      : '(' + [...this._args.values()].map(arg => arg.toString()).join(', ') + ')';
+    return `${this.name}${args}: ${this.type()}`;
+  }
+}
+
+export class MutableFieldDefinition extends FieldDefinition<MutableWorld> implements MutableSchemaElement {
+  setType(type: MutableOutputType): MutableFieldDefinition {
+    if (!this.document()) {
+      // Let's not allow manipulating detached elements too much as this could make our lives harder.
+      throw new GraphQLError(`Cannot set the type of field ${this.name} as it is detached`);
+    }
+    if (type.document() != this.document()) {
+      const attachement = type.document() ? 'attached to another document' : 'detached';
+      throw new GraphQLError(`Cannot set provided type ${type} to field ${this.name} as it is not attached to this document (it is ${attachement})`);
+    }
+    this._type = type;
+    return this;
+  }
+
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  /**
+   * Removes this field definition from its parent type.
+   *
+   * After calling this method, this field definition will be "detached": it wil have no parent, document, type,
+   * arguments or directives.
+   */
+  remove(): MutableSchemaElement[] {
+    if (!this._parent) {
+      return [];
+    }
+    (this._parent.fields as Map<string, MutableFieldDefinition>).delete(this.name);
+    // We "clean" all the attributes of the object. This is because we mean detached element to be essentially
+    // dead and meant to be GCed and this ensure we don't prevent that for no good reason.
+    this._parent = undefined;
+    this._type = undefined;
+    for (const arg of this._args.values()) {
+      arg.remove();
+    }
+    // Fields have nothing that can reference them outside of their parents
+    return [];
+  }
+}
+
+export class InputFieldDefinition<W extends World = ImmutableWorld> extends BaseNamedElement<W['inputObjectType'], W> {
+  protected constructor(
+    name: string,
+    parent: W['inputObjectType'] | W['detached'],
+    protected _type: W['inputType'] | W['detached'],
+    source?: ASTNode
+  ) {
+    super(name, parent, source);
+  }
+
+  coordinate(): string {
+    const parent = this.parent();
+    return `${parent == undefined ? '<detached>' : parent.coordinate()}.${this.name}`;
+  }
+
+  kind: 'InputFieldDefinition' = 'InputFieldDefinition';
+
+  type(): W['inputType'] | W['detached'] {
+    return this._type;
+  }
+
+  protected removeTypeReference(type: W['namedType']): void {
+    if (this._type == type) {
+      this._type = undefined;
+    }
+  }
+
+  toString(): string {
+    return `${this.name}: ${this.type()}`;
+  }
+}
+
+export class MutableInputFieldDefinition extends InputFieldDefinition<MutableWorld> implements MutableSchemaElement {
+  setType(type: MutableInputType): MutableInputFieldDefinition {
+    if (!this.document()) {
+      // Let's not allow manipulating detached elements too much as this could make our lives harder.
+      throw new GraphQLError(`Cannot set the type of input field ${this.name} as it is detached`);
+    }
+    if (type.document() != this.document()) {
+      const attachement = type.document() ? 'attached to another document' : 'detached';
+      throw new GraphQLError(`Cannot set provided type ${type} to input field ${this.name} as it is not attached to this document (it is ${attachement})`);
+    }
+    this._type = type;
+    return this;
+  }
+
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  /**
+   * Removes this field definition from its parent type.
+   *
+   * After calling this method, this field definition will be "detached": it wil have no parent, document, type,
+   * arguments or directives.
+   */
+  remove(): MutableSchemaElement[] {
+    if (!this._parent) {
+      return [];
+    }
+    (this._parent.fields as Map<string, MutableInputFieldDefinition>).delete(this.name);
+    // We "clean" all the attributes of the object. This is because we mean detached element to be essentially
+    // dead and meant to be GCed and this ensure we don't prevent that for no good reason.
+    this._parent = undefined;
+    this._type = undefined;
+    // Fields have nothing that can reference them outside of their parents
+    return [];
+  }
+}
+
+export class ArgumentDefinition<P extends W['fieldDefinition'] | W['directiveDefinition'], W extends World = ImmutableWorld> extends BaseNamedElement<P, W> {
+  protected constructor(
+    name: string,
+    parent: P | W['detached'],
+    protected _type: W['inputType'] | W['detached'],
+    protected _defaultValue: any,
+    source?: ASTNode
+  ) {
+    super(name, parent, source);
+  }
+
+  kind: 'ArgumentDefinition' = 'ArgumentDefinition';
+
+  coordinate(): string {
+    const parent = this.parent();
+    return `${parent == undefined ? '<detached>' : parent.coordinate()}(${this.name}:)`;
+  }
+
+  type(): W['inputType'] | W['detached'] {
+    return this._type;
+  }
+
+  defaultValue(): any {
+    return this._defaultValue;
+  }
+
+  protected removeTypeReference(type: W['namedType']): void {
+    if (this._type == type) {
+      this._type = undefined;
+    }
+  }
+
+  toString() {
+    const defaultStr = this._defaultValue == undefined ? "" : ` = ${this._defaultValue}`;
+    return `${this.name}: ${this._type}${defaultStr}`;
+  }
+}
+
+export class MutableArgumentDefinition<P extends MutableFieldDefinition | MutableDirectiveDefinition> extends ArgumentDefinition<P, MutableWorld> implements MutableSchemaElement {
+  applyDirective(name: string, args?: Map<string, any>): MutableDirective {
+    return this.addAppliedDirective(Ctors.mutable.createDirective(name, this, args ?? new Map()));
+  }
+
+  /**
+   * Removes this argument definition from its parent element (field or directive).
+   *
+   * After calling this method, this argument definition will be "detached": it wil have no parent, document, type,
+   * default value or directives.
+   */
+  remove(): MutableSchemaElement[] {
+    if (!this._parent) {
+      return [];
+    }
+    (this._parent.arguments() as Map<string, any>).delete(this.name);
+    // We "clean" all the attributes of the object. This is because we mean detached element to be essentially
+    // dead and meant to be GCed and this ensure we don't prevent that for no good reason.
+    this._parent = undefined;
+    this._type = undefined;
+    this._defaultValue = undefined;
+    return [];
+  }
+}
+
+export class DirectiveDefinition<W extends World = ImmutableWorld> extends BaseNamedElement<W['document'], W> {
+  protected readonly _args: Map<string, W['directiveArgumentDefinition']> = new Map();
+
+  protected constructor(
+    name: string,
+    document: W['document'] | W['detached'],
+    source?: ASTNode
+  ) {
+    super(name, document, source);
+  }
+
+  kind: 'Directive' = 'Directive';
+
+  coordinate(): string {
+    throw new Error('TODO');
+  }
+
+  arguments(): ReadonlyMap<string, W['directiveArgumentDefinition']> {
+    return this._args;
+  }
+
+  argument(name: string): W['directiveArgumentDefinition'] | undefined {
+    return this._args.get(name);
+  }
+
+  protected removeTypeReference(_: W['namedType']): void {
+    assert(false, "Directive definitions can never reference other types directly (their arguments might)");
+  }
+
+  toString(): string {
+    return this.name;
+  }
+}
+
+export class MutableDirectiveDefinition extends DirectiveDefinition<MutableWorld> implements MutableSchemaElement {
+  addArgument(name: string, type: MutableInputType, defaultValue?: any): MutableArgumentDefinition<MutableDirectiveDefinition> {
+    if (!this.document()) {
+      // Let's not allow manipulating detached elements too much as this could make our lives harder.
+      throw new GraphQLError(`Cannot add argument to directive definition ${this.name} as it is detached`);
+    }
+    if (type.document() != this.document()) {
+      const attachement = type.document() ? 'attached to another document' : 'detached';
+      throw new GraphQLError(`Cannot use type ${type} for argument of directive definition ${this.name} as it is not attached to this document (it is ${attachement})`);
+    }
+    const newArg = Ctors.mutable.createDirectiveArgumentDefinition(name, this, type, defaultValue);
+    this._args.set(name, newArg);
+    return newArg;
+  }
+
+  remove(): MutableSchemaElement[] {
+    throw new Error('TODO');
+  }
+}
+
+export class Directive<W extends World = ImmutableWorld> implements Named {
+  protected constructor(
+    readonly name: string,
+    protected _parent: W['schemaElement'] | W['detached'],
+    protected _args: Map<string, any>,
+    readonly source?: ASTNode
+  ) {
+  }
+
+  document(): W['document'] | W['detached'] {
+    return this._parent?.document();
+  }
+
+  parent(): W['schemaElement'] | W['detached'] {
+    return this._parent;
+  }
+
+  definition(): W['directiveDefinition'] | W['detached'] {
+    const doc = this.document();
+    return doc?.directive(this.name);
+  }
+
+  get arguments() : ReadonlyMap<string, any> {
+    return this._args;
+  }
+
+  argument(name: string): any {
+    return this._args.get(name);
+  }
+
+  matchArguments(expectedArgs: Map<string, any>): boolean {
+    if (this._args.size !== expectedArgs.size) {
+      return false;
+    }
+    for (var [key, val] of this._args) {
+      const expectedVal = expectedArgs.get(key);
+      // In cases of an undefined value, make sure the key actually exists on the object so there are no false positives
+      if (!valueEquals(expectedVal, val) || (expectedVal === undefined && !expectedArgs.has(key))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  toString(): string {
+    const args = this._args.size == 0 ? '' : '(' + [...this._args.entries()].map(([n, v]) => `${n}: ${valueToString(v)}`).join(', ') + ')';
+    return `@${this.name}${args}`;
+  }
+}
+
+export class MutableDirective extends Directive<MutableWorld> {
+  /**
+   * Removes this directive application from its parent type.
+   *
+   * @returns whether the directive was actually removed, that is whether it had a parent.
+   */
+  remove(): boolean {
+    if (!this._parent) {
+      return false;
+    }
+    const parentDirectives = this._parent.appliedDirectives() as MutableDirective[];
+    const index = parentDirectives.indexOf(this);
+    assert(index >= 0, `Directive ${this} lists ${this._parent} as parent, but that parent doesn't list it as applied directive`);
+    parentDirectives.splice(index, 1);
+    this._parent = undefined;
+    return true;
+  }
+}
+
+class Ctors<W extends World> {
+  // The definitions below are a hack to work around that typescript does not have "module" visibility for class constructors.
+  // Meaning, we don't want the constructors below to be exposed (because it would be way too easy to break some of the class
+  // invariants if using them, and more generally we don't want users to care about that level of detail), so all those ctors
+  // are protected, but we still need to access them here, hence the `Function.prototype` hack.
+  // Note: this is fairly well contained so manageable but certainly ugly and a bit error-prone, so if someone knowns a better way?
+  static immutable = new Ctors<ImmutableWorld>(
+    () => new (Function.prototype.bind.call(GraphQLDocument, null)),
+    (parent, source) => new (Function.prototype.bind.call(Schema, null, parent, source)),
+    (name, doc, source) => new (Function.prototype.bind.call(ScalarType, null, name, doc, source)),
+    (name, doc, source) => new (Function.prototype.bind.call(ObjectType, null, name, doc, source)),
+    (name, doc, source) => new (Function.prototype.bind.call(UnionType, null, name, doc, source)),
+    (name, doc, source) => new (Function.prototype.bind.call(InputObjectType, null, name, doc, source)),
+    (type) => new (Function.prototype.bind.call(ListType, null, type)),
+    (name, parent, type, source) => new (Function.prototype.bind.call(FieldDefinition, null, name, parent, type, source)),
+    (name, parent, type, source) => new (Function.prototype.bind.call(InputFieldDefinition, null, name, parent, type, source)),
+    (name, parent, type, value, source) => new (Function.prototype.bind.call(ArgumentDefinition, null, name, parent, type, value, source)),
+    (name, parent, type, value, source) => new (Function.prototype.bind.call(ArgumentDefinition, null, name, parent, type, value, source)),
+    (name, parent, source) => new (Function.prototype.bind.call(DirectiveDefinition, null, name, parent, source)),
+    (name, parent, args, source) => new (Function.prototype.bind.call(Directive, null, name, parent, args, source)),
+    (v) => { 
+      if (v == undefined)
+        // TODO: Better error; maybe pass a string to include so the message is more helpful.
+        throw new Error("Invalid detached value"); 
+      return v;
+    }
+  );
+
+  static mutable = new Ctors<MutableWorld>(
+    () => new (Function.prototype.bind.call(MutableGraphQLDocument, null)),
+    (parent, source) => new (Function.prototype.bind.call(MutableSchema, null, parent, source)),
+    (name, doc,  source) => new (Function.prototype.bind.call(MutableScalarType, null, name, doc, source)),
+    (name, doc, source) => new (Function.prototype.bind.call(MutableObjectType, null, name, doc, source)),
+    (name, doc, source) => new (Function.prototype.bind.call(MutableUnionType, null, name, doc, source)),
+    (name, doc, source) => new (Function.prototype.bind.call(MutableInputObjectType, null, name, doc, source)),
+    (type) => new (Function.prototype.bind.call(MutableListType, null, type)),
+    (name, parent, type, source) => new (Function.prototype.bind.call(MutableFieldDefinition, null, name, parent, type, source)),
+    (name, parent, type, source) => new (Function.prototype.bind.call(MutableInputFieldDefinition, null, name, parent, type, source)),
+    (name, parent, type, value, source) => new (Function.prototype.bind.call(MutableArgumentDefinition, null, name, parent, type, value, source)),
+    (name, parent, type, value, source) => new (Function.prototype.bind.call(MutableArgumentDefinition, null, name, parent, type, value, source)),
+    (name, parent, source) => new (Function.prototype.bind.call(MutableDirectiveDefinition, null, name, parent, source)),
+    (name, parent, args, source) => new (Function.prototype.bind.call(MutableDirective, null, name, parent, args, source)),
+    (v) => v
+  );
+
+  constructor(
+    private readonly createDocument: () => W['document'],
+    private readonly createSchema: (parent: W['document'] | W['detached'], source?: ASTNode) => W['schema'],
+    readonly createScalarType: (name: string, document: W['document'] | W['detached'], source?: ASTNode) => W['scalarType'],
+    readonly createObjectType: (name: string, document: W['document'] | W['detached'], source?: ASTNode) => W['objectType'],
+    readonly createUnionType: (name: string, document: W['document'] | W['detached'], source?: ASTNode) => W['unionType'],
+    readonly createInputObjectType: (name: string, document: W['document'] | W['detached'], source?: ASTNode) => W['inputObjectType'],
+    readonly createList: <T extends W['type']>(type: T) => W['listType'],
+    readonly createFieldDefinition: (name: string, parent: W['objectType'] | W['detached'], type: W['outputType'], source?: ASTNode) => W['fieldDefinition'],
+    readonly createInputFieldDefinition: (name: string, parent: W['inputObjectType'] | W['detached'], type: W['inputType'], source?: ASTNode) => W['inputFieldDefinition'],
+    readonly createFieldArgumentDefinition: (name: string, parent: W['fieldDefinition'] | W['detached'], type: W['inputType'], defaultValue: any, source?: ASTNode) => W['fieldArgumentDefinition'],
+    readonly createDirectiveArgumentDefinition: (name: string, parent: W['directiveDefinition'] | W['detached'], type: W['inputType'], defaultValue: any, source?: ASTNode) => W['directiveArgumentDefinition'],
+    readonly createDirectiveDefinition: (name: string, parent: W['document'] | W['detached'], source?: ASTNode) => W['directiveDefinition'],
+    readonly createDirective: (name: string, parent: W['schemaElement'] | W['detached'], args: Map<string, any>, source?: ASTNode) => W['directive'],
+    readonly checkDetached: <T>(v: T | undefined) => T | W['detached']
+  ) {
+  }
+
+  document(): W['document'] {
+    const doc = this.createDocument();
+    for (const builtIn of builtInTypes) {
+      BaseGraphQLDocument.prototype['setBuiltIn'].call(doc, builtIn, this.createScalarType(builtIn, doc));
+    }
+    return doc;
+  }
+
+  addSchema(document: W['document'], source?: ASTNode): W['document'] {
+    const schema = this.createSchema(document, source);
+    BaseGraphQLDocument.prototype['setSchema'].call(document, schema);
+    return document;
+  }
+
+  createNamedType(kind: string, name: string, document: W['document'], source?: ASTNode): W['namedType'] {
+    switch (kind) {
+      case 'ScalarType':
+        return this.createScalarType(name, document, source);
+      case 'ObjectType':
+        return this.createObjectType(name, document, source);
+      case 'UnionType':
+        return this.createUnionType(name, document, source);
+      case 'InputObjectType':
+        return this.createInputObjectType(name, document, source);
+      default:
+        assert(false, "Missing branch for type " + kind);
+    }
+  }
+}
+
+function addTypeDefinition<W extends World>(namedType: W['namedType'], document: W['document']) {
+  (document.types as Map<string, W['namedType']>).set(namedType.name, namedType);
+}
+
+function removeTypeDefinition<W extends World>(namedType: W['namedType'], document: W['document']) {
+  (document.types as Map<string, W['namedType']>).delete(namedType.name);
+}
+
+function addDirectiveDefinition<W extends World>(definition: W['directiveDefinition'], document: W['document']) {
+  (document.directives as Map<string, W['directiveDefinition']>).set(definition.name, definition);
+}
+
+function addRoot<W extends World>(root: SchemaRoot, typeName: string, schema: W['schema']) {
+  const type = schema.document()!.type(typeName)! as W['objectType'];
+  (schema.roots as Map<SchemaRoot, W['objectType']>).set(root, type);
+  addReferencerToType(schema, type);
+}
+
+function addFieldArg<W extends World>(arg: W['fieldArgumentDefinition'], field: W['fieldDefinition']) {
+  (field.arguments() as Map<string, W['fieldArgumentDefinition']>).set(arg.name, arg);
+}
+
+function addDirectiveArg<W extends World>(arg: W['directiveArgumentDefinition'], directive: W['directiveDefinition']) {
+  (directive.arguments() as Map<string, W['directiveArgumentDefinition']>).set(arg.name, arg);
+}
+
+function addField<W extends World>(field: W['fieldDefinition'] | W['inputFieldDefinition'], objectType: W['objectType'] | W['inputObjectType']) {
+  (objectType.fields as Map<string, W['fieldDefinition'] | W['inputFieldDefinition']>).set(field.name, field);
+}
+
+function addTypeToUnion<W extends World>(typeName: string, unionType: W['unionType']) {
+  const type = unionType.document()!.type(typeName)! as W['objectType'];
+  (unionType.types as W['objectType'][]).push(type);
+  addReferencerToType(unionType, type);
+}
+
+function addReferencerToType<W extends World>(referencer: W['schemaElement'], type: W['type']) {
+  switch (type.kind) {
+    case 'ListType':
+      addReferencerToType(referencer, (type as W['listType']).baseType());
+      break;
+    default:
+      BaseNamedType.prototype['addReferencer'].call(type, referencer);
+      break;
+  }
+}
+
+function buildValue(value?: ValueNode): any {
+  // TODO: Should we rewrite a version of valueFromAST instead of using valueFromASTUntyped? Afaict, what we're missing out on is
+  // 1) coercions, which concretely, means:
+  //   - for enums, we get strings
+  //   - for int, we don't get the validation that it should be a 32bit value.
+  //   - for ID, which accepts strings and int, we don't get int converted to string.
+  //   - for floats, we get either int or float, we don't get int converted to float.
+  //   - we don't get any custom coercion (but neither is buildSchema in graphQL-js anyway).
+  // 2) type validation. 
+  return value ? valueFromASTUntyped(value) : undefined;
+}
+
+function buildDocumentInternal<W extends World>(documentNode: DocumentNode, ctors: Ctors<W>): W['document'] {
+  const doc = ctors.document();
+  buildNamedTypeShallow(documentNode, doc, ctors);
+  for (const definitionNode of documentNode.definitions) {
+    switch (definitionNode.kind) {
+      case 'OperationDefinition':
+      case 'FragmentDefinition':
+        throw new GraphQLError("Invalid executable definition found while building document", definitionNode);
+      case 'SchemaDefinition':
+        buildSchema(definitionNode, doc, ctors);
+        break;
+      case 'ScalarTypeDefinition':
+      case 'ObjectTypeDefinition':
+      case 'InterfaceTypeDefinition':
+      case 'UnionTypeDefinition':
+      case 'EnumTypeDefinition':
+      case 'InputObjectTypeDefinition':
+        buildNamedTypeInner(definitionNode, doc.type(definitionNode.name.value)!, ctors);
+        break;
+      case 'DirectiveDefinition':
+        addDirectiveDefinition(buildDirectiveDefinition(definitionNode, doc, ctors), doc);
+        break;
+      case 'SchemaExtension':
+      case 'ScalarTypeExtension':
+      case 'ObjectTypeExtension':
+      case 'InterfaceTypeExtension':
+      case 'UnionTypeExtension':
+      case 'EnumTypeExtension':
+      case 'InputObjectTypeExtension':
+        throw new Error("Extensions are a TODO");
+    }
+  }
+  return doc;
+}
+
+function buildNamedTypeShallow<W extends World>(documentNode: DocumentNode, document: W['document'], ctors: Ctors<W>) {
+  for (const definitionNode of documentNode.definitions) {
+    switch (definitionNode.kind) {
+      case 'ScalarTypeDefinition':
+      case 'ObjectTypeDefinition':
+      case 'InterfaceTypeDefinition':
+      case 'UnionTypeDefinition':
+      case 'EnumTypeDefinition':
+      case 'InputObjectTypeDefinition':
+        addTypeDefinition(ctors.createNamedType(withoutTrailingDefinition(definitionNode.kind), definitionNode.name.value, document, definitionNode), document);
+        break;
+      case 'SchemaExtension':
+      case 'ScalarTypeExtension':
+      case 'ObjectTypeExtension':
+      case 'InterfaceTypeExtension':
+      case 'UnionTypeExtension':
+      case 'EnumTypeExtension':
+      case 'InputObjectTypeExtension':
+        throw new Error("Extensions are a TODO");
+    }
+  }
+}
+
+type NodeWithDirectives = {directives?: ReadonlyArray<DirectiveNode>};
+
+function withoutTrailingDefinition(str: string): string {
+  return str.slice(0, str.length - 'Definition'.length);
+}
+
+function buildSchema<W extends World>(schemaNode: SchemaDefinitionNode, document: W['document'], ctors: Ctors<W>) {
+  ctors.addSchema(document, schemaNode);
+  buildAppliedDirectives(schemaNode, document.schema, ctors);
+  for (const opTypeNode of schemaNode.operationTypes) {
+    addRoot(opTypeNode.operation, opTypeNode.type.name.value, document.schema);
+  }
+}
+
+function buildAppliedDirectives<W extends World>(elementNode: NodeWithDirectives, element: W['schemaElement'], ctors: Ctors<W>) {
+  for (const directive of elementNode.directives ?? []) {
+    BaseElement.prototype['addAppliedDirective'].call(element, buildDirective(directive, element, ctors));
+  }
+}
+
+function buildDirective<W extends World>(directiveNode: DirectiveNode, element: W['schemaElement'], ctors: Ctors<W>): W['directive'] {
+  const args = new Map();
+  for (const argNode of directiveNode.arguments ?? []) {
+    args.set(argNode.name.value, buildValue(argNode.value));
+  }
+  return ctors.createDirective(directiveNode.name.value, element, args, directiveNode);
+}
+
+function buildNamedTypeInner<W extends World>(definitionNode: DefinitionNode & NodeWithDirectives, type: W['namedType'], ctors: Ctors<W>) {
+  buildAppliedDirectives(definitionNode, type, ctors);
+  switch (definitionNode.kind) {
+    case 'ObjectTypeDefinition':
+      const objectType = type as W['objectType'];
+      for (const fieldNode of definitionNode.fields ?? []) {
+        addField(buildFieldDefinition(fieldNode, objectType, ctors), objectType);
+      }
+      break;
+    case 'InterfaceTypeDefinition':
+      throw new Error("TODO");
+    case 'UnionTypeDefinition':
+      const unionType = type as W['unionType'];
+      for (const namedType of definitionNode.types ?? []) {
+        addTypeToUnion(namedType.name.value, unionType);
+      }
+      break;
+    case 'EnumTypeDefinition':
+      throw new Error("TODO");
+    case 'InputObjectTypeDefinition':
+      const inputObjectType = type as W['inputObjectType'];
+      for (const fieldNode of definitionNode.fields ?? []) {
+        addField(buildInputFieldDefinition(fieldNode, inputObjectType, ctors), inputObjectType);
+      }
+      break;
+  }
+}
+
+function buildFieldDefinition<W extends World>(fieldNode: FieldDefinitionNode, parentType: W['objectType'], ctors: Ctors<W>): W['fieldDefinition'] {
+  const type = buildWrapperTypeOrTypeRef(fieldNode.type, parentType.document()!, ctors) as W['outputType'];
+  const builtField = ctors.createFieldDefinition(fieldNode.name.value, parentType, type, fieldNode);
+  buildAppliedDirectives(fieldNode, builtField, ctors);
+  for (const inputValueDef of fieldNode.arguments ?? []) {
+    addFieldArg(buildFieldArgumentDefinition(inputValueDef, builtField, ctors), builtField);
+  }
+  addReferencerToType(builtField, type);
+  return builtField;
+}
+
+function buildWrapperTypeOrTypeRef<W extends World>(typeNode: TypeNode, document: W['document'], ctors: Ctors<W>): W['type'] {
+  switch (typeNode.kind) {
+    case 'ListType':
+      return ctors.createList(buildWrapperTypeOrTypeRef(typeNode.type, document, ctors));
+    case 'NonNullType':
+      throw new Error('TODO');
+    default:
+      return document.type(typeNode.name.value)!;
+  }
+}
+
+function buildFieldArgumentDefinition<W extends World>(inputNode: InputValueDefinitionNode, parent: W['fieldDefinition'], ctors: Ctors<W>): W['fieldArgumentDefinition'] {
+  const type = buildWrapperTypeOrTypeRef(inputNode.type, parent.document()!, ctors) as W['inputType'];
+  const built = ctors.createFieldArgumentDefinition(inputNode.name.value, parent, type, buildValue(inputNode.defaultValue), inputNode);
+  buildAppliedDirectives(inputNode, built, ctors);
+  addReferencerToType(built, type);
+  return built;
+}
+
+function buildInputFieldDefinition<W extends World>(fieldNode: InputValueDefinitionNode, parentType: W['inputObjectType'], ctors: Ctors<W>): W['inputFieldDefinition'] {
+  const type = buildWrapperTypeOrTypeRef(fieldNode.type, parentType.document()!, ctors) as W['inputType'];
+  const builtField = ctors.createInputFieldDefinition(fieldNode.name.value, parentType, type, fieldNode);
+  buildAppliedDirectives(fieldNode, builtField, ctors);
+  addReferencerToType(builtField, type);
+  return builtField;
+}
+
+function buildDirectiveDefinition<W extends World>(directiveNode: DirectiveDefinitionNode, parent: W['document'], ctors: Ctors<W>): W['directiveDefinition'] {
+  const builtDirective = ctors.createDirectiveDefinition(directiveNode.name.value, parent, directiveNode);
+  for (const inputValueDef of directiveNode.arguments ?? []) {
+    addDirectiveArg(buildDirectiveArgumentDefinition(inputValueDef, builtDirective, ctors), builtDirective);
+  }
+  return builtDirective;
+}
+
+function buildDirectiveArgumentDefinition<W extends World>(inputNode: InputValueDefinitionNode, parent: W['directiveDefinition'], ctors: Ctors<W>): W['directiveArgumentDefinition'] {
+  const type = buildWrapperTypeOrTypeRef(inputNode.type, parent.document()!, ctors) as W['inputType'];
+  const built = ctors.createDirectiveArgumentDefinition(inputNode.name.value, parent, type, buildValue(inputNode.defaultValue), inputNode);
+  buildAppliedDirectives(inputNode, built, ctors);
+  addReferencerToType(built, type);
+  return built;
+}
+
+function copy<WS extends World, WD extends World>(source: WS['document'], destCtors: Ctors<WD>): WD['document'] {
+  const doc = destCtors.addSchema(destCtors.document(), source.schema.source());
+  for (const type of source.types.values()) {
+    addTypeDefinition(copyNamedTypeShallow(type, doc, destCtors), doc);
+  }
+  copySchemaInner(source.schema, doc.schema, destCtors);
+  for (const type of source.types.values()) {
+    copyNamedTypeInner(type, doc.type(type.name)!, destCtors);
+  }
+  for (const directive of source.directives.values()) {
+    addDirectiveDefinition(copyDirectiveDefinition(directive, doc, destCtors), doc);
+  }
+  return doc;
+}
+
+function copySchemaInner<WS extends World, WD extends World>(source: WS['schema'], dest: WD['schema'], destCtors: Ctors<WD>) {
+  for (const [root, type] of source.roots.entries()) {
+    addRoot(root, type.name, dest);
+  }
+  copyAppliedDirectives(source, dest, destCtors);
+}
+
+function copyAppliedDirectives<WS extends World, WD extends World>(source: WS['schemaElement'], dest: WD['schemaElement'], destCtors: Ctors<WD>) {
+  for (const directive of source.appliedDirectives()) {
+    BaseElement.prototype['addAppliedDirective'].call(dest, copyDirective(directive, dest, destCtors));
+  }
+}
+
+function copyDirective<WS extends World, WD extends World>(source: WS['directive'], parentDest: WD['schemaElement'], destCtors: Ctors<WD>): WD['directive'] {
+  const args = new Map();
+  for (const [name, value] of source.arguments.entries()) {
+    args.set(name, value);
+  }
+  return destCtors.createDirective(source.name, parentDest, args, source.source);
+}
+
+// Because types can refer to one another (through fields or directive applications), we first create a shallow copy of
+// all types, and then copy fields (see below) assuming that the type "shell" exists.
+function copyNamedTypeShallow<WS extends World, WD extends World>(source: WS['namedType'], document: WD['document'], destCtors: Ctors<WD>): WD['namedType'] {
+  return destCtors.createNamedType(source.kind, source.name, document, source.source());
+}
+
+function copyNamedTypeInner<WS extends World, WD extends World>(source: WS['namedType'], dest: WD['namedType'], destCtors: Ctors<WD>) {
+  copyAppliedDirectives(source, dest, destCtors);
+  switch (source.kind) {
+    case 'ObjectType':
+      const sourceObjectType = source as WS['objectType'];
+      const destObjectType = dest as WD['objectType'];
+      for (const field of sourceObjectType.fields.values()) {
+        addField(copyFieldDefinition(field, destObjectType, destCtors), destObjectType); 
+      }
+      break;
+    case 'UnionType':
+      const sourceUnionType = source as WS['unionType'];
+      const destUnionType = dest as WD['unionType'];
+      for (const type of sourceUnionType.types) {
+        addTypeToUnion(type.name, destUnionType);
+      }
+      break;
+    case 'InputObjectType':
+      const sourceInputObjectType = source as WS['inputObjectType'];
+      const destInputObjectType = dest as WD['inputObjectType'];
+      for (const field of sourceInputObjectType.fields.values()) {
+        addField(copyInputFieldDefinition(field, destInputObjectType, destCtors), destInputObjectType);
+      }
+  }
+}
+
+function copyFieldDefinition<WS extends World, WD extends World>(source: WS['fieldDefinition'], destParent: WD['objectType'], destCtors: Ctors<WD>): WD['fieldDefinition'] {
+  const type = copyWrapperTypeOrTypeRef(source.type(), destParent.document()!, destCtors) as WD['outputType'];
+  const copiedField = destCtors.createFieldDefinition(source.name, destParent, type, source.source());
+  copyAppliedDirectives(source, copiedField, destCtors);
+  for (const sourceArg of source.arguments().values()) {
+    addFieldArg(copyFieldArgumentDefinition(sourceArg, copiedField, destCtors), copiedField);
+  }
+  addReferencerToType(copiedField, type);
+  return copiedField;
+}
+
+function copyInputFieldDefinition<WS extends World, WD extends World>(source: WS['inputFieldDefinition'], destParent: WD['inputObjectType'], destCtors: Ctors<WD>): WD['inputFieldDefinition'] {
+  const type = copyWrapperTypeOrTypeRef(source.type(), destParent.document()!, destCtors) as WD['inputType'];
+  const copied = destCtors.createInputFieldDefinition(source.name, destParent, type, source.source());
+  copyAppliedDirectives(source, copied, destCtors);
+  addReferencerToType(copied, type);
+  return copied;
+}
+
+function copyWrapperTypeOrTypeRef<WS extends World, WD extends World>(source: WS['type'] | WS['detached'], destParent: WD['document'], destCtors: Ctors<WD>): WD['type'] | WD['detached'] {
+  if (source == undefined) {
+    return destCtors.checkDetached(undefined);
+  }
+  switch (source.kind) {
+    case 'ListType':
+      return destCtors.createList(copyWrapperTypeOrTypeRef((source as WS['listType']).ofType(), destParent, destCtors) as WD['type']);
+    default:
+      return destParent.type((source as WS['namedType']).name)!;
+  }
+}
+
+function copyFieldArgumentDefinition<WS extends World, WD extends World>(source: WS['fieldArgumentDefinition'], destParent: WD['fieldDefinition'], destCtors: Ctors<WD>): WD['fieldArgumentDefinition'] {
+  const type = copyWrapperTypeOrTypeRef(source.type(), destParent.document()!, destCtors) as WD['inputType'];
+  const copied = destCtors.createFieldArgumentDefinition(source.name, destParent, type, source.defaultValue(), source.source());
+  copyAppliedDirectives(source, copied, destCtors);
+  addReferencerToType(copied, type);
+  return copied;
+}
+
+function copyDirectiveDefinition<WS extends World, WD extends World>(source: WS['directiveDefinition'], destParent: WD['document'], destCtors: Ctors<WD>): WD['directiveDefinition'] {
+  const copiedDirective = destCtors.createDirectiveDefinition(source.name, destParent, source.source());
+  for (const sourceArg of source.arguments().values()) {
+    addDirectiveArg(copyDirectiveArgumentDefinition(sourceArg, copiedDirective, destCtors), copiedDirective);
+  }
+  return copiedDirective;
+}
+function copyDirectiveArgumentDefinition<WS extends World, WD extends World>(source: WS['directiveArgumentDefinition'], destParent: WD['directiveDefinition'], destCtors: Ctors<WD>): WD['directiveArgumentDefinition'] {
+  const type = copyWrapperTypeOrTypeRef(source.type(), destParent.document()!, destCtors) as InputType;
+  const copied = destCtors.createDirectiveArgumentDefinition(source.name, destParent, type, source.defaultValue(), source.source());
+  copyAppliedDirectives(source, copied, destCtors);
+  addReferencerToType(copied, type);
+  return copied;
+}

--- a/core-js/src/definitions.ts
+++ b/core-js/src/definitions.ts
@@ -74,7 +74,7 @@ export function isObjectType(type: Type): type is ObjectType {
 }
 
 export function isInterfaceType(type: Type): type is InterfaceType {
-  return type.kind == 'ObjectType';
+  return type.kind == 'InterfaceType';
 }
 
 export function isEnumType(type: Type): type is EnumType {

--- a/core-js/src/federation.ts
+++ b/core-js/src/federation.ts
@@ -1,2 +1,22 @@
-export const federationMachineryTypesNames = [ '_Entity', '_Service', '_Any' ];
-export const federationDirectivesNames = [ 'key', 'extends', 'external', 'requires', 'provides' ];
+import { BuiltIns } from "./definitions";
+
+export class FederationBuiltIns extends BuiltIns {
+  protected createBuiltInTypes(): void {
+    super.populateBuiltInTypes();
+    // TODO: add Entity, which is a union (initially empty, populated later)
+    //this.addUnionType('_Entity');
+    this.addObjectType('_Service').addField('sdl', this.getType('String'));
+    this.addScalarType('_Any');
+  }
+
+  protected populateBuiltInDirectives(): void {
+    this.addDirective('key');
+    this.addDirective('extends');
+    this.addDirective('external');
+    this.addDirective('requires');
+    this.addDirective('provides');
+    this.addDirective('inaccessible');
+  }
+}
+
+export const federationBuiltIns = new FederationBuiltIns();

--- a/core-js/src/federation.ts
+++ b/core-js/src/federation.ts
@@ -1,0 +1,2 @@
+export const federationMachineryTypesNames = [ '_Entity', '_Service', '_Any' ];
+export const federationDirectivesNames = [ 'key', 'extends', 'external', 'requires', 'provides' ];

--- a/core-js/src/federation.ts
+++ b/core-js/src/federation.ts
@@ -1,32 +1,35 @@
-import { BuiltIns } from "./definitions";
+import { BuiltIns, Schema } from "./definitions";
 
 // TODO: Need a way to deal with the fact that the _Entity type is built after validation.
 export class FederationBuiltIns extends BuiltIns {
-  protected createBuiltInTypes(): void {
-    super.populateBuiltInTypes();
-    this.addUnionType('_Entity');
-    this.addObjectType('_Service').addField('sdl', this.getType('String'));
-    this.addScalarType('_Any');
+  addBuiltInTypes(schema: Schema) {
+    super.addBuiltInTypes(schema);
+
+    this.addBuiltInUnion(schema, '_Entity');
+    this.addBuiltInObject(schema, '_Service').addField('sdl', schema.stringType());
+    this.addBuiltInScalar(schema, '_Any');
   }
 
-  protected populateBuiltInDirectives(): void {
-    this.addDirective('key')
-      .addLocations('OBJECT', 'INTERFACE')
-      .addArgument('fields', this.getType('String'));
+  addBuiltInDirectives(schema: Schema) {
+    super.addBuiltInDirectives(schema);
 
-    this.addDirective('extends')
+    this.addBuiltInDirective(schema, 'key')
+      .addLocations('OBJECT', 'INTERFACE')
+      .addArgument('fields', schema.stringType());
+
+    this.addBuiltInDirective(schema, 'extends')
       .addLocations('OBJECT', 'INTERFACE');
 
-    this.addDirective('external')
+    this.addBuiltInDirective(schema, 'external')
       .addLocations('OBJECT', 'FIELD_DEFINITION');
 
     for (const name of ['requires', 'provides']) {
-      this.addDirective(name)
+      this.addBuiltInDirective(schema, name)
         .addLocations('FIELD_DEFINITION')
-        .addArgument('fields', this.getType('String'));
+        .addArgument('fields', schema.stringType());
     }
 
-    this.addDirective('inaccessible')
+    this.addBuiltInDirective(schema, 'inaccessible')
       .addAllLocations();
   }
 }

--- a/core-js/src/federation.ts
+++ b/core-js/src/federation.ts
@@ -1,21 +1,33 @@
 import { BuiltIns } from "./definitions";
 
+// TODO: Need a way to deal with the fact that the _Entity type is built after validation.
 export class FederationBuiltIns extends BuiltIns {
   protected createBuiltInTypes(): void {
     super.populateBuiltInTypes();
-    // TODO: add Entity, which is a union (initially empty, populated later)
-    //this.addUnionType('_Entity');
+    this.addUnionType('_Entity');
     this.addObjectType('_Service').addField('sdl', this.getType('String'));
     this.addScalarType('_Any');
   }
 
   protected populateBuiltInDirectives(): void {
-    this.addDirective('key');
-    this.addDirective('extends');
-    this.addDirective('external');
-    this.addDirective('requires');
-    this.addDirective('provides');
-    this.addDirective('inaccessible');
+    this.addDirective('key')
+      .addLocations('OBJECT', 'INTERFACE')
+      .addArgument('fields', this.getType('String'));
+
+    this.addDirective('extends')
+      .addLocations('OBJECT', 'INTERFACE');
+
+    this.addDirective('external')
+      .addLocations('OBJECT', 'FIELD_DEFINITION');
+
+    for (const name of ['requires', 'provides']) {
+      this.addDirective(name)
+        .addLocations('FIELD_DEFINITION')
+        .addArgument('fields', this.getType('String'));
+    }
+
+    this.addDirective('inaccessible')
+      .addAllLocations();
   }
 }
 

--- a/core-js/src/federation.ts
+++ b/core-js/src/federation.ts
@@ -1,4 +1,4 @@
-import { BuiltIns, Schema } from "./definitions";
+import { BuiltIns, Schema, DirectiveDefinition, NonNullType } from "./definitions";
 
 // TODO: Need a way to deal with the fact that the _Entity type is built after validation.
 export class FederationBuiltIns extends BuiltIns {
@@ -15,7 +15,7 @@ export class FederationBuiltIns extends BuiltIns {
 
     this.addBuiltInDirective(schema, 'key')
       .addLocations('OBJECT', 'INTERFACE')
-      .addArgument('fields', schema.stringType());
+      .addArgument('fields', new NonNullType(schema.stringType()));
 
     this.addBuiltInDirective(schema, 'extends')
       .addLocations('OBJECT', 'INTERFACE');
@@ -26,11 +26,35 @@ export class FederationBuiltIns extends BuiltIns {
     for (const name of ['requires', 'provides']) {
       this.addBuiltInDirective(schema, name)
         .addLocations('FIELD_DEFINITION')
-        .addArgument('fields', schema.stringType());
+        .addArgument('fields', new NonNullType(schema.stringType()));
     }
 
     this.addBuiltInDirective(schema, 'inaccessible')
       .addAllLocations();
+  }
+
+  keyDirective(schema: Schema): DirectiveDefinition<{fields: string}> {
+    return this.getTypedDirective(schema, 'key');
+  }
+
+  extendsDirective(schema: Schema): DirectiveDefinition<{}> {
+    return this.getTypedDirective(schema, 'extends');
+  }
+
+  externalDirective(schema: Schema): DirectiveDefinition<{}> {
+    return this.getTypedDirective(schema, 'external');
+  }
+
+  requiresDirective(schema: Schema): DirectiveDefinition<{fields: string}> {
+    return this.getTypedDirective(schema, 'requires');
+  }
+
+  providesDirective(schema: Schema): DirectiveDefinition<{fields: string}> {
+    return this.getTypedDirective(schema, 'provides');
+  }
+
+  inaccessibleDirective(schema: Schema): DirectiveDefinition<{}> {
+    return this.getTypedDirective(schema, 'inaccessible');
   }
 }
 

--- a/core-js/src/index.ts
+++ b/core-js/src/index.ts
@@ -1,0 +1,6 @@
+export * from './definitions';
+export * from './buildSchema';
+export * from './print';
+export * from './values';
+export * from './federation';
+export * from './utils';

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -1,14 +1,14 @@
 import {
-    AnyDirective,
+  AnyDirective,
   AnyDirectiveDefinition,
   AnyFieldDefinition,
-  AnyGraphQLDocument,
+  AnySchema,
   AnyInputFieldDefinition,
   AnyInputObjectType,
   AnyNamedType,
   AnyObjectType,
   AnyScalarType,
-  AnySchema,
+  AnySchemaDefinition,
   AnySchemaElement,
   AnyUnionType,
   defaultRootTypeName,
@@ -29,21 +29,21 @@ const defaultDirectiveFilter = (directive: AnyDirectiveDefinition) => (
   !federationDirectivesNames.includes(directive.name)
 );
 
-export function printDocument(document: AnyGraphQLDocument): string {
-  return printFilteredDocument(document, defaultTypeFilter, defaultDirectiveFilter);
+export function printSchema(schema: AnySchema): string {
+  return printFilteredSchema(schema, defaultTypeFilter, defaultDirectiveFilter);
 }
 
-function printFilteredDocument(
-  document: AnyGraphQLDocument,
+function printFilteredSchema(
+  schema: AnySchema,
   typeFilter: (type: AnyNamedType) => boolean,
   directiveFilter: (type: AnyDirectiveDefinition) => boolean
 ): string {
-  const directives = [...document.directives.values()].filter(directiveFilter);
-  const types = [...document.types.values()]
+  const directives = [...schema.directives.values()].filter(directiveFilter);
+  const types = [...schema.types.values()]
     .sort((type1, type2) => type1.name.localeCompare(type2.name))
     .filter(typeFilter);
   return (
-    [printSchema(document.schema)]
+    [printSchemaDefinition(schema.schemaDefinition)]
       .concat(
         directives.map(directive => printDirectiveDefinition(directive)),
         types.map(type => printTypeDefinition(type)),
@@ -53,11 +53,11 @@ function printFilteredDocument(
   );
 }
 
-function printSchema(schema: AnySchema): string | undefined {
-  if (isSchemaOfCommonNames(schema)) {
+function printSchemaDefinition(schemaDefinition: AnySchemaDefinition): string | undefined {
+  if (isSchemaOfCommonNames(schemaDefinition)) {
     return;
   }
-  const rootEntries = [...schema.roots.entries()].map(([root, type]) => `${indent}${root}: ${type}`);
+  const rootEntries = [...schemaDefinition.roots.entries()].map(([root, type]) => `${indent}${root}: ${type}`);
   return `schema {\n${rootEntries.join('\n')}\n}`;
 }
 
@@ -73,7 +73,7 @@ function printSchema(schema: AnySchema): string | undefined {
  *
  * When using this naming convention, the schema description can be omitted.
  */
-function isSchemaOfCommonNames(schema: AnySchema): boolean {
+function isSchemaOfCommonNames(schema: AnySchemaDefinition): boolean {
   for (const [root, type] of schema.roots) {
     if (type.name != defaultRootTypeName(root)) {
       return false;

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -1,0 +1,139 @@
+import {
+    AnyDirective,
+  AnyDirectiveDefinition,
+  AnyFieldDefinition,
+  AnyGraphQLDocument,
+  AnyInputFieldDefinition,
+  AnyInputObjectType,
+  AnyNamedType,
+  AnyObjectType,
+  AnyScalarType,
+  AnySchema,
+  AnySchemaElement,
+  AnyUnionType,
+  defaultRootTypeName,
+  isBuiltInDirective,
+  isBuiltInType
+} from "./definitions";
+import { federationMachineryTypesNames, federationDirectivesNames } from "./federation";
+
+const indent = "  "; // Could be made an option at some point
+
+const defaultTypeFilter = (type: AnyNamedType) => (
+  !isBuiltInType(type) &&
+  !federationMachineryTypesNames.includes(type.name)
+);
+
+const defaultDirectiveFilter = (directive: AnyDirectiveDefinition) => (
+  !isBuiltInDirective(directive) &&
+  !federationDirectivesNames.includes(directive.name)
+);
+
+export function printDocument(document: AnyGraphQLDocument): string {
+  return printFilteredDocument(document, defaultTypeFilter, defaultDirectiveFilter);
+}
+
+function printFilteredDocument(
+  document: AnyGraphQLDocument,
+  typeFilter: (type: AnyNamedType) => boolean,
+  directiveFilter: (type: AnyDirectiveDefinition) => boolean
+): string {
+  const directives = [...document.directives.values()].filter(directiveFilter);
+  const types = [...document.types.values()]
+    .sort((type1, type2) => type1.name.localeCompare(type2.name))
+    .filter(typeFilter);
+  return (
+    [printSchema(document.schema)]
+      .concat(
+        directives.map(directive => printDirectiveDefinition(directive)),
+        types.map(type => printTypeDefinition(type)),
+      )
+      .filter(Boolean)
+      .join('\n\n')
+  );
+}
+
+function printSchema(schema: AnySchema): string | undefined {
+  if (isSchemaOfCommonNames(schema)) {
+    return;
+  }
+  const rootEntries = [...schema.roots.entries()].map(([root, type]) => `${indent}${root}: ${type}`);
+  return `schema {\n${rootEntries.join('\n')}\n}`;
+}
+
+/**
+ * GraphQL schema define root types for each type of operation. These types are
+ * the same as any other type and can be named in any manner, however there is
+ * a common naming convention:
+ *
+ *   schema {
+ *     query: Query
+ *     mutation: Mutation
+ *   }
+ *
+ * When using this naming convention, the schema description can be omitted.
+ */
+function isSchemaOfCommonNames(schema: AnySchema): boolean {
+  for (const [root, type] of schema.roots) {
+    if (type.name != defaultRootTypeName(root)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function printTypeDefinition(type: AnyNamedType): string {
+  switch (type.kind) {
+    case 'ScalarType': return printScalarType(type);
+    case 'ObjectType': return printObjectType(type);
+    case 'UnionType': return printUnionType(type);
+    case 'InputObjectType': return printInputObjectType(type);
+  }
+}
+
+export function printDirectiveDefinition(directive: AnyDirectiveDefinition): string {
+  const args = directive.arguments().size == 0
+    ? "" 
+    : [...directive.arguments().values()].map(arg => arg.toString()).join(', ');
+  // TODO: missing isRepeatable and locations
+  return `directive @${directive}${args}`;
+}
+
+function printAppliedDirectives(element: AnySchemaElement): string {
+  const appliedDirectives = element.appliedDirectives();
+  return appliedDirectives.length == 0 ? "" : " " + appliedDirectives.map((d: AnyDirective) => d.toString()).join(" ");
+}
+
+function printScalarType(type: AnyScalarType): string {
+  return `scalar ${type.name}${printAppliedDirectives(type)}`
+}
+
+function printObjectType(type: AnyObjectType): string {
+  // TODO: missing interfaces
+  return `type ${type.name}${printAppliedDirectives(type)}` + printFields([...type.fields.values()]);
+}
+
+function printUnionType(type: AnyUnionType): string {
+  const possibleTypes = type.types.length ? ' = ' + type.types.join(' | ') : '';
+  return `union ${type}${possibleTypes}`;
+}
+
+function printInputObjectType(type: AnyInputObjectType): string {
+  return `input ${type.name}${printAppliedDirectives(type)}` + printFields([...type.fields.values()]);
+}
+
+function printFields(fields: AnyFieldDefinition[] | AnyInputFieldDefinition[]): string {
+  return printBlock(fields.map((f: AnyFieldDefinition | AnyInputFieldDefinition) => indent + `${printField(f)}${printAppliedDirectives(f)}`));
+}
+
+function printField(field: AnyFieldDefinition | AnyInputFieldDefinition): string {
+  let args = '';
+  if (field.kind == 'FieldDefinition' && field.arguments().size > 0) {
+    args = '(' + [...field.arguments().values()].map(arg => `${arg}${printAppliedDirectives(arg)}`).join(', ') + ')';
+  }
+  return `${field.name}${args}: ${field.type()}`;
+}
+
+function printBlock(items: string[]): string {
+  return items.length !== 0 ? ' {\n' + items.join('\n') + '\n}' : '';
+}

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -19,8 +19,8 @@ import {
 const indent = "  "; // Could be made an option at some point
 
 export function printSchema(schema: Schema): string {
-  const directives = [...schema.directives.values()];
-  const types = [...schema.types.values()]
+  const directives = [...schema.directives()];
+  const types = [...schema.types()]
     .sort((type1, type2) => type1.name.localeCompare(type2.name));
   return (
     [printSchemaDefinition(schema.schemaDefinition)]
@@ -78,7 +78,7 @@ export function printTypeDefinition(type: NamedType): string {
 
 export function printDirectiveDefinition(directive: DirectiveDefinition): string {
   const locations = directive.locations.join(' | ');
-  return `${printDescription(directive)}directive @${directive}${printArgs([...directive.arguments.values()])}${directive.repeatable ? ' repeatable' : ''} on ${locations}`;
+  return `${printDescription(directive)}directive @${directive}${printArgs([...directive.arguments()])}${directive.repeatable ? ' repeatable' : ''} on ${locations}`;
 }
 
 function printAppliedDirectives(element: SchemaElement<any, any>): string {

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -19,9 +19,8 @@ import {
 const indent = "  "; // Could be made an option at some point
 
 export function printSchema(schema: Schema): string {
-  const directives = [...schema.directives.values()].filter(d => !d.isBuiltIn);
+  const directives = [...schema.directives.values()];
   const types = [...schema.types.values()]
-    .filter(t => !t.isBuiltIn)
     .sort((type1, type2) => type1.name.localeCompare(type2.name));
   return (
     [printSchemaDefinition(schema.schemaDefinition)]

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -53,7 +53,7 @@ function printSchemaDefinition(schemaDefinition: AnySchemaDefinition): string | 
  * When using this naming convention, the schema description can be omitted.
  */
 function isSchemaOfCommonNames(schema: AnySchemaDefinition): boolean {
-  if (schema.appliedDirectives().length > 0) {
+  if (schema.appliedDirectives.length > 0) {
     return false;
   }
   for (const [root, type] of schema.roots) {
@@ -74,15 +74,15 @@ export function printTypeDefinition(type: AnyNamedType): string {
 }
 
 export function printDirectiveDefinition(directive: AnyDirectiveDefinition): string {
-  const args = directive.arguments().size == 0
+  const args = directive.arguments.size == 0
     ? "" 
-    : [...directive.arguments().values()].map(arg => arg.toString()).join(', ');
+    : [...directive.arguments.values()].map(arg => arg.toString()).join(', ');
   const locations = directive.locations.join(' | ');
   return `directive @${directive}${args}${directive.repeatable ? ' repeatable' : ''} on ${locations}`;
 }
 
 function printAppliedDirectives(element: AnySchemaElement): string {
-  const appliedDirectives = element.appliedDirectives();
+  const appliedDirectives = element.appliedDirectives;
   return appliedDirectives.length == 0 ? "" : " " + appliedDirectives.map((d: AnyDirective) => d.toString()).join(" ");
 }
 
@@ -110,10 +110,10 @@ function printFields(fields: AnyFieldDefinition[] | AnyInputFieldDefinition[]): 
 
 function printField(field: AnyFieldDefinition | AnyInputFieldDefinition): string {
   let args = '';
-  if (field.kind == 'FieldDefinition' && field.arguments().size > 0) {
-    args = '(' + [...field.arguments().values()].map(arg => `${arg}${printAppliedDirectives(arg)}`).join(', ') + ')';
+  if (field.kind == 'FieldDefinition' && field.arguments.size > 0) {
+    args = '(' + [...field.arguments.values()].map(arg => `${arg}${printAppliedDirectives(arg)}`).join(', ') + ')';
   }
-  return `${field.name}${args}: ${field.type()}`;
+  return `${field.name}${args}: ${field.type}`;
 }
 
 function printBlock(items: string[]): string {

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -11,7 +11,8 @@ import {
   AnySchemaDefinition,
   AnySchemaElement,
   AnyUnionType,
-  defaultRootTypeName
+  defaultRootTypeName,
+  AnyInterfaceType
 } from "./definitions";
 
 const indent = "  "; // Could be made an option at some point
@@ -68,6 +69,7 @@ export function printTypeDefinition(type: AnyNamedType): string {
   switch (type.kind) {
     case 'ScalarType': return printScalarType(type);
     case 'ObjectType': return printObjectType(type);
+    case 'InterfaceType': return printInterfaceType(type);
     case 'UnionType': return printUnionType(type);
     case 'InputObjectType': return printInputObjectType(type);
   }
@@ -93,6 +95,11 @@ function printScalarType(type: AnyScalarType): string {
 function printObjectType(type: AnyObjectType): string {
   // TODO: missing interfaces
   return `type ${type.name}${printAppliedDirectives(type)}` + printFields([...type.fields.values()]);
+}
+
+function printInterfaceType(type: AnyInterfaceType): string {
+  // TODO: missing interfaces
+  return `interface ${type.name}${printAppliedDirectives(type)}` + printFields([...type.fields.values()]);
 }
 
 function printUnionType(type: AnyUnionType): string {

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -81,13 +81,13 @@ export function printDirectiveDefinition(directive: DirectiveDefinition): string
   return `${printDescription(directive)}directive @${directive}${printArgs([...directive.arguments()])}${directive.repeatable ? ' repeatable' : ''} on ${locations}`;
 }
 
-function printAppliedDirectives(element: SchemaElement<any, any>): string {
+function printAppliedDirectives(element: SchemaElement<any>): string {
   const appliedDirectives = element.appliedDirectives;
   return appliedDirectives.length == 0 ? "" : " " + appliedDirectives.map(d => d.toString()).join(" ");
 }
 
 function printDescription(
-  element: SchemaElement<any, any>,
+  element: SchemaElement<any>,
   indentation: string = '',
   firstInBlock: boolean = true
 ): string {

--- a/core-js/src/print.ts
+++ b/core-js/src/print.ts
@@ -18,6 +18,7 @@ import {
   SchemaElement,
   UnionType
 } from "./definitions";
+import { valueToString } from "./values";
 
 export type Options = {
   indentString: string;
@@ -249,7 +250,10 @@ function printFields(fields: readonly (FieldDefinition<any> | InputFieldDefiniti
 
 function printField(field: FieldDefinition<any> | InputFieldDefinition, options: Options): string {
   let args = field.kind == 'FieldDefinition' ? printArgs([...field.arguments.values()], options.indentString) : '';
-  return `${field.name}${args}: ${field.type}`;
+  let defaultValue = field.kind == 'InputFieldDefinition' && field.defaultValue !== undefined
+    ? ' = ' + valueToString(field.defaultValue)
+    : '';
+  return `${field.name}${args}: ${field.type}${defaultValue}`;
 }
 
 function printArgs(args: ArgumentDefinition<any>[], indentation = '') {

--- a/core-js/src/suggestions.ts
+++ b/core-js/src/suggestions.ts
@@ -1,0 +1,51 @@
+import levenshtein from 'js-levenshtein';
+
+/**
+ * Given an invalid input string and a list of valid options, returns a filtered
+ * list of valid options sorted based on their similarity with the input.
+ */
+export function suggestionList(input: string, options: string[]): string[] {
+  const optionsByDistance = new Map<string, number>();
+
+  const threshold = Math.floor(input.length * 0.4) + 1;
+  const inputLowerCase = input.toLowerCase();
+  for (const option of options) {
+    // Special casing so that if the only mismatch is in uppper/lower-case, then the
+    // option is always shown.
+    const distance = inputLowerCase === option.toLowerCase()
+      ? 1
+      : levenshtein(input, option);
+    if (distance <= threshold) {
+      optionsByDistance.set(option, distance);
+    }
+  }
+
+  return [...optionsByDistance.keys()].sort((a, b) => {
+    const distanceDiff = optionsByDistance.get(a)! - optionsByDistance.get(b)!;
+    return distanceDiff !== 0 ? distanceDiff : a.localeCompare(b);
+  });
+}
+
+const MAX_SUGGESTIONS = 5;
+
+/**
+ * Given [ A, B, C ] return ' Did you mean A, B, or C?'.
+ */
+export function didYouMean(suggestions: readonly string[]): string {
+  let message = ' Did you mean ';
+
+  const quotedSuggestions = suggestions.map((x) => `"${x}"`);
+  switch (suggestions.length) {
+    case 0:
+      return '';
+    case 1:
+      return message + quotedSuggestions[0] + '?';
+    case 2:
+      return message + quotedSuggestions[0] + ' or ' + quotedSuggestions[1] + '?';
+  }
+
+  const selected = quotedSuggestions.slice(0, MAX_SUGGESTIONS);
+  const lastItem = selected.pop();
+  return message + selected.join(', ') + ', or ' + lastItem + '?';
+}
+

--- a/core-js/src/utils.ts
+++ b/core-js/src/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * For lack of a "home of federation utilities", this function is copy/pasted
+ * verbatim across the federation, gateway, and query-planner packages. Any changes
+ * made here should be reflected in the other two locations as well.
+ *
+ * @param condition
+ * @param message
+ * @throws
+ */
+export function assert(condition: any, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/core-js/src/values.ts
+++ b/core-js/src/values.ts
@@ -1,0 +1,99 @@
+import deepEqual from 'deep-equal';
+import { ArgumentDefinition, InputType, isInputObjectType, isListType, isNonNullType } from './definitions';
+import { GraphQLError } from 'graphql';
+import { didYouMean, suggestionList } from './suggestions';
+
+export function valueToString(v: any): string {
+  if (v === undefined || v === null) {
+    return "null";
+  }
+
+  if (Array.isArray(v)) {
+    return '[' + v.map(e => valueToString(e)).join(', ') + ']';
+  }
+
+  if (typeof v === 'object') {
+    return '{' + Object.keys(v).map(k => `${k}: ${valueToString(v[k])}`).join(', ') + '}';
+  }
+
+  if (typeof v === 'string') {
+    return JSON.stringify(v);
+  }
+
+  return String(v);
+}
+
+export function valueEquals(a: any, b: any): boolean {
+  return deepEqual(a, b);
+}
+
+function buildError(message: string): Error {
+  // Maybe not the right error for this?
+  return new Error(message);
+}
+
+export function applyDefaultValues(value: any, type: InputType): any {
+  if (value === null) {
+    if (isNonNullType(type)) {
+      throw new GraphQLError(`Invalid null value for non-null type ${type} while computing default values`);
+    }
+    return null;
+  }
+
+  if (isNonNullType(type)) {
+    return applyDefaultValues(value, type.ofType);
+  }
+
+  if (isListType(type)) {
+    if (Array.isArray(value)) {
+      return value.map(v => applyDefaultValues(v, type.ofType));
+    } else {
+      return applyDefaultValues(value, type.ofType);
+    }
+  }
+
+  if (isInputObjectType(type)) {
+    if (typeof value !== 'object') {
+      throw new GraphQLError(`Expected value for type ${type} to be an object, but is ${typeof value}.`);
+    }
+
+    const updated = Object.create(null);
+    for (const field of type.fields.values()) {
+      if (!field.type) {
+        throw buildError(`Cannot compute default value for field ${field.name} of ${type} as the field type is undefined`);
+      }
+      const fieldValue = value[field.name];
+      if (fieldValue === undefined) {
+        if (field.defaultValue !== undefined) {
+          updated[field.name] = applyDefaultValues(field.defaultValue, field.type);
+        } else if (isNonNullType(field.type)) {
+          throw new GraphQLError(`Field "${field.name}" of required type ${type} was not provided.`);
+        }
+      } else {
+        updated[field.name] = applyDefaultValues(fieldValue, field.type);
+      }
+    }
+
+    // Ensure every provided field is defined.
+    for (const fieldName of Object.keys(value)) {
+      if (!type.fields.has(fieldName)) {
+        const suggestions = suggestionList(fieldName, [...type.fields.keys()]);
+        throw new GraphQLError(`Field "${fieldName}" is not defined by type "${type}".` + didYouMean(suggestions));
+      }
+    }
+    return updated;
+  }
+  return value;
+}
+
+export function withDefaultValues(value: any, argument: ArgumentDefinition<any>): any {
+  if (!argument.type) {
+    throw buildError(`Cannot compute default value for argument ${argument} as the type is undefined`);
+  }
+  if (value === undefined) {
+    if (argument.defaultValue) {
+      return applyDefaultValues(argument.defaultValue ?? null, argument.type);
+    }
+  }
+  return applyDefaultValues(value, argument.type);
+}

--- a/core-js/tsconfig.json
+++ b/core-js/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__"],
+  "references": []
+}

--- a/core-js/tsconfig.test.json
+++ b/core-js/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.test.base",
+  "files": [],
+  "include": ["**/__tests__/**/*"],
+  "references": [
+    { "path": "./" },
+  ]
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "packages": [
+    "core-js",
     "federation-js",
     "federation-integration-testsuite-js",
     "gateway-js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       }
     },
     "core-js": {
+      "name": "@apollo/core",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@apollo/core": "file:core-js",
         "@apollo/federation": "file:federation-js",
         "@apollo/gateway": "file:gateway-js",
         "@apollo/harmonizer": "file:harmonizer",
@@ -59,6 +60,20 @@
       "engines": {
         "node": ">=12.13.0 <17.0",
         "npm": "7.x"
+      }
+    },
+    "core-js": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jest": "^26.0.23",
+        "deep-equal": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=12.13.0 <17.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.5.0 || ^15.0.0"
       }
     },
     "federation-integration-testsuite-js": {
@@ -148,6 +163,10 @@
       "peerDependencies": {
         "graphql": "^14.5.0 || ^15.0.0"
       }
+    },
+    "node_modules/@apollo/core": {
+      "resolved": "core-js",
+      "link": true
     },
     "node_modules/@apollo/federation": {
       "resolved": "federation-js",
@@ -6068,7 +6087,6 @@
       "version": "26.0.23",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
       "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
-      "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -9291,7 +9309,6 @@
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-      "dev": true,
       "engines": {
         "node": ">= 10.14.2"
       }
@@ -12508,7 +12525,6 @@
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
       "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^26.6.2",
@@ -12586,7 +12602,6 @@
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
       "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-      "dev": true,
       "engines": {
         "node": ">= 10.14.2"
       }
@@ -19932,6 +19947,13 @@
     }
   },
   "dependencies": {
+    "@apollo/core": {
+      "version": "file:core-js",
+      "requires": {
+        "@types/jest": "^26.0.23",
+        "deep-equal": "^2.0.5"
+      }
+    },
     "@apollo/federation": {
       "version": "file:federation-js",
       "requires": {
@@ -25258,7 +25280,6 @@
       "version": "26.0.23",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
       "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
-      "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -27972,8 +27993,7 @@
     "diff-sequences": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-      "dev": true
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -30597,7 +30617,6 @@
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
       "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^26.6.2",
@@ -30659,8 +30678,7 @@
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-      "dev": true
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
     },
     "jest-haste-map": {
       "version": "26.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,10 @@
       "license": "MIT",
       "dependencies": {
         "@types/jest": "^26.0.23",
-        "deep-equal": "^2.0.5"
+        "js-levenshtein": "^1.1.6"
+      },
+      "devDependencies": {
+        "@types/js-levenshtein": "^1.1.0"
       },
       "engines": {
         "node": ">=12.13.0 <17.0"
@@ -6092,6 +6095,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
+      "integrity": "sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==",
+      "dev": true
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.1",
@@ -13040,6 +13049,14 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -19952,7 +19969,8 @@
       "version": "file:core-js",
       "requires": {
         "@types/jest": "^26.0.23",
-        "deep-equal": "^2.0.5"
+        "@types/js-levenshtein": "^1.1.0",
+        "js-levenshtein": "^1.1.6"
       }
     },
     "@apollo/federation": {
@@ -25285,6 +25303,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "@types/js-levenshtein": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
+      "integrity": "sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==",
+      "dev": true
     },
     "@types/js-yaml": {
       "version": "4.0.1",
@@ -31015,6 +31039,11 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "npm": "7.x"
   },
   "dependencies": {
+    "@apollo/core": "file:core-js",
     "@apollo/federation": "file:federation-js",
     "@apollo/gateway": "file:gateway-js",
     "@apollo/harmonizer": "file:harmonizer",
@@ -79,6 +80,7 @@
   },
   "jest": {
     "projects": [
+      "<rootDir>/core-js",
       "<rootDir>/federation-js",
       "<rootDir>/federation-integration-testsuite-js",
       "<rootDir>/gateway-js",

--- a/tsconfig.build-stage-03.json
+++ b/tsconfig.build-stage-03.json
@@ -5,6 +5,7 @@
   "files": [],
   "include": [],
   "references": [
+    { "path": "./core-js" },
     { "path": "./gateway-js" },
     { "path": "./federation-integration-testsuite-js" },
   ]


### PR DESCRIPTION
WIP: open to early comments, but not to be considered ready for a full review.

This adds a new abstraction that is meant to be alternative to `GrapQLSchema` for federation code with the following main differences:
- Directives (particularly thinking directive _applications_) are first class citizen.
- It is mutable, has a notion of `SchemaElement` and has links between elements that reference each others. With the goal of making transformation of schemas and schema navigation a lot easier/safer.
- It allows to work with federation specific "built-in" a bit more conveniently.