### PR TITLE
Remove root redirect in docs

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,5 +1,3 @@
-/ /docs/federation/
-
 /docs/federation/core-concepts/ /docs/federation/implementing-services/
 /docs/federation/implementing-services/ /docs/federation/subgraphs/
 /docs/federation/managed-federation/advanced-topics/ /docs/federation/managed-federation/overview/


### PR DESCRIPTION
This branch removes the root level redirects in the docs, previously used to send our root-level deploy preview links to the right place when clicked on in the Netlify GitHub check. Unfortunately, it seems like these redirects are causing issues with Netlify when we use split tests, causing users to be redirected from our home page to the docs.

This change is an attempt to fix that, at the known cost of having to manually add "/docs" or "/docs/studio" to the end of deploy previews when previewing changes.

I'm going to investigate options to conditionally add a root redirect to deploy previews only but we want to unblock split testing first, so I made this a separate PR.

In the meantime, we can use a tag like the one below to tell Netlify what path to point deploy preview links in GitHub to.

@netlify /docs/federation