### PR TITLE
Make the parent getter assert that parent exists

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -975,7 +975,7 @@ class Merger {
     dest: T,
     allTypesEqual: boolean
   ) {
-    if (!this.needsJoinField(sources, dest.parent!.name, allTypesEqual)) {
+    if (!this.needsJoinField(sources, dest.parent.name, allTypesEqual)) {
       return;
     }
     const joinFieldDirective = joinSpec.fieldDirective(this.merged);

--- a/internals-js/src/buildSchema.ts
+++ b/internals-js/src/buildSchema.ts
@@ -57,7 +57,7 @@ function buildValue(value?: ValueNode): any {
   //   - for ID, which accepts strings and int, we don't get int converted to string.
   //   - for floats, we get either int or float, we don't get int converted to float.
   //   - we don't get any custom coercion (but neither is buildSchema in graphQL-js anyway).
-  // 2) type validation. 
+  // 2) type validation.
   return value ? valueFromASTUntyped(value) : undefined;
 }
 
@@ -91,7 +91,7 @@ export function buildSchemaFromAST(documentNode: DocumentNode, builtIns: BuiltIn
       case 'SchemaExtension':
         buildSchemaDefinitionInner(
           definitionNode,
-          schema.schemaDefinition, 
+          schema.schemaDefinition,
           schema.schemaDefinition.newExtension());
         break;
       case 'ScalarTypeDefinition':
@@ -300,7 +300,7 @@ function buildNamedTypeInner(
 }
 
 function buildFieldDefinitionInner(fieldNode: FieldDefinitionNode, field: FieldDefinition<any>) {
-  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema()!);
+  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema());
   field.type = ensureOutputType(type, field.coordinate, fieldNode);
   for (const inputValueDef of fieldNode.arguments ?? []) {
     buildArgumentDefinitionInner(inputValueDef, field.addArgument(inputValueDef.name.value));
@@ -346,7 +346,7 @@ function buildTypeReferenceFromAST(typeNode: TypeNode, schema: Schema): Type {
 }
 
 function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: ArgumentDefinition<any>) {
-  const type = buildTypeReferenceFromAST(inputNode.type, arg.schema()!);
+  const type = buildTypeReferenceFromAST(inputNode.type, arg.schema());
   arg.type = ensureInputType(type, arg.coordinate, inputNode);
   arg.defaultValue = buildValue(inputNode.defaultValue);
   buildAppliedDirectives(inputNode, arg);
@@ -355,7 +355,7 @@ function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: 
 }
 
 function buildInputFieldDefinitionInner(fieldNode: InputValueDefinitionNode, field: InputFieldDefinition) {
-  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema()!);
+  const type = buildTypeReferenceFromAST(fieldNode.type, field.schema());
   field.type = ensureInputType(type, field.coordinate, fieldNode);
   field.defaultValue = buildValue(fieldNode.defaultValue);
   buildAppliedDirectives(fieldNode, field);

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -49,12 +49,12 @@ export abstract class FeatureDefinition {
   }
 
   isSpecType(type: NamedType): boolean {
-    const nameInSchema = this.nameInSchema(type.schema()!);
+    const nameInSchema = this.nameInSchema(type.schema());
     return nameInSchema !== undefined && type.name.startsWith(`${nameInSchema}__`);
   }
 
   isSpecDirective(directive: DirectiveDefinition): boolean {
-    const nameInSchema = this.nameInSchema(directive.schema()!);
+    const nameInSchema = this.nameInSchema(directive.schema());
     return nameInSchema != undefined && (directive.name === nameInSchema || directive.name.startsWith(`${nameInSchema}__`));
   }
 
@@ -128,11 +128,11 @@ export function isCoreSpecDirectiveApplication(directive: Directive<SchemaDefini
     return false;
   }
   const featureArg = definition.argument('feature');
-  if (!featureArg || !sameType(featureArg.type!, new NonNullType(directive.schema()!.stringType()))) {
+  if (!featureArg || !sameType(featureArg.type!, new NonNullType(directive.schema().stringType()))) {
     return false;
   }
   const asArg = definition.argument('as');
-  if (asArg && !sameType(asArg.type!, directive.schema()!.stringType())) {
+  if (asArg && !sameType(asArg.type!, directive.schema().stringType())) {
     return false;
   }
   if (!definition.repeatable || definition.locations.length !== 1 || definition.locations[0] !== DirectiveLocation.SCHEMA) {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -2531,7 +2531,7 @@ export class Directive<
   }
 
   private isAttachedToSchemaElement(): boolean {
-    return this._parent !== undefined && this._parent instanceof SchemaElement;
+    return this.isAttached();
   }
 
   setArguments(args: TArgs) {

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -298,7 +298,7 @@ function addSubgraphObjectOrInterfaceField(
   subgraph: Subgraph,
   encodedType?: string
 ): FieldDefinition<ObjectType | InterfaceType> | undefined {
-  const subgraphType = subgraph.schema.type(supergraphField.parent!.name);
+  const subgraphType = subgraph.schema.type(supergraphField.parent.name);
   if (subgraphType) {
     const copiedType = encodedType
       ? decodeType(encodedType, subgraph.schema, subgraph.name)
@@ -318,7 +318,7 @@ function addSubgraphInputField(
   subgraph: Subgraph,
   encodedType?: string
 ): InputFieldDefinition | undefined {
-  const subgraphType = subgraph.schema.type(supergraphField.parent!.name);
+  const subgraphType = subgraph.schema.type(supergraphField.parent.name);
   if (subgraphType) {
     const copiedType = encodedType
       ? decodeType(encodedType, subgraph.schema, subgraph.name)

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -186,7 +186,7 @@ function validateAllFieldSet<TParent extends SchemaElement<any, any>>(
   allowOnNonExternalLeafFields: boolean,
 ): void {
   for (const application of definition.applications()) {
-    const elt = application.parent! as TParent;
+    const elt = application.parent as TParent;
     const type = targetTypeExtractor(elt);
     const targetDescription = targetDescriptionExtractor(elt);
     const parentType = isOnParentType ? type : (elt.parent as NamedType);
@@ -236,7 +236,7 @@ function validateAllExternalFieldsUsed(
 }
 
 function isFieldSatisfyingInterface(field: FieldDefinition<ObjectType | InterfaceType>): boolean {
-  return field.parent!.interfaces().some(itf => itf.field(field.name));
+  return field.parent.interfaces().some(itf => itf.field(field.name));
 }
 
 export class FederationBuiltIns extends BuiltIns {
@@ -384,7 +384,7 @@ export class FederationBuiltIns extends BuiltIns {
     // it.
     validateAllFieldSet<FieldDefinition<CompositeType>>(
       this.requiresDirective(schema),
-      field => field.parent!,
+      field => field.parent,
       field => `field "${field.coordinate}"`,
       errors,
       externalTester,
@@ -495,7 +495,7 @@ export function isFederationTypeName(typeName: string): boolean {
 }
 
 export function isFederationField(field: FieldDefinition<CompositeType>): boolean {
-  if (field.parent === field.schema()!.schemaDefinition.root("query")?.type) {
+  if (field.parent === field.schema().schemaDefinition.root("query")?.type) {
     return FEDERATION_ROOT_FIELDS.includes(field.name);
   }
   return false;
@@ -535,7 +535,7 @@ function validateFieldSetValue(directive: Directive<NamedType | FieldDefinition<
   const fields = directive.arguments().fields;
   if (typeof fields !== 'string') {
     throw new GraphQLError(
-      `Invalid value for argument ${directive.definition!.argument('fields')!.coordinate} on ${directive.parent!.coordinate}: must be a string.`,
+      `Invalid value for argument ${directive.definition!.argument('fields')!.coordinate} on ${directive.parent.coordinate}: must be a string.`,
       directive.sourceAST
     );
   }
@@ -672,7 +672,7 @@ export class ExternalTester {
       return;
     }
     for (const key of keyDirective.applications()) {
-      const parent = key.parent! as CompositeType;
+      const parent = key.parent as CompositeType;
       if (!(key.ofExtension() || parent.hasAppliedDirective(extendsDirectiveName))) {
         continue;
       }

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -86,7 +86,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     readonly variableDefinitions: VariableDefinitions = new VariableDefinitions(),
     readonly alias?: string
   ) {
-    super(definition.schema()!, variablesInArguments(args));
+    super(definition.schema(), variablesInArguments(args));
     this.validate();
   }
 
@@ -99,7 +99,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
   }
 
   get parentType(): CompositeType {
-    return this.definition.parent!;
+    return this.definition.parent;
   }
 
   withUpdatedDefinition(newDefinition: FieldDefinition<any>): Field<TArgs> {
@@ -180,7 +180,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
 
   updateForAddingTo(selectionSet: SelectionSet): Field<TArgs> {
     const selectionParent = selectionSet.parentType;
-    const fieldParent = this.definition.parent!;
+    const fieldParent = this.definition.parent;
     if (selectionParent.name !== fieldParent.name) {
       if (this.name === typenameFieldName) {
         return this.withUpdatedDefinition(selectionParent.typenameField()!);
@@ -236,7 +236,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
   ) {
     // TODO: we should do some validation here (remove the ! with proper error, and ensure we have some intersection between
     // the source type and the type condition)
-    super(sourceType.schema()!, []);
+    super(sourceType.schema(), []);
     this.typeCondition = typeCondition !== undefined && typeof typeCondition === 'string'
       ? this.schema().type(typeCondition)! as CompositeType
       : typeCondition;
@@ -368,7 +368,7 @@ function addDirectiveNodesToElement(directiveNodes: readonly DirectiveNode[] | u
   if (!directiveNodes) {
     return;
   }
-  const schema = element.schema()!;
+  const schema = element.schema();
   for (const node of directiveNodes) {
     const directiveDef = schema.directive(node.name.value);
     validate(directiveDef, () => `Unknown directive "@${node.name.value}" in selection`)

--- a/internals-js/src/tagSpec.ts
+++ b/internals-js/src/tagSpec.ts
@@ -29,7 +29,7 @@ export class TagSpecDefinition extends FeatureDefinition {
     assert(definition.name === 'tag', () => `This method should not have been called on directive named ${definition.name}`);
     const hasUnknownArguments = Object.keys(definition.arguments()).length > 1;
     const nameArg = definition.argument('name');
-    const hasValidNameArg = nameArg && sameType(nameArg.type!, new NonNullType(definition.schema()!.stringType()));
+    const hasValidNameArg = nameArg && sameType(nameArg.type!, new NonNullType(definition.schema().stringType()));
     const hasValidLocations = definition.locations.every(loc => tagLocations.includes(loc));
     if (hasUnknownArguments || !hasValidNameArg || !hasValidLocations) {
       return error(

--- a/internals-js/src/validate.ts
+++ b/internals-js/src/validate.ts
@@ -300,7 +300,7 @@ class Validator {
         continue;
       }
       if (!isValidValue(value, argument, this.emptyVariables)) {
-        const parent = application.parent!;
+        const parent = application.parent;
         // The only non-named SchemaElement is the `schema` definition.
         const parentDesc = parent instanceof NamedSchemaElement
           ? parent.coordinate

--- a/internals-js/src/values.ts
+++ b/internals-js/src/values.ts
@@ -76,7 +76,7 @@ export function valueToString(v: any, expectedType?: InputType): string {
       if (isEnumType(expectedType)) {
         return v;
       }
-      if (expectedType === expectedType.schema()!.idType() && integerStringRegExp.test(v)) {
+      if (expectedType === expectedType.schema().idType() && integerStringRegExp.test(v)) {
         return v;
       }
     }
@@ -308,7 +308,7 @@ export function valueToAST(value: any, type: InputType): ValueNode | undefined {
     }
 
     // ID types can use Int literals.
-    if (type === type.schema()?.idType() && integerStringRegExp.test(value)) {
+    if (type === type.schema().idType() && integerStringRegExp.test(value)) {
       return { kind: Kind.INT, value: value };
     }
 
@@ -459,7 +459,7 @@ function isValidValueApplication(value: any, locationType: InputType, locationDe
 
   // TODO: we may have to handle some coercions (not sure it matters in our use case
   // though).
-  const schema = locationType.schema()!;
+  const schema = locationType.schema();
 
   if (typeof value === 'boolean') {
     return locationType === schema.booleanType();

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -804,7 +804,7 @@ export function advancePathWithTransition<V extends Vertex>(
 
   const allDeadEnds = deadEnds.concat(pathsWithNonCollecting.deadEnds.reasons);
   if (transition.kind === 'FieldCollection') {
-    const typeName = transition.definition.parent!.name;
+    const typeName = transition.definition.parent.name;
     const fieldName = transition.definition.name;
     const subgraphsWithDeadEnd = new Set(allDeadEnds.map(e => e.destSubgraph));
     for (const [subgraph, schema] of subgraphPath.graph.sources.entries()) {
@@ -1129,7 +1129,7 @@ function advancePathWithDirectTransition<V extends Vertex>(
       // is a @require).
       assert(transition.kind === 'FieldCollection', () => `Shouldn't have conditions on direct transition ${transition}`);
       const field = transition.definition;
-      const parentTypeInSubgraph = path.graph.sources.get(edge.head.source)!.type(field.parent!.name)! as CompositeType;
+      const parentTypeInSubgraph = path.graph.sources.get(edge.head.source)!.type(field.parent.name)! as CompositeType;
       deadEnds.push({
         sourceSubgraph: edge.head.source,
         destSubgraph: edge.head.source,
@@ -1181,7 +1181,7 @@ function warnOnKeyFieldsMarkedExternal(type: CompositeType): string {
   // on their key field. The problem is that doing that make the key field truly external, and that could easily make @require
   // condition no satisfiable (because the key you'd need to get the require is now external). To help user locate that mistake
   // we add a specific pointer to this potential problem is the type is indeed an entity.
-  const keyDirective = federationBuiltIns.keyDirective(type.schema()!);
+  const keyDirective = federationBuiltIns.keyDirective(type.schema());
   const keys = type.appliedDirectivesOf(keyDirective);
   if (keys.length === 0) {
     return "";

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -1358,7 +1358,7 @@ function createNewFetchSelectionContext(type: CompositeType, selections: Selecti
     return [inputSelection, path];
   }
 
-  const schema = type.schema()!;
+  const schema = type.schema();
   // We add the first include/skip to the current typeCast and then wrap in additional type-casts for the next ones
   // if necessary. Note that we use type-casts (... on <type>), but, outside of the first one, we could well also
   // use fragments with no type-condition. We do the former mostly to preverve older behavior, but doing the latter
@@ -1429,7 +1429,7 @@ function computeGroupsForTree(
 
             assert(isObjectType(edge.head.type) && isObjectType(edge.tail.type), () => `Expected an objects for the vertices of ${edge}`);
             const type = edge.tail.type;
-            assert(type === type.schema()!.schemaDefinition.rootType(rootKind), () => `Expected ${type} to be the root ${rootKind} type, but that is ${type.schema()!.schemaDefinition.rootType(rootKind)}`);
+            assert(type === type.schema().schemaDefinition.rootType(rootKind), () => `Expected ${type} to be the root ${rootKind} type, but that is ${type.schema().schemaDefinition.rootType(rootKind)}`);
 
             // We're querying a field `q` of a subgraph, get one of the root type, and follow with a query on another
             // subgraph. But that mean that on the original subgraph, we may not have added _any_ selection for


### PR DESCRIPTION
Rather than forcing clients to check or assert that the parent exists, do it in the getter. The rest of the changes are either fallouts of this decision or cleaning up type assertions.

Note that in some cases, we had internal functions start accessing the _parent value directly rather than through the parent getter because they are checking to see if the parent exists while in an intermediate state

For example, code in the Element hierarchy that looked like this:
```typescript
if (this.parent?.schema()) {
}
```

Now looks like this:
```typescript
if (this._parent?.schema()) {
}
```