### PR TITLE
gateway-js: Change behavior for core v0.1 to what it was before core v0.2 was introduced

### DIFF
--- a/gateway-js/src/core/index.ts
+++ b/gateway-js/src/core/index.ts
@@ -41,8 +41,7 @@ export function featureSupport(this: CoreSchemaContext) {
   }
 
   for (const feature of this.features) {
-    if (!feature.purpose) continue;
-    if (feature.purpose === 'EXECUTION' || feature.purpose === 'SECURITY') {
+    if (coreVersionZeroDotOne || feature.purpose === 'EXECUTION' || feature.purpose === 'SECURITY') {
       if (!SUPPORTED_FEATURES.has(feature.url.base.toString())) {
         this.report(ErrUnsupportedFeature(feature));
       }


### PR DESCRIPTION
In core v0.1, any unknown features would cause gateway to error when loading a supergraph core schema.

When core v0.2 was introduced, we also changed how documents on core v0.1 were handled, so that any unknown features would no longer error during load.

This PR reverts back to the previous behavior.

To describe more clearly what kind of error this change is trying to prevent, imagine the following scenario:
1. A user has a supergraph core schema using core v0.1.
2. Let's suppose that schema has some feature that's security-related (e.g. inaccessible v0.1).
3. Suppose they're on some gateway version in the future, and that feature version has removed support for inaccessible v0.1.
4. In that case, gateway would not complain about the lack of support for inaccessible v0.1, and just silently ignore it.

The logic in this PR here would cause this to error instead. (Essentially, this is setting what the default `for` should be for v0.1, although really this is about maintaining behavior.)