### PR TITLE
Fed2: fix handling of nested provides and add tests

### DIFF
--- a/query-graphs-js/src/transition.ts
+++ b/query-graphs-js/src/transition.ts
@@ -50,7 +50,10 @@ export class FieldCollection {
   readonly kind = 'FieldCollection' as const;
   readonly collectOperationElements = true as const;
 
-  constructor(readonly definition: FieldDefinition<CompositeType>) {}
+  constructor(
+    readonly definition: FieldDefinition<CompositeType>,
+    readonly isPartOfProvide: boolean = false
+  ) {}
 
   toString() {
     return this.definition.name;

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -190,3 +190,754 @@ test('pick keys that minimize fetches', () => {
     }
   `);
 });
+
+describe('@provides', () => {
+  it('works with nested provides', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          doSomething: Response
+          doSomethingWithProvides: Response @provides(fields: "responseValue { subResponseValue { subSubResponseValue } }")
+        }
+
+        type Response {
+          responseValue: SubResponse
+        }
+
+        type SubResponse {
+          subResponseValue: SubSubResponse
+        }
+
+        type SubSubResponse @key(fields: "id") {
+          id: ID!
+          subSubResponseValue: Int @external
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      typeDefs: gql`
+        type SubSubResponse @key(fields: "id") {
+          id: ID!
+          subSubResponseValue: Int
+        }
+      `
+    }
+
+    let [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+    let operation = operationFromDocument(api, gql`
+      {
+        doSomething {
+          responseValue {
+            subResponseValue {
+              subSubResponseValue
+            }
+          }
+        }
+      }
+      `);
+
+    let plan = queryPlanner.buildQueryPlan(operation);
+    // This is our sanity check: we first query _without_ the provides to make sure we _do_ need to
+    // go the the second subgraph.
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              doSomething {
+                responseValue {
+                  subResponseValue {
+                    __typename
+                    id
+                  }
+                }
+              }
+            }
+          },
+          Flatten(path: "doSomething.responseValue.subResponseValue") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on SubSubResponse {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on SubSubResponse {
+                  subSubResponseValue
+                }
+              }
+            },
+          },
+        },
+      }
+      `);
+
+    // And now make sure with the provides we do only get a fetch to subgraph1
+    operation = operationFromDocument(api, gql`
+      {
+        doSomethingWithProvides {
+          responseValue {
+            subResponseValue {
+              subSubResponseValue
+            }
+          }
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            doSomethingWithProvides {
+              responseValue {
+                subResponseValue {
+                  subSubResponseValue
+                }
+              }
+            }
+          }
+        },
+      }
+      `);
+  });
+
+  it('works on interfaces', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          noProvides: I
+          withProvides: I @provides(fields: "v { a }")
+        }
+
+        interface I {
+          v: Value
+        }
+
+        type Value {
+          a: Int
+        }
+
+        type T1 implements I @key(fields: "id") {
+          id: ID!
+          v: Value @external
+        }
+
+        type T2 implements I @key(fields: "id") {
+          id: ID!
+          v: Value @external
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      typeDefs: gql`
+        type Value {
+          a: Int
+          b: Int
+        }
+
+        type T1 @key(fields: "id") {
+          id: ID!
+          v: Value
+        }
+
+        type T2 @key(fields: "id") {
+          id: ID!
+          v: Value
+        }
+      `
+    }
+
+    let [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+    let operation = operationFromDocument(api, gql`
+      {
+        noProvides {
+          v {
+            a
+          }
+        }
+      }
+      `);
+
+    let plan = queryPlanner.buildQueryPlan(operation);
+    // This is our sanity check: we first query _without_ the provides to make sure we _do_ need to
+    // go the the second subgraph.
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              noProvides {
+                __typename
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "noProvides") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T1 {
+                  v {
+                    a
+                  }
+                }
+                ... on T2 {
+                  v {
+                    a
+                  }
+                }
+              }
+            },
+          },
+        },
+      }
+      `);
+
+    // Ensuring that querying only `a` can be done with subgraph1 only.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvides {
+          v {
+            a
+          }
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            withProvides {
+              __typename
+              v {
+                a
+              }
+            }
+          }
+        },
+      }
+      `);
+
+    // Sanity check that if we query `b` however we have to got to subgraph2.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvides {
+          v {
+            a
+            b
+          }
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              withProvides {
+                __typename
+                v {
+                  a
+                }
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "withProvides") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T1 {
+                  v {
+                    b
+                  }
+                }
+                ... on T2 {
+                  v {
+                    b
+                  }
+                }
+              }
+            },
+          },
+        },
+      }
+      `);
+  });
+
+  it('works on unions', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          noProvides: U
+          withProvidesForT1: U @provides(fields: "... on T1 { a }")
+          withProvidesForBoth: U @provides(fields: "... on T1 { a } ... on T2 {b}")
+        }
+
+        union U = T1 | T2
+
+        type T1 @key(fields: "id") {
+          id: ID!
+          a: Int @external
+        }
+
+        type T2 @key(fields: "id") {
+          id: ID!
+          a: Int
+          b: Int @external
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      typeDefs: gql`
+        type T1 @key(fields: "id") {
+          id: ID!
+          a: Int
+        }
+
+        type T2 @key(fields: "id") {
+          id: ID!
+          b: Int
+        }
+      `
+    }
+
+    let [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+    let operation = operationFromDocument(api, gql`
+      {
+        noProvides {
+          ... on T1 {
+            a
+          }
+          ... on T2 {
+            a
+            b
+          }
+        }
+      }
+      `);
+
+    let plan = queryPlanner.buildQueryPlan(operation);
+    // This is our sanity check: we first query _without_ the provides to make sure we _do_ need to
+    // go the the second subgraph.
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              noProvides {
+                __typename
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  __typename
+                  id
+                  a
+                }
+              }
+            }
+          },
+          Flatten(path: "noProvides") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T1 {
+                  a
+                }
+                ... on T2 {
+                  b
+                }
+              }
+            },
+          },
+        },
+      }
+      `);
+
+    // Ensuring that querying only `a` can be done with subgraph1 only when provided.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvidesForT1 {
+          ... on T1 {
+            a
+          }
+          ... on T2 {
+            a
+          }
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            withProvidesForT1 {
+              __typename
+              ... on T1 {
+                a
+              }
+              ... on T2 {
+                a
+              }
+            }
+          }
+        },
+      }
+      `);
+
+    // But ensure that querying `b` still goes to subgraph2 if only a is provided.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvidesForT1 {
+          ... on T1 {
+            a
+          }
+          ... on T2 {
+            a
+            b
+          }
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              withProvidesForT1 {
+                __typename
+                ... on T1 {
+                  a
+                }
+                ... on T2 {
+                  __typename
+                  id
+                  a
+                }
+              }
+            }
+          },
+          Flatten(path: "withProvidesForT1") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T2 {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T2 {
+                  b
+                }
+              }
+            },
+          },
+        },
+      }
+      `);
+
+    // Lastly, if both are provided, ensures we only hit subgraph1.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvidesForBoth {
+          ... on T1 {
+            a
+          }
+          ... on T2 {
+            a
+            b
+          }
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            withProvidesForBoth {
+              __typename
+              ... on T1 {
+                a
+              }
+              ... on T2 {
+                a
+                b
+              }
+            }
+          }
+        },
+      }
+      `);
+  });
+
+  it('allow providing fields for only some subtype', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          noProvides: I
+          withProvidesOnA: I @provides(fields: "... on T2 { a }")
+          withProvidesOnB: I @provides(fields: "... on T2 { b }")
+        }
+
+        interface I {
+          a: Int
+          b: Int
+        }
+
+        type T1 implements I @key(fields: "id") {
+          id: ID!
+          a: Int
+          b: Int @external
+        }
+
+        type T2 implements I @key(fields: "id") {
+          id: ID!
+          a: Int @external
+          b: Int @external
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      typeDefs: gql`
+        type T1 @key(fields: "id") {
+          id: ID!
+          b: Int
+        }
+
+        type T2 @key(fields: "id") {
+          id: ID!
+          a: Int
+          b: Int
+        }
+      `
+    }
+
+    let [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+    let operation = operationFromDocument(api, gql`
+      {
+        noProvides {
+          a
+          b
+        }
+      }
+      `);
+
+    let plan = queryPlanner.buildQueryPlan(operation);
+    // This is our sanity check: we first query _without_ the provides to make sure we _do_ need to
+    // go the the second subgraph.
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              noProvides {
+                __typename
+                ... on T1 {
+                  __typename
+                  id
+                  a
+                }
+                ... on T2 {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "noProvides") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T1 {
+                  b
+                }
+                ... on T2 {
+                  a
+                  b
+                }
+              }
+            },
+          },
+        },
+      }
+      `);
+
+    // Ensuring that querying only `a` can be done with subgraph1 only.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvidesOnA {
+          a
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            withProvidesOnA {
+              __typename
+              ... on T1 {
+                a
+              }
+              ... on T2 {
+                a
+              }
+            }
+          }
+        },
+      }
+      `);
+
+    // Ensuring that for `b`, only the T2 value is provided by subgraph1.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvidesOnB {
+          b
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              withProvidesOnB {
+                __typename
+                ... on T1 {
+                  __typename
+                  id
+                }
+                ... on T2 {
+                  b
+                }
+              }
+            }
+          },
+          Flatten(path: "withProvidesOnB") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T1 {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T1 {
+                  b
+                }
+              }
+            },
+          },
+        },
+      }
+      `);
+
+    // But if we only query for T2, then no reason to go to subgraph2.
+    operation = operationFromDocument(api, gql`
+      {
+        withProvidesOnB {
+          ... on T2 {
+            b
+          }
+        }
+      }
+      `);
+
+    plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            withProvidesOnB {
+              __typename
+              ... on T2 {
+                b
+              }
+            }
+          }
+        },
+      }
+      `);
+  });
+});


### PR DESCRIPTION
While adding tests for nested provides for the fed2 code, I realised their handling was slightly busted and this commit adds the tests with the fix.

This also add tests for `@provides` of fields of interfaces and unions, which were meant to be supported but untested (and unsurprising need a few minor fixes as well).
