### PR TITLE
chore(harmonizer): Rebuild bridge.js when relevant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "which",
 ]
 
 [[package]]
@@ -549,11 +550,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "which"
-version = "4.1.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
  "either",
+ "lazy_static",
  "libc",
 ]
 

--- a/harmonizer/Cargo.toml
+++ b/harmonizer/Cargo.toml
@@ -23,3 +23,6 @@ thiserror = "1.0.23"
 
 [dev-dependencies]
 insta = "1.8.0"
+
+[build-dependencies]
+which = "4.2.2"

--- a/harmonizer/build.rs
+++ b/harmonizer/build.rs
@@ -1,13 +1,81 @@
-use std::fs::metadata;
+use std::fs;
+use std::path::Path;
 use std::process::Command;
+use std::time::SystemTime;
 
 fn main() {
-    if metadata("dist/composition.js").is_err() {
-        assert!(Command::new("npm")
-            .current_dir("../")
-            .args(&["run", "compile:for-harmonizer-build-rs"])
-            .status()
-            .unwrap()
-            .success());
+    let target_dir = std::env::var_os("OUT_DIR").unwrap();
+    // Always rerun the script
+    println!("cargo:rerun-if-changed={:?}", target_dir);
+
+    let bridge_last_update = if let Ok(b) = fs::metadata("dist/bridge.js") {
+        b.modified()
+    } else {
+        // No dist/bridge.js, let's create it
+        return update_bridge();
+    };
+
+    let mut federation_js_last_update = None;
+
+    if sub_last_modified_date(&mut federation_js_last_update, "../federation-js/src").is_err()
+        || federation_js_last_update.is_none()
+    {
+        // Os doesn't allow querying the metadata, this is weird. let's update the bridge.
+        return update_bridge();
+    };
+
+    match (&bridge_last_update, &federation_js_last_update) {
+        // the federation folder has evolved since the last time we built harmonizer.
+        (Ok(bridge), Some(federation)) if federation > bridge => update_bridge(),
+        // Os didn't allow to query for metadata, we can't know for sure the bridge is up to date.
+        (Err(_), _) => update_bridge(),
+        _ => {
+            println!("cargo:warning=bridge.js is already up to date!");
+        }
     }
+}
+
+fn update_bridge() {
+    println!("cargo:warning=Updating bridge.js");
+    let npm = which::which("npm").unwrap();
+    let current_dir = std::env::current_dir().unwrap();
+    let repo_dir = current_dir.parent().unwrap();
+
+    assert!(Command::new(&npm)
+        .current_dir(&repo_dir)
+        .args(&["install"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new(&npm)
+        .current_dir(&repo_dir)
+        .args(&["run", "compile:for-harmonizer-build-rs"])
+        .status()
+        .unwrap()
+        .success());
+}
+
+fn sub_last_modified_date(
+    mut latest_metadata: &mut Option<SystemTime>,
+    dir: impl AsRef<Path>,
+) -> std::io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        let metadata = fs::metadata(&path)?;
+        let last_modified = metadata.modified()?;
+
+        if latest_metadata.is_none()
+            || latest_metadata.is_some() && latest_metadata.unwrap() < last_modified
+        {
+            *latest_metadata = Some(last_modified);
+        }
+
+        if metadata.is_dir() {
+            sub_last_modified_date(&mut latest_metadata, path)?;
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
This commit allows us to run npm install and npm run compile:for-harmonizer-build-rs if and only if file or folders have in `federation-js` have been modified since the last time `dist/bridge.js` has been generated.

Bonus point we get a warning when working on the federation, that allows to know whether the bridge has been generated or not, thus making sure we're working against an up to date bridge and definitions:

When the bridge is up to date:
![image](https://user-images.githubusercontent.com/9465678/134949259-013010be-2594-44e2-be44-9431c021c19a.png)

When the bridge is not up to date:
![image](https://user-images.githubusercontent.com/9465678/134949283-a3f0c4c8-dbc9-4439-ae1e-63045de6163a.png)


This warning can be displayed when working downstream using `--verbose` twice as explained [in the cargo build display options](https://doc.rust-lang.org/cargo/commands/cargo-build.html#display-options).