### PR TITLE
Fix tests to force DNS failure

### DIFF
--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'accounts';
-export const url = `https://${name}.api.com`;
+export const url = `https://${name}.api.com.invalid`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD

--- a/federation-integration-testsuite-js/src/fixtures/books.ts
+++ b/federation-integration-testsuite-js/src/fixtures/books.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'books';
-export const url = `https://${name}.api.com`;
+export const url = `https://${name}.api.com.invalid`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD

--- a/federation-integration-testsuite-js/src/fixtures/documents.ts
+++ b/federation-integration-testsuite-js/src/fixtures/documents.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const name = 'documents';
-export const url = `https://${name}.api.com`;
+export const url = `https://${name}.api.com.invalid`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD

--- a/federation-integration-testsuite-js/src/fixtures/inventory.ts
+++ b/federation-integration-testsuite-js/src/fixtures/inventory.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'inventory';
-export const url = `https://${name}.api.com`;
+export const url = `https://${name}.api.com.invalid`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD

--- a/federation-integration-testsuite-js/src/fixtures/product.ts
+++ b/federation-integration-testsuite-js/src/fixtures/product.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'product';
-export const url = `https://${name}.api.com`;
+export const url = `https://${name}.api.com.invalid`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD

--- a/federation-integration-testsuite-js/src/fixtures/reviews.ts
+++ b/federation-integration-testsuite-js/src/fixtures/reviews.ts
@@ -2,7 +2,7 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 import gql from 'graphql-tag';
 
 export const name = 'reviews';
-export const url = `https://${name}.api.com`;
+export const url = `https://${name}.api.com.invalid`;
 export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD

--- a/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
+++ b/federation-js/src/service/__tests__/printSupergraphSdl.test.ts
@@ -183,12 +183,12 @@ describe('printSupergraphSdl', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        ACCOUNTS @join__graph(name: \\"accounts\\", url: \\"https://accounts.api.com\\")
-        BOOKS @join__graph(name: \\"books\\", url: \\"https://books.api.com\\")
-        DOCUMENTS @join__graph(name: \\"documents\\", url: \\"https://documents.api.com\\")
-        INVENTORY @join__graph(name: \\"inventory\\", url: \\"https://inventory.api.com\\")
-        PRODUCT @join__graph(name: \\"product\\", url: \\"https://product.api.com\\")
-        REVIEWS @join__graph(name: \\"reviews\\", url: \\"https://reviews.api.com\\")
+        ACCOUNTS @join__graph(name: \\"accounts\\", url: \\"https://accounts.api.com.invalid\\")
+        BOOKS @join__graph(name: \\"books\\", url: \\"https://books.api.com.invalid\\")
+        DOCUMENTS @join__graph(name: \\"documents\\", url: \\"https://documents.api.com.invalid\\")
+        INVENTORY @join__graph(name: \\"inventory\\", url: \\"https://inventory.api.com.invalid\\")
+        PRODUCT @join__graph(name: \\"product\\", url: \\"https://product.api.com.invalid\\")
+        REVIEWS @join__graph(name: \\"reviews\\", url: \\"https://reviews.api.com.invalid\\")
       }
 
       scalar JSON
@@ -573,12 +573,12 @@ describe('printSupergraphSdl', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        ACCOUNTS @join__graph(name: \\"accounts\\", url: \\"https://accounts.api.com\\")
-        BOOKS @join__graph(name: \\"books\\", url: \\"https://books.api.com\\")
-        DOCUMENTS @join__graph(name: \\"documents\\", url: \\"https://documents.api.com\\")
-        INVENTORY @join__graph(name: \\"inventory\\", url: \\"https://inventory.api.com\\")
-        PRODUCT @join__graph(name: \\"product\\", url: \\"https://product.api.com\\")
-        REVIEWS @join__graph(name: \\"reviews\\", url: \\"https://reviews.api.com\\")
+        ACCOUNTS @join__graph(name: \\"accounts\\", url: \\"https://accounts.api.com.invalid\\")
+        BOOKS @join__graph(name: \\"books\\", url: \\"https://books.api.com.invalid\\")
+        DOCUMENTS @join__graph(name: \\"documents\\", url: \\"https://documents.api.com.invalid\\")
+        INVENTORY @join__graph(name: \\"inventory\\", url: \\"https://inventory.api.com.invalid\\")
+        PRODUCT @join__graph(name: \\"product\\", url: \\"https://product.api.com.invalid\\")
+        REVIEWS @join__graph(name: \\"reviews\\", url: \\"https://reviews.api.com.invalid\\")
       }
 
       type KeyValue

