### PR TITLE
Prevent field argument collision in diffTypeNodes

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing to see here. Stay tuned._
+- Fix a bug that would prevent types with similar field arguments from being composed as value types [PR #1298](https://github.com/apollographql/federation/pull/1298)
 
 ## v0.33.8
 

--- a/federation-js/src/composition/__tests__/utils.test.ts
+++ b/federation-js/src/composition/__tests__/utils.test.ts
@@ -1,11 +1,586 @@
 import gql from 'graphql-tag';
 import deepFreeze from 'deep-freeze';
-import { stripExternalFieldsFromTypeDefs } from '../utils';
+import { TypeDefinitionNode } from 'graphql';
+import { stripExternalFieldsFromTypeDefs, diffTypeNodes } from '../utils';
 import { astSerializer } from 'apollo-federation-integration-testsuite';
 
 expect.addSnapshotSerializer(astSerializer);
 
 describe('Composition utility functions', () => {
+  describe('diffTypeNodes', () => {
+    it('should produce an empty diff for the same type', () => {
+      const typeDefs = gql`
+        type Product {
+          name: String
+        }
+      `;
+
+      const def = typeDefs.definitions[0] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(def, def);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on two types with different names', () => {
+      const typeDefs = gql`
+        type A
+        type B
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: ['A','B'],
+        kind: [],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on two different types', () => {
+      const typeDefs = gql`
+        type A
+        input A
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: ['ObjectTypeDefinition', 'InputObjectTypeDefinition'],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on types with different field names', () => {
+      const typeDefs = gql`
+        type A {
+          x: String
+        }
+        type A {
+          y: String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {
+          x: ['String'],
+          y: ['String']
+        },
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on types with different field types', () => {
+      const typeDefs = gql`
+        type A {
+          x: String
+        }
+        type A {
+          x: String!
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {
+          x: ['String','String!'],
+        },
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on types with different field arguments', () => {
+      const typeDefs = gql`
+        type A {
+          x(i: Int): String
+        }
+        type A {
+          x(j: Int): String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {
+          x: {
+            i: ['Int'],
+            j: ['Int']
+          }
+        },
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on types with different number of arguments', () => {
+      const typeDefs = gql`
+        type A {
+          x(i: Int, k: Int): String
+        }
+        type A {
+          x(i: Int): String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {
+          x: {
+            k: ['Int']
+          }
+        },
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on types with different field arguments', () => {
+      const typeDefs = gql`
+        type A {
+          x(i: Int): String
+        }
+        type A {
+          x(j: Int): String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {
+          x: {
+            i: ['Int'],
+            j: ['Int']
+          }
+        },
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on types with field arguments of different types', () => {
+      const typeDefs = gql`
+        type A {
+          x(i: Int): String
+        }
+        type A {
+          x(i: Int!): String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {
+          x: {
+            i: ['Int','Int!']
+          }
+        },
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on inputs with different field names', () => {
+      const typeDefs = gql`
+        input A {
+          x: String
+        }
+        input A {
+          y: String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {
+          x: ['String'],
+          y: ['String']
+        },
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on inputs with different field types', () => {
+      const typeDefs = gql`
+        input A {
+          x: String
+        }
+        input A {
+          x: String!
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {
+          x: ['String','String!'],
+        },
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on interfaces with different field names', () => {
+      const typeDefs = gql`
+        interface A {
+          x: String
+        }
+        interface A {
+          y: String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {
+          x: ['String'],
+          y: ['String']
+        },
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on interface with different field types', () => {
+      const typeDefs = gql`
+        interface A {
+          x: String
+        }
+        interface A {
+          x: String!
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {
+          x: ['String','String!'],
+        },
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on interface with field with different arguments', () => {
+      const typeDefs = gql`
+        interface A {
+          x(i: Int): String
+        }
+        interface A {
+          x(j: Int): String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {
+          x: {
+            i: ['Int'],
+            j: ['Int']
+          }
+        },
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on interface with field with different argument types', () => {
+      const typeDefs = gql`
+        interface A {
+          x(i: Int): String
+        }
+        interface A {
+          x(i: Int!): String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {
+          x: {
+            i: ['Int','Int!']
+          }
+        },
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on interface with field with different number of arguments', () => {
+      const typeDefs = gql`
+        interface A {
+          x(i: Int): String
+        }
+        interface A {
+          x(i: Int, j: String): String
+        }
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {
+          x: {
+            j: ['String']
+          }
+        },
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on two directives with different locations', () => {
+      const typeDefs = gql`
+        directive @custom on FIELD | ENUM
+        directive @custom on FIELD
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [
+          'ENUM'
+        ],
+        directiveArgs: {}
+      });
+    });
+
+    it('should produce a diff on two directives with different arguments', () => {
+      const typeDefs = gql`
+        directive @custom(a: String!) on FIELD
+        directive @custom(b: String!) on FIELD
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {
+          a: ['String!'],
+          b: ['String!']
+        }
+      });
+    });
+
+    it('should produce a diff on two directives with different argument types', () => {
+      const typeDefs = gql`
+        directive @custom(a: String!) on FIELD
+        directive @custom(a: String) on FIELD
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {
+          a: ['String!','String']
+        }
+      });
+    });
+
+    it('should produce a diff on two directives with different number of arguments', () => {
+      const typeDefs = gql`
+        directive @custom(a: String!) on FIELD
+        directive @custom(a: String!, b: Int) on FIELD
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {},
+        locations: [],
+        directiveArgs: {
+          b: ['Int']
+        }
+      });
+    });
+
+    it('should produce a diff for difference union types', () => {
+      const typeDefs = gql`
+        union UnionA = A | B
+        union UnionA = B | C
+      `;
+
+      const defA = typeDefs.definitions[0] as TypeDefinitionNode;
+      const defB = typeDefs.definitions[1] as TypeDefinitionNode;
+
+      const result = diffTypeNodes(defA, defB);
+
+      expect(result).toEqual({
+        name: [],
+        kind: [],
+        fields: {},
+        fieldArgs: {},
+        unionTypes: {
+          A: true,
+          C: true
+        },
+        locations: [],
+        directiveArgs: {}
+      });
+    });
+  });
+
   describe('stripExternalFieldsFromTypeDefs', () => {
     it('returns a new DocumentNode with @external fields removed as well as information about the removed fields', () => {
       const typeDefs = gql`

--- a/federation-js/src/composition/validate/sdl/uniqueFieldDefinitionNames.ts
+++ b/federation-js/src/composition/validate/sdl/uniqueFieldDefinitionNames.ts
@@ -150,7 +150,7 @@ export function UniqueFieldDefinitionNames(
       valueTypeFromSchema || possibleValueTypes[node.name.value];
 
     if (duplicateTypeNode) {
-      const { fields, inputValues } = diffTypeNodes(node, duplicateTypeNode);
+      const { fields, fieldArgs } = diffTypeNodes(node, duplicateTypeNode);
 
       // This is the condition required for a *near* value type. At this point, we know the
       // parent type names are the same. We know the field names are the same if either:
@@ -160,14 +160,15 @@ export function UniqueFieldDefinitionNames(
         return false;
       }
 
-      // not all types might have input values, we only want to check the diff if there's any
-      const inputValuesTypes = Object.values(inputValues);
-
-      if (
-        inputValuesTypes.length > 0 &&
-        inputValuesTypes.every((diffEntry) => diffEntry.length === 2)
-      ) {
-        return false;
+      const fieldArgDiffs = Object.values(fieldArgs);
+      for (const argDiff of fieldArgDiffs) {
+        const argTypes = Object.values(argDiff);
+        if (
+          argTypes.length > 0 &&
+          argTypes.every((diffEntry) => diffEntry.length === 2)
+        ) {
+          return false;
+        }
       }
     } else {
       possibleValueTypes[node.name.value] = node;


### PR DESCRIPTION
This MR addresses the bug outlined in #1100, where value types with similarly named field arguments result in a composition error.

I outlined some of the implementation details in my [issue comment](https://github.com/apollographql/federation/issues/1100#issuecomment-974504381), but the summary of the changes in this PR are:

* `diffTypeNodes` has been adjusted to consider arguments on a per-field basis
* `diffTypeNodes`'s return value has the following changes:
    ```diff
     {
       name: [],
       kind: [],
       fields: {},
    -  inputValues: {},
    +  fieldArgs: {},
       unionTypes: {},
       locations: [],
    -  args: {},
    +  directiveArgs: {}
     }
    ```
* All call sites to `diffTypeNodes` have been updated to handle the new return value's shape. In cases where the call site previously used the `inputValues` entry in the diff, a loop has been added to handle `fieldArgs` holding nested diffs per-field name.
* Added new unit test coverage for `diffTypeNodes`