### PR TITLE
Ensure error resolving an entity don't impact resolvable ones (for `version-0.x` branch)

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing to see here. Stay tuned._
+- Continue resolving when an `@external` reference cannot be resolved. [#376](https://github.com/apollographql/federation/issues/376)
 
 ## v0.45.0
 

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -523,7 +523,17 @@ function executeSelectionSet(
         const selections = (selection as QueryPlanFieldNode).selections;
 
         if (typeof source[responseName] === 'undefined') {
-          throw new Error(`Field "${responseName}" was not found in response.`);
+          // This method is called to collect the inputs/requires of a fetch. So, assuming query plans are correct
+          // (and we have not reason to assume otherwise here), all inputs should be fetched beforehand and the
+          // only reason for not finding one of the inputs is that we had an error fetching it _and_ that field
+          // is non-nullable (it it was nullable, error fetching the input would have make that input `null`; not
+          // having the input means the field is non-nullable so the whole entity had to be nullified/ignored,
+          // leading use to not have the field at all).
+          // In any case, we don't have all the necessary inputs for this particular entity and should ignore it.
+          // Note that an error has already been logged for whichever issue happen while fetching the inputs we're
+          // missing here, and that error had much more context, so no reason to log a duplicate (less useful) error
+          // here.
+          return null;
         }
         if (Array.isArray(source[responseName])) {
           result[responseName] = source[responseName].map((value: any) =>


### PR DESCRIPTION
This is a rebased and modified version of https://github.com/apollographql/apollo-server/pull/3914. The differences with that earlier PR are that:
1. it provides a tad more test coverage, but also use tests that don't reuse existing fixtures (I happen to think that having common fixtures reused by all tests is not a good idea, and that has created issues in the past, so I'm advocating from moving away from doing so).
2. the fix is slightly different because:
  - it doesn't log an error in `executeSelectionSet` anymore: the reasoning (explained in a comment in the code) is that another error has already been logged and that error has more context, so adding a new error is redundant and I think it's confusing because that particular error lacks context and so doesn't really tell you what the problem is. So at best, you happen to know it's just a consequence of a previous error and ignore it, but better not have it then.
  - it uses a `return null` instead of a `break`: I personally think that it's unreasonable that when you require a non-nullable field then you may actually have to resolve without that required field. If you knew how to do that, then you wouldn't a `@require` for that field in the first place. So if you can't get all the requires of fetch (and thus, in particular, of a `@require`), then I think we should simply not do that fetch for the entity at all, which is what `return null` does. Using `break` instead means we'd attempt the fetch nonetheless but with only parts of the inputs present. Note that if a required field is nullable, then this code don't get trigger and we correctly do the fetch with `null` values (I added tests that show it's the case).
