### PR TITLE
feat(gateway): Default to Uplink for composed supergraph managed federation

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet. Stay tuned!_
+- Change default managed federation mechanism over to use Apollo's new Uplink service. This service handles composition and sends the entire supergraph to the gateway. Previously the gateway was responsible for downloading each service's SDL from GCS and handling the composition itself. If you have any issues trying to use this new behavior, you may use the gateway config option `schemaConfigDeliveryEndpoint: null` to continue using the previous mechanism for the time being. If you were previously setting the `experimental_schemaConfigDeliveryEndpoint` config option, you will need to update the name of the option itself (or you can remove it entirely if you were using Apollo's Uplink service). [PR #881](https://github.com/apollographql/federation/pull/881)
 
 ## v0.33.0
 

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -111,7 +111,7 @@ describe('gateway configuration warnings', () => {
     gateway = new ApolloGateway({
       logger,
       // TODO(trevor:cloudconfig): remove
-      experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
     });
 
     await gateway.load(mockApolloConfig);
@@ -309,10 +309,10 @@ describe('gateway config / env behavior', () => {
 
       gateway = new ApolloGateway({
         logger,
-        experimental_schemaConfigDeliveryEndpoint: 'code-config',
+        schemaConfigDeliveryEndpoint: 'code-config',
       });
 
-      expect(gateway['experimental_schemaConfigDeliveryEndpoint']).toEqual(
+      expect(gateway['schemaConfigDeliveryEndpoint']).toEqual(
         'code-config',
       );
 
@@ -326,10 +326,10 @@ describe('gateway config / env behavior', () => {
 
       gateway = new ApolloGateway({
         logger,
-        experimental_schemaConfigDeliveryEndpoint: null,
+        schemaConfigDeliveryEndpoint: null,
       });
 
-      expect(gateway['experimental_schemaConfigDeliveryEndpoint']).toEqual(
+      expect(gateway['schemaConfigDeliveryEndpoint']).toEqual(
         null,
       );
 

--- a/gateway-js/src/__tests__/integration/legacyNetworkRequests.test.ts
+++ b/gateway-js/src/__tests__/integration/legacyNetworkRequests.test.ts
@@ -107,7 +107,7 @@ it('Extracts service definitions from remote storage', async () => {
   mockImplementingServicesSuccess(service);
   mockRawPartialSchemaSuccess(service);
 
-  gateway = new ApolloGateway({ logger });
+  gateway = new ApolloGateway({ logger, schemaConfigDeliveryEndpoint: null });
 
   await gateway.load({
     apollo: { keyHash: apiKeyHash, graphId, graphVariant: 'current' },
@@ -137,7 +137,11 @@ it(`Retries GCS (up to ${GCS_RETRY_COUNT} times) on failure for each request and
   failNTimes(GCS_RETRY_COUNT, () => mockRawPartialSchema(service));
   mockRawPartialSchemaSuccess(service);
 
-  gateway = new ApolloGateway({ fetcher, logger });
+  gateway = new ApolloGateway({
+    fetcher,
+    logger,
+    schemaConfigDeliveryEndpoint: null,
+  });
 
   await gateway.load({
     apollo: { keyHash: apiKeyHash, graphId, graphVariant: 'current' },
@@ -155,7 +159,11 @@ describe('Managed mode', () => {
 
     mockServiceHealthCheckSuccess(service);
 
-    gateway = new ApolloGateway({ serviceHealthCheck: true, logger });
+    gateway = new ApolloGateway({
+      serviceHealthCheck: true,
+      logger,
+      schemaConfigDeliveryEndpoint: null,
+    });
 
     await gateway.load({
       apollo: { keyHash: apiKeyHash, graphId, graphVariant: 'current' },
@@ -174,7 +182,11 @@ describe('Managed mode', () => {
 
     mockServiceHealthCheck(service).reply(500);
 
-    const gateway = new ApolloGateway({ serviceHealthCheck: true, logger });
+    const gateway = new ApolloGateway({
+      serviceHealthCheck: true,
+      logger,
+      schemaConfigDeliveryEndpoint: null,
+    });
 
     await expect(
       gateway.load({
@@ -205,7 +217,11 @@ describe('Managed mode', () => {
     let resolve: () => void;
     const schemaChangeBlocker = new Promise<void>((res) => (resolve = res));
 
-    gateway = new ApolloGateway({ serviceHealthCheck: true, logger });
+    gateway = new ApolloGateway({
+      serviceHealthCheck: true,
+      logger,
+      schemaConfigDeliveryEndpoint: null,
+    });
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
     gateway.experimental_pollInterval = 100;
 

--- a/gateway-js/src/__tests__/integration/networkRequests.test.ts
+++ b/gateway-js/src/__tests__/integration/networkRequests.test.ts
@@ -104,7 +104,7 @@ it('Fetches Supergraph SDL from remote storage', async () => {
 
   gateway = new ApolloGateway({
     logger,
-    experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+    schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
   });
 
   await gateway.load(mockApolloConfig);
@@ -145,7 +145,7 @@ it('Updates Supergraph SDL from remote storage', async () => {
 
   gateway = new ApolloGateway({
     logger,
-    experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+    schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
   });
   // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
   gateway.experimental_pollInterval = 100;
@@ -164,7 +164,7 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
     });
 
     await expect(
@@ -192,7 +192,7 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
     });
 
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
@@ -225,7 +225,7 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
     });
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
     gateway.experimental_pollInterval = 100;
@@ -262,7 +262,7 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
     });
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
     gateway.experimental_pollInterval = 100;
@@ -292,7 +292,7 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
     });
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
     gateway.experimental_pollInterval = 100;
@@ -332,7 +332,7 @@ it('Rollsback to a previous schema when triggered', async () => {
 
   gateway = new ApolloGateway({
     logger,
-    experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+    schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
   });
   // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
   gateway.experimental_pollInterval = 100;
@@ -416,7 +416,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
       });
       // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
       gateway.experimental_pollInterval = 100;
@@ -439,7 +439,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
       });
 
       // This is the ideal, but our version of Jest has a bug with printing error snapshots.
@@ -498,7 +498,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
       });
       // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
       gateway.experimental_pollInterval = 100;
@@ -540,7 +540,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        experimental_schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
       });
       // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
       gateway.experimental_pollInterval = 100;

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -138,11 +138,20 @@ export interface RemoteGatewayConfig extends GatewayConfigBase {
 // TODO(trevor:cloudconfig): This type goes away
 export interface LegacyManagedGatewayConfig extends GatewayConfigBase {
   federationVersion?: number;
+  /**
+   * Setting this to null will cause the gateway to use the old mechanism for
+   * managed federation via GCS + composition.
+   */
   schemaConfigDeliveryEndpoint: null;
 }
 
 // TODO(trevor:cloudconfig): This type becomes the only managed config
 export interface PrecomposedManagedGatewayConfig extends GatewayConfigBase {
+  /**
+   * This configuration option shouldn't be used unless by recommendation from
+   * Apollo staff. This can also be set to `null` (see above) in order to revert
+   * to the previous mechanism for managed federation.
+   */
   schemaConfigDeliveryEndpoint?: string;
 }
 

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -215,12 +215,13 @@ export function isPrecomposedManagedConfig(
   config: GatewayConfig,
 ): config is PrecomposedManagedGatewayConfig {
   return (
-    ('schemaConfigDeliveryEndpoint' in config &&
+    !isLegacyManagedConfig(config) &&
+    (('schemaConfigDeliveryEndpoint' in config &&
       typeof config.schemaConfigDeliveryEndpoint === 'string') ||
-    (!isRemoteConfig(config) &&
-      !isLocalConfig(config) &&
-      !isSupergraphSdlConfig(config) &&
-      !isManuallyManagedConfig(config))
+      (!isRemoteConfig(config) &&
+        !isLocalConfig(config) &&
+        !isSupergraphSdlConfig(config) &&
+        !isManuallyManagedConfig(config)))
   );
 }
 

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -126,13 +126,6 @@ interface GatewayConfigBase {
   experimental_autoFragmentization?: boolean;
   fetcher?: typeof fetch;
   serviceHealthCheck?: boolean;
-  /**
-   * Enable an upcoming mechanism for fetching a graph’s schema and
-   * configuration when using managed federation. This mechanism is currently in
-   * a preview state and should not be used in production graphs.
-   * See https://go.apollo.dev/g/supergraph-preview for details.
-   */
-  experimental_schemaConfigDeliveryEndpoint?: null | string;
 }
 
 export interface RemoteGatewayConfig extends GatewayConfigBase {
@@ -145,17 +138,12 @@ export interface RemoteGatewayConfig extends GatewayConfigBase {
 // TODO(trevor:cloudconfig): This type goes away
 export interface LegacyManagedGatewayConfig extends GatewayConfigBase {
   federationVersion?: number;
+  schemaConfigDeliveryEndpoint: null;
 }
 
 // TODO(trevor:cloudconfig): This type becomes the only managed config
 export interface PrecomposedManagedGatewayConfig extends GatewayConfigBase {
-  /**
-   * @deprecated This configuration option shouldn't be used unless by
-   *             recommendation from Apollo staff. This behavior will be
-   *             defaulted in a future release and this option will strictly be
-   *             used as an override.
-   */
-  experimental_schemaConfigDeliveryEndpoint: string;
+  schemaConfigDeliveryEndpoint?: string;
 }
 
 // TODO(trevor:cloudconfig): This union is no longer needed
@@ -219,13 +207,7 @@ export function isManuallyManagedConfig(
 export function isManagedConfig(
   config: GatewayConfig,
 ): config is ManagedGatewayConfig {
-  return (
-    isPrecomposedManagedConfig(config) ||
-    (!isRemoteConfig(config) &&
-      !isLocalConfig(config) &&
-      !isSupergraphSdlConfig(config) &&
-      !isManuallyManagedConfig(config))
-  );
+  return isPrecomposedManagedConfig(config) || isLegacyManagedConfig(config);
 }
 
 // TODO(trevor:cloudconfig): This merges with `isManagedConfig`
@@ -233,8 +215,21 @@ export function isPrecomposedManagedConfig(
   config: GatewayConfig,
 ): config is PrecomposedManagedGatewayConfig {
   return (
-    'experimental_schemaConfigDeliveryEndpoint' in config &&
-    config.experimental_schemaConfigDeliveryEndpoint !== null
+    ('schemaConfigDeliveryEndpoint' in config &&
+      typeof config.schemaConfigDeliveryEndpoint === 'string') ||
+    (!isRemoteConfig(config) &&
+      !isLocalConfig(config) &&
+      !isSupergraphSdlConfig(config) &&
+      !isManuallyManagedConfig(config))
+  );
+}
+
+export function isLegacyManagedConfig(
+  config: GatewayConfig,
+): config is LegacyManagedGatewayConfig {
+  return (
+    'schemaConfigDeliveryEndpoint' in config &&
+    config.schemaConfigDeliveryEndpoint === null
   );
 }
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -917,8 +917,6 @@ export class ApolloGateway implements GraphQLService {
       );
     }
 
-    config;
-
     // TODO(trevor:cloudconfig): This condition goes away completely
     if (isPrecomposedManagedConfig(config)) {
       return loadSupergraphSdlFromStorage({

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -236,6 +236,7 @@ export class ApolloGateway implements GraphQLService {
     // 3. If config is explicitly set to `null`, fallback to GCS
     // 4. If the env var is set, use that
     this.schemaConfigDeliveryEndpoint = 'https://uplink.api.apollographql.com/';
+    // This if case unobviously handles both 1 and 2.
     if (isPrecomposedManagedConfig(this.config)) {
       this.schemaConfigDeliveryEndpoint =
         this.config.schemaConfigDeliveryEndpoint ??

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -204,7 +204,7 @@ export class ApolloGateway implements GraphQLService {
   // Configure the endpoint by which gateway will access its precomposed schema.
   // `null` will revert the gateway to legacy mode (polling GCS and composing the schema itself).
   // TODO(trevor:cloudconfig): `null` should be disallowed in the future.
-  private schemaConfigDeliveryEndpoint: string | null;
+  private schemaConfigDeliveryEndpoint?: string | null;
 
   constructor(config?: GatewayConfig) {
     this.config = {
@@ -232,10 +232,9 @@ export class ApolloGateway implements GraphQLService {
     this.experimental_pollInterval = config?.experimental_pollInterval;
 
     // 1. If config is set to a `string`, use it
-    // 2. If config is `undefined`, use the default uplink URL
-    // 3. If config is explicitly set to `null`, fallback to GCS
-    // 4. If the env var is set, use that
-    this.schemaConfigDeliveryEndpoint = 'https://uplink.api.apollographql.com/';
+    // 2. If config is explicitly set to `null`, fallback to GCS
+    // 3. If the env var is set, use that
+    // 4. If config is `undefined`, use the default uplink URL
 
     // This if case unobviously handles 1, 2, and 4.
     if (isPrecomposedManagedConfig(this.config)) {
@@ -243,7 +242,7 @@ export class ApolloGateway implements GraphQLService {
       this.schemaConfigDeliveryEndpoint =
         this.config.schemaConfigDeliveryEndpoint ??
         envEndpoint ??
-        this.schemaConfigDeliveryEndpoint;
+        'https://uplink.api.apollographql.com/';
     } else if (isLegacyManagedConfig(this.config)) {
       this.schemaConfigDeliveryEndpoint = null;
     }

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -236,16 +236,16 @@ export class ApolloGateway implements GraphQLService {
     // 3. If config is explicitly set to `null`, fallback to GCS
     // 4. If the env var is set, use that
     this.schemaConfigDeliveryEndpoint = 'https://uplink.api.apollographql.com/';
-    // This if case unobviously handles both 1 and 2.
+
+    // This if case unobviously handles 1, 2, and 4.
     if (isPrecomposedManagedConfig(this.config)) {
+      const envEndpoint = process.env.APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT;
       this.schemaConfigDeliveryEndpoint =
         this.config.schemaConfigDeliveryEndpoint ??
+        envEndpoint ??
         this.schemaConfigDeliveryEndpoint;
     } else if (isLegacyManagedConfig(this.config)) {
       this.schemaConfigDeliveryEndpoint = null;
-    } else {
-      const envEndpoint = process.env.APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT;
-      if (envEndpoint) this.schemaConfigDeliveryEndpoint = envEndpoint;
     }
 
     if (isManuallyManagedConfig(this.config)) {

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -202,7 +202,7 @@ export class ApolloGateway implements GraphQLService {
   // how often service defs should be loaded/updated (in ms)
   private experimental_pollInterval?: number;
   // Configure the endpoint by which gateway will access its precomposed schema.
-  // For now, `null` is default and means to continue using the legacy managed mode.
+  // `null` will revert the gateway to legacy mode (polling GCS and composing the schema itself).
   // TODO(trevor:cloudconfig): `null` should be disallowed in the future.
   private schemaConfigDeliveryEndpoint: string | null;
 


### PR DESCRIPTION
This PR switches our default managed federation behavior over to our new service (named Uplink). Under the hood, this is a fairly significant change. Gateway currently handles composition of the subgraphs itself, pulling them down from GCS. Via uplink, the gateway receives the composition outright, meaning it doesn't perform any composition itself.

The rules for configuring Uplink are as follows:
1. If `config.schemaConfigDeliveryEndpoint` is set to a `string`, use it
2. If `config.schemaConfigDeliveryEndpoint` is explicitly set to `null`, fallback to GCS and old behavior
3. If the env var (`APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT`) is set, use that
4. If `config.schemaConfigDeliveryEndpoint` is `undefined`, use the default uplink URL


Note: there are a lot of related TODOs - since we're keeping the option to fallback to old behavior for now those cannot be resolved.

Closes https://github.com/apollographql/polaris-planning/issues/58
