### PR TITLE
makeRequest method to modify url and method

### DIFF
--- a/federation-integration-testsuite-js/src/matchers/toHaveFetched.ts
+++ b/federation-integration-testsuite-js/src/matchers/toHaveFetched.ts
@@ -18,7 +18,7 @@ function prepareHttpOptions(requestUrl: string, requestOpts: RequestInitWithJSON
   headers.set('Content-Type', 'application/json');
 
   const requestHttp = {
-    method: 'POST',
+    method: requestOpts.method ?? 'POST',
     headers,
     url: requestUrl
   };

--- a/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -276,6 +276,78 @@ describe('fetcher', () => {
   });
 });
 
+describe('makeRequest', () => {
+  it('allows for modifying url', async () => {
+    const DataSource = new RemoteGraphQLDataSource({
+      url: 'https://api.example.com/foo',
+      makeRequest: ({ request }) => {
+        const headers = (request.http && request.http.headers) || new Headers();
+        headers.set('Content-Type', 'application/json');
+
+        return {
+          method: 'POST',
+          url: 'https://api.example.com/bar',
+          headers: headers
+        };
+      },
+    });
+
+    fetch.mockJSONResponseOnce({ data: { me: 'james' } });
+
+    const { data } = await DataSource.process({
+      request: {
+        query: '{ me { name } }',
+        variables: { id: '1' },
+      },
+      context: {},
+    });
+
+    expect(data).toEqual({ me: 'james' });
+    expect(fetch).toHaveFetched('https://api.example.com/bar', {
+      body: {
+        query: '{ me { name } }',
+        variables: { id: '1' },
+      },
+    });
+  });
+
+  it('allows for modifying method', async () => {
+    const DataSource = new RemoteGraphQLDataSource({
+      url: 'https://api.example.com/foo',
+      makeRequest: ({ request }) => {
+
+        const headers = (request.http && request.http.headers) || new Headers();
+        headers.set('Content-Type', 'application/json');
+
+        return {
+          method: 'GET',
+          url: 'https://api.example.com/foo',
+          headers: headers
+        };
+      },
+    });
+
+    fetch.mockJSONResponseOnce({ data: { me: 'james' } });
+
+    const { data } = await DataSource.process({
+      request: {
+        query: '{ me { name } }',
+        variables: { id: '1' },
+      },
+      context: {},
+    });
+
+    expect(data).toEqual({ me: 'james' });
+    expect(fetch).toHaveFetched('https://api.example.com/foo', {
+      method: 'GET',
+      body: {
+        query: '{ me { name } }',
+        variables: { id: '1' },
+      },
+    });
+  });
+});
+
 describe('willSendRequest', () => {
   it('allows for modifying variables', async () => {
     const DataSource = new RemoteGraphQLDataSource({


### PR DESCRIPTION
This PR is linked to this issue #901 
This PR enables us to modify the url and the http method for every request. The url change is was easy but to enable the method change I had to change the sendRequest method as it is always sending the body to a GET request as well which throws up a type error `TypeError: Request with GET/HEAD method cannot have body` [here](https://github.com/apollographql/federation/blob/44eebf9d47db76052df4f9edeeb1e42278167615/gateway-js/src/datasources/RemoteGraphQLDataSource.ts#L150)
I would recommend that we call the makeRequest method inside the sendRequest itself so that we can create the Request Object dynamically and this can be modified