### PR TITLE
Change subtitle to 'Federation'

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -13,7 +13,7 @@ module.exports = {
           'docset:federation',
           ['docset:server', 'docset:rover', 'docset:studio'],
         ],
-        subtitle: 'Federation 2 alpha',
+        subtitle: 'Federation',
         description: 'A guide to using Apollo Federation',
         githubRepo: 'apollographql/federation',
         defaultVersion: '1',


### PR DESCRIPTION
The current subtitle feels misleading because in the dropdown picker, it says "Federation 2 alpha", but you can still switch between the docs for v1 and v2. Leaving it as just "Federation" with these different version options feels more natural. See [Slack thread](https://apollograph.slack.com/archives/C0721M2F6/p1635949546025900) for more context.

