### PR TITLE
Revert "chore(harmonizer): run npm install in build.rs (#833)"

### DIFF
--- a/harmonizer/build.rs
+++ b/harmonizer/build.rs
@@ -1,22 +1,13 @@
-use std::fs;
+use std::fs::metadata;
 use std::process::Command;
 
 fn main() {
-    if fs::metadata("node_modules").is_err() {
-        assert!(Command::new("npm")
-            .current_dir("../")
-            .arg("install")
-            .status()
-            .expect("Could not execute `npm install`, is npm installed?")
-            .success())
-    }
-
-    if fs::metadata("dist/composition.js").is_err() {
+    if metadata("dist/composition.js").is_err() {
         assert!(Command::new("npm")
             .current_dir("../")
             .args(&["run", "compile:for-harmonizer-build-rs"])
             .status()
-            .expect("Could not compile harmonizer.")
+            .unwrap()
             .success());
     }
 }

--- a/harmonizer/src/lib.rs
+++ b/harmonizer/src/lib.rs
@@ -79,7 +79,7 @@ pub type ServiceList = Vec<ServiceDefinition>;
 
 /// An error which occurred during JavaScript composition.
 ///
-/// The shape of this error is meant to mimick that of the error created within
+/// The shape of this error is meant to mimic that of the error created within
 /// JavaScript, which is a [`GraphQLError`] from the [`graphql-js`] library.
 ///
 /// [`graphql-js']: https://npm.im/graphql


### PR DESCRIPTION
This reverts commit b55a7b0e8234bf75b234f34e8a867d0818a201ab - I think we should eventually add this back but it seems to be failing on Windows. This should unblock CI tests but will break `cargo install --git` commands



