### PR TITLE
renovate: bundle non-major npm updates, run always

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,7 +36,7 @@
       groupName: "all non-major dependencies",
       matchUpdateTypes: ["patch", "minor"],
       groupSlug: "all-npm-minor-patch",
-      matchManagers: [ "npm" ]],
+      matchManagers: [ "npm" ],
     },
     {
       "matchPaths": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   "extends": [
     "apollo-open-source"
   ],
+  schedule: null,
   "dependencyDashboard": true,
   // The "circleci" manager is intentionally disabled right now (e.g., not
   // included in this list).  While we do benefit from its updating of "Orb"
@@ -27,10 +28,15 @@
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "12.x"
     },
-    // Put all Apollo Server upgrades into one PR (eg, don't separate out apollo-server-env).
+    // Bunch up all non-major npm dependencies into a single PR.  In the common case
+    // where the upgrades apply cleanly, this causes less noise and is resolved faster
+    // than starting a bunch of upgrades in parallel for what may turn out to be
+    // a suite of related packages all released at once.
     {
-      matchPackagePrefixes: ["apollo-server"],
-      groupName: "all Apollo Server",
+      groupName: "all non-major dependencies",
+      matchUpdateTypes: ["patch", "minor"],
+      groupSlug: "all-npm-minor-patch",
+      matchManagers: [ "npm" ]],
     },
     {
       "matchPaths": [


### PR DESCRIPTION
We've been having issues where Renovate will make multiple PRs that fail CI separately but would succeed together. So far we've been happy with a "combine non-major upgrades into one PR" strategy in apollo-server so let's try it here too.

Also, let's turn off the "only run on weekends except for Apollo packages" schedule, which would have weird semantics when combined with "bundle Apollo and non-Apollo packages into one branch". Anyone annoyed about spammy updates on the large number of open major version upgrade PRs should feel inspired to merge them or pin the versions in this file.
