### PR TITLE
feat(federation): @tag support for Object, Interface, and Union types

### DIFF
--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -56,7 +56,7 @@ If Apollo Gateway encounters an error, composition fails. This document lists co
 ## `@tag`
 | Code | Description |
 |---|---|
-| `TAG_DIRECTIVE_DEFINITION_INVALID` | The `@tag` directive definition is included but defined incorrectly. Please include the correct `@tag` directive definition: `directive @tag(name: String!) repeatable on FIELD_DEFINITION`|
+| `TAG_DIRECTIVE_DEFINITION_INVALID` | The `@tag` directive definition is included but defined incorrectly. Please include the correct `@tag` directive definition: `directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION`|
 
 ## Custom directives
 

--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -41,7 +41,7 @@ export const typeDefs = gql`
     number: String
   }
 
-  union AccountType @tag(name: "from accounts") = PasswordAccount | SMSAccount
+  union AccountType @tag(name: "from-accounts") = PasswordAccount | SMSAccount
 
   type UserMetadata {
     name: String
@@ -49,7 +49,7 @@ export const typeDefs = gql`
     description: String
   }
 
-  type User @key(fields: "id") @key(fields: "username name { first last }") @tag(name: "from accounts") {
+  type User @key(fields: "id") @key(fields: "username name { first last }") @tag(name: "from-accounts") {
     id: ID! @tag(name: "accounts")
     name: Name @cacheControl(inheritMaxAge: true)
     username: String

--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -6,7 +6,11 @@ export const url = `https://${name}.api.com`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD
-  directive @tag(name: String!) repeatable on FIELD_DEFINITION
+  directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
 
   enum CacheControlScope {
     PUBLIC
@@ -45,7 +49,7 @@ export const typeDefs = gql`
     description: String
   }
 
-  type User @key(fields: "id") @key(fields: "username name { first last }") {
+  type User @key(fields: "id") @key(fields: "username name { first last }") @tag(name: "from accounts") {
     id: ID! @tag(name: "accounts")
     name: Name @cacheControl(inheritMaxAge: true)
     username: String

--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -41,7 +41,7 @@ export const typeDefs = gql`
     number: String
   }
 
-  union AccountType = PasswordAccount | SMSAccount
+  union AccountType @tag(name: "from accounts") = PasswordAccount | SMSAccount
 
   type UserMetadata {
     name: String

--- a/federation-integration-testsuite-js/src/fixtures/reviews.ts
+++ b/federation-integration-testsuite-js/src/fixtures/reviews.ts
@@ -6,7 +6,11 @@ export const url = `https://${name}.api.com`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD
-  directive @tag(name: String!) repeatable on FIELD_DEFINITION
+  directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
 
   extend type Query {
     topReviews(first: Int = 5): [Review]
@@ -29,7 +33,7 @@ export const typeDefs = gql`
     address: String @external
   }
 
-  extend type User @key(fields: "id") {
+  extend type User @key(fields: "id") @tag(name: "from reviews") {
     id: ID! @external @tag(name: "on external")
     username: String @external
     reviews: [Review]

--- a/federation-integration-testsuite-js/src/fixtures/reviews.ts
+++ b/federation-integration-testsuite-js/src/fixtures/reviews.ts
@@ -7,8 +7,8 @@ export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD
   directive @tag(name: String!) repeatable on
-    | FIELD_DEFINITION
     | INTERFACE
+    | FIELD_DEFINITION
     | OBJECT
     | UNION
 

--- a/federation-integration-testsuite-js/src/fixtures/reviews.ts
+++ b/federation-integration-testsuite-js/src/fixtures/reviews.ts
@@ -33,8 +33,8 @@ export const typeDefs = gql`
     address: String @external
   }
 
-  extend type User @key(fields: "id") @tag(name: "from reviews") {
-    id: ID! @external @tag(name: "on external")
+  extend type User @key(fields: "id") @tag(name: "from-reviews") {
+    id: ID! @external @tag(name: "on-external")
     username: String @external
     reviews: [Review]
     numberOfReviews: Int!
@@ -42,7 +42,7 @@ export const typeDefs = gql`
     goodAddress: Boolean @requires(fields: "metadata { address }")
   }
 
-  extend interface Product @tag(name: "from reviews") {
+  extend interface Product @tag(name: "from-reviews") {
     reviews: [Review]
   }
 

--- a/federation-integration-testsuite-js/src/fixtures/reviews.ts
+++ b/federation-integration-testsuite-js/src/fixtures/reviews.ts
@@ -42,7 +42,7 @@ export const typeDefs = gql`
     goodAddress: Boolean @requires(fields: "metadata { address }")
   }
 
-  extend interface Product {
+  extend interface Product @tag(name: "from reviews") {
     reviews: [Review]
   }
 

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -5,6 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Rename `buildFederatedSchema` to `buildSubgraphSchema`. The previous name will continue to be supported but is deprecated. No functional change, usages of `buildFederatedSchema` should just be replaced with `buildSubgraphSchema`. [PR #915](https://github.com/apollographql/federation/pull/913)
+- Support @tag directive on Object, Interface, and Union types. This is a breaking change for current @tag users, as one of the validations was updated. Existing @tag definitions must now accomodate the additional locations `OBJECT | INTERFACE | UNION`. Usages of the @tag directive are rolled up indiscriminately during composition, just as they currently are with fields. For example, a @tag usage on an entity extension will end up in the supergraph alongside any other @tag usages on the same entity in other subgraphs. [PR #945](https://github.com/apollographql/federation/pull/945) 
 
 ## v0.28.0
 

--- a/federation-js/src/composition/DirectiveMetadata.ts
+++ b/federation-js/src/composition/DirectiveMetadata.ts
@@ -1,0 +1,192 @@
+import {
+  DirectiveNode,
+  FieldDefinitionNode,
+  GraphQLFieldMap,
+  GraphQLNamedType,
+  GraphQLSchema,
+  TypeDefinitionNode,
+  TypeExtensionNode,
+  visit,
+} from 'graphql';
+import { mapGetOrSet } from '../utilities';
+import { FederationField, FederationType, ServiceDefinition } from './types';
+import { getFederationMetadata } from './utils';
+
+// key is name of directive
+export type DirectiveUsages = Map<string, DirectiveNode[]>;
+
+// key is field or type name the usages are found on
+type DirectiveUsagesPerField = Map<string, DirectiveUsages>;
+
+type DirectiveUsagesPerType = Map<
+  string,
+  { directives: DirectiveUsages; fields: DirectiveUsagesPerField }
+>;
+
+type DirectiveUsagesPerSubgraph = Map<string, DirectiveUsagesPerType>;
+
+export class DirectiveMetadata {
+  directiveUsagesPerSubgraph: DirectiveUsagesPerSubgraph;
+
+  constructor(subgraphs: ServiceDefinition[]) {
+    this.directiveUsagesPerSubgraph = new Map();
+    for (const subgraph of subgraphs) {
+      const visitor = objectLikeDirectivesVisitor(
+        subgraph.name,
+        this.directiveUsagesPerSubgraph,
+      );
+      visit(subgraph.typeDefs, {
+        ObjectTypeDefinition: visitor,
+        ObjectTypeExtension: visitor,
+        InterfaceTypeDefinition: visitor,
+        InterfaceTypeExtension: visitor,
+        UnionTypeDefinition: visitor,
+        UnionTypeExtension: visitor,
+      });
+    }
+  }
+
+  hasUsages(directiveName: string) {
+    for (const directiveUsagesPerType of this.directiveUsagesPerSubgraph.values()) {
+      for (const { directives, fields } of directiveUsagesPerType.values()) {
+        const usagesOnType = directives.get(directiveName);
+        if (usagesOnType && usagesOnType.length > 0) return true;
+
+        for (const directiveUsages of fields.values()) {
+          const usagesOnField = directiveUsages.get(directiveName);
+          if (usagesOnField && usagesOnField.length > 0) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  applyMetadataToSupergraphSchema(schema: GraphQLSchema) {
+    // TODO: only capture usages of non-repeatable directives once.
+    // might be a printer concern instead.
+    for (const [
+      _subgraphName,
+      directiveUsagesPerType,
+    ] of this.directiveUsagesPerSubgraph.entries()) {
+      for (const [
+        typeName,
+        { directives, fields },
+      ] of directiveUsagesPerType.entries()) {
+        const namedType = schema.getType(typeName) as
+          | GraphQLNamedType
+          | undefined;
+        if (!namedType) continue;
+
+        const existingMetadata = getFederationMetadata(namedType);
+        let directiveUsages = existingMetadata?.directiveUsages;
+
+        if (directiveUsages) {
+          for (const [directiveName, usages] of directiveUsages.entries()) {
+            usages.push(...(directives.get(directiveName) ?? []));
+          }
+        } else {
+          directiveUsages = directives;
+        }
+
+        const typeFederationMetadata: FederationType = {
+          ...existingMetadata,
+          directiveUsages,
+        };
+        namedType.extensions = {
+          ...namedType.extensions,
+          federation: typeFederationMetadata,
+        };
+
+        interface HasFields {
+          getFields(): GraphQLFieldMap<any, any>;
+        }
+
+        for (const [fieldName, usagesPerDirective] of fields.entries()) {
+          const field = (namedType as HasFields).getFields()[fieldName];
+          if (!field) continue;
+
+          const originalMetadata = getFederationMetadata(field);
+          let directiveUsages = originalMetadata?.directiveUsages;
+          if (directiveUsages) {
+            for (const [directiveName, usages] of directiveUsages.entries()) {
+              usages.push(...(usagesPerDirective.get(directiveName) ?? []));
+            }
+          } else {
+            directiveUsages = usagesPerDirective;
+          }
+
+          const fieldFederationMetadata: FederationField = {
+            ...originalMetadata,
+            directiveUsages,
+          };
+
+          field.extensions = {
+            ...field.extensions,
+            federation: fieldFederationMetadata,
+          };
+        }
+      }
+    }
+  }
+}
+
+function objectLikeDirectivesVisitor(
+  subgraphName: string,
+  directiveUsagesPerSubgraph: DirectiveUsagesPerSubgraph,
+) {
+  return function <
+    T extends (TypeDefinitionNode | TypeExtensionNode) & {
+      directives?: readonly DirectiveNode[];
+      fields?: readonly FieldDefinitionNode[] | undefined;
+    },
+  >(node: T) {
+    const directiveUsagesPerType: DirectiveUsagesPerType = mapGetOrSet(
+      directiveUsagesPerSubgraph,
+      subgraphName,
+      new Map(),
+    );
+
+    for (const directive of node.directives ?? []) {
+      const { directives: usagesByDirectiveName } = mapGetOrSet(
+        directiveUsagesPerType,
+        node.name.value,
+        {
+          directives: new Map<string, DirectiveNode[]>(),
+          fields: new Map<string, DirectiveUsages>(),
+        },
+      );
+      const usages = mapGetOrSet(
+        usagesByDirectiveName,
+        directive.name.value,
+        [],
+      );
+      usages.push(directive);
+    }
+
+    if ('fields' in node && node.fields) {
+      for (const field of node.fields) {
+        for (const directive of field.directives ?? []) {
+          const { fields: usagesByFieldName } = mapGetOrSet(
+            directiveUsagesPerType,
+            node.name.value,
+            {
+              directives: new Map<string, DirectiveNode[]>(),
+              fields: new Map<string, DirectiveUsages>(),
+            },
+          );
+          const usagesByDirectiveName = mapGetOrSet(
+            usagesByFieldName,
+            field.name.value,
+            new Map<string, DirectiveNode[]>(),
+          );
+          const usages = mapGetOrSet(
+            usagesByDirectiveName,
+            directive.name.value,
+            [],
+          );
+          usages.push(directive);
+        }
+      }
+    }
+  };
+}

--- a/federation-js/src/composition/__tests__/compose.test.ts
+++ b/federation-js/src/composition/__tests__/compose.test.ts
@@ -1076,6 +1076,11 @@ describe('composeServices', () => {
           .toMatchInlineSnapshot(`
           Object {
             "belongsToValueType": false,
+            "directiveUsages": Map {
+              "provides" => Array [
+                @provides(fields: "sku"),
+              ],
+            },
             "provides": sku,
             "serviceName": "serviceA",
           }
@@ -1159,6 +1164,11 @@ describe('composeServices', () => {
           .toMatchInlineSnapshot(`
           Object {
             "belongsToValueType": false,
+            "directiveUsages": Map {
+              "provides" => Array [
+                @provides(fields: "sku"),
+              ],
+            },
             "provides": sku,
             "serviceName": "serviceA",
           }

--- a/federation-js/src/composition/__tests__/composeAndValidate.test.ts
+++ b/federation-js/src/composition/__tests__/composeAndValidate.test.ts
@@ -175,7 +175,7 @@ describe('unknown types', () => {
     const inventory = {
       name: 'inventory',
       typeDefs: gql`
-        directive @tag(name: String!) repeatable on FIELD_DEFINITION
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
         extend type Product @key(fields: "id") {
           id: ID! @external @tag(name: "hi from inventory")
         }

--- a/federation-js/src/composition/__tests__/composeAndValidate.test.ts
+++ b/federation-js/src/composition/__tests__/composeAndValidate.test.ts
@@ -177,7 +177,7 @@ describe('unknown types', () => {
       typeDefs: gql`
         directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
         extend type Product @key(fields: "id") {
-          id: ID! @external @tag(name: "hi from inventory")
+          id: ID! @external @tag(name: "from-inventory")
         }
       `,
     };

--- a/federation-js/src/composition/compose.ts
+++ b/federation-js/src/composition/compose.ts
@@ -143,7 +143,6 @@ export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
   const directiveMetadata = new DirectiveMetadata(serviceList);
 
   for (const { typeDefs, name: serviceName } of serviceList) {
-
     // Build a new SDL with @external fields removed, as well as information about
     // the fields that were removed.
     const {
@@ -619,8 +618,8 @@ export function addFederationMetadataToSchemaNodes({
     };
   }
 
-  // TODO: only capture usages of non-repeatable directives once.
-  // might be a printer concern instead.
+  // currently this is only used to capture @tag metadata but could be used
+  // for others directives in the future
   directiveMetadata.applyMetadataToSupergraphSchema(schema);
 }
 

--- a/federation-js/src/composition/types.ts
+++ b/federation-js/src/composition/types.ts
@@ -3,7 +3,6 @@ import {
   DocumentNode,
   FieldDefinitionNode,
   DirectiveDefinitionNode,
-  DirectiveNode,
 } from 'graphql';
 import { DirectiveUsages } from './DirectiveMetadata';
 
@@ -41,7 +40,6 @@ export interface FederationField {
   requires?: ReadonlyArray<SelectionNode>;
   provides?: ReadonlyArray<SelectionNode>;
   belongsToValueType?: boolean;
-  otherKnownDirectiveUsages?: DirectiveNode[]
   directiveUsages?: DirectiveUsages
 }
 

--- a/federation-js/src/composition/types.ts
+++ b/federation-js/src/composition/types.ts
@@ -5,6 +5,7 @@ import {
   DirectiveDefinitionNode,
   DirectiveNode,
 } from 'graphql';
+import { DirectiveUsages } from './compose';
 
 export type Maybe<T> = null | undefined | T;
 
@@ -32,6 +33,7 @@ export interface FederationType {
     [serviceName: string]: ExternalFieldDefinition[];
   };
   isValueType?: boolean;
+  directiveUsages?: DirectiveUsages
 }
 
 export interface FederationField {
@@ -40,6 +42,7 @@ export interface FederationField {
   provides?: ReadonlyArray<SelectionNode>;
   belongsToValueType?: boolean;
   otherKnownDirectiveUsages?: DirectiveNode[]
+  directiveUsages?: DirectiveUsages
 }
 
 export interface FederationDirective {

--- a/federation-js/src/composition/types.ts
+++ b/federation-js/src/composition/types.ts
@@ -5,7 +5,7 @@ import {
   DirectiveDefinitionNode,
   DirectiveNode,
 } from 'graphql';
-import { DirectiveUsages } from './compose';
+import { DirectiveUsages } from './DirectiveMetadata';
 
 export type Maybe<T> = null | undefined | T;
 

--- a/federation-js/src/composition/validate/preNormalization/__tests__/tagDirective.test.ts
+++ b/federation-js/src/composition/validate/preNormalization/__tests__/tagDirective.test.ts
@@ -29,7 +29,9 @@ describe('tagDirective', () => {
     it('when there are @tag usages and a correct @tag definition', () => {
       const serviceA = {
         typeDefs: gql`
-          directive @tag(name: String!) repeatable on FIELD_DEFINITION
+          directive @tag(
+            name: String!
+          ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
           type Query {
             hello: String @tag(name: "hello")
           }
@@ -44,11 +46,15 @@ describe('tagDirective', () => {
     it('permits descriptions in the @tag definition', () => {
       const serviceA = {
         typeDefs: gql`
-          """description"""
+          """
+          description
+          """
           directive @tag(
-            """description"""
+            """
+            description
+            """
             name: String!
-          ) repeatable on FIELD_DEFINITION
+          ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
           type Query {
             hello: String @tag(name: "hello")
           }
@@ -118,7 +124,7 @@ describe('tagDirective', () => {
               },
             ],
             "message": "[@tag] -> Found @tag definition in service serviceA, but the @tag directive definition was invalid. Please ensure the directive definition in your schema's type definitions matches the following:
-        	directive @tag(name: String!) repeatable on FIELD_DEFINITION",
+        	directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION",
           },
         ]
       `);
@@ -127,7 +133,9 @@ describe('tagDirective', () => {
     it('when @tag usage is missing args', () => {
       const serviceA = {
         typeDefs: gql`
-          directive @tag(name: String!) repeatable on FIELD_DEFINITION
+          directive @tag(
+            name: String!
+          ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
 
           type Query {
             hello: String @tag
@@ -145,7 +153,7 @@ describe('tagDirective', () => {
             "locations": Array [
               Object {
                 "column": 17,
-                "line": 5,
+                "line": 7,
               },
             ],
             "message": "Directive \\"@tag\\" argument \\"name\\" of type \\"String!\\" is required, but it was not provided.",
@@ -157,7 +165,9 @@ describe('tagDirective', () => {
     it('when @tag usage has invalid args', () => {
       const serviceA = {
         typeDefs: gql`
-          directive @tag(name: String!) repeatable on FIELD_DEFINITION
+          directive @tag(
+            name: String!
+          ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
 
           type Query {
             hello: String @tag(invalid: 1)
@@ -175,7 +185,7 @@ describe('tagDirective', () => {
             "locations": Array [
               Object {
                 "column": 22,
-                "line": 5,
+                "line": 7,
               },
             ],
             "message": "Unknown argument \\"invalid\\" on directive \\"@tag\\".",
@@ -185,7 +195,7 @@ describe('tagDirective', () => {
             "locations": Array [
               Object {
                 "column": 17,
-                "line": 5,
+                "line": 7,
               },
             ],
             "message": "Directive \\"@tag\\" argument \\"name\\" of type \\"String!\\" is required, but it was not provided.",

--- a/federation-js/src/composition/validate/preNormalization/tagDirective.ts
+++ b/federation-js/src/composition/validate/preNormalization/tagDirective.ts
@@ -5,6 +5,7 @@ import {
   visit,
   BREAK,
   print,
+  NameNode,
 } from 'graphql';
 import { KnownArgumentNamesOnDirectivesRule } from 'graphql/validation/rules/KnownArgumentNamesRule';
 import { ProvidedRequiredArgumentsOnDirectivesRule } from 'graphql/validation/rules/ProvidedRequiredArgumentsRule';
@@ -51,9 +52,9 @@ export const tagDirective = ({
     const printedTagDefinition =
       'directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION';
 
-    // TODO: sort locations
     if (
-      print(stripDescriptions(tagDirectiveDefinition)) !== printedTagDefinition
+      print(normalizeDirectiveDefinitionNode(tagDirectiveDefinition)) !==
+      printedTagDefinition
     ) {
       errors.push(
         errorWithCode(
@@ -71,3 +72,11 @@ export const tagDirective = ({
       !errorsMessagesToFilter.some((keyWord) => message === keyWord),
   );
 };
+
+function normalizeDirectiveDefinitionNode(node: DirectiveDefinitionNode) {
+  // Remove descriptions from the AST
+  node = stripDescriptions(node);
+  // Sort locations alphabetically
+  (node.locations as NameNode[]).sort((a, b) => a.value.localeCompare(b.value));
+  return node;
+}

--- a/federation-js/src/composition/validate/preNormalization/tagDirective.ts
+++ b/federation-js/src/composition/validate/preNormalization/tagDirective.ts
@@ -49,8 +49,9 @@ export const tagDirective = ({
   // Ensure the tag directive definition is correct
   if (tagDirectiveDefinition) {
     const printedTagDefinition =
-      'directive @tag(name: String!) repeatable on FIELD_DEFINITION';
+      'directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION';
 
+    // TODO: sort locations
     if (
       print(stripDescriptions(tagDirectiveDefinition)) !== printedTagDefinition
     ) {

--- a/federation-js/src/directives.ts
+++ b/federation-js/src/directives.ts
@@ -58,7 +58,12 @@ export const ProvidesDirective = new GraphQLDirective({
 
 export const TagDirective = new GraphQLDirective({
   name: 'tag',
-  locations: [DirectiveLocation.FIELD_DEFINITION],
+  locations: [
+    DirectiveLocation.FIELD_DEFINITION,
+    DirectiveLocation.OBJECT,
+    DirectiveLocation.INTERFACE,
+    DirectiveLocation.UNION,
+  ],
   isRepeatable: true,
   args: {
     name: {

--- a/federation-js/src/service/__tests__/printFederatedSchema.test.ts
+++ b/federation-js/src/service/__tests__/printFederatedSchema.test.ts
@@ -16,7 +16,7 @@ describe('printFederatedSchema', () => {
 
       directive @transform(from: String!) on FIELD
 
-      union AccountType @tag(name: \\"from accounts\\") = PasswordAccount | SMSAccount
+      union AccountType @tag(name: \\"from-accounts\\") = PasswordAccount | SMSAccount
 
       type Amazon {
         referrer: String
@@ -119,7 +119,7 @@ describe('printFederatedSchema', () => {
         email: String!
       }
 
-      interface Product @tag(name: \\"from reviews\\") {
+      interface Product @tag(name: \\"from-reviews\\") {
         details: ProductDetails
         inStock: Boolean
         name: String
@@ -186,12 +186,12 @@ describe('printFederatedSchema', () => {
         id: ID!
       }
 
-      type User @key(fields: \\"id\\") @key(fields: \\"username name { first last }\\") @tag(name: \\"from accounts\\") @tag(name: \\"from reviews\\") {
+      type User @key(fields: \\"id\\") @key(fields: \\"username name { first last }\\") @tag(name: \\"from-accounts\\") @tag(name: \\"from-reviews\\") {
         account: AccountType
         birthDate(locale: String): String @tag(name: \\"admin\\") @tag(name: \\"dev\\")
         goodAddress: Boolean @requires(fields: \\"metadata { address }\\")
         goodDescription: Boolean @requires(fields: \\"metadata { description }\\")
-        id: ID! @tag(name: \\"accounts\\") @tag(name: \\"on external\\")
+        id: ID! @tag(name: \\"accounts\\") @tag(name: \\"on-external\\")
         metadata: [UserMetadata]
         name: Name
         numberOfReviews: Int!

--- a/federation-js/src/service/__tests__/printFederatedSchema.test.ts
+++ b/federation-js/src/service/__tests__/printFederatedSchema.test.ts
@@ -119,7 +119,7 @@ describe('printFederatedSchema', () => {
         email: String!
       }
 
-      interface Product {
+      interface Product @tag(name: \\"from reviews\\") {
         details: ProductDetails
         inStock: Boolean
         name: String

--- a/federation-js/src/service/__tests__/printFederatedSchema.test.ts
+++ b/federation-js/src/service/__tests__/printFederatedSchema.test.ts
@@ -16,7 +16,7 @@ describe('printFederatedSchema', () => {
 
       directive @transform(from: String!) on FIELD
 
-      union AccountType = PasswordAccount | SMSAccount
+      union AccountType @tag(name: \\"from accounts\\") = PasswordAccount | SMSAccount
 
       type Amazon {
         referrer: String

--- a/federation-js/src/service/__tests__/printFederatedSchema.test.ts
+++ b/federation-js/src/service/__tests__/printFederatedSchema.test.ts
@@ -186,7 +186,7 @@ describe('printFederatedSchema', () => {
         id: ID!
       }
 
-      type User @key(fields: \\"id\\") @key(fields: \\"username name { first last }\\") {
+      type User @key(fields: \\"id\\") @key(fields: \\"username name { first last }\\") @tag(name: \\"from accounts\\") @tag(name: \\"from reviews\\") {
         account: AccountType
         birthDate(locale: String): String @tag(name: \\"admin\\") @tag(name: \\"dev\\")
         goodAddress: Boolean @requires(fields: \\"metadata { address }\\")

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -54,7 +54,7 @@ describe('printSupergraphSdl', () => {
       directive @transform(from: String!) on FIELD
 
       union AccountType
-        @tag(name: \\"from accounts\\")
+        @tag(name: \\"from-accounts\\")
       = PasswordAccount | SMSAccount
 
       type Amazon {
@@ -193,7 +193,7 @@ describe('printSupergraphSdl', () => {
       }
 
       interface Product
-        @tag(name: \\"from reviews\\")
+        @tag(name: \\"from-reviews\\")
       {
         details: ProductDetails
         inStock: Boolean
@@ -274,14 +274,14 @@ describe('printSupergraphSdl', () => {
         @join__type(graph: INVENTORY, key: \\"id\\")
         @join__type(graph: PRODUCT, key: \\"id\\")
         @join__type(graph: REVIEWS, key: \\"id\\")
-        @tag(name: \\"from accounts\\")
-        @tag(name: \\"from reviews\\")
+        @tag(name: \\"from-accounts\\")
+        @tag(name: \\"from-reviews\\")
       {
         account: AccountType @join__field(graph: ACCOUNTS)
         birthDate(locale: String): String @join__field(graph: ACCOUNTS) @tag(name: \\"admin\\") @tag(name: \\"dev\\")
         goodAddress: Boolean @join__field(graph: REVIEWS, requires: \\"metadata{address}\\")
         goodDescription: Boolean @join__field(graph: INVENTORY, requires: \\"metadata{description}\\")
-        id: ID! @join__field(graph: ACCOUNTS) @tag(name: \\"accounts\\") @tag(name: \\"on external\\")
+        id: ID! @join__field(graph: ACCOUNTS) @tag(name: \\"accounts\\") @tag(name: \\"on-external\\")
         metadata: [UserMetadata] @join__field(graph: ACCOUNTS)
         name: Name @join__field(graph: ACCOUNTS)
         numberOfReviews: Int! @join__field(graph: REVIEWS)

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -49,7 +49,7 @@ describe('printSupergraphSdl', () => {
 
       directive @stream on FIELD
 
-      directive @tag(name: String!) repeatable on FIELD_DEFINITION
+      directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
 
       directive @transform(from: String!) on FIELD
 
@@ -270,6 +270,8 @@ describe('printSupergraphSdl', () => {
         @join__type(graph: INVENTORY, key: \\"id\\")
         @join__type(graph: PRODUCT, key: \\"id\\")
         @join__type(graph: REVIEWS, key: \\"id\\")
+        @tag(name: \\"from accounts\\")
+        @tag(name: \\"from reviews\\")
       {
         account: AccountType @join__field(graph: ACCOUNTS)
         birthDate(locale: String): String @join__field(graph: ACCOUNTS) @tag(name: \\"admin\\") @tag(name: \\"dev\\")

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -53,7 +53,9 @@ describe('printSupergraphSdl', () => {
 
       directive @transform(from: String!) on FIELD
 
-      union AccountType = PasswordAccount | SMSAccount
+      union AccountType
+        @tag(name: \\"from accounts\\")
+      = PasswordAccount | SMSAccount
 
       type Amazon {
         referrer: String

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -190,7 +190,9 @@ describe('printSupergraphSdl', () => {
         email: String! @join__field(graph: ACCOUNTS)
       }
 
-      interface Product {
+      interface Product
+        @tag(name: \\"from reviews\\")
+      {
         details: ProductDetails
         inStock: Boolean
         name: String

--- a/federation-js/src/service/printFederatedSchema.ts
+++ b/federation-js/src/service/printFederatedSchema.ts
@@ -255,7 +255,13 @@ function printInterface(type: GraphQLInterfaceType, options?: Options): string {
 function printUnion(type: GraphQLUnionType, options?: Options): string {
   const types = type.getTypes();
   const possibleTypes = types.length ? ' = ' + types.join(' | ') : '';
-  return printDescription(options, type) + 'union ' + type.name + possibleTypes;
+  return (
+    printDescription(options, type) +
+    'union ' +
+    type.name +
+    printKnownDirectiveUsagesOnType(type) +
+    possibleTypes
+  );
 }
 
 function printEnum(type: GraphQLEnumType, options?: Options): string {

--- a/federation-js/src/service/printFederatedSchema.ts
+++ b/federation-js/src/service/printFederatedSchema.ts
@@ -219,7 +219,9 @@ function printObject(type: GraphQLObjectType, options?: Options): string {
   );
 }
 
-function printKnownDirectiveUsagesOnType(type: GraphQLObjectType): string {
+function printKnownDirectiveUsagesOnType(
+  type: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
+): string {
   const directiveUsages = (type.extensions?.federation as FederationType)
     ?.directiveUsages;
 
@@ -245,6 +247,7 @@ function printInterface(type: GraphQLInterfaceType, options?: Options): string {
     // Federation change: graphql@14 doesn't support interfaces implementing interfaces
     // printImplementedInterfaces(type) +
     printFederationDirectives(type) +
+    printKnownDirectiveUsagesOnType(type) +
     printFields(options, type)
   );
 }

--- a/federation-js/src/service/printFederatedSchema.ts
+++ b/federation-js/src/service/printFederatedSchema.ts
@@ -226,7 +226,7 @@ function printKnownDirectiveUsagesOnType(
     (type.extensions?.federation as FederationType)?.directiveUsages?.get(
       'tag',
     ) ?? [];
-  if (!tagUsages || tagUsages.length === 0) return '';
+  if (tagUsages.length === 0) return '';
 
   return ' ' + tagUsages.map(print).join(' ');
 }

--- a/federation-js/src/service/printFederatedSchema.ts
+++ b/federation-js/src/service/printFederatedSchema.ts
@@ -222,11 +222,10 @@ function printObject(type: GraphQLObjectType, options?: Options): string {
 function printKnownDirectiveUsagesOnType(
   type: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
 ): string {
-  const directiveUsages = (type.extensions?.federation as FederationType)
-    ?.directiveUsages;
-
-  if (!directiveUsages) return '';
-  const tagUsages = directiveUsages.get('tag');
+  const tagUsages =
+    (type.extensions?.federation as FederationType)?.directiveUsages?.get(
+      'tag',
+    ) ?? [];
   if (!tagUsages || tagUsages.length === 0) return '';
 
   return ' ' + tagUsages.map(print).join(' ');
@@ -329,9 +328,9 @@ function printFederationDirectives(
 // Core addition: print `@tag` directive usages (and possibly other future known
 // directive usages) found in subgraph SDL.
 function printKnownDirectiveUsagesOnFields(field: GraphQLField<any, any>) {
-  const directiveUsages = (field.extensions?.federation as FederationField)
-    ?.directiveUsages;
-  const tagUsages = directiveUsages?.get('tag');
+ const tagUsages = (
+   field.extensions?.federation as FederationField
+ )?.directiveUsages?.get('tag');
   if (!tagUsages || tagUsages.length < 1) return '';
   return ` ${tagUsages
     .slice()

--- a/federation-js/src/service/printSupergraphSdl.ts
+++ b/federation-js/src/service/printSupergraphSdl.ts
@@ -241,10 +241,11 @@ function printObject(
 function printKnownDirectiveUsagesOnType(
   type: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
 ): string {
-  const tagUsages = (
-    type.extensions?.federation as FederationField
-  )?.directiveUsages?.get('tag');
-  if (!tagUsages || tagUsages.length === 0) return '';
+  const tagUsages =
+    (type.extensions?.federation as FederationType)?.directiveUsages?.get(
+      'tag',
+    ) ?? [];
+  if (tagUsages.length === 0) return '';
 
   return '\n  ' + tagUsages.map(print).join('\n  ');
 }

--- a/federation-js/src/service/printSupergraphSdl.ts
+++ b/federation-js/src/service/printSupergraphSdl.ts
@@ -238,7 +238,9 @@ function printObject(
   );
 }
 
-function printKnownDirectiveUsagesOnType(type: GraphQLObjectType): string {
+function printKnownDirectiveUsagesOnType(
+  type: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
+): string {
   const directiveUsages = (type.extensions?.federation as FederationType)
     ?.directiveUsages;
 
@@ -315,6 +317,7 @@ function printInterface(
     `interface ${type.name}` +
     // Core addition for printing @join__owner and @join__type usages
     printTypeJoinDirectives(type, context) +
+    printKnownDirectiveUsagesOnType(type) +
     printFields(options, type, context)
   );
 }
@@ -387,8 +390,11 @@ function printFields(
   // Core change: for entities, we want to print the block on a new line.
   // This is just a formatting nice-to-have.
   const isEntity = Boolean(type.extensions?.federation?.keys);
+  const hasTags = Boolean(
+    type.extensions?.federation?.directiveUsages?.get('tag')?.length,
+  );
 
-  return printBlock(fields, isEntity);
+  return printBlock(fields, isEntity || hasTags);
 }
 
 /**

--- a/federation-js/src/service/printSupergraphSdl.ts
+++ b/federation-js/src/service/printSupergraphSdl.ts
@@ -241,11 +241,9 @@ function printObject(
 function printKnownDirectiveUsagesOnType(
   type: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
 ): string {
-  const directiveUsages = (type.extensions?.federation as FederationType)
-    ?.directiveUsages;
-
-  if (!directiveUsages) return '';
-  const tagUsages = directiveUsages.get('tag');
+  const tagUsages = (
+    type.extensions?.federation as FederationField
+  )?.directiveUsages?.get('tag');
   if (!tagUsages || tagUsages.length === 0) return '';
 
   return '\n  ' + tagUsages.map(print).join('\n  ');
@@ -469,9 +467,9 @@ function printJoinFieldDirectives(
 // Core addition: print `@tag` directives (and possibly other future known
 // directives) found in subgraph SDL into the supergraph SDL
 function printKnownDirectiveUsagesOnFields(field: GraphQLField<any, any>) {
-  const directiveUsages = (field.extensions?.federation as FederationField)
-    ?.directiveUsages;
-  const tagUsages = directiveUsages?.get('tag');
+  const tagUsages = (
+    field.extensions?.federation as FederationField
+  )?.directiveUsages?.get('tag');
   if (!tagUsages || tagUsages.length < 1) return '';
   return ` ${tagUsages
     .slice()

--- a/federation-js/src/service/printSupergraphSdl.ts
+++ b/federation-js/src/service/printSupergraphSdl.ts
@@ -324,8 +324,17 @@ function printInterface(
 
 function printUnion(type: GraphQLUnionType, options?: Options): string {
   const types = type.getTypes();
-  const possibleTypes = types.length ? ' = ' + types.join(' | ') : '';
-  return printDescription(options, type) + 'union ' + type.name + possibleTypes;
+  const knownDirectiveUsages = printKnownDirectiveUsagesOnType(type);
+  const possibleTypes = types.length
+    ? `${knownDirectiveUsages.length ? '\n' : ' '}= ` + types.join(' | ')
+    : '';
+  return (
+    printDescription(options, type) +
+    'union ' +
+    type.name +
+    knownDirectiveUsages +
+    possibleTypes
+  );
 }
 
 function printEnum(type: GraphQLEnumType, options?: Options): string {

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -21,7 +21,7 @@ describe('loadSupergraphSdlFromStorage', () => {
     }
   });
 
-  it('fetches Supergraph SDL as expected', async () => {
+  fit('fetches Supergraph SDL as expected', async () => {
     mockSupergraphSdlRequestSuccess();
 
     const fetcher = getDefaultFetcher();
@@ -56,7 +56,7 @@ describe('loadSupergraphSdlFromStorage', () => {
 
       directive @stream on FIELD
 
-      directive @tag(name: String!) repeatable on FIELD_DEFINITION
+      directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
 
       directive @transform(from: String!) on FIELD
 

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -61,7 +61,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       directive @transform(from: String!) on FIELD
 
       union AccountType
-        @tag(name: \\"from accounts\\")
+        @tag(name: \\"from-accounts\\")
       = PasswordAccount | SMSAccount
 
       type Amazon {
@@ -200,7 +200,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       }
 
       interface Product
-        @tag(name: \\"from reviews\\")
+        @tag(name: \\"from-reviews\\")
       {
         details: ProductDetails
         inStock: Boolean
@@ -281,14 +281,14 @@ describe('loadSupergraphSdlFromStorage', () => {
         @join__type(graph: INVENTORY, key: \\"id\\")
         @join__type(graph: PRODUCT, key: \\"id\\")
         @join__type(graph: REVIEWS, key: \\"id\\")
-        @tag(name: \\"from accounts\\")
-        @tag(name: \\"from reviews\\")
+        @tag(name: \\"from-accounts\\")
+        @tag(name: \\"from-reviews\\")
       {
         account: AccountType @join__field(graph: ACCOUNTS)
         birthDate(locale: String): String @join__field(graph: ACCOUNTS) @tag(name: \\"admin\\") @tag(name: \\"dev\\")
         goodAddress: Boolean @join__field(graph: REVIEWS, requires: \\"metadata{address}\\")
         goodDescription: Boolean @join__field(graph: INVENTORY, requires: \\"metadata{description}\\")
-        id: ID! @join__field(graph: ACCOUNTS) @tag(name: \\"accounts\\") @tag(name: \\"on external\\")
+        id: ID! @join__field(graph: ACCOUNTS) @tag(name: \\"accounts\\") @tag(name: \\"on-external\\")
         metadata: [UserMetadata] @join__field(graph: ACCOUNTS)
         name: Name @join__field(graph: ACCOUNTS)
         numberOfReviews: Int! @join__field(graph: REVIEWS)

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -21,7 +21,7 @@ describe('loadSupergraphSdlFromStorage', () => {
     }
   });
 
-  fit('fetches Supergraph SDL as expected', async () => {
+  it('fetches Supergraph SDL as expected', async () => {
     mockSupergraphSdlRequestSuccess();
 
     const fetcher = getDefaultFetcher();

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -197,7 +197,9 @@ describe('loadSupergraphSdlFromStorage', () => {
         email: String! @join__field(graph: ACCOUNTS)
       }
 
-      interface Product {
+      interface Product
+        @tag(name: \\"from reviews\\")
+      {
         details: ProductDetails
         inStock: Boolean
         name: String
@@ -277,6 +279,8 @@ describe('loadSupergraphSdlFromStorage', () => {
         @join__type(graph: INVENTORY, key: \\"id\\")
         @join__type(graph: PRODUCT, key: \\"id\\")
         @join__type(graph: REVIEWS, key: \\"id\\")
+        @tag(name: \\"from accounts\\")
+        @tag(name: \\"from reviews\\")
       {
         account: AccountType @join__field(graph: ACCOUNTS)
         birthDate(locale: String): String @join__field(graph: ACCOUNTS) @tag(name: \\"admin\\") @tag(name: \\"dev\\")

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -60,7 +60,9 @@ describe('loadSupergraphSdlFromStorage', () => {
 
       directive @transform(from: String!) on FIELD
 
-      union AccountType = PasswordAccount | SMSAccount
+      union AccountType
+        @tag(name: \\"from accounts\\")
+      = PasswordAccount | SMSAccount
 
       type Amazon {
         referrer: String

--- a/query-planner-js/src/composedSchema/metadata.ts
+++ b/query-planner-js/src/composedSchema/metadata.ts
@@ -1,4 +1,9 @@
-import { FieldNode, InlineFragmentNode, GraphQLField, GraphQLObjectType, DirectiveNode } from 'graphql';
+import {
+  FieldNode,
+  InlineFragmentNode,
+  GraphQLField,
+  GraphQLObjectType,
+} from 'graphql';
 import { MultiMap } from '../utilities/MultiMap';
 
 declare module 'graphql' {
@@ -13,7 +18,7 @@ declare module 'graphql' {
   interface GraphQLFieldExtensions<
     _TSource,
     _TContext,
-    _TArgs = { [argName: string]: any }
+    _TArgs = { [argName: string]: any },
   > {
     federation?: FederationFieldMetadata;
   }
@@ -55,7 +60,7 @@ export type FederationTypeMetadata =
 
 export interface FederationEntityTypeMetadata {
   graphName: GraphName;
-  keys: MultiMap<GraphName, FieldSet>,
+  keys: MultiMap<GraphName, FieldSet>;
   isValueType: false;
 }
 
@@ -73,5 +78,4 @@ export interface FederationFieldMetadata {
   graphName?: GraphName;
   requires?: FieldSet;
   provides?: FieldSet;
-  otherKnownDirectiveUsages?: DirectiveNode[];
 }


### PR DESCRIPTION
Add @tag support in subgraphs and supergraphs for object, interface, and union types.

With this change, @tag is now additionally permitted on the listed types above. Users currently using @tag have been required by our validations to include the directive definition - this definition will need to be updated accordingly. During composition, @tag usages in subgraphs will be indiscriminately "rolled up" to the final type in the supergraph.

Note: the updated definition should be:
```graphql
directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
```

This PR takes a more principled approach to capturing directive usages than what we've done in the past. Currently, most of our directive usages are captured ad-hoc - from federation directive usages (with @external being a particular oddball), to tag usages, etc. This new data structure captures _all_ directive usages in a lossless manner. The originating service, parent type name, and field name (if applicable) are all preserved.

I think this approach opens the door for some cleanup / refactoring since the previously mentioned ad-hoc ways of capturing directive usages are now effectively duplicated information and subsets of what I'm capturing. This approach is also future-proof if we choose to introduce other user-applied directives, or if we decide we need subgraph origin information captured in @tag directives (for example).

TODO:
- [x] Considering making a `class` out of this directive usages map. It consists of deeply nested maps - updating and accessing them is pretty verbose and a cumbersome DX.
- [x] Validation of @tag definition should be agnostic to location ordering (a simple sort should solve)

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
