### PR TITLE
Revert "Gateway: pass through errors encountered when running final execute"

### DIFF
--- a/gateway-js/src/__tests__/executeQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/executeQueryPlan.test.ts
@@ -1322,6 +1322,23 @@ describe('executeQueryPlan', () => {
       `);
     });
 
+    // THIS TEST SHOULD BE MODIFIED AFTER THE ISSUE OUTLINED IN
+    // https://github.com/apollographql/federation/issues/981 HAS BEEN RESOLVED.
+    // IT IS BEING LEFT HERE AS A TEST THAT WILL INTENTIONALLY FAIL WHEN
+    // IT IS RESOLVED IF IT'S NOT ADDRESSED.
+    //
+    // This test became relevant after a combination of two things:
+    //   1. when the gateway started surfacing errors from subgraphs happened in
+    //      https://github.com/apollographql/federation/pull/159
+    //   2. the idea of field redaction became necessary after
+    //      https://github.com/apollographql/federation/pull/893,
+    //      which introduced the notion of inaccessible fields.
+    //      The redaction started in
+    //      https://github.com/apollographql/federation/issues/974, which added
+    //      the following test.
+    //
+    // However, the error surfacing (first, above) needed to be reverted, thus
+    // de-necessitating this redaction logic which is no longer tested.
     it(`doesn't leak @inaccessible typenames in error messages`, async () => {
       const operationString = `#graphql
         query {
@@ -1353,11 +1370,13 @@ describe('executeQueryPlan', () => {
       );
 
       expect(response.data?.vehicle).toEqual(null);
-      expect(response.errors).toMatchInlineSnapshot(`
-        Array [
-          [GraphQLError: Abstract type "Vehicle" was resolve to a type [inaccessible type] that does not exist inside schema.],
-        ]
-      `);
+      expect(response.errors).toBeUndefined();
+      // SEE COMMENT ABOVE THIS TEST.  SHOULD BE RE-ENABLED AFTER #981 IS FIXED!
+      // expect(response.errors).toMatchInlineSnapshot(`
+      //   Array [
+      //     [GraphQLError: Abstract type "Vehicle" was resolve to a type [inaccessible type] that does not exist inside schema.],
+      //   ]
+      // `);
     });
   });
 });


### PR DESCRIPTION
This reverts commit 9045f553075829393c8dfd9a69898701178d7b72, which was from https://github.com/apollographql/federation/pull/159.

See the comment in https://github.com/apollographql/federation/issues/981 which explains the justification as well, but briefly:

While that PR was an improvement in principle, it:

- has a bug that was first captured in https://github.com/apollographql/federation/pull/159#issuecomment-901246314

  To quote that here:

  > I think there's a bug here. Let's say we have a query `{ x }` where `x` is a non-nullable field, and the federated execution has `x` throw an error. This turns all of `data` into `null` (not `{ x: null }`). But then this re-execution adds another error saying that the non-null field is null.
  >
  > Take a look at https://codesandbox.io/s/angry-raman-uuzuf?file=/src/index.js for an example of what's going on here.

- Sometimes — unexpectedly to current users, at least — breaks client expectations.

As of now, the pain points seem to be outweighing the gains.  We'll need to revert this and revisit this when time allows with a slightly different approach and https://github.com/apollographql/federation/issues/981 tracks the need to do so.

Ref: https://github.com/apollographql/federation/pull/159
Ref: https://github.com/apollographql/apollo-server/issues/5550
Ref: https://github.com/apollographql/federation/issues/974
Ref: https://github.com/apollographql/apollo-server/pull/4523

Closes: https://github.com/apollographql/federation/issues/974