### PR TITLE
docs: rm instruction to set `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT` for Uplink

### DIFF
--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -57,12 +57,9 @@ After obtaining your graph API key, you set two environment variables in your ga
 
 ```sh:title=.env
 APOLLO_KEY=<YOUR_GRAPH_API_KEY>
-APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT=https://uplink.api.apollographql.com/
 ```
 
 You can also set these values directly in the command you use to start your gateway.
-
-The second environment variable, `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT`, instructs the gateway to fetch its configuration from a new (and recommended) Apollo-hosted endpoint called the **uplink**. If you don't set this value, the gateway instead fetches its configuration from a file hosted in Google Cloud Storage.
 
 > When running your gateway in an environment where outbound traffic to the internet is restricted, consult the [directions for configuring a proxy](https://www.apollographql.com/docs/apollo-server/proxy-configuration/) within Apollo Server.
 

--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -53,7 +53,7 @@ Like your subgraphs, your gateway uses an API key to identify itself to Studio.
 
 <ObtainGraphApiKey />
 
-After obtaining your graph API key, you set two environment variables in your gateway's environment. If you're using a `.env` file with a library like [`dotenv`](https://www.npmjs.com/package/dotenv), those environment variables look like this:
+After obtaining your graph API key, you set an environment variable in your gateway's environment. If you're using a `.env` file with a library like [`dotenv`](https://www.npmjs.com/package/dotenv), that environment variable looks like this:
 
 ```sh:title=.env
 APOLLO_KEY=<YOUR_GRAPH_API_KEY>

--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -59,7 +59,7 @@ After obtaining your graph API key, you set two environment variables in your ga
 APOLLO_KEY=<YOUR_GRAPH_API_KEY>
 ```
 
-You can also set these values directly in the command you use to start your gateway.
+You can also set this value directly in the command you use to start your gateway.
 
 > When running your gateway in an environment where outbound traffic to the internet is restricted, consult the [directions for configuring a proxy](https://www.apollographql.com/docs/apollo-server/proxy-configuration/) within Apollo Server.
 

--- a/docs/source/quickstart-pt-2.mdx
+++ b/docs/source/quickstart-pt-2.mdx
@@ -145,7 +145,6 @@ So now, how do we connect and authenticate our gateway with Apollo Studio? With 
 
     ```shell
     APOLLO_KEY=YOUR_API_KEY
-    APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT=https://uplink.api.apollographql.com/
     ```
 
 4. Add the `dotenv` Node.js library to your project:


### PR DESCRIPTION
Follows up #881, which changed the *default* behavior to use Uplink, thus eliminating the need for instruction.