### PR TITLE
chore: polyfill URL in deno runtime

### DIFF
--- a/harmonizer/js/url_polyfill.mjs
+++ b/harmonizer/js/url_polyfill.mjs
@@ -1,0 +1,3 @@
+import "fast-text-encoding";
+import * as url from "whatwg-url";
+export default url;

--- a/harmonizer/package.json
+++ b/harmonizer/package.json
@@ -20,7 +20,9 @@
     "node": ">=12.13.0 <17.0"
   },
   "dependencies": {
-    "@apollo/federation": "file:../federation-js"
+    "@apollo/federation": "file:../federation-js",
+    "fast-text-encoding": "^1.0.3",
+    "whatwg-url": "^9.1.0"
   },
   "peerDependencies": {
     "graphql": "^14.5.0 || ^15.0.0"

--- a/harmonizer/rollup.config.js
+++ b/harmonizer/rollup.config.js
@@ -1,9 +1,26 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json'
 import nodePolyfills from 'rollup-plugin-node-polyfills';
 import path from 'path';
 
 export default [
+  {
+    input: path.resolve(__dirname, './js/url_polyfill.mjs'),
+    output: {
+      name: 'url_shim',
+      file: path.resolve(__dirname, './dist/url_shim.js'),
+      format: 'iife',
+      globals: {}
+    },
+    external: [],
+    plugins: [
+      json(),
+      nodePolyfills(),
+      resolve(),
+      commonjs()
+    ]
+  },
   {
     input: path.resolve(__dirname, './js/index.mjs'),
     output: {
@@ -15,14 +32,21 @@ export default [
         // empty object. e.g., `node_fetch_1={}`.
         // It will not be used for composition.
         'node-fetch': 'node_fetch_1',
+
+        // v8 doesn't include the `URL` API natively, so we must shim it
+        'url': 'whatwg_url_1'
       },
       sourcemap: true,
     },
     // This just cuts off the awkward traversal that happens because of
     // `apollo-env` which brings in all of `node-fetch`, which in turn tries
     // to load Node.js' `http`, `https`, `stream`, etc.
-    external: ['node-fetch'],
+    external: [
+      'node-fetch',
+      'url'
+    ],
     plugins: [
+      json(),
       nodePolyfills(),
       resolve(),
       commonjs(),

--- a/harmonizer/src/lib.rs
+++ b/harmonizer/src/lib.rs
@@ -223,6 +223,15 @@ exports = {};
         )
         .expect("unable to initialize composition runtime environment");
 
+    // Load URL polyfill
+    runtime
+        .execute("url_shim.js", include_str!("../dist/url_shim.js"))
+        .expect("unable to evaluate url_shim module");
+
+    runtime
+        .execute("<url_shim_assignment>", "whatwg_url_1 = url_shim;")
+        .expect("unable to assign url_shim");
+
     // Load the composition library.
     runtime
         .execute("composition.js", include_str!("../dist/composition.js"))

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@iarna/toml": "2.2.5",
         "@opentelemetry/node": "0.24.0",
         "@rollup/plugin-commonjs": "20.0.0",
+        "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "13.0.5",
         "@types/bunyan": "1.8.7",
         "@types/deep-equal": "1.0.1",
@@ -121,13 +122,27 @@
       "version": "0.33.0",
       "license": "MIT",
       "dependencies": {
-        "@apollo/federation": "file:../federation-js"
+        "@apollo/federation": "file:../federation-js",
+        "fast-text-encoding": "^1.0.3",
+        "whatwg-url": "^9.1.0"
       },
       "engines": {
         "node": ">=12.13.0 <17.0"
       },
       "peerDependencies": {
         "graphql": "^14.5.0 || ^15.0.0"
+      }
+    },
+    "harmonizer/node_modules/whatwg-url": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+      "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+      "dependencies": {
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@apollo/core-schema": {
@@ -6383,6 +6398,18 @@
         "rollup": "^2.38.3"
       }
     },
+    "node_modules/@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "13.0.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz",
@@ -10660,6 +10687,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "node_modules/fastq": {
       "version": "1.11.0",
@@ -20070,7 +20102,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -22367,10 +22398,9 @@
       }
     },
     "node_modules/tr46": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -23030,7 +23060,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-      "dev": true,
       "engines": {
         "node": ">=10.4"
       }
@@ -23645,7 +23674,20 @@
     "@apollo/harmonizer": {
       "version": "file:harmonizer",
       "requires": {
-        "@apollo/federation": "file:../federation-js"
+        "@apollo/federation": "file:../federation-js",
+        "fast-text-encoding": "^1.0.3",
+        "whatwg-url": "^9.1.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+          "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+          "requires": {
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "@apollo/protobufjs": {
@@ -28617,6 +28659,15 @@
         "resolve": "^1.17.0"
       }
     },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "13.0.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz",
@@ -32162,6 +32213,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
+    },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "fastq": {
       "version": "1.11.0",
@@ -39662,8 +39718,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -41572,10 +41627,9 @@
       }
     },
     "tr46": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -42097,8 +42151,7 @@
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-      "dev": true
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@iarna/toml": "2.2.5",
     "@opentelemetry/node": "0.24.0",
     "@rollup/plugin-commonjs": "20.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "13.0.5",
     "@types/bunyan": "1.8.7",
     "@types/deep-equal": "1.0.1",


### PR DESCRIPTION
fixes #1050 by adding a polyfill/shim (what's the difference again?) for the `URL` API.