### PR TITLE
chore: run `npm install` on `cargo build` if `node_modules` does not exist

### DIFF
--- a/harmonizer/build.rs
+++ b/harmonizer/build.rs
@@ -1,13 +1,22 @@
-use std::fs::metadata;
+use std::fs;
 use std::process::Command;
 
 fn main() {
-    if metadata("dist/composition.js").is_err() {
+    if fs::metadata("node_modules").is_err() {
+        assert!(Command::new("npm")
+            .current_dir("../")
+            .arg("install")
+            .status()
+            .expect("Could not execute `npm install`, is npm installed?")
+            .success())
+    }
+
+    if fs::metadata("dist/composition.js").is_err() {
         assert!(Command::new("npm")
             .current_dir("../")
             .args(&["run", "compile:for-harmonizer-build-rs"])
             .status()
-            .unwrap()
+            .expect("Could not compile harmonizer.")
             .success());
     }
 }


### PR DESCRIPTION
This makes it so that anybody can run `cargo build` from the root repo from a fresh clone. Also added some nicer error messages with `expect` instead of `unwrap`.