### PR TITLE
Deploy the prod site at the root

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
-  base    = "docs/"
-  publish = "public/"
-  command = "gatsby build --prefix-paths && mkdir -p docs/federation && mv public/* docs/federation && mv docs public/ && mv public/docs/federation/_redirects public"
+  base    = "docs"
+  publish = "public"
+  command = "gatsby build"
   # Netlify tries to short-circuit when the build hasn't changed, but it's
   # presently wrong.  I would encourage removing this eventually, but for now,
   # we'll check to see if `/bin/false` returns true (it won't) as a gauge.
@@ -9,5 +9,7 @@
 [build.environment]
   NODE_VERSION = "14"
   NPM_VERSION  = "7"
-[context.deploy-preview]
-  command = "gatsby build"
+[context.production.environment]
+  PREFIX_PATHS = "true"
+[context.branch-deploy.environment]
+  PREFIX_PATHS = "true"


### PR DESCRIPTION
This branch changes our prod deploy to no longer put its built files in a nested directory structure. This was inspired by https://github.com/apollographql/federation/pull/964#pullrequestreview-732605899 and follows the same patterns already tested and deployed in the Community docs (more info here: https://github.com/apollographql/federation/pull/964#issuecomment-901306430) as well as the docs homepage and Studio docs.

After merging, we'll need to update the website router to reflect this change of location of the built files, but this change will uncomplicate our prod build command considerably.