### PR TITLE
Add operationName variable for health_check_query

### DIFF
--- a/gateway-js/src/__tests__/integration/legacyNockMocks.ts
+++ b/gateway-js/src/__tests__/integration/legacyNockMocks.ts
@@ -1,4 +1,4 @@
-import { HEALTH_CHECK_QUERY, SERVICE_DEFINITION_QUERY } from '@apollo/gateway';
+import { HEALTH_CHECK_QUERY, HEALTH_CHECK_QUERY_OPERATION_NAME, SERVICE_DEFINITION_QUERY } from '@apollo/gateway';
 import nock from 'nock';
 import { MockService } from './legacyNetworkRequests.test';
 
@@ -23,6 +23,7 @@ export function mockSdlQuerySuccess(service: MockService) {
 export function mockServiceHealthCheck({ url }: MockService) {
   return nock(url).post('/', {
     query: HEALTH_CHECK_QUERY,
+    operationName: HEALTH_CHECK_QUERY_OPERATION_NAME,
   });
 }
 

--- a/gateway-js/src/__tests__/integration/nockMocks.ts
+++ b/gateway-js/src/__tests__/integration/nockMocks.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import { MockService } from './networkRequests.test';
-import { HEALTH_CHECK_QUERY, SERVICE_DEFINITION_QUERY } from '../..';
+import { HEALTH_CHECK_QUERY, HEALTH_CHECK_QUERY_OPERATION_NAME, SERVICE_DEFINITION_QUERY } from '../..';
 import { SUPERGRAPH_SDL_QUERY } from '../../loadSupergraphSdlFromStorage';
 import { getTestingSupergraphSdl } from '../../__tests__/execution-utils';
 import { print } from 'graphql';
@@ -34,6 +34,7 @@ export function mockSdlQuerySuccess(service: MockService) {
 export function mockServiceHealthCheck({ url }: MockService) {
   return nock(url).post('/', {
     query: HEALTH_CHECK_QUERY,
+    operationName: HEALTH_CHECK_QUERY_OPERATION_NAME,
   });
 }
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -119,6 +119,7 @@ export const GCS_RETRY_COUNT = 5;
 
 export const HEALTH_CHECK_QUERY =
   'query __ApolloServiceHealthCheck__ { __typename }';
+export const HEALTH_CHECK_QUERY_OPERATION_NAME = 'ApolloServiceHealthCheck';
 export const SERVICE_DEFINITION_QUERY =
   'query __ApolloGetServiceDefinition__ { _service { sdl } }';
 
@@ -667,7 +668,7 @@ export class ApolloGateway implements GraphQLService {
     return Promise.all(
       Object.entries(serviceMap).map(([name, { dataSource }]) =>
         dataSource
-          .process({ request: { query: HEALTH_CHECK_QUERY }, context: {} })
+          .process({ request: { query: HEALTH_CHECK_QUERY, operationName: HEALTH_CHECK_QUERY_OPERATION_NAME }, context: {} })
           .then((response) => ({ name, response }))
           .catch((e) => {
             throw new Error(`[${name}]: ${e.message}`);

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -119,7 +119,7 @@ export const GCS_RETRY_COUNT = 5;
 
 export const HEALTH_CHECK_QUERY =
   'query __ApolloServiceHealthCheck__ { __typename }';
-export const HEALTH_CHECK_QUERY_OPERATION_NAME = 'ApolloServiceHealthCheck';
+export const HEALTH_CHECK_QUERY_OPERATION_NAME = '__ApolloServiceHealthCheck__';
 export const SERVICE_DEFINITION_QUERY =
   'query __ApolloGetServiceDefinition__ { _service { sdl } }';
 


### PR DESCRIPTION
Fixes #835

There is another issue that is slightly related https://github.com/apollographql/federation/issues/768 but the code is standalone for healthcheckquery, thus I am fixing this just for health check.

This is the payload for the data being sent by apollographql healthcheck and it is missing operationName
![image](https://user-images.githubusercontent.com/1703663/123407899-0b5d0180-d5df-11eb-8e32-5ac4b2230234.png)

Why do we need this?
1. If you do a call with graphiql, you can see a operationName key being sent out too.
2. This operationName will be logged in metrics such as `gql.operation.name` in netflix dgs framework metrics https://netflix.github.io/dgs/advanced/instrumentation/#shared-tags
3. For us to filter out health check requests, we can use operationName to filter them out.

These images show the payload within graphiql
![image](https://user-images.githubusercontent.com/1703663/123406934-021f6500-d5de-11eb-81a2-fffb9fa1ed57.png)
![image](https://user-images.githubusercontent.com/1703663/123407028-17948f00-d5de-11eb-89aa-1c19dc1da3f7.png)


