### PR TITLE
RemoteGraphQLDataSource uses `make-fetch-happen` by default

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1284](https://github.com/apollographql/federation/pull/1284)
+
 ## v2.0.0-alpha.2
 
 - Conditional schema update based on ifAfterId [PR #1152](https://github.com/apollographql/federation/pull/1152)

--- a/gateway-js/src/__mocks__/make-fetch-happen-fetcher.ts
+++ b/gateway-js/src/__mocks__/make-fetch-happen-fetcher.ts
@@ -20,6 +20,7 @@ interface MakeFetchHappenMock extends jest.MockedFunction<typeof fetch> {
 }
 
 const mockMakeFetchHappen = jest.fn(fetcher) as unknown as MakeFetchHappenMock;
+const defaults = () => mockMakeFetchHappen;
 
 mockMakeFetchHappen.mockResponseOnce = (
   data?: BodyInit,
@@ -47,7 +48,8 @@ mockMakeFetchHappen.mockJSONResponseOnce = (
 };
 
 const makeFetchMock = {
-  makeFetchHappenFetcher: mockMakeFetchHappen,
+  fetch: mockMakeFetchHappen,
+  defaults,
 };
 
 jest.doMock('make-fetch-happen', () => makeFetchMock);

--- a/gateway-js/src/__tests__/gateway/buildService.test.ts
+++ b/gateway-js/src/__tests__/gateway/buildService.test.ts
@@ -1,4 +1,4 @@
-import { fetch } from '../../__mocks__/apollo-server-env';
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 
 import { RemoteGraphQLDataSource } from '../../datasources/RemoteGraphQLDataSource';

--- a/gateway-js/src/__tests__/gateway/composedSdl.test.ts
+++ b/gateway-js/src/__tests__/gateway/composedSdl.test.ts
@@ -1,6 +1,6 @@
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import { ApolloGateway } from '@apollo/gateway';
 import { ApolloServer } from 'apollo-server';
-import { fetch } from '../../__mocks__/apollo-server-env';
 import { getTestingSupergraphSdl } from '../execution-utils';
 
 async function getSupergraphSdlGatewayServer() {

--- a/gateway-js/src/__tests__/gateway/executor.test.ts
+++ b/gateway-js/src/__tests__/gateway/executor.test.ts
@@ -1,8 +1,8 @@
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import gql from 'graphql-tag';
 import { ApolloGateway } from '../../';
 import { fixtures } from 'apollo-federation-integration-testsuite';
 import { Logger } from 'apollo-server-types';
-import { fetch } from '../../__mocks__/apollo-server-env';
 
 let logger: {
   warn: jest.MockedFunction<Logger['warn']>,

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -30,6 +30,9 @@ export class RemoteGraphQLDataSource<
       ThisType<RemoteGraphQLDataSource<TContext>>,
   ) {
     this.fetcher = fetcher.defaults({
+      // although this is the default, we want to take extra care and be very
+      // explicity to ensure that mutations cannot be retried. please leave this
+      // intact.
       retry: false,
     });
     if (config) {

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -17,18 +17,21 @@ import { isObject } from '../utilities/predicates';
 import { GraphQLDataSource, GraphQLDataSourceProcessOptions, GraphQLDataSourceRequestKind } from './types';
 import createSHA from 'apollo-server-core/dist/utils/createSHA';
 import { parseCacheControlHeader } from './parseCacheControlHeader';
-
+import fetcher from 'make-fetch-happen';
 export class RemoteGraphQLDataSource<
   TContext extends Record<string, any> = Record<string, any>,
 > implements GraphQLDataSource<TContext>
 {
-  fetcher: typeof fetch = fetch;
+  fetcher: typeof fetch;
 
   constructor(
     config?: Partial<RemoteGraphQLDataSource<TContext>> &
       object &
       ThisType<RemoteGraphQLDataSource<TContext>>,
   ) {
+    this.fetcher = fetcher.defaults({
+      retry: false,
+    });
     if (config) {
       return Object.assign(this, config);
     }

--- a/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -1,5 +1,5 @@
-import { fetch } from '../../__mocks__/apollo-server-env';
-import { makeFetchHappenFetcher } from '../../__mocks__/make-fetch-happen-fetcher';
+import { fetch as customFetcher } from '../../__mocks__/apollo-server-env';
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 
 import {
   ApolloError,
@@ -264,7 +264,7 @@ describe('fetcher', () => {
   });
 
   it('supports a custom fetcher, like `make-fetch-happen`', async () => {
-    const injectedFetch = makeFetchHappenFetcher.mockJSONResponseOnce({
+    const injectedFetch = customFetcher.mockJSONResponseOnce({
       data: { me: 'james' },
     });
     const DataSource = new RemoteGraphQLDataSource({

--- a/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -263,7 +263,7 @@ describe('fetcher', () => {
     expect(data).toEqual({ injected: true });
   });
 
-  it('supports a custom fetcher, like `make-fetch-happen`', async () => {
+  it('supports a custom fetcher, like `node-fetch`', async () => {
     const injectedFetch = customFetcher.mockJSONResponseOnce({
       data: { me: 'james' },
     });


### PR DESCRIPTION
As the subject says. Couple of things that I'm not sure about.

1. When I make a call to `.defaults()` do I need to pass any extra parameters? Didn't look like the `node-fetch` version did, but I want to make sure we don't want to add any extra headers or anything. For reasons stated in #192, I'm being careful and turning off retries completely, but I believe this was also the case in `node-fetch`

2. Obviously this needs to get into the CHANGELOG, but I'm assuming we do that when we cut a new version?

Fixes #192
Fixes #1232