### PR TITLE
fix(composition): Add missing `@apollo/query-graphs` dependency

### DIFF
--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -27,7 +27,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@apollo/federation-internals": "file:../internals-js"
+    "@apollo/federation-internals": "file:../internals-js",
+    "@apollo/query-graphs": "file:../query-graphs-js"
   },
   "peerDependencies": {
     "graphql": "^14.5.0 || ^15.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,8 @@
       "version": "2.0.0-alpha.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@apollo/federation-internals": "file:../internals-js"
+        "@apollo/federation-internals": "file:../internals-js",
+        "@apollo/query-graphs": "file:../query-graphs-js"
       },
       "engines": {
         "node": ">=12.13.0 <17.0"
@@ -23322,7 +23323,8 @@
     "@apollo/composition": {
       "version": "file:composition-js",
       "requires": {
-        "@apollo/federation-internals": "file:../internals-js"
+        "@apollo/federation-internals": "file:../internals-js",
+        "@apollo/query-graphs": "file:../query-graphs-js"
       }
     },
     "@apollo/core-schema": {


### PR DESCRIPTION
The `@apollo/composition` package is missing the `@apollo/query-graphs` dependency in its `package.json` file.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
