### PR TITLE
fix(federation): Composition propagates @deprecated usages on input type object fields

### DIFF
--- a/federation-integration-testsuite-js/src/fixtures/reviews.ts
+++ b/federation-integration-testsuite-js/src/fixtures/reviews.ts
@@ -74,8 +74,14 @@ export const typeDefs = gql`
     retailPrice: String @requires(fields: "price")
   }
 
+  input ReviewProduct {
+    upc: String!
+    body: String!
+    stars: Int @deprecated(reason: "Stars are no longer in use")
+  }
+
   extend type Mutation {
-    reviewProduct(upc: String!, body: String!): Product
+    reviewProduct(input: ReviewProduct!): Product
     updateReview(review: UpdateReviewInput!): Review
     deleteReview(id: ID!): Boolean
   }
@@ -157,7 +163,7 @@ export const resolvers: GraphQLResolverMap<any> = {
     },
   },
   Mutation: {
-    reviewProduct(_, { upc, body }) {
+    reviewProduct(_, { input: { upc, body } }) {
       const id = `${Number(reviews[reviews.length - 1].id) + 1}`;
       reviews.push({
         id,
@@ -168,7 +174,7 @@ export const resolvers: GraphQLResolverMap<any> = {
       return { upc, __typename: 'Furniture' };
     },
     updateReview(_, { review: { id }, review: updatedReview }) {
-      let review = reviews.find(review => review.id === id);
+      let review = reviews.find((review) => review.id === id);
 
       if (!review) {
         return null;
@@ -183,7 +189,7 @@ export const resolvers: GraphQLResolverMap<any> = {
     },
     deleteReview(_, { id }) {
       const deleted = reviews.splice(
-        reviews.findIndex(review => review.id === id),
+        reviews.findIndex((review) => review.id === id),
         1,
       );
       return Boolean(deleted);
@@ -196,13 +202,13 @@ export const resolvers: GraphQLResolverMap<any> = {
   },
   User: {
     reviews(user) {
-      return reviews.filter(review => review.authorID === user.id);
+      return reviews.filter((review) => review.authorID === user.id);
     },
     numberOfReviews(user) {
-      return reviews.filter(review => review.authorID === user.id).length;
+      return reviews.filter((review) => review.authorID === user.id).length;
     },
     username(user) {
-      const found = usernames.find(username => username.id === user.id);
+      const found = usernames.find((username) => username.id === user.id);
       return found ? found.username : null;
     },
     goodAddress(object) {
@@ -211,18 +217,18 @@ export const resolvers: GraphQLResolverMap<any> = {
   },
   Furniture: {
     reviews(product) {
-      return reviews.filter(review => review.product.upc === product.upc);
+      return reviews.filter((review) => review.product.upc === product.upc);
     },
   },
   Book: {
     reviews(product) {
-      return reviews.filter(review => review.product.isbn === product.isbn);
+      return reviews.filter((review) => review.product.isbn === product.isbn);
     },
     relatedReviews(book) {
       return book.similarBooks
         ? book.similarBooks
             .map(({ isbn }: any) =>
-              reviews.filter(review => review.product.isbn === isbn),
+              reviews.filter((review) => review.product.isbn === isbn),
             )
             .flat()
         : [];

--- a/federation-integration-testsuite-js/src/fixtures/special-cases/reviewsWithoutTag.ts
+++ b/federation-integration-testsuite-js/src/fixtures/special-cases/reviewsWithoutTag.ts
@@ -67,8 +67,14 @@ export const typeDefs = gql`
     retailPrice: String @requires(fields: "price")
   }
 
+  input ReviewProduct {
+    upc: String!
+    body: String!
+    stars: Int @deprecated(reason: "Stars are no longer in use")
+  }
+
   extend type Mutation {
-    reviewProduct(upc: String!, body: String!): Product
+    reviewProduct(input: ReviewProduct): Product
     updateReview(review: UpdateReviewInput!): Review
     deleteReview(id: ID!): Boolean
   }

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- __BREAKING__: This is a breaking change due to a `peerDependencies` update (`graphql@^15.4.0` -> `graphql@^15.5.3`). This `graphql` version includes a fix which resolves an issue which prevented the correct propagation of `@deprecated` usages on input type object fields into the printed subgraph schema. This can be considered a follow-up to PR #996, which previously attempted to propagate @deprecated on *ALL* input values. [PR #1008](https://github.com/apollographql/federation/pull/1008)
 
 ## v0.31.0
 

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -28,6 +28,6 @@
     "lodash.xorby": "^4.7.0"
   },
   "peerDependencies": {
-    "graphql": "^15.4.0"
+    "graphql": "^15.5.3"
   }
 }

