### PR TITLE
feat: Only update the router-bridge when necessary.

### DIFF
--- a/router-bridge/build.rs
+++ b/router-bridge/build.rs
@@ -1,5 +1,3 @@
-use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 fn main() {

--- a/router-bridge/build.rs
+++ b/router-bridge/build.rs
@@ -26,19 +26,3 @@ fn update_bridge() {
         .unwrap()
         .success());
 }
-
-fn recurse_rerun_if_changed(dir: impl AsRef<Path>) -> std::io::Result<()> {
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-
-        let metadata = fs::metadata(&path)?;
-        if metadata.is_dir() {
-            recurse_rerun_if_changed(path)?;
-        } else {
-            println!("cargo:rerun-if-changed={:?}", path);
-        }
-    }
-
-    Ok(())
-}

--- a/router-bridge/build.rs
+++ b/router-bridge/build.rs
@@ -1,38 +1,10 @@
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::time::SystemTime;
 
 fn main() {
-    let target_dir = std::env::var_os("OUT_DIR").unwrap();
-    // Always rerun the script
-    println!("cargo:rerun-if-changed={:?}", target_dir);
-
-    let bridge_last_update = if let Ok(b) = fs::metadata("bundled/bridge.js") {
-        b.modified()
-    } else {
-        // No bridge.js, let's create it
-        return update_bridge();
-    };
-
-    let mut js_dist_last_update = None;
-
-    if sub_last_modified_date(&mut js_dist_last_update, "./js-dist").is_err()
-        || js_dist_last_update.is_none()
-    {
-        // Os doesn't allow querying the metadata, this is weird. let's update the bridge.
-        return update_bridge();
-    };
-
-    match (&bridge_last_update, &js_dist_last_update) {
-        // the federation folder has evolved since the last time we built the rust-bridge.
-        (Ok(bridge), Some(js)) if js > bridge => update_bridge(),
-        // Os didn't allow to query for metadata, we can't know for sure the bridge is up to date.
-        (Err(_), _) => update_bridge(),
-        _ => {
-            println!("cargo:warning=router-bridge is already up to date!");
-        }
-    }
+    println!("cargo:rerun-if-changed=js-src");
+    update_bridge();
 }
 
 fn update_bridge() {
@@ -55,25 +27,16 @@ fn update_bridge() {
         .success());
 }
 
-fn sub_last_modified_date(
-    mut latest_metadata: &mut Option<SystemTime>,
-    dir: impl AsRef<Path>,
-) -> std::io::Result<()> {
+fn recurse_rerun_if_changed(dir: impl AsRef<Path>) -> std::io::Result<()> {
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
 
         let metadata = fs::metadata(&path)?;
-        let last_modified = metadata.modified()?;
-
-        if latest_metadata.is_none()
-            || latest_metadata.is_some() && latest_metadata.unwrap() < last_modified
-        {
-            *latest_metadata = Some(last_modified);
-        }
-
         if metadata.is_dir() {
-            sub_last_modified_date(&mut latest_metadata, path)?;
+            recurse_rerun_if_changed(path)?;
+        } else {
+            println!("cargo:rerun-if-changed={:?}", path);
         }
     }
 


### PR DESCRIPTION
We used to always check for file modifications and rebuild the router-bridge's js-dist files, which unfortunately has an impact on downstream built times. It also isn't required anymore since the bridge is stable now. This pr fixes this.
