### PR TITLE
Removed unused `@apollographql/apollo-tools` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@apollo/query-planner": "file:query-planner-js",
         "@apollo/router-bridge": "file:router-bridge",
         "@apollo/subgraph": "file:subgraph-js",
-        "@apollographql/apollo-tools": "0.5.2",
         "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@apollo/query-planner": "file:query-planner-js",
     "@apollo/router-bridge": "file:router-bridge",
     "@apollo/subgraph": "file:subgraph-js",
-    "@apollographql/apollo-tools": "0.5.2",
     "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
   },
   "devDependencies": {


### PR DESCRIPTION
I was wondering where apollo-tools was used and couldn't find any reference to it.
CI also seem to pass without it...