### PR TITLE
change Element parent type to remove undefined

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -394,7 +394,7 @@ class Merger {
         }
         const previous = this.merged.type(type.name);
         if (!previous) {
-          this.merged.addType(newNamedType(type.kind, type.name));
+          this.merged.addType(newNamedType(this.merged, type.kind, type.name));
         } else if (previous.kind !== type.kind) {
           mismatchedTypes.add(type.name);
         }
@@ -414,7 +414,7 @@ class Merger {
           continue;
         }
         if (!this.merged.directive(directive.name)) {
-          this.merged.addDirectiveDefinition(new DirectiveDefinition(directive.name));
+          this.merged.addDirectiveDefinition(new DirectiveDefinition(this.merged, directive.name));
         }
       }
     }

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -975,7 +975,7 @@ class Merger {
     dest: T,
     allTypesEqual: boolean
   ) {
-    if (!this.needsJoinField(sources, dest.parent!.name, allTypesEqual)) {
+    if (!this.needsJoinField(sources, dest.parent.name, allTypesEqual)) {
       return;
     }
     const joinFieldDirective = joinSpec.fieldDirective(this.merged);

--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -114,8 +114,8 @@ expect.extend({
 
 test('building a simple schema programatically', () => {
   const schema = new Schema(federationBuiltIns);
-  const queryType = schema.schemaDefinition.setRoot('query', schema.addType(new ObjectType('Query'))).type;
-  const typeA = schema.addType(new ObjectType('A'));
+  const queryType = schema.schemaDefinition.setRoot('query', schema.addType(new ObjectType(schema, 'Query'))).type;
+  const typeA = schema.addType(new ObjectType(schema, 'A'));
   const key = federationBuiltIns.keyDirective(schema);
 
   queryType.addField('a', typeA);

--- a/internals-js/src/buildSchema.ts
+++ b/internals-js/src/buildSchema.ts
@@ -300,7 +300,7 @@ function buildNamedTypeInner(
 }
 
 function buildFieldDefinitionInner(fieldNode: FieldDefinitionNode, field: FieldDefinition<any>) {
-  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema()!);
+  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema());
   field.type = ensureOutputType(type, field.coordinate, fieldNode);
   for (const inputValueDef of fieldNode.arguments ?? []) {
     buildArgumentDefinitionInner(inputValueDef, field.addArgument(inputValueDef.name.value));
@@ -346,7 +346,7 @@ function buildTypeReferenceFromAST(typeNode: TypeNode, schema: Schema): Type {
 }
 
 function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: ArgumentDefinition<any>) {
-  const type = buildTypeReferenceFromAST(inputNode.type, arg.schema()!);
+  const type = buildTypeReferenceFromAST(inputNode.type, arg.schema());
   arg.type = ensureInputType(type, arg.coordinate, inputNode);
   arg.defaultValue = buildValue(inputNode.defaultValue);
   buildAppliedDirectives(inputNode, arg);
@@ -355,7 +355,7 @@ function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: 
 }
 
 function buildInputFieldDefinitionInner(fieldNode: InputValueDefinitionNode, field: InputFieldDefinition) {
-  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema()!);
+  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema());
   field.type = ensureInputType(type, field.coordinate, fieldNode);
   field.defaultValue = buildValue(fieldNode.defaultValue);
   buildAppliedDirectives(fieldNode, field);

--- a/internals-js/src/buildSchema.ts
+++ b/internals-js/src/buildSchema.ts
@@ -57,7 +57,7 @@ function buildValue(value?: ValueNode): any {
   //   - for ID, which accepts strings and int, we don't get int converted to string.
   //   - for floats, we get either int or float, we don't get int converted to float.
   //   - we don't get any custom coercion (but neither is buildSchema in graphQL-js anyway).
-  // 2) type validation. 
+  // 2) type validation.
   return value ? valueFromASTUntyped(value) : undefined;
 }
 
@@ -91,7 +91,7 @@ export function buildSchemaFromAST(documentNode: DocumentNode, builtIns: BuiltIn
       case 'SchemaExtension':
         buildSchemaDefinitionInner(
           definitionNode,
-          schema.schemaDefinition, 
+          schema.schemaDefinition,
           schema.schemaDefinition.newExtension());
         break;
       case 'ScalarTypeDefinition':
@@ -144,7 +144,7 @@ function buildNamedTypeAndDirectivesShallow(documentNode: DocumentNode, schema: 
         // But at the same time, we want to allow redefining built-in types, because some users do it.
         const existing = schema.type(definitionNode.name.value);
         if (!existing || existing.isBuiltIn) {
-          schema.addType(newNamedType(withoutTrailingDefinition(definitionNode.kind), definitionNode.name.value));
+          schema.addType(newNamedType(schema, withoutTrailingDefinition(definitionNode.kind), definitionNode.name.value));
         }
         break;
       case 'DirectiveDefinition':

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -48,12 +48,12 @@ export abstract class FeatureDefinition {
   }
 
   isSpecType(type: NamedType): boolean {
-    const nameInSchema = this.nameInSchema(type.schema()!);
+    const nameInSchema = this.nameInSchema(type.schema());
     return nameInSchema !== undefined && type.name.startsWith(`${nameInSchema}__`);
   }
 
   isSpecDirective(directive: DirectiveDefinition): boolean {
-    const nameInSchema = this.nameInSchema(directive.schema()!);
+    const nameInSchema = this.nameInSchema(directive.schema());
     return nameInSchema != undefined && (directive.name === nameInSchema || directive.name.startsWith(`${nameInSchema}__`));
   }
 
@@ -127,11 +127,11 @@ export function isCoreSpecDirectiveApplication(directive: Directive<SchemaDefini
     return false;
   }
   const featureArg = definition.argument('feature');
-  if (!featureArg || !sameType(featureArg.type!, new NonNullType(directive.schema()!.stringType()))) {
+  if (!featureArg || !sameType(featureArg.type!, new NonNullType(directive.schema().stringType()))) {
     return false;
   }
   const asArg = definition.argument('as');
-  if (asArg && !sameType(asArg.type!, directive.schema()!.stringType())) {
+  if (asArg && !sameType(asArg.type!, directive.schema().stringType())) {
     return false;
   }
   if (!definition.repeatable || definition.locations.length !== 1 || definition.locations[0] !== DirectiveLocation.SCHEMA) {

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -95,11 +95,11 @@ export abstract class FeatureDefinition {
   }
 
   protected addScalarType(schema: Schema, name: string): ScalarType {
-    return schema.addType(new ScalarType(this.elementNameInSchema(schema, name)!));
+    return schema.addType(new ScalarType(schema, this.elementNameInSchema(schema, name)!));
   }
 
   protected addEnumType(schema: Schema, name: string): EnumType {
-    return schema.addType(new EnumType(this.elementNameInSchema(schema, name)!));
+    return schema.addType(new EnumType(schema, this.elementNameInSchema(schema, name)!));
   }
 
   protected featureInSchema(schema: Schema): CoreFeature | undefined {
@@ -173,7 +173,7 @@ export class CoreSpecDefinition extends FeatureDefinition {
     core.addArgument('feature', new NonNullType(schema.stringType()));
     core.addArgument('as', schema.stringType());
     if (this.supportPurposes()) {
-      const purposeEnum = schema.addType(new EnumType(`${nameInSchema}__Purpose`));
+      const purposeEnum = schema.addType(new EnumType(schema, `${nameInSchema}__Purpose`));
       for (const purpose of corePurposes) {
         purposeEnum.addValue(purpose).description = purposesDescription(purpose);
       }
@@ -281,7 +281,7 @@ export class FeatureVersion {
    * ```
    * expect(FeatureVersion.parse('v1.0')).toEqual(new FeatureVersion(1, 0))
    * expect(FeatureVersion.parse('v0.1')).toEqual(new FeatureVersion(0, 1))
-   * expect(FeatureVersion.parse("v987.65432")).toEqual(new FeatureVersion(987, 65432)) 
+   * expect(FeatureVersion.parse("v987.65432")).toEqual(new FeatureVersion(987, 65432))
    * ```
    */
   public static parse(input: string): FeatureVersion {
@@ -327,7 +327,7 @@ export class FeatureVersion {
    * Compares this version to the provide one, returning 1 if it strictly greater, 0 if they are equals, and -1 if this
     * version is strictly smaller. The underlying ordering is that of major version and then minor versions.
    *
-   * Be aware that this ordering does *not* imply compatibility. For example, `FeatureVersion(2, 0) > FeatureVersion(1, 9)`, 
+   * Be aware that this ordering does *not* imply compatibility. For example, `FeatureVersion(2, 0) > FeatureVersion(1, 9)`,
     * but an implementation of `FeatureVersion(2, 0)` *cannot* satisfy a request for `FeatureVersion(1, 9)`. To check for
     * version compatibility, use [the `satisfies` method](#satisfies).
    */
@@ -362,7 +362,7 @@ export class FeatureVersion {
 
   /**
    * return the string version tag, like "v2.9"
-   * 
+   *
    * @returns a version tag
    */
   public toString() {
@@ -371,7 +371,7 @@ export class FeatureVersion {
 
   /**
    * return true iff this version is exactly equal to the provided version
-   * 
+   *
    * @param other the version to compare
    * @returns true if versions are strictly equal
    */
@@ -424,7 +424,7 @@ export class FeatureUrl {
   /**
    * Return true if and only if this spec satisfies the `requested`
    * spec.
-   * 
+   *
    * @param request
    */
   public satisfies(requested: FeatureUrl): boolean {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -1220,13 +1220,13 @@ export class Schema {
     if (existing && !existing.isBuiltIn) {
       throw error(`Type ${type} already exists in this schema`);
     }
-    if (type._attachedToParent) {
-      // For convenience, let's not error out on adding an already added type.
-      if (type.parent == this) {
-        return type;
-      }
-      throw error(`Cannot add type ${type} to this schema; it is already attached to another schema`);
-    }
+    // if (type._attachedToParent) {
+    //   // For convenience, let's not error out on adding an already added type.
+    //   if (type.parent == this) {
+    //     return type;
+    //   }
+    //   throw error(`Cannot add type ${type} to this schema; it is already attached to another schema`);
+    // }
     if (type.isBuiltIn) {
       if (!this.isConstructed) {
         this._builtInTypes.set(type.name, type);

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -82,7 +82,7 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
     if (!typeApplications.length) {
       // Imply the type is in all subgraphs (technically, some subgraphs may not have had this type, but adding it
       // in that case is harmless because it will be unreachable anyway).
-      subgraphs.values().map(sg => sg.schema).forEach(schema => schema.addType(newNamedType(type.kind, type.name)));
+      subgraphs.values().map(sg => sg.schema).forEach(schema => schema.addType(newNamedType(schema, type.kind, type.name)));
     } else {
       for (const application of typeApplications) {
         const args = application.arguments();
@@ -91,7 +91,7 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
         // We can have more than one type directive for a given subgraph
         let subgraphType = schema.type(type.name);
         if (!subgraphType) {
-          subgraphType = schema.addType(newNamedType(type.kind, type.name));
+          subgraphType = schema.addType(newNamedType(schema, type.kind, type.name));
         }
         if (args.key) {
           const directive = subgraphType.applyDirective('key', {'fields': args.key});

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -298,7 +298,7 @@ function addSubgraphObjectOrInterfaceField(
   subgraph: Subgraph,
   encodedType?: string
 ): FieldDefinition<ObjectType | InterfaceType> | undefined {
-  const subgraphType = subgraph.schema.type(supergraphField.parent!.name);
+  const subgraphType = subgraph.schema.type(supergraphField.parent.name);
   if (subgraphType) {
     const copiedType = encodedType
       ? decodeType(encodedType, subgraph.schema, subgraph.name)
@@ -318,7 +318,7 @@ function addSubgraphInputField(
   subgraph: Subgraph,
   encodedType?: string
 ): InputFieldDefinition | undefined {
-  const subgraphType = subgraph.schema.type(supergraphField.parent!.name);
+  const subgraphType = subgraph.schema.type(supergraphField.parent.name);
   if (subgraphType) {
     const copiedType = encodedType
       ? decodeType(encodedType, subgraph.schema, subgraph.name)

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -311,7 +311,7 @@ export class FederationBuiltIns extends BuiltIns {
 
     // Adds the _entities and _service fields to the root query type.
     const queryRoot = schema.schemaDefinition.root("query");
-    const queryType = queryRoot ? queryRoot.type : schema.addType(new ObjectType("Query"));
+    const queryType = queryRoot ? queryRoot.type : schema.addType(new ObjectType(schema, "Query"));
     const entityField = queryType.field(entitiesFieldName);
     if (hasEntities) {
       const anyType = schema.type(anyTypeName);

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -186,7 +186,7 @@ function validateAllFieldSet<TParent extends SchemaElement<any, any>>(
   allowOnNonExternalLeafFields: boolean,
 ): void {
   for (const application of definition.applications()) {
-    const elt = application.parent! as TParent;
+    const elt = application.parent as TParent;
     const type = targetTypeExtractor(elt);
     const targetDescription = targetDescriptionExtractor(elt);
     const parentType = isOnParentType ? type : (elt.parent as NamedType);
@@ -236,7 +236,7 @@ function validateAllExternalFieldsUsed(
 }
 
 function isFieldSatisfyingInterface(field: FieldDefinition<ObjectType | InterfaceType>): boolean {
-  return field.parent!.interfaces().some(itf => itf.field(field.name));
+  return field.parent.interfaces().some(itf => itf.field(field.name));
 }
 
 export class FederationBuiltIns extends BuiltIns {
@@ -384,7 +384,7 @@ export class FederationBuiltIns extends BuiltIns {
     // it.
     validateAllFieldSet<FieldDefinition<CompositeType>>(
       this.requiresDirective(schema),
-      field => field.parent!,
+      field => field.parent,
       field => `field "${field.coordinate}"`,
       errors,
       externalTester,
@@ -495,7 +495,7 @@ export function isFederationTypeName(typeName: string): boolean {
 }
 
 export function isFederationField(field: FieldDefinition<CompositeType>): boolean {
-  if (field.parent === field.schema()!.schemaDefinition.root("query")?.type) {
+  if (field.parent === field.schema().schemaDefinition.root("query")?.type) {
     return FEDERATION_ROOT_FIELDS.includes(field.name);
   }
   return false;
@@ -535,7 +535,7 @@ function validateFieldSetValue(directive: Directive<NamedType | FieldDefinition<
   const fields = directive.arguments().fields;
   if (typeof fields !== 'string') {
     throw new GraphQLError(
-      `Invalid value for argument ${directive.definition!.argument('fields')!.coordinate} on ${directive.parent!.coordinate}: must be a string.`,
+      `Invalid value for argument ${directive.definition!.argument('fields')!.coordinate} on ${directive.parent.coordinate}: must be a string.`,
       directive.sourceAST
     );
   }
@@ -682,7 +682,7 @@ export class ExternalTester {
       return;
     }
     for (const key of keyDirective.applications()) {
-      const parent = key.parent! as CompositeType;
+      const parent = key.parent as CompositeType;
       if (!(key.ofExtension() || parent.hasAppliedDirective(extendsDirectiveName))) {
         continue;
       }

--- a/internals-js/src/introspection.ts
+++ b/internals-js/src/introspection.ts
@@ -11,7 +11,7 @@ export function addIntrospectionFields(schema: Schema) {
   if (schema.type('__Schema')) {
     return;
   }
-  const typeKindEnum = schema.addType(new EnumType('__TypeKind', true));
+  const typeKindEnum = schema.addType(new EnumType(schema, '__TypeKind', true));
   typeKindEnum.addValue('SCALAR');
   typeKindEnum.addValue('OBJECT');
   typeKindEnum.addValue('INTERFACE');
@@ -21,10 +21,10 @@ export function addIntrospectionFields(schema: Schema) {
   typeKindEnum.addValue('LIST');
   typeKindEnum.addValue('NON_NULL');
 
-  const inputValueType = schema.addType(new ObjectType('__InputValue', true));
-  const fieldType = schema.addType(new ObjectType('__Field', true));
-  const typeType = schema.addType(new ObjectType('__Type', true));
-  const enumValueType = schema.addType(new ObjectType('__EnumValue', true));
+  const inputValueType = schema.addType(new ObjectType(schema, '__InputValue', true));
+  const fieldType = schema.addType(new ObjectType(schema, '__Field', true));
+  const typeType = schema.addType(new ObjectType(schema, '__Type', true));
+  const enumValueType = schema.addType(new ObjectType(schema, '__EnumValue', true));
 
   typeType.addField('kind', new NonNullType(typeKindEnum));
   typeType.addField('name', schema.stringType());
@@ -56,19 +56,19 @@ export function addIntrospectionFields(schema: Schema) {
   enumValueType.addField('isDeprecated', new NonNullType(schema.booleanType()));
   enumValueType.addField('deprecationReason', schema.stringType());
 
-  const directiveLocationEnum = schema.addType(new EnumType('__DirectiveLocation', true));
+  const directiveLocationEnum = schema.addType(new EnumType(schema, '__DirectiveLocation', true));
   for (const location of Object.values(DirectiveLocation)) {
     directiveLocationEnum.addValue(location);
   }
 
-  const directiveType = schema.addType(new ObjectType('__Directive', true));
+  const directiveType = schema.addType(new ObjectType(schema, '__Directive', true));
   directiveType.addField('name', new NonNullType(schema.stringType()));
   directiveType.addField('description', schema.stringType());
   directiveType.addField('locations', new NonNullType(new ListType(new NonNullType(directiveLocationEnum))));
   directiveType.addField('args', new NonNullType(new ListType(new NonNullType(inputValueType))));
   directiveType.addField('isRepeatable', new NonNullType(schema.booleanType()));
 
-  const schemaType = schema.addType(new ObjectType('__Schema', true));
+  const schemaType = schema.addType(new ObjectType(schema, '__Schema', true));
   schemaType.addField('description', schema.stringType());
   schemaType.addField('types', new NonNullType(new ListType(new NonNullType(typeType))));
   schemaType.addField('queryType', new NonNullType(typeType));
@@ -78,11 +78,11 @@ export function addIntrospectionFields(schema: Schema) {
 
   let queryRoot = schema.schemaDefinition.rootType('query');
   if (!queryRoot) {
-    queryRoot = schema.addType(new ObjectType('Query'));
+    queryRoot = schema.addType(new ObjectType(schema, 'Query'));
     schema.schemaDefinition.setRoot('query', queryRoot);
   }
 
-  queryRoot.addField(new FieldDefinition('__schema', true), new NonNullType(schemaType));
-  queryRoot.addField(new FieldDefinition('__type', true), typeType)
+  queryRoot.addField(new FieldDefinition(queryRoot, '__schema', true), new NonNullType(schemaType));
+  queryRoot.addField(new FieldDefinition(queryRoot, '__type', true), typeType)
     .addArgument('name', new NonNullType(schema.stringType()));
 }

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -86,7 +86,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     readonly variableDefinitions: VariableDefinitions = new VariableDefinitions(),
     readonly alias?: string
   ) {
-    super(definition.schema()!, variablesInArguments(args));
+    super(definition.schema(), variablesInArguments(args));
     this.validate();
   }
 
@@ -99,7 +99,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
   }
 
   get parentType(): CompositeType {
-    return this.definition.parent!;
+    return this.definition.parent;
   }
 
   withUpdatedDefinition(newDefinition: FieldDefinition<any>): Field<TArgs> {
@@ -180,7 +180,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
 
   updateForAddingTo(selectionSet: SelectionSet): Field<TArgs> {
     const selectionParent = selectionSet.parentType;
-    const fieldParent = this.definition.parent!;
+    const fieldParent = this.definition.parent;
     if (selectionParent.name !== fieldParent.name) {
       if (this.name === typenameFieldName) {
         return this.withUpdatedDefinition(selectionParent.typenameField()!);
@@ -236,7 +236,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
   ) {
     // TODO: we should do some validation here (remove the ! with proper error, and ensure we have some intersection between
     // the source type and the type condition)
-    super(sourceType.schema()!, []);
+    super(sourceType.schema(), []);
     this.typeCondition = typeCondition !== undefined && typeof typeCondition === 'string'
       ? this.schema().type(typeCondition)! as CompositeType
       : typeCondition;
@@ -368,7 +368,7 @@ function addDirectiveNodesToElement(directiveNodes: readonly DirectiveNode[] | u
   if (!directiveNodes) {
     return;
   }
-  const schema = element.schema()!;
+  const schema = element.schema();
   for (const node of directiveNodes) {
     const directiveDef = schema.directive(node.name.value);
     validate(directiveDef, () => `Unknown directive "@${node.name.value}" in selection`)

--- a/internals-js/src/tagSpec.ts
+++ b/internals-js/src/tagSpec.ts
@@ -29,7 +29,7 @@ export class TagSpecDefinition extends FeatureDefinition {
     assert(definition.name === 'tag', () => `This method should not have been called on directive named ${definition.name}`);
     const hasUnknownArguments = Object.keys(definition.arguments()).length > 1;
     const nameArg = definition.argument('name');
-    const hasValidNameArg = nameArg && sameType(nameArg.type!, new NonNullType(definition.schema()!.stringType()));
+    const hasValidNameArg = nameArg && sameType(nameArg.type!, new NonNullType(definition.schema().stringType()));
     const hasValidLocations = definition.locations.every(loc => tagLocations.includes(loc));
     if (hasUnknownArguments || !hasValidNameArg || !hasValidLocations) {
       return error(

--- a/internals-js/src/validate.ts
+++ b/internals-js/src/validate.ts
@@ -300,7 +300,7 @@ class Validator {
         continue;
       }
       if (!isValidValue(value, argument, this.emptyVariables)) {
-        const parent = application.parent!;
+        const parent = application.parent;
         // The only non-named SchemaElement is the `schema` definition.
         const parentDesc = parent instanceof NamedSchemaElement
           ? parent.coordinate

--- a/internals-js/src/values.ts
+++ b/internals-js/src/values.ts
@@ -76,7 +76,7 @@ export function valueToString(v: any, expectedType?: InputType): string {
       if (isEnumType(expectedType)) {
         return v;
       }
-      if (expectedType === expectedType.schema()!.idType() && integerStringRegExp.test(v)) {
+      if (expectedType === expectedType.schema().idType() && integerStringRegExp.test(v)) {
         return v;
       }
     }
@@ -308,7 +308,7 @@ export function valueToAST(value: any, type: InputType): ValueNode | undefined {
     }
 
     // ID types can use Int literals.
-    if (type === type.schema()?.idType() && integerStringRegExp.test(value)) {
+    if (type === type.schema().idType() && integerStringRegExp.test(value)) {
       return { kind: Kind.INT, value: value };
     }
 
@@ -459,7 +459,7 @@ function isValidValueApplication(value: any, locationType: InputType, locationDe
 
   // TODO: we may have to handle some coercions (not sure it matters in our use case
   // though).
-  const schema = locationType.schema()!;
+  const schema = locationType.schema();
 
   if (typeof value === 'boolean') {
     return locationType === schema.booleanType();

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -804,7 +804,7 @@ export function advancePathWithTransition<V extends Vertex>(
 
   const allDeadEnds = deadEnds.concat(pathsWithNonCollecting.deadEnds.reasons);
   if (transition.kind === 'FieldCollection') {
-    const typeName = transition.definition.parent!.name;
+    const typeName = transition.definition.parent.name;
     const fieldName = transition.definition.name;
     const subgraphsWithDeadEnd = new Set(allDeadEnds.map(e => e.destSubgraph));
     for (const [subgraph, schema] of subgraphPath.graph.sources.entries()) {
@@ -1129,7 +1129,7 @@ function advancePathWithDirectTransition<V extends Vertex>(
       // is a @require).
       assert(transition.kind === 'FieldCollection', () => `Shouldn't have conditions on direct transition ${transition}`);
       const field = transition.definition;
-      const parentTypeInSubgraph = path.graph.sources.get(edge.head.source)!.type(field.parent!.name)! as CompositeType;
+      const parentTypeInSubgraph = path.graph.sources.get(edge.head.source)!.type(field.parent.name)! as CompositeType;
       deadEnds.push({
         sourceSubgraph: edge.head.source,
         destSubgraph: edge.head.source,
@@ -1181,7 +1181,7 @@ function warnOnKeyFieldsMarkedExternal(type: CompositeType): string {
   // on their key field. The problem is that doing that make the key field truly external, and that could easily make @require
   // condition no satisfiable (because the key you'd need to get the require is now external). To help user locate that mistake
   // we add a specific pointer to this potential problem is the type is indeed an entity.
-  const keyDirective = federationBuiltIns.keyDirective(type.schema()!);
+  const keyDirective = federationBuiltIns.keyDirective(type.schema());
   const keys = type.appliedDirectivesOf(keyDirective);
   if (keys.length === 0) {
     return "";

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -546,7 +546,7 @@ function federateSubgraphs(subgraphs: QueryGraph[]): QueryGraph {
   const builder = new GraphBuilder(verticesCount);
   rootKinds.forEach(k => builder.createRootVertex(
     k,
-    new ObjectType(federatedGraphRootTypeName(k)),
+    new ObjectType(FEDERATED_GRAPH_ROOT_SCHEMA, federatedGraphRootTypeName(k)), // TODO: I think this one is right?
     FEDERATED_GRAPH_ROOT_SOURCE,
     FEDERATED_GRAPH_ROOT_SCHEMA
   ));

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -1358,7 +1358,7 @@ function createNewFetchSelectionContext(type: CompositeType, selections: Selecti
     return [inputSelection, path];
   }
 
-  const schema = type.schema()!;
+  const schema = type.schema();
   // We add the first include/skip to the current typeCast and then wrap in additional type-casts for the next ones
   // if necessary. Note that we use type-casts (... on <type>), but, outside of the first one, we could well also
   // use fragments with no type-condition. We do the former mostly to preverve older behavior, but doing the latter
@@ -1429,7 +1429,7 @@ function computeGroupsForTree(
 
             assert(isObjectType(edge.head.type) && isObjectType(edge.tail.type), () => `Expected an objects for the vertices of ${edge}`);
             const type = edge.tail.type;
-            assert(type === type.schema()!.schemaDefinition.rootType(rootKind), () => `Expected ${type} to be the root ${rootKind} type, but that is ${type.schema()!.schemaDefinition.rootType(rootKind)}`);
+            assert(type === type.schema().schemaDefinition.rootType(rootKind), () => `Expected ${type} to be the root ${rootKind} type, but that is ${type.schema().schemaDefinition.rootType(rootKind)}`);
 
             // We're querying a field `q` of a subgraph, get one of the root type, and follow with a query on another
             // subgraph. But that mean that on the original subgraph, we may not have added _any_ selection for


### PR DESCRIPTION
Want to get some feedback on this before I spend too much more time on it. Basic issue is that we're doing a lot of type assertions where a client asserts that a parent (or schema) exists, but without any real type safety guarantees.

From my reading of the code, it seems that the parent is always known at creation time and we never reassign the parent. Given this, it seems like the best way to go is to just add the parent as a parameter to the constructor. This creates a bit of weirdness given that there is a lot of code that sets parents after instantiation, but I've basically just disabled that code rather than rewrite it for now. We have support for the onAttached() callback, which I don't 100% understand what it's for, so I'm not sure if that can / should be moved into the constructor or left where it is for now.

Rather than remove the parent reference, I've added a boolean _attachedToParent which tracks the state of whether the element is actually attached. 

Throwing this out there to get comments before I work on it further. I do think it's valuable to try to get rid of type assertions so that we can trust the type system, but wanted to solicit feedback on this particular approach. Thoughts?