### PR TITLE
Have Subgraphs use OrderedMap

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -77,9 +77,9 @@ import {
   hintInconsistentDescription,
 } from "../hints";
 
-const coreSpec = CORE_VERSIONS.latest()!;
-const joinSpec = JOIN_VERSIONS.latest()!;
-const tagSpec = TAG_VERSIONS.latest()!;
+const coreSpec = CORE_VERSIONS.latest();
+const joinSpec = JOIN_VERSIONS.latest();
+const tagSpec = TAG_VERSIONS.latest();
 
 // When displaying a list of something in a human readable form, after what size (in
 // number of characters) we start displaying only a subset of the list.
@@ -267,9 +267,9 @@ class Merger {
 
   constructor(readonly subgraphs: Subgraphs, readonly options: CompositionOptions) {
     this.names = subgraphs.names();
-    this.subgraphsSchema = this.names.map(name => subgraphs.get(name)!.schema);
+    this.subgraphsSchema = subgraphs.values().map(subgraph => subgraph.schema);
     this.subgraphNamesToJoinSpecName = this.prepareSupergraph();
-    this.externalTesters = subgraphs.values().map(s => new ExternalTester(s.schema));
+    this.externalTesters = this.subgraphsSchema.map(schema => new ExternalTester(schema));
   }
 
   private prepareSupergraph(): Map<string, string> {

--- a/internals-js/src/__tests__/utils.test.ts
+++ b/internals-js/src/__tests__/utils.test.ts
@@ -5,11 +5,11 @@ describe('OrderedMap', () => {
     const orderedMap = new OrderedMap<string, number>();
     orderedMap.add('one', 0);
     expect(orderedMap.get('one')).toBe(0);
-    expect(orderedMap.size()).toBe(1);
+    expect(orderedMap.size).toBe(1);
 
     orderedMap.add('one', 1);
     expect(orderedMap.get('one')).toBe(1);
-    expect(orderedMap.size()).toBe(1);
+    expect(orderedMap.size).toBe(1);
     expect(orderedMap.keys()).toEqual(['one']);
     expect(orderedMap.values()).toEqual([1]);
   });
@@ -39,9 +39,9 @@ describe('OrderedMap', () => {
     expect(orderedMap.get('ten')).toBeUndefined();
 
     // testing size function
-    expect(orderedMap.size()).toBe(9);
+    expect(orderedMap.size).toBe(9);
     orderedMap.add('one', 1);
-    expect(orderedMap.size()).toBe(9);
+    expect(orderedMap.size).toBe(9);
     expect(orderedMap.values()).toEqual(sortedArr);
 
     // has function

--- a/internals-js/src/__tests__/utils.test.ts
+++ b/internals-js/src/__tests__/utils.test.ts
@@ -1,0 +1,92 @@
+import { OrderedMap } from '../utils';
+
+describe('OrderedMap', () => {
+  it('updating value works', () => {
+    const orderedMap = new OrderedMap<string, number>();
+    orderedMap.add('one', 0);
+    expect(orderedMap.get('one')).toBe(0);
+    expect(orderedMap.size()).toBe(1);
+
+    orderedMap.add('one', 1);
+    expect(orderedMap.get('one')).toBe(1);
+    expect(orderedMap.size()).toBe(1);
+    expect(orderedMap.keys()).toEqual(['one']);
+    expect(orderedMap.values()).toEqual([1]);
+  });
+
+  it('test lexicographical sorting of map (default sorting algorithm)', () => {
+    const orderedMap = new OrderedMap<string, number>();
+    orderedMap.add('one', 1);
+    orderedMap.add('two', 2);
+    orderedMap.add('three', 3);
+    orderedMap.add('four', 4);
+    orderedMap.add('five', 5);
+    orderedMap.add('six', 6);
+    orderedMap.add('seven', 7);
+    orderedMap.add('eight', 8);
+    orderedMap.add('nine', 9);
+
+    // keys are in alphabetical order
+    expect(orderedMap.keys()).toEqual(['eight', 'five', 'four', 'nine', 'one', 'seven', 'six', 'three', 'two']);
+    const sortedArr = [8,5,4,9,1,7,6,3,2];
+    expect(orderedMap.values()).toEqual(sortedArr);
+
+    // test using spread operator to make sure iterator is performing correctly
+    expect([...orderedMap]).toEqual(sortedArr);
+
+    // testing get function
+    expect(orderedMap.get('one')).toBe(1);
+    expect(orderedMap.get('ten')).toBeUndefined();
+
+    // testing size function
+    expect(orderedMap.size()).toBe(9);
+    orderedMap.add('one', 1);
+    expect(orderedMap.size()).toBe(9);
+    expect(orderedMap.values()).toEqual(sortedArr);
+
+    // has function
+    expect(orderedMap.has('one')).toBe(true);
+    expect(orderedMap.has('fifty')).toBe(false);
+  });
+
+  it('sort by string length', () => {
+    const orderedMap = new OrderedMap<string, number>((a: string, b: string) => {
+      if (a.length < b.length) {
+        return -1;
+      } else if (b.length < a.length) {
+        return 1;
+      }
+      return 0;
+    });
+    orderedMap.add('eight', 8);
+    orderedMap.add('seventy', 70);
+    orderedMap.add('six', 6);
+    orderedMap.add('four', 4);
+
+    expect(orderedMap.keys()).toEqual(['six', 'four', 'eight', 'seventy']);
+    const sortedArr = [6,4,8,70];
+    expect(orderedMap.values()).toEqual(sortedArr);
+
+    // test using spread operator to make sure iterator is performing correctly
+    expect([...orderedMap]).toEqual(sortedArr);
+  });
+
+  it('sort numerically', () => {
+    const orderedMap = new OrderedMap<number, number>();
+    orderedMap.add(4, 40);
+    orderedMap.add(1, 10);
+    orderedMap.add(7, 70);
+    orderedMap.add(2, 20);
+    orderedMap.add(6, 60);
+    orderedMap.add(3, 30);
+    orderedMap.add(9, 90);
+    orderedMap.add(5, 50);
+    orderedMap.add(8, 80);
+
+    const keys = [1,2,3,4,5,6,7,8,9];
+    const values = [10,20,30,40,50,60,70,80,90];
+    expect(orderedMap.keys()).toEqual(keys);
+    expect(orderedMap.values()).toEqual(values);
+    expect([...orderedMap]).toEqual(values);
+  });
+});

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -3,6 +3,7 @@ import { URL } from "url";
 import { CoreFeature, Directive, DirectiveDefinition, EnumType, NamedType, NonNullType, ScalarType, Schema, SchemaDefinition } from "./definitions";
 import { sameType } from "./types";
 import { err } from '@apollo/core-schema';
+import { assert } from './utils';
 
 export const coreIdentity = 'https://specs.apollo.dev/core';
 
@@ -263,7 +264,8 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
     return this._definitions.map(def => def.version);
   }
 
-  latest(): T | undefined {
+  latest(): T {
+    assert(this._definitions.length > 0, 'Trying to get latest when no definitions exist');
     return this._definitions[0];
   }
 }
@@ -281,7 +283,7 @@ export class FeatureVersion {
    * ```
    * expect(FeatureVersion.parse('v1.0')).toEqual(new FeatureVersion(1, 0))
    * expect(FeatureVersion.parse('v0.1')).toEqual(new FeatureVersion(0, 1))
-   * expect(FeatureVersion.parse("v987.65432")).toEqual(new FeatureVersion(987, 65432)) 
+   * expect(FeatureVersion.parse("v987.65432")).toEqual(new FeatureVersion(987, 65432))
    * ```
    */
   public static parse(input: string): FeatureVersion {
@@ -327,7 +329,7 @@ export class FeatureVersion {
    * Compares this version to the provide one, returning 1 if it strictly greater, 0 if they are equals, and -1 if this
     * version is strictly smaller. The underlying ordering is that of major version and then minor versions.
    *
-   * Be aware that this ordering does *not* imply compatibility. For example, `FeatureVersion(2, 0) > FeatureVersion(1, 9)`, 
+   * Be aware that this ordering does *not* imply compatibility. For example, `FeatureVersion(2, 0) > FeatureVersion(1, 9)`,
     * but an implementation of `FeatureVersion(2, 0)` *cannot* satisfy a request for `FeatureVersion(1, 9)`. To check for
     * version compatibility, use [the `satisfies` method](#satisfies).
    */
@@ -362,7 +364,7 @@ export class FeatureVersion {
 
   /**
    * return the string version tag, like "v2.9"
-   * 
+   *
    * @returns a version tag
    */
   public toString() {
@@ -371,7 +373,7 @@ export class FeatureVersion {
 
   /**
    * return true iff this version is exactly equal to the provided version
-   * 
+   *
    * @param other the version to compare
    * @returns true if versions are strictly equal
    */
@@ -424,7 +426,7 @@ export class FeatureUrl {
   /**
    * Return true if and only if this spec satisfies the `requested`
    * spec.
-   * 
+   *
    * @param request
    */
   public satisfies(requested: FeatureUrl): boolean {

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -597,7 +597,7 @@ export class Subgraphs {
   }
 
   size(): number {
-    return this.subgraphs.size();
+    return this.subgraphs.size;
   }
 
   names(): readonly string[] {

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -30,6 +30,88 @@ export class MultiMap<K, V> extends Map<K, V[]> {
 }
 
 /**
+ * Generic OrderedMap class that can sort keys based on an arbitrary sorting function
+ * Insert time is O(log(N))
+ * Remove is not implemented, but the trivial implementation would be O(N)
+ * Uses '<' '>' sorting by default
+ * Collisions are fine, it will just overwrite the old value
+ */
+export class OrderedMap<K,V> {
+  private _keys: K[] = [];
+  private _values: Map<K,V> = new Map<K,V>();
+  private _compareFn: (a: K, b: K) => number;
+
+  private static defaultCompareFn<K>(a: K, b: K) {
+    if (a < b) {
+      return -1;
+    } else if (b < a) {
+      return 1;
+    }
+    return 0;
+  }
+
+  constructor(compareFn: (a: K, b: K) => number = OrderedMap.defaultCompareFn) {
+    this._compareFn = compareFn;
+  }
+
+  add(key: K, value: V) {
+    if (!this._values.has(key)) {
+      this.insertKeyInOrder(key);
+    }
+    this._values.set(key, value);
+  }
+
+  get(key: K): V | undefined {
+    return this._values.get(key);
+  }
+
+  has(key: K): boolean {
+    return this._values.has(key);
+  }
+
+  size(): number {
+    return this._keys.length;
+  }
+
+  keys(): K[] {
+    return this._keys;
+  }
+
+  values(): V[] {
+    return this._keys.map(key => {
+      const v = this._values.get(key);
+      assert(v, 'value for known key not found in OrderedMap');
+      return v;
+    });
+  }
+
+  // O(log(N)) - find location via middle finding
+  private insertKeyInOrder(key: K) {
+    let lower = 0;
+    let upper = this._keys.length - 1;
+    while (lower <= upper) {
+      const middle = Math.floor((upper + lower) / 2);
+      if (this._compareFn(this._keys[middle], key) < 0) {
+        lower = middle + 1;
+      } else {
+        upper = middle - 1;
+      }
+    }
+    this._keys = this._keys.slice(0, lower).concat(key).concat(this._keys.slice(lower));
+  }
+
+  // remove(key: K): void - not implemented
+
+  *[Symbol.iterator]() {
+    for (let i = 0; i < this._keys.length; i += 1) {
+      const v = this._values.get(this._keys[i]);
+      assert(v, 'value for known key not found in OrderedMap');
+      yield v;
+    }
+  }
+}
+
+/**
  * Tests if the provided arrays have the same elements (using '===' equality or the provided
  * equality function).
  * This is _not_ a deep equality by default, though you can build one somewhat when passing

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -69,7 +69,7 @@ export class OrderedMap<K,V> {
     return this._values.has(key);
   }
 
-  size(): number {
+  get size() {
     return this._keys.length;
   }
 


### PR DESCRIPTION
Two non-functional changes:
- Rather than having Subgraphs keep track of ordering, split out logic into OrderedMap class
- latest() asserts there is a latest version rather than potentially returning undefined
