### PR TITLE
Backport Release @apollo/federation@0.29.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       # Note: This is a no-op at the second, but bear with me on this.  If this
       # comment is not removed by 2021-06-30 remove it along with the next line.
       # renovate: datasource=github-tags depName=nodejs/node versioning=node
-      NODE_VERSION: 14.16.1
+      NODE_VERSION: 14.17.5
       NPM_VERSION: 7.10.0
     steps:
       - checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- Fix a bug in directive merging logic during composition [PR #1185](https://github.com/apollographql/federation/pull/1185)
 
 ## v0.29.0
 

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Apollo Federation Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-js/src/composition/DirectiveMetadata.ts
+++ b/federation-js/src/composition/DirectiveMetadata.ts
@@ -143,19 +143,12 @@ export class DirectiveMetadata {
         if (!namedType) continue;
 
         const existingMetadata = getFederationMetadata(namedType);
-        let directiveUsages = existingMetadata?.directiveUsages;
-
-        if (directiveUsages && directiveUsages.size > 0) {
-          for (const [directiveName, usages] of directiveUsages.entries()) {
-            usages.push(...(directives.get(directiveName) ?? []));
-          }
-        } else {
-          directiveUsages = directives;
-        }
-
         const typeFederationMetadata: FederationType = {
           ...existingMetadata,
-          directiveUsages,
+          directiveUsages: mergeDirectiveUsages(
+            existingMetadata?.directiveUsages,
+            directives,
+          ),
         };
         namedType.extensions = {
           ...namedType.extensions,
@@ -167,19 +160,13 @@ export class DirectiveMetadata {
           const field = namedType.getFields()[fieldName];
           if (!field) continue;
 
-          const originalMetadata = getFederationMetadata(field);
-          let directiveUsages = originalMetadata?.directiveUsages;
-          if (directiveUsages && directiveUsages.size > 0) {
-            for (const [directiveName, usages] of directiveUsages.entries()) {
-              usages.push(...(usagesPerDirective.get(directiveName) ?? []));
-            }
-          } else {
-            directiveUsages = usagesPerDirective;
-          }
-
+          const existingMetadata = getFederationMetadata(field);
           const fieldFederationMetadata: FederationField = {
-            ...originalMetadata,
-            directiveUsages,
+            ...existingMetadata,
+            directiveUsages: mergeDirectiveUsages(
+              existingMetadata?.directiveUsages,
+              usagesPerDirective,
+            ),
           };
 
           field.extensions = {
@@ -190,4 +177,24 @@ export class DirectiveMetadata {
       }
     }
   }
+}
+
+function mergeDirectiveUsages(
+  first: DirectiveUsages | undefined,
+  second: DirectiveUsages,
+): DirectiveUsages {
+  const merged: DirectiveUsages = new Map();
+
+  if (first) {
+    for (const [directiveName, usages] of first.entries()) {
+      merged.set(directiveName, [...usages]);
+    }
+  }
+
+  for (const [directiveName, newUsages] of second.entries()) {
+    const usages = mapGetOrSet(merged, directiveName, []);
+    usages.push(...newUsages);
+  }
+
+  return merged;
 }

--- a/federation-js/src/composition/__tests__/composeAndValidate.test.ts
+++ b/federation-js/src/composition/__tests__/composeAndValidate.test.ts
@@ -959,24 +959,31 @@ describe('composition of schemas with directives', () => {
 
     expect(compositionResult.supergraphSdl).toMatchInlineSnapshot(`
       "schema
-        @core(feature: \\"https://specs.apollo.dev/core/v0.2\\"),
-        @core(feature: \\"https://specs.apollo.dev/join/v0.1\\", for: EXECUTION),
+        @core(feature: \\"https://specs.apollo.dev/core/v0.1\\"),
+        @core(feature: \\"https://specs.apollo.dev/join/v0.1\\"),
         @core(feature: \\"https://specs.apollo.dev/tag/v0.1\\")
       {
         query: Query
       }
 
-      directive @core(as: String, feature: String!, for: core__Purpose) repeatable on SCHEMA
+      directive @core(feature: String!) repeatable on SCHEMA
 
-      directive @join__field(graph: join__Graph, provides: join__FieldSet, requires: join__FieldSet) on FIELD_DEFINITION
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+      directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+
+      directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
-      directive @join__owner(graph: join__Graph!) on INTERFACE | OBJECT
-
-      directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on INTERFACE | OBJECT
-
       directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+      scalar join__FieldSet
+
+      enum join__Graph {
+        PRODUCTS @join__graph(name: \\"products\\" url: \\"https://products.api.com\\")
+        USERS @join__graph(name: \\"users\\" url: \\"https://users.api.com\\")
+      }
 
       type Product
         @join__owner(graph: PRODUCTS)
@@ -988,25 +995,6 @@ describe('composition of schemas with directives', () => {
 
       type Query {
         topProducts: [Product] @join__field(graph: PRODUCTS)
-      }
-
-      enum core__Purpose {
-        \\"\\"\\"
-        \`EXECUTION\` features provide metadata necessary to for operation execution.
-        \\"\\"\\"
-        EXECUTION
-
-        \\"\\"\\"
-        \`SECURITY\` features provide metadata necessary to securely resolve fields.
-        \\"\\"\\"
-        SECURITY
-      }
-
-      scalar join__FieldSet
-
-      enum join__Graph {
-        PRODUCTS @join__graph(name: \\"products\\" url: \\"https://products.api.com\\")
-        USERS @join__graph(name: \\"users\\" url: \\"https://users.api.com\\")
       }
       "
     `);

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "Apollo Gateway",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/gateway-js/src/__generated__/graphqlTypes.ts
+++ b/gateway-js/src/__generated__/graphqlTypes.ts
@@ -91,7 +91,7 @@ export type Query = {
 export type QueryRouterConfigArgs = {
   ref: Scalars['String'];
   apiKey: Scalars['String'];
-  supportedSpecURLs?: Array<Scalars['String']>;
+  ifAfterId?: Maybe<Scalars['ID']>;
 };
 
 export type Request = {
@@ -106,7 +106,7 @@ export type Response = {
   body?: Maybe<Scalars['String']>;
 };
 
-export type RouterConfigResponse = RouterConfigResult | FetchError;
+export type RouterConfigResponse = RouterConfigResult | Unchanged | FetchError;
 
 export type RouterConfigResult = {
   __typename?: 'RouterConfigResult';
@@ -118,13 +118,18 @@ export type RouterConfigResult = {
 };
 
 
+export type Unchanged = {
+  __typename?: 'Unchanged';
+  id: Scalars['ID'];
+};
+
 export type SupergraphSdlQueryVariables = Exact<{
   apiKey: Scalars['String'];
   ref: Scalars['String'];
 }>;
 
 
-export type SupergraphSdlQuery = { __typename?: 'Query', routerConfig: { __typename: 'RouterConfigResult', id: string, supergraphSdl: string } | { __typename: 'FetchError', code: FetchErrorCode, message: string } };
+export type SupergraphSdlQuery = { __typename?: 'Query', routerConfig: { __typename: 'RouterConfigResult', id: string, supergraphSdl: string } | { __typename: 'Unchanged' } | { __typename: 'FetchError', code: FetchErrorCode, message: string } };
 
 export type OobReportMutationVariables = Exact<{
   input?: Maybe<ApiMonitoringReport>;

--- a/harmonizer/package.json
+++ b/harmonizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/harmonizer",
   "private": true,
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Apollo Federation Harmonizer JS Entrypoint",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/federation": "file:../federation-js",


### PR DESCRIPTION
Additional (out of the ordinary) note! This PR branches from an old release branch for the sake of backporting a fix (https://github.com/apollographql/federation/pull/1185) to a previous version of the federation and gateway packages. Note that this fix is a one-off and will not be backported to all previous versions of `@apollo/federation`. In order to incorporate this fix into your project, you should use the following versions or later:
```
- @apollo/federation@0.33.7
- @apollo/gateway@0.44.0
```
These were released officially as of PR #1214

_Back to your regularly scheduled programming..._

As with release PRs in the past, this is a PR tracking a release-x.y.z branch for an upcoming release. 🙌 The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR). Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. alpha, beta, rc) without affecting the main branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers. The main branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release. Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an -rc.x release suffix. Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the latest npm tag, this PR will be merged into main.