### PR TITLE
chore(federation): Update schema printers

### DIFF
--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -23,6 +23,8 @@ export const typeDefs = gql`
     inheritMaxAge: Boolean
   ) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
+  scalar JSON @specifiedBy(url: "https://json-spec.dev")
+
   schema {
     query: RootQuery
     mutation: Mutation
@@ -65,7 +67,11 @@ export const typeDefs = gql`
   }
 
   type Mutation {
-    login(username: String!, password: String!): User
+    login(
+      username: String!
+      password: String!
+      userId: String @deprecated(reason: "Use username instead")
+    ): User
   }
 
   extend type Library @key(fields: "id") {

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -5,6 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Remove composition responsibilities from supergraph printer. Fix schema sorting for sub- and super-graphs. [PR #1000](https://github.com/apollographql/federation/pull/1000)
+- Update our subgraph and supergraph schema printers to match the printSchema function from graphql-js as closely as possible. Introduce printing capabilities for the @specifiedBy directive as well as @deprecated on input values. [PR #996](https://github.com/apollographql/federation/pull/996)
 
 ## v0.30.0
 

--- a/federation-js/src/service/__tests__/printSubgraphSchema.test.ts
+++ b/federation-js/src/service/__tests__/printSubgraphSchema.test.ts
@@ -22,6 +22,8 @@ describe('printSubgraphSchema', () => {
         PRIVATE
       }
 
+      scalar JSON @specifiedBy(url: \\"https://json-spec.dev\\")
+
       type PasswordAccount @key(fields: \\"email\\") {
         email: String!
       }
@@ -54,7 +56,7 @@ describe('printSubgraphSchema', () => {
       }
 
       type Mutation {
-        login(username: String!, password: String!): User
+        login(username: String!, password: String!, userId: String @deprecated(reason: \\"Use username instead\\")): User
       }
 
       extend type RootQuery {

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -141,6 +141,8 @@ describe('printSupergraphSdl', () => {
         url: String!
       }
 
+      scalar JSON @specifiedBy(url: \\"https://json-spec.dev\\")
+
       type KeyValue {
         key: String!
         value: String!
@@ -160,7 +162,7 @@ describe('printSupergraphSdl', () => {
 
       type Mutation {
         deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
-        login(password: String!, username: String!): User @join__field(graph: ACCOUNTS)
+        login(password: String!, userId: String @deprecated(reason: \\"Use username instead\\"), username: String!): User @join__field(graph: ACCOUNTS)
         reviewProduct(body: String!, upc: String!): Product @join__field(graph: REVIEWS)
         updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
       }

--- a/federation-js/src/service/printSubgraphSchema.ts
+++ b/federation-js/src/service/printSubgraphSchema.ts
@@ -367,7 +367,7 @@ function printInputValue(arg: GraphQLInputField) {
   if (defaultAST) {
     argDecl += ` = ${print(defaultAST)}`;
   }
-  return argDecl;
+  return argDecl + printDeprecated(arg.deprecationReason);
 }
 
 function printDirective(directive: GraphQLDirective) {

--- a/federation-js/src/service/printSupergraphSdl.ts
+++ b/federation-js/src/service/printSupergraphSdl.ts
@@ -1,5 +1,5 @@
 /**
- * Forked from graphql-js printSchema.ts file @ v15.5.0
+ * Forked from graphql-js printSchema.ts file @ v16.0.0
  * This file has been modified to support printing federated
  * schema, including associated federation directives.
  */
@@ -37,12 +37,12 @@ import { printFieldSet } from '../composition/utils';
 import { otherKnownDirectiveDefinitions } from '../directives';
 
 interface PrintingContext {
-  // Core addition: we need access to a map from serviceName to its corresponding
+  // Apollo addition: we need access to a map from serviceName to its corresponding
   // sanitized / uniquified enum value `Name` from the `join__Graph` enum
   graphNameToEnumValueName?: Record<string, string>;
 }
 
-// Core change: we need service and url information for the join__Graph enum
+// Apollo change: we need service and url information for the join__Graph enum
 export function printSupergraphSdl(
   schema: GraphQLSchema,
   graphNameToEnumValueName: Record<string, string>,
@@ -64,7 +64,7 @@ export function printIntrospectionSchema(schema: GraphQLSchema): string {
     schema,
     isSpecifiedDirective,
     isIntrospectionType,
-    // Core change: no printing context needed for introspection
+    // Apollo change: no printing context needed for introspection
     {},
   );
 }
@@ -77,7 +77,7 @@ function printFilteredSchema(
   schema: GraphQLSchema,
   directiveFilter: (type: GraphQLDirective) => boolean,
   typeFilter: (type: GraphQLNamedType) => boolean,
-  // Core addition - see `PrintingContext` type for details
+  // Apollo addition - see `PrintingContext` type for details
   context: PrintingContext,
 ): string {
   const directives = schema.getDirectives().filter(directiveFilter);
@@ -95,7 +95,7 @@ function printFilteredSchema(
 }
 
 function printSchemaDefinition(schema: GraphQLSchema): string {
-  // Core removal: we always print the schema definition
+  // Apollo removal: we always print the schema definition
   // if (schema.description == null && isSchemaOfCommonNames(schema)) {
   //   return;
   // }
@@ -119,7 +119,7 @@ function printSchemaDefinition(schema: GraphQLSchema): string {
   return (
     printDescription(schema) +
     'schema' +
-    // Core change: print @core directive usages on schema node
+    // Apollo change: print @core directive usages on schema node
     printCoreDirectives(schema) +
     `\n{\n${operationTypes.join('\n')}\n}`
   );
@@ -153,20 +153,25 @@ function printCoreDirectives(schema: GraphQLSchema) {
 
 export function printType(
   type: GraphQLNamedType,
-  // Core addition - see `PrintingContext` type for details
+  // Apollo addition - see `PrintingContext` type for details
   context: PrintingContext,
 ): string {
   if (isScalarType(type)) {
     return printScalar(type);
-  } else if (isObjectType(type)) {
+  }
+  if (isObjectType(type)) {
     return printObject(type, context);
-  } else if (isInterfaceType(type)) {
+  }
+  if (isInterfaceType(type)) {
     return printInterface(type, context);
-  } else if (isUnionType(type)) {
+  }
+  if (isUnionType(type)) {
     return printUnion(type);
-  } else if (isEnumType(type)) {
+  }
+  if (isEnumType(type)) {
     return printEnum(type);
-  } else if (isInputObjectType(type)) {
+  }
+  if (isInputObjectType(type)) {
     return printInputObject(type);
   }
 
@@ -191,21 +196,21 @@ function printImplementedInterfaces(
 
 function printObject(
   type: GraphQLObjectType,
-  // Core addition - see `PrintingContext` type for details
+  // Apollo addition - see `PrintingContext` type for details
   context: PrintingContext,
 ): string {
   return (
     printDescription(type) +
     `type ${type.name}` +
     printImplementedInterfaces(type) +
-    // Core addition for printing @join__owner and @join__type usages
+    // Apollo addition for printing @join__owner and @join__type usages
     printTypeJoinDirectives(type, context) +
     printKnownDirectiveUsagesOnType(type) +
     printFields(type, context)
   );
 }
 
-// Core addition: print @tag usages (+ other future Apollo-specific directives)
+// Apollo addition: print @tag usages (+ other future Apollo-specific directives)
 function printKnownDirectiveUsagesOnType(
   type: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
 ): string {
@@ -218,7 +223,7 @@ function printKnownDirectiveUsagesOnType(
   return '\n  ' + tagUsages.map(print).join('\n  ');
 }
 
-// Core addition: print @join__owner and @join__type usages
+// Apollo addition: print @join__owner and @join__type usages
 function printTypeJoinDirectives(
   type: GraphQLObjectType | GraphQLInterfaceType,
   context: PrintingContext,
@@ -274,14 +279,14 @@ function printTypeJoinDirectives(
 
 function printInterface(
   type: GraphQLInterfaceType,
-  // Core addition - see `PrintingContext` type for details
+  // Apollo addition - see `PrintingContext` type for details
   context: PrintingContext,
 ): string {
   return (
     printDescription(type) +
     `interface ${type.name}` +
     printImplementedInterfaces(type) +
-    // Core addition for printing @join__owner and @join__type usages
+    // Apollo addition for printing @join__owner and @join__type usages
     printTypeJoinDirectives(type, context) +
     printKnownDirectiveUsagesOnType(type) +
     printFields(type, context)
@@ -299,6 +304,7 @@ function printUnion(type: GraphQLUnionType): string {
     printDescription(type) +
     'union ' +
     type.name +
+    // Apollo addition: print @tag usages
     knownDirectiveUsages +
     possibleTypes
   );
@@ -313,7 +319,7 @@ function printEnum(type: GraphQLEnumType): string {
         '  ' +
         value.name +
         printDeprecated(value.deprecationReason) +
-        // Core addition: print federation directives on `join__Graph` enum values
+        // Apollo addition: print federation directives on `join__Graph` enum values
         printDirectivesOnEnumValue(type, value),
     );
 
@@ -322,7 +328,7 @@ function printEnum(type: GraphQLEnumType): string {
   );
 }
 
-// Core addition: print federation directives on `join__Graph` enum values
+// Apollo addition: print federation directives on `join__Graph` enum values
 function printDirectivesOnEnumValue(type: GraphQLEnumType, value: GraphQLEnumValue) {
   if (type.name === "join__Graph") {
     return ` @join__graph(name: ${printStringLiteral((value.value.name))} url: ${printStringLiteral(value.value.url ?? '')})`
@@ -339,7 +345,7 @@ function printInputObject(type: GraphQLInputObjectType): string {
 
 function printFields(
   type: GraphQLObjectType | GraphQLInterfaceType,
-  // Core addition - see `PrintingContext` type for details
+  // Apollo addition - see `PrintingContext` type for details
   context: PrintingContext,
 ) {
   const fields = Object.values(type.getFields()).map(
@@ -370,7 +376,7 @@ function printFields(
 }
 
 /**
- * Core addition: print @join__field directives
+ * Apollo addition: print @join__field directives
  *
  * @param field
  * @param parentType
@@ -378,7 +384,7 @@ function printFields(
 function printJoinFieldDirectives(
   field: GraphQLField<any, any>,
   parentType: GraphQLObjectType | GraphQLInterfaceType,
-  // Core addition - see `PrintingContext` type for details
+  // Apollo addition - see `PrintingContext` type for details
   context: PrintingContext,
 ): string {
   const directiveArgs: string[] = [];
@@ -429,7 +435,7 @@ function printJoinFieldDirectives(
   return ` @join__field(${directiveArgs.join(', ')})`;
 }
 
-// Core addition: print `@tag` directives (and possibly other future known
+// Apollo addition: print `@tag` directives (and possibly other future known
 // directives) found in subgraph SDL into the supergraph SDL
 function printKnownDirectiveUsagesOnFields(field: GraphQLField<any, any>) {
   const tagUsages = (
@@ -443,7 +449,7 @@ function printKnownDirectiveUsagesOnFields(field: GraphQLField<any, any>) {
     .join(' ')}`;
 };
 
-// Core addition: `onNewLine` is a formatting nice-to-have for printing
+// Apollo addition: `onNewLine` is a formatting nice-to-have for printing
 // types that have a list of directives attached, i.e. an entity.
 function printBlock(items: string[], onNewLine?: boolean) {
   return items.length !== 0

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -148,6 +148,8 @@ describe('loadSupergraphSdlFromStorage', () => {
         url: String!
       }
 
+      scalar JSON @specifiedBy(url: \\"https://json-spec.dev\\")
+
       type KeyValue {
         key: String!
         value: String!
@@ -167,7 +169,7 @@ describe('loadSupergraphSdlFromStorage', () => {
 
       type Mutation {
         deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
-        login(password: String!, username: String!): User @join__field(graph: ACCOUNTS)
+        login(password: String!, userId: String @deprecated(reason: \\"Use username instead\\"), username: String!): User @join__field(graph: ACCOUNTS)
         reviewProduct(body: String!, upc: String!): Product @join__field(graph: REVIEWS)
         updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
       }


### PR DESCRIPTION
Update our subgraph and supergraph schema printers to match the `printSchema` function from `graphql-js` as closely as possible. This introduces printing capabilities for the `@specifiedBy` directive as well as `@deprecated` on input values.

This PR depends on #1000 which resolves a few problems I turned up after addressing @martijnwalraven's sorting concern.
* The supergraph printer was doing some composition-level operations on the schema (adding directives and types). I pushed this behavior more appropriately up to composition where it belongs.
* This change resulted in supergraphs being sorted correctly (`lexicographicSortSchema` was being called, but the printer was modifying the schema after that sort).
* This change was also reflected in the subgraph printer tests which was odd. I found that the `printFederatedSchema` test was testing printing a composed graph rather than a subgraph, so I fixed the test.
* Alias and deprecate `printFederatedSchema` (which was exported as `printSchema`) to `printSubgraphSchema` to prevent naming confusion.

Fixes #994
Fixes #635
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
