### PR TITLE
add APOLLO_GRAPH_ID to setup.mdx

### DIFF
--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -53,16 +53,19 @@ Like your subgraphs, your gateway uses an API key to identify itself to Studio.
 
 <ObtainGraphApiKey />
 
-After obtaining your graph API key, you set two environment variables in your gateway's environment. If you're using a `.env` file with a library like [`dotenv`](https://www.npmjs.com/package/dotenv), those environment variables look like this:
+After obtaining your graph API key, you set three environment variables in your gateway's environment. If you're using a `.env` file with a library like [`dotenv`](https://www.npmjs.com/package/dotenv), those environment variables look like this:
 
 ```sh:title=.env
 APOLLO_KEY=<YOUR_GRAPH_API_KEY>
 APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT=https://uplink.api.apollographql.com/
+APOLLO_GRAPH_REF=<YOUR_GRAPH_ID>@<VARIANT>
 ```
 
 You can also set these values directly in the command you use to start your gateway.
 
 The second environment variable, `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT`, instructs the gateway to fetch its configuration from a new (and recommended) Apollo-hosted endpoint called the **uplink**. If you don't set this value, the gateway instead fetches its configuration from a file hosted in Google Cloud Storage.
+
+The third environment variable, `APOLLO_GRAPH_KEY`, tells the gateway which graph to use and with which variant. You would supply your Graph Id and the variant you want to use (ex: current).
 
 > When running your gateway in an environment where outbound traffic to the internet is restricted, consult the [directions for configuring a proxy](https://www.apollographql.com/docs/apollo-server/proxy-configuration/) within Apollo Server.
 

--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -65,7 +65,7 @@ You can also set these values directly in the command you use to start your gate
 
 The second environment variable, `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT`, instructs the gateway to fetch its configuration from a new (and recommended) Apollo-hosted endpoint called the **uplink**. If you don't set this value, the gateway instead fetches its configuration from a file hosted in Google Cloud Storage.
 
-The third environment variable, `APOLLO_GRAPH_KEY`, tells the gateway which graph to use and with which variant. You would supply your Graph Id and the variant you want to use (ex: current).
+The third environment variable, `APOLLO_GRAPH_REF`, tells the gateway which graph to use and with which variant. You would supply your graph id and the variant you want to use (for example, `current`). You can always find a a graph's ref at the top of its Schema Reference page in Studio.
 
 > When running your gateway in an environment where outbound traffic to the internet is restricted, consult the [directions for configuring a proxy](https://www.apollographql.com/docs/apollo-server/proxy-configuration/) within Apollo Server.
 


### PR DESCRIPTION
Hey everyone! This is my first OSS contribution ever.

While trying to setup my ApolloGateway with a managed federation, I couldn't get my server to connect to Apollo. For a couple days I couldn't figure out how to resolve the error: **UnhandledPromiseRejectionWarning: Error: When a manual configuration is not provided, gateway requires an Apollo configuration. See https://www.apollographql.com/docs/apollo-server/federation/managed-federation/ for more information. Manual configuration options include: `serviceList`, `supergraphSdl`, and `experimental_updateServiceDefinitions`.**

I followed the guides as well as I could and looked through a bunch of tutorials and guides on non-managed federations to find a clue.

I dug into the source code of apollo/gateway and went to where the error was being thrown. I noticed it was looking for a graphRef, but that wasn't mentioned in the setup part of the Managed Federation as a key that needed to be set too.

I feel having this change might save someone else time if they run across this issue too. I very well may have missed something somewhere else that refers to this key, but I read the docs multiple times and couldn't see it anywhere. Even still, I feel if it was included in that section, it might be more clear that the key is required as part of the Apollo Federation setup.

I know when you create a new graph in Apollo Studio, it mentions those keys, but it seemed a bit confusing on using Apollo Server and Federation because it seemed like it was one or the other. Anyway, I just wanted to present this in case it helps someone out.