### PR TITLE
Throw descriptive error if service in serviceList config does not have a 'name'.

### DIFF
--- a/gateway-js/src/__tests__/loadServicesFromRemoteEndpoint.test.ts
+++ b/gateway-js/src/__tests__/loadServicesFromRemoteEndpoint.test.ts
@@ -17,6 +17,23 @@ describe('getServiceDefinitionsFromRemoteEndpoint', () => {
     );
   });
 
+  it("errors when no name was specified", async () => {
+    const serviceSdlCache = new Map<string, string>();
+    const url = 'http://api.example.com/graphql';
+
+    const dataSource = new RemoteGraphQLDataSource({ url });
+    const serviceList = [{ url, dataSource }];
+    await expect(
+      getServiceDefinitionsFromRemoteEndpoint({
+        serviceList,
+        serviceSdlCache,
+        getServiceIntrospectionHeaders: async () => ({})
+      }),
+    ).rejects.toThrowError(
+      "Tried to load schema for service but no 'name' was specified.",
+    );
+  });
+
   it('throws when the downstream service returns errors', async () => {
     const serviceSdlCache = new Map<string, string>();
     const host = 'http://host-which-better-not-resolve';

--- a/gateway-js/src/loadServicesFromRemoteEndpoint.ts
+++ b/gateway-js/src/loadServicesFromRemoteEndpoint.ts
@@ -30,6 +30,11 @@ export async function getServiceDefinitionsFromRemoteEndpoint({
   let isNewSchema = false;
   // for each service, fetch its introspection schema
   const promiseOfServiceList = serviceList.map(async ({ name, url, dataSource }) => {
+    if (!name) {
+      throw new Error(
+        `Tried to load schema for service but no 'name' was specified.`);
+    }
+
     if (!url) {
       throw new Error(
         `Tried to load schema for '${name}' but no 'url' was specified.`);


### PR DESCRIPTION
This PR adds a nicer error for the condition in which a service in the `serviceList` config is missing a 'name' property when the gateway is trying to fetch service definitions at initialization. Currently the gateway prints a one line error when this is encountered:

`This data graph is missing a valid configuration. Cannot read property 'replace' of undefined`

@abernix mentioned [here](https://github.com/apollographql/federation/issues/473#issuecomment-886564559) in #473 that it would be nice if the error handling was improved.

This test and implementation closely mirror the way it is already being handled for the service 'url' property.

I also tested this out locally against [the bug reproduction I had created](https://github.com/spencerarogers/apollo-federation-439-repro) for #473 and it worked as expected.