--- a/gateway-js/src/__tests__/gateway/composedSdl.test.ts
+++ b/gateway-js/src/__tests__/gateway/composedSdl.test.ts
@@ -35,7 +35,7 @@ describe('Using supergraphSdl configuration', () => {
     `);
 
     const [url, request] = fetch.mock.calls[0];
-    expect(url).toEqual('https://accounts.api.com');
+    expect(url).toEqual('https://accounts.api.com.invalid');
     expect(request?.body).toEqual(
       JSON.stringify({ query: '{me{username}}', variables: {} }),
     );

--- a/gateway-js/src/__tests__/loadServicesFromRemoteEndpoint.test.ts
+++ b/gateway-js/src/__tests__/loadServicesFromRemoteEndpoint.test.ts
@@ -19,7 +19,7 @@ describe('getServiceDefinitionsFromRemoteEndpoint', () => {
 
   it('throws when the downstream service returns errors', async () => {
     const serviceSdlCache = new Map<string, string>();
-    const host = 'http://host-which-better-not-resolve';
+    const host = 'http://host-which-better-not-resolve.invalid';
     const url = host + '/graphql';
 
     const dataSource = new RemoteGraphQLDataSource({ url });
@@ -34,7 +34,7 @@ describe('getServiceDefinitionsFromRemoteEndpoint', () => {
         getServiceIntrospectionHeaders: async () => ({}),
       }),
     ).rejects.toThrowError(
-      /^Couldn't load service definitions for "test" at http:\/\/host-which-better-not-resolve\/graphql: request to http:\/\/host-which-better-not-resolve\/graphql failed, reason: getaddrinfo (ENOTFOUND|EAI_AGAIN)/,
+      /^Couldn't load service definitions for "test" at http:\/\/host-which-better-not-resolve.invalid\/graphql: request to http:\/\/host-which-better-not-resolve.invalid\/graphql failed, reason: getaddrinfo (ENOTFOUND|EAI_AGAIN)/,
     );
   });
 });

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -193,12 +193,12 @@ describe('loadSupergraphSdlFromStorage', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        ACCOUNTS @join__graph(name: \\"accounts\\", url: \\"https://accounts.api.com\\")
-        BOOKS @join__graph(name: \\"books\\", url: \\"https://books.api.com\\")
-        DOCUMENTS @join__graph(name: \\"documents\\", url: \\"https://documents.api.com\\")
-        INVENTORY @join__graph(name: \\"inventory\\", url: \\"https://inventory.api.com\\")
-        PRODUCT @join__graph(name: \\"product\\", url: \\"https://product.api.com\\")
-        REVIEWS @join__graph(name: \\"reviews\\", url: \\"https://reviews.api.com\\")
+        ACCOUNTS @join__graph(name: \\"accounts\\", url: \\"https://accounts.api.com.invalid\\")
+        BOOKS @join__graph(name: \\"books\\", url: \\"https://books.api.com.invalid\\")
+        DOCUMENTS @join__graph(name: \\"documents\\", url: \\"https://documents.api.com.invalid\\")
+        INVENTORY @join__graph(name: \\"inventory\\", url: \\"https://inventory.api.com.invalid\\")
+        PRODUCT @join__graph(name: \\"product\\", url: \\"https://product.api.com.invalid\\")
+        REVIEWS @join__graph(name: \\"reviews\\", url: \\"https://reviews.api.com.invalid\\")
       }
 
       scalar JSON

--- a/gateway-js/src/core/__tests__/core.test.ts
+++ b/gateway-js/src/core/__tests__/core.test.ts
@@ -41,7 +41,7 @@ describe('core v0.1', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        WORLD @join__graph(name: "world", url: "https://world.api.com")
+        WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
       }
 
       type Query {
@@ -97,7 +97,7 @@ describe('core v0.1', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        WORLD @join__graph(name: "world", url: "https://world.api.com")
+        WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
       }
 
       type Query {
@@ -173,7 +173,7 @@ describe('core v0.2', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        WORLD @join__graph(name: "world", url: "https://world.api.com")
+        WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
       }
 
       type Query {
@@ -243,7 +243,7 @@ describe('core v0.2', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        WORLD @join__graph(name: "world", url: "https://world.api.com")
+        WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
       }
 
       type Query {
@@ -315,7 +315,7 @@ describe('core v0.2', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        WORLD @join__graph(name: "world", url: "https://world.api.com")
+        WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
       }
 
       type Query {
@@ -391,7 +391,7 @@ describe('core v0.2', () => {
       scalar join__FieldSet
 
       enum join__Graph {
-        WORLD @join__graph(name: "world", url: "https://world.api.com")
+        WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
       }
 
       type Query {


### PR DESCRIPTION
AT&T decides that it wants to resolve invalid hostnames to an IP address which causes tests to fail locally. Adding `.invalid` suffix to all bogus hostnames to get around this issue.