### PR TITLE
Deploy deploy previews at /

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,5 @@
 [build.environment]
   NODE_VERSION = "14"
   NPM_VERSION  = "7"
+[context.deploy-preview]
+  command = "gatsby build"


### PR DESCRIPTION
This branch tells netlify to deploy our docs deploy previews at / instead of nesting them in the location we expect them to be in prod. This was inspired by https://github.com/apollographql/federation/pull/962#issuecomment-900239383. Thanks @abernix 🙏 