### PR TITLE
Update NODE_VERSION to 14.7.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       # Note: This is a no-op at the second, but bear with me on this.  If this
       # comment is not removed by 2021-06-30 remove it along with the next line.
       # renovate: datasource=github-tags depName=nodejs/node versioning=node
-      NODE_VERSION: 14.16.1
+      NODE_VERSION: 14.17.5
       NPM_VERSION: 7.10.0
     steps:
       - checkout


### PR DESCRIPTION
The CI started failing on Windows because it was using the wrong nodejs version.
The router team decided to use version 14.17.5 everywhere, which makes the CI pass.
Here's a cherry pick of our commit, which should make the CI pass on federation as well.
