### PR TITLE
fix(query-planner): Remove unions from API schema which have only @inaccessible types

### DIFF
--- a/query-planner-js/src/composedSchema/removeInaccessibleElements.ts
+++ b/query-planner-js/src/composedSchema/removeInaccessibleElements.ts
@@ -39,19 +39,26 @@ export function removeInaccessibleElements(
     }),
   );
 
-  Object.values(typeMap)
-    // skip checking types already marked for removal
-    .filter((type) => !typesToRemove.has(type))
-    .filter(isUnionType)
-    .forEach((type) => {
-      const accessibleTypes = type
-        .getTypes()
-        .filter((t) => !typesToRemove.has(t));
+  // remove unions which have no accessible types
+  // this is a loop since unions can contain other unions
+  let shouldRevisitSchema = true;
+  while (shouldRevisitSchema) {
+    shouldRevisitSchema = false;
+    Object.values(typeMap)
+      // skip checking types already marked for removal
+      .filter((type) => !typesToRemove.has(type))
+      .filter(isUnionType)
+      .forEach((type) => {
+        const accessibleTypes = type
+          .getTypes()
+          .filter((t) => !typesToRemove.has(t));
 
-      if (accessibleTypes.length === 0) {
-        typesToRemove.add(type);
-      }
-    });
+        if (accessibleTypes.length === 0) {
+          typesToRemove.add(type);
+          shouldRevisitSchema = true;
+        }
+      });
+  }
 
   removeRootTypesIfNeeded();
 


### PR DESCRIPTION
`removeInaccessibleElements` currently leaves unions in the schema even if all of their types are inaccessible. This change removes them from the schema.

Note that unions can consist of unions, so this action of marking unions for removal must be repeated until none are found.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
