### PR TITLE
Release @apollo/subgraph@0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- _Nothing yet. Stay tuned._
+
+## v0.33.1
+
 - Refine internal types to `FieldSet`s in places where we previously used `SelectionNode[]` [PR #1030](https://github.com/apollographql/federation/pull/1030)
-- Emit a deprecation warning for deprecated functions. [PR #1033](https://github.com/apollographql/federation/pull/1033). 
-We would advise to adjust the code to use the new functionality, as the deprecated functions will be removed in a future version. If needed, deprecation warnings can be muted with either the --no-deprecation or --no-warnings command-line flags for node.js. Please keep in mind in doing so will also prevent any future deprecation warnings from node.js itself as well as from any package.
+- Emit a deprecation warning for deprecated functions. We would advise to adjust the code to use the new functionality, as the deprecated functions will be removed in a future version. If needed, deprecation warnings can be muted with either the --no-deprecation or --no-warnings command-line flags for node.js. Please keep in mind in doing so will also prevent any future deprecation warnings from node.js itself as well as from any package.[PR #1033](https://github.com/apollographql/federation/pull/1033).
 
 ## v0.33.0
 

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Apollo Federation Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- Emit a deprecation warning for deprecated functions. [PR #1033](https://github.com/apollographql/federation/pull/1033)
+- _Nothing yet. Stay tuned._
+
+## v0.42.1
+
+- Emit a deprecation warning for deprecated functions. We would advise to adjust the code to use the new functionality, as the deprecated functions will be removed in a future version. If needed, deprecation warnings can be muted with either the --no-deprecation or --no-warnings command-line flags for node.js. Please keep in mind in doing so will also prevent any future deprecation warnings from node.js itself as well as from any package.[PR #1033](https://github.com/apollographql/federation/pull/1033).
 
 ## v0.42.0
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Apollo Gateway",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/harmonizer/Cargo.toml
+++ b/harmonizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harmonizer"
-version = "0.33.0"
+version = "0.33.1"
 authors = [ "Apollo Graph, Inc. <opensource@apollographql.com>" ]
 edition = "2018"
 description = "Apollo Federation utility to compose a supergraph from subgraphs"

--- a/harmonizer/package.json
+++ b/harmonizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/harmonizer",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Apollo Federation Harmonizer JS Entrypoint",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "license": "MIT",
       "dependencies": {
         "apollo-graphql": "^0.9.3",
@@ -77,7 +77,7 @@
     },
     "federation-js": {
       "name": "@apollo/federation",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/subgraph": "file:../subgraph-js",
@@ -94,7 +94,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "0.42.0",
+      "version": "0.42.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/core-schema": "^0.1.0",
@@ -122,7 +122,7 @@
     },
     "harmonizer": {
       "name": "@apollo/harmonizer",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/federation": "file:../federation-js",
@@ -24743,7 +24743,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "apollo-graphql": "^0.9.3",
@@ -24760,7 +24760,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "apollo-graphql": "^0.9.3"

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- _Nothing yet. Stay tuned._
+
 ## v0.5.0
 
 - __BREAKING__: This is a breaking change due to a `peerDependencies` update (`graphql@^15.4.0` -> `graphql@^15.5.3`). This `graphql` version includes a fix which is being necessarily adopted within the `@apollo/federation` package. See associated CHANGELOG entry in the `federation-js` folder for additional details. [PR #1008](https://github.com/apollographql/federation/pull/1008)

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Apollo Query Planner",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -4,5 +4,9 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- _Nothing yet. Stay tuned._
+
+## v0.1.0
+
 - Initial release of new `@apollo/subgraph` package. This package is the subgraph-related slice of the `@apollo/federation` package which was previously responsible for both subgraph and composition bits. `@apollo/federation` users will experience no change in behavior for now, but our docs will suggest the usage of the `@apollo/subgraph` package going forward. For past iterations and CHANGELOG information of related work, see the [`@apollo/federation` CHANGELOG.md](../federation-js/CHANGELOG.md)[PR #1058](https://github.com/apollographql/federation/pull/1058)
 

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
As with release PRs in the past, this is a PR tracking a release-subgraph-x.y.z branch for an upcoming release. 🙌 The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR). Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. alpha, beta, rc) without affecting the main branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers. The main branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release. Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an -rc.x release suffix. Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the latest npm tag, this PR will be merged into main.