### PR TITLE
infra: template that can be used when creating release branches

### DIFF
--- a/.github/APOLLO_RELEASE_TEMPLATE.md
+++ b/.github/APOLLO_RELEASE_TEMPLATE.md
@@ -1,0 +1,11 @@
+Release @apollo/PACKAGE1@X.Y.Z [, @apollo/PACKAGE2@X.Y.Z]
+
+As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌   The version in the title of this PR should correspond to the appropriate branch.
+
+Check the appropriate milestone (to the right) for more details on what we hope to get into this release!
+
+The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.
+
+PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.
+
+When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.

--- a/.github/APOLLO_RELEASE_TEMPLATE.md
+++ b/.github/APOLLO_RELEASE_TEMPLATE.md
@@ -2,8 +2,6 @@ Release @apollo/PACKAGE1@X.Y.Z [, @apollo/PACKAGE2@X.Y.Z]
 
 As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌   The version in the title of this PR should correspond to the appropriate branch.
 
-Check the appropriate milestone (to the right) for more details on what we hope to get into this release!
-
 The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.
 
 PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.


### PR DESCRIPTION
This adds a template (markdown) that can be used with CLI tools to create release branches automatically.  For example, I use the [`hub`] command to do this:

    hub pull-request -F ./.github/APOLLO_RELEASE_TEMPLATE.md  -l ":label: release"

The `hub` command has been superseded by the newer [`gh`] command, but I haven't upgraded myself yet.  It offers the same functionality using the [`gh pr create`] command:

    gh pr create -F ./.github/APOLLO_RELEASE_TEMPLATE.md -l ":label: release"

[`hub`]: https://github.com/github/hub
[`gh`]: https://cli.github.com/
[`gh pr create`]: https://cli.github.com/manual/gh_pr_create
