### PR TITLE
Release @apollo/gateway@2.0.0-alpha.2, @apollo/composition@2.0.0-alpha.2, @apollo/query-planner@2.0.0-alpha.2, @apollo/subgraph@2.0.0-alpha.2, @apollo/query-graphs@2.0.0-alpha.2, @apollo/federation-internals@2.0.0-alpha.2.

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -1,4 +1,4 @@
-# CHANGELOG for `@apollo/federation-internals`
+# CHANGELOG for `@apollo/composition`
 
 ## vNEXT
 
@@ -7,6 +7,7 @@
 ## v2.0.0-alpha.2
 
 - __BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)
+- Add missing dependency to `@apollo/query-graphs`
 
 ## v2.0.0-alpha.1
 

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -1,12 +1,17 @@
 # CHANGELOG for `@apollo/gateway`
 
-## vNEXT
+## vNext
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+
+## v2.0.0-alpha.2
 
 - Conditional schema update based on ifAfterId [PR #1152](https://github.com/apollographql/federation/pull/1152)
 - __BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)
 - __BREAKING__: Remove legacy GCS fetcher for schema updates. If you're currently opted-in to the backwards compatibility provided by setting `schemaConfigDeliveryEndpoint: null`, you may be affected by this update. Please see the PR for additional details. [PR #1226](https://github.com/apollographql/federation/pull/1226)
+- Fix the handling of nested `@provides` directives [PR #1148](https://github.com/apollographql/federation/pull/1148).
+- Remove outdated composition code. A concrete consequence of which is the removal of the `@apollo/federation` package. If your code was importing the `ServiceDefinition` interface from `@apollo/federation`, this can now be imported from `@apollo/gateway` [PR #1208](https://github.com/apollographql/federation/pull/1208).
+- Fix query planner sending queries to a subgraph involving interfaces it doesn't know [#817](https://github.com/apollographql/federation/issues/817).
 
 ## v2.0.0-alpha.1
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/harmonizer/package.json
+++ b/harmonizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/harmonizer",
   "private": true,
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Federation Harmonizer JS Entrypoint",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -4,4 +4,11 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
--__BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)
+## v2.0.0-alpha.2
+
+- __BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)
+- Fix the handling of nested `@provides` directives [PR #1148](https://github.com/apollographql/federation/pull/1148).
+
+## v2.0.0-alpha.1
+
+- :tada: Initial alpha release of Federation 2.0.  For more information, see our [documentation](https://www.apollographql.com/docs/federation/v2/).  We look forward to your feedback!

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
--__BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)
+## v2.0.0-alpha.2
+
+- __BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)
+- Fix the handling of nested `@provides` directives [PR #1148](https://github.com/apollographql/federation/pull/1148).
+- Fix query planner sending queries to a subgraph involving interfaces it doesn't know [#817](https://github.com/apollographql/federation/issues/817).
 
 ## v2.0.0-alpha.1
 

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/router-bridge/package.json
+++ b/router-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/router-bridge",
   "private": true,
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Router JS Bridge Entrypoint",
   "scripts": {
     "rollup": "rollup -c ./rollup.config.js"

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+## v2.0.0-alpha.2
+
+- __BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)
+
 ## v2.0.0-alpha.1
 
 - :tada: Initial alpha release of Federation 2.0.  For more information, see our [documentation](https://www.apollographql.com/d      ocs/federation/v2/).  We look forward to your feedback!

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌   The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.