--- a/federation-js/src/service/__tests__/printSubgraphSchema.test.ts
+++ b/federation-js/src/service/__tests__/printSubgraphSchema.test.ts
@@ -74,4 +74,102 @@ describe('printSubgraphSchema', () => {
       "
     `);
   });
+
+  it('prints reviews subgraph correctly', () => {
+    const schema = buildSubgraphSchema(fixtures[5].typeDefs);
+    expect(printSubgraphSchema(schema)).toMatchInlineSnapshot(`
+      "directive @stream on FIELD
+
+      directive @transform(from: String!) on FIELD
+
+      type Review @key(fields: \\"id\\") {
+        id: ID!
+        body(format: Boolean = false): String
+        author: User @provides(fields: \\"username\\")
+        product: Product
+        metadata: [MetadataOrError]
+      }
+
+      input UpdateReviewInput {
+        id: ID!
+        body: String
+      }
+
+      input ReviewProduct {
+        upc: String!
+        body: String!
+        stars: Int @deprecated(reason: "Stars are no longer in use")
+      }
+
+      type KeyValue {
+        key: String!
+        value: String!
+      }
+
+      type Error {
+        code: Int
+        message: String
+      }
+
+      union MetadataOrError = KeyValue | Error
+
+      extend type Query {
+        _entities(representations: [_Any!]!): [_Entity]!
+        _service: _Service!
+        topReviews(first: Int = 5): [Review]
+      }
+
+      extend type UserMetadata {
+        address: String @external
+      }
+
+      extend type User @key(fields: \\"id\\") {
+        id: ID! @external
+        username: String @external
+        reviews: [Review]
+        numberOfReviews: Int!
+        metadata: [UserMetadata] @external
+        goodAddress: Boolean @requires(fields: \\"metadata { address }\\")
+      }
+
+      extend interface Product {
+        reviews: [Review]
+      }
+
+      extend type Furniture implements Product @key(fields: \\"upc\\") {
+        upc: String! @external
+        reviews: [Review]
+      }
+
+      extend type Book implements Product @key(fields: \\"isbn\\") {
+        isbn: String! @external
+        reviews: [Review]
+        similarBooks: [Book]! @external
+        relatedReviews: [Review!]! @requires(fields: \\"similarBooks { isbn }\\")
+      }
+
+      extend interface Vehicle {
+        retailPrice: String
+      }
+
+      extend type Car implements Vehicle @key(fields: \\"id\\") {
+        id: String! @external
+        price: String @external
+        retailPrice: String @requires(fields: \\"price\\")
+      }
+
+      extend type Van implements Vehicle @key(fields: \\"id\\") {
+        id: String! @external
+        price: String @external
+        retailPrice: String @requires(fields: \\"price\\")
+      }
+
+      extend type Mutation {
+        reviewProduct(input: ReviewProduct!): Product
+        updateReview(review: UpdateReviewInput!): Review
+        deleteReview(id: ID!): Boolean
+      }
+      "
+    `);
+  });
 });

--- a/federation-js/src/service/__tests__/printSubgraphSchema.test.ts
+++ b/federation-js/src/service/__tests__/printSubgraphSchema.test.ts
@@ -98,7 +98,7 @@ describe('printSubgraphSchema', () => {
       input ReviewProduct {
         upc: String!
         body: String!
-        stars: Int @deprecated(reason: "Stars are no longer in use")
+        stars: Int @deprecated(reason: \\"Stars are no longer in use\\")
       }
 
       type KeyValue {

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -236,7 +236,7 @@ describe('printSupergraphSdl', () => {
 
       input ReviewProduct {
         body: String!
-        stars: Int @deprecated(reason: "Stars are no longer in use")
+        stars: Int @deprecated(reason: \\"Stars are no longer in use\\")
         upc: String!
       }
 
@@ -548,7 +548,7 @@ describe('printSupergraphSdl', () => {
 
       input ReviewProduct {
         body: String!
-        stars: Int @deprecated(reason: "Stars are no longer in use")
+        stars: Int @deprecated(reason: \\"Stars are no longer in use\\")
         upc: String!
       }
 

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -163,7 +163,7 @@ describe('printSupergraphSdl', () => {
       type Mutation {
         deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
         login(password: String!, userId: String @deprecated(reason: \\"Use username instead\\"), username: String!): User @join__field(graph: ACCOUNTS)
-        reviewProduct(body: String!, upc: String!): Product @join__field(graph: REVIEWS)
+        reviewProduct(input: ReviewProduct!): Product @join__field(graph: REVIEWS)
         updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
       }
 
@@ -232,6 +232,12 @@ describe('printSupergraphSdl', () => {
         id: ID! @join__field(graph: REVIEWS)
         metadata: [MetadataOrError] @join__field(graph: REVIEWS)
         product: Product @join__field(graph: REVIEWS)
+      }
+
+      input ReviewProduct {
+        body: String!
+        stars: Int @deprecated(reason: "Stars are no longer in use")
+        upc: String!
       }
 
       type SMSAccount
@@ -471,7 +477,7 @@ describe('printSupergraphSdl', () => {
       type Mutation {
         deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
         login(password: String!, username: String!): User @join__field(graph: ACCOUNTS)
-        reviewProduct(body: String!, upc: String!): Product @join__field(graph: REVIEWS)
+        reviewProduct(input: ReviewProduct): Product @join__field(graph: REVIEWS)
         updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
       }
 
@@ -538,6 +544,12 @@ describe('printSupergraphSdl', () => {
         id: ID! @join__field(graph: REVIEWS)
         metadata: [MetadataOrError] @join__field(graph: REVIEWS)
         product: Product @join__field(graph: REVIEWS)
+      }
+
+      input ReviewProduct {
+        body: String!
+        stars: Int @deprecated(reason: "Stars are no longer in use")
+        upc: String!
       }
 
       type SMSAccount

--- a/federation-js/src/service/printSubgraphSchema.ts
+++ b/federation-js/src/service/printSubgraphSchema.ts
@@ -39,12 +39,6 @@ import { federationDirectives, gatherDirectives } from '../directives';
  */
 export const printSchema = printSubgraphSchema;
 
-/**
- * Accepts options as a second argument:
- *
- *    - commentDescriptions:
- *        Provide true to use preceding comments as the description.
- */
 export function printSubgraphSchema(schema: GraphQLSchema): string {
   return printFilteredSchema(
     schema,

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- __BREAKING__: This is a breaking change due to a `peerDependencies` update (`graphql@^15.4.0` -> `graphql@^15.5.3`). This `graphql` version includes a fix which is being necessarily adopted within the `@apollo/federation` package. See associated CHANGELOG entry in the `federation-js` folder for additional details. [PR #1008](https://github.com/apollographql/federation/pull/1008)
 
 ## v0.40.0
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -42,6 +42,6 @@
     "pretty-format": "^26.0.0"
   },
   "peerDependencies": {
-    "graphql": "^15.4.0"
+    "graphql": "^15.5.3"
   }
 }

--- a/gateway-js/src/__tests__/build-query-plan.feature
+++ b/gateway-js/src/__tests__/build-query-plan.feature
@@ -1066,7 +1066,7 @@ Scenario: returning across service boundaries
   Given query
   """
   mutation Review($upc: String!, $body: String!) {
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: {upc: $upc, body: $body}) {
       ... on Furniture {
         name
       }
@@ -1087,7 +1087,7 @@ Scenario: returning across service boundaries
             "upc",
             "body"
           ],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -1139,7 +1139,7 @@ Scenario: supports multiple root mutations
         }
       }
     }
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: {upc: $upc, body: $body}) {
       ... on Furniture {
         name
       }
@@ -1228,7 +1228,7 @@ Scenario: supports multiple root mutations
             "upc",
             "body"
           ],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -1275,7 +1275,7 @@ Scenario: multiple root mutations with correct service order
     $password: String!
     $reviewId: ID!
   ) {
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: {upc: $upc, body: $body}) {
       ... on Furniture {
         upc
       }
@@ -1309,7 +1309,7 @@ Scenario: multiple root mutations with correct service order
             "body",
             "updatedReview"
           ],
-          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
+          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
         },
         {
           "kind": "Fetch",

--- a/gateway-js/src/__tests__/integration/mutations.test.ts
+++ b/gateway-js/src/__tests__/integration/mutations.test.ts
@@ -1,5 +1,8 @@
 import { execute } from '../execution-utils';
-import { astSerializer, queryPlanSerializer } from 'apollo-federation-integration-testsuite';
+import {
+  astSerializer,
+  queryPlanSerializer,
+} from 'apollo-federation-integration-testsuite';
 import { accounts, reviews } from 'apollo-federation-integration-testsuite';
 
 expect.addSnapshotSerializer(astSerializer);
@@ -47,7 +50,7 @@ it('supports mutations', async () => {
 it('returning across service boundaries', async () => {
   const query = `#graphql
     mutation Review($upc: String!, $body: String!) {
-      reviewProduct(upc: $upc, body: $body) {
+      reviewProduct(input: { upc: $upc, body: $body }) {
         ... on Furniture {
           name
         }
@@ -92,7 +95,7 @@ it('multiple root mutations', async () => {
           }
         }
       }
-      reviewProduct(upc: $upc, body: $body) {
+      reviewProduct(input: { upc: $upc, body: $body }) {
         ... on Furniture {
           name
         }
@@ -148,7 +151,7 @@ it('multiple root mutations with correct service order', async () => {
       $password: String!
       $reviewId: ID!
     ) {
-      reviewProduct(upc: $upc, body: $body) {
+      reviewProduct(input: { upc: $upc, body: $body }) {
         ... on Furniture {
           upc
         }
@@ -208,7 +211,7 @@ it('multiple root mutations with correct service order', async () => {
       Sequence {
         Fetch(service: "reviews") {
           {
-            reviewProduct(upc: $upc, body: $body) {
+            reviewProduct(input: {upc: $upc, body: $body}) {
               __typename
               ... on Furniture {
                 upc

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -243,7 +243,7 @@ describe('loadSupergraphSdlFromStorage', () => {
 
       input ReviewProduct {
         body: String!
-        stars: Int @deprecated(reason: "Stars are no longer in use")
+        stars: Int @deprecated(reason: \\"Stars are no longer in use\\")
         upc: String!
       }
 

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -170,7 +170,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       type Mutation {
         deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
         login(password: String!, userId: String @deprecated(reason: \\"Use username instead\\"), username: String!): User @join__field(graph: ACCOUNTS)
-        reviewProduct(body: String!, upc: String!): Product @join__field(graph: REVIEWS)
+        reviewProduct(input: ReviewProduct!): Product @join__field(graph: REVIEWS)
         updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
       }
 
@@ -239,6 +239,12 @@ describe('loadSupergraphSdlFromStorage', () => {
         id: ID! @join__field(graph: REVIEWS)
         metadata: [MetadataOrError] @join__field(graph: REVIEWS)
         product: Product @join__field(graph: REVIEWS)
+      }
+
+      input ReviewProduct {
+        body: String!
+        stars: Int @deprecated(reason: "Stars are no longer in use")
+        upc: String!
       }
 
       type SMSAccount

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "node": ">=12.13.0 <17.0"
       },
       "peerDependencies": {
-        "graphql": "^15.4.0"
+        "graphql": "^15.5.3"
       }
     },
     "gateway-js": {
@@ -112,7 +112,7 @@
         "node": ">=12.13.0 <17.0"
       },
       "peerDependencies": {
-        "graphql": "^15.4.0"
+        "graphql": "^15.5.3"
       }
     },
     "harmonizer": {
@@ -23581,7 +23581,7 @@
         "node": ">=12.13.0 <17.0"
       },
       "peerDependencies": {
-        "graphql": "^15.4.0"
+        "graphql": "^15.5.3"
       }
     }
   },

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- __BREAKING__: This is a breaking change due to a `peerDependencies` update (`graphql@^15.4.0` -> `graphql@^15.5.3`). This `graphql` version includes a fix which is being necessarily adopted within the `@apollo/federation` package. See associated CHANGELOG entry in the `federation-js` folder for additional details. [PR #1008](https://github.com/apollographql/federation/pull/1008)
+
 ## v0.3.1
 
 - Narrow `graphql` peer dependency to a more fitting range `^15.4.0` based on our current usage of the package. This requirement was introduced by, but not captured in, changes within the recently released `@apollo/query-planner@0.3.0`. As such, this change will be released as a `patch` since the breaking change already accidentally happened and this is a correction to that oversight. [PR #913](https://github.com/apollographql/federation/pull/913)

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -31,6 +31,6 @@
     "pretty-format": "^26.0.0"
   },
   "peerDependencies": {
-    "graphql": "^15.4.0"
+    "graphql": "^15.5.3"
   }
 }

--- a/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
+++ b/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
@@ -1368,7 +1368,7 @@ Scenario: returning across service boundaries
             "upc",
             "body"
           ],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -1509,7 +1509,7 @@ Scenario: supports multiple root mutations
             "upc",
             "body"
           ],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -1590,7 +1590,7 @@ Scenario: multiple root mutations with correct service order
             "body",
             "updatedReview"
           ],
-          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input: { upc: $upc, body: $body }){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
+          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
         },
         {
           "kind": "Fetch",

--- a/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
+++ b/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
@@ -1347,7 +1347,7 @@ Scenario: returning across service boundaries
   Given query
   """
   mutation Review($upc: String!, $body: String!) {
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: { upc: $upc, body: $body }) {
       ... on Furniture {
         name
       }
@@ -1368,7 +1368,7 @@ Scenario: returning across service boundaries
             "upc",
             "body"
           ],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -1420,7 +1420,7 @@ Scenario: supports multiple root mutations
         }
       }
     }
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: { upc: $upc, body: $body }) {
       ... on Furniture {
         name
       }
@@ -1509,7 +1509,7 @@ Scenario: supports multiple root mutations
             "upc",
             "body"
           ],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -1556,7 +1556,7 @@ Scenario: multiple root mutations with correct service order
     $password: String!
     $reviewId: ID!
   ) {
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: { upc: $upc, body: $body }) {
       ... on Furniture {
         upc
       }
@@ -1590,7 +1590,7 @@ Scenario: multiple root mutations with correct service order
             "body",
             "updatedReview"
           ],
-          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
+          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input: { upc: $upc, body: $body }){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
         },
         {
           "kind": "Fetch",

--- a/query-planner-js/src/__tests__/features/basic/mutations.feature
+++ b/query-planner-js/src/__tests__/features/basic/mutations.feature
@@ -93,7 +93,7 @@ Scenario: mutations across service boundaries
           "kind": "Fetch",
           "serviceName": "reviews",
           "variableUsages": ["upc", "body"],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -201,7 +201,7 @@ Scenario: multiple root mutations
           "kind": "Fetch",
           "serviceName": "reviews",
           "variableUsages": ["upc", "body"],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -270,7 +270,7 @@ Scenario: multiple root mutations with correct service order
           "kind": "Fetch",
           "serviceName": "reviews",
           "variableUsages": ["upc", "body", "updatedReview"],
-          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
+          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
         },
         {
           "kind": "Fetch",

--- a/query-planner-js/src/__tests__/features/basic/mutations.feature
+++ b/query-planner-js/src/__tests__/features/basic/mutations.feature
@@ -75,7 +75,7 @@ Scenario: mutations across service boundaries
   Given query
   """
   mutation Review($upc: String!, $body: String!) {
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: { upc: $upc, body: $body }) {
       ... on Furniture {
         name
       }
@@ -93,7 +93,7 @@ Scenario: mutations across service boundaries
           "kind": "Fetch",
           "serviceName": "reviews",
           "variableUsages": ["upc", "body"],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -137,7 +137,7 @@ Scenario: multiple root mutations
         }
       }
     }
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: { upc: $upc, body: $body }) {
       ... on Furniture {
         name
       }
@@ -201,7 +201,7 @@ Scenario: multiple root mutations
           "kind": "Fetch",
           "serviceName": "reviews",
           "variableUsages": ["upc", "body"],
-          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{__typename upc}}}"
         },
         {
           "kind": "Flatten",
@@ -240,7 +240,7 @@ Scenario: multiple root mutations with correct service order
     $password: String!
     $reviewId: ID!
   ) {
-    reviewProduct(upc: $upc, body: $body) {
+    reviewProduct(input: { upc: $upc, body: $body }) {
       ... on Furniture {
         upc
       }
@@ -270,7 +270,7 @@ Scenario: multiple root mutations with correct service order
           "kind": "Fetch",
           "serviceName": "reviews",
           "variableUsages": ["upc", "body", "updatedReview"],
-          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
+          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc,body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
         },
         {
           "kind": "Fetch",

--- a/query-planner-js/src/__tests__/features/basic/supergraphSdl.graphql
+++ b/query-planner-js/src/__tests__/features/basic/supergraphSdl.graphql
@@ -139,9 +139,15 @@ type Library
 
 union MetadataOrError = KeyValue | Error
 
+input ReviewProduct {
+    upc: String!
+    body: String!
+    starts: Int @deprecated(reason: "Stars are no longer in use")
+}
+
 type Mutation {
     login(username: String!, password: String!): User @join__field(graph: ACCOUNTS)
-    reviewProduct(upc: String!, body: String!): Product @join__field(graph: REVIEWS)
+    reviewProduct(input: ReviewProduct!): Product @join__field(graph: REVIEWS)
     updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
     deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
 }


### PR DESCRIPTION
Follow-up to #996

In landing #996, @sachindshinde discovered that `@deprecated` propagation failed specifically for fields on input type objects.

We discovered this was an issue in `graphql-js` itself which has since been landed and released in `v15.5.3`
https://github.com/graphql/graphql-js/pull/3260

This PR pushes our `graphql` `peerDependencies` to `latest` and as such is a breaking change for gateway users, requiring a (relatively small) update to their project's `graphql` dependency from `15.4.0`. 

This is a breaking change for the federation, query-planner, and gateway packages and should be landed to a release branch.

TODO
- [x] Changelog entry
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
