### PR TITLE
Ensure error resolving an entity don't impact resolvable ones (for `main` branch)

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Option #1: use the existing environment variable `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT` which will now be treated as a comma-separated list of URLs. 
     - Option #2: use the new `uplinkEndpoints`, which must be single URL or a comma-separated list of URLs for the Uplink End-points to be used, and `uplinkMaxRetries` which is how many times the Uplink URLs should be retried.
   - The old `schemaConfigDeliveryEndpoint` configuration value still work, but is deprecated and will be removed in a subsequent release.
+- Continue resolving when an `@external` reference cannot be resolved. [#376](https://github.com/apollographql/federation/issues/376)
 
 ## v2.0.0-alpha.2
 

--- a/gateway-js/src/__tests__/executeQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/executeQueryPlan.test.ts
@@ -2138,4 +2138,610 @@ describe('executeQueryPlan', () => {
       }
       `);
   });
+
+  describe('@requires', () => {
+    test('handles null in required field correctly (with nullable fields)', async () => {
+      const s1 = {
+        name: 'S1',
+        typeDefs: gql`
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String
+          }
+        `
+      }
+
+      const s2 = {
+        name: 'S2',
+        typeDefs: gql`
+          type Query {
+            getT1s: [T1]
+          }
+
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String @external
+            f2: T2 @requires(fields: "f1")
+          }
+
+          type T2 {
+            a: String
+          }
+        `
+      }
+
+      const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
+
+      const s1_data = [
+        { id: 0, f1: "foo" },
+        { id: 1, f1: null },
+        { id: 2, f1: "bar" },
+      ];
+
+      addResolversToSchema(serviceMap['S1'].schema, {
+        T1: {
+          __resolveReference(ref) {
+            return s1_data[ref.id];
+          },
+        },
+      });
+
+      addResolversToSchema(serviceMap['S2'].schema, {
+        Query: {
+          getT1s() {
+            return [{id: 0}, {id: 1}, {id: 2}];
+          },
+        },
+        T1: {
+          __resolveReference(ref) {
+            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+            return ref;
+          },
+          f2(o) {
+            return o.f1 === null ? null : { a: `t1:${o.f1}` };
+          }
+        }
+      });
+
+      const operation = parseOp(`
+        query {
+          getT1s {
+            id
+            f1
+            f2 {
+              a
+            }
+          }
+        }
+        `, schema);
+      const queryPlan = buildPlan(operation, queryPlanner);
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Sequence {
+            Fetch(service: "S2") {
+              {
+                getT1s {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S1") {
+                {
+                  ... on T1 {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f1
+                  }
+                }
+              },
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S2") {
+                {
+                  ... on T1 {
+                    __typename
+                    f1
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f2 {
+                      a
+                    }
+                  }
+                }
+              },
+            },
+          },
+        }
+      `);
+      const response = await executePlan(queryPlan, operation, undefined, schema, serviceMap);
+      expect(response.data).toMatchInlineSnapshot(`
+        Object {
+          "getT1s": Array [
+            Object {
+              "f1": "foo",
+              "f2": Object {
+                "a": "t1:foo",
+              },
+              "id": 0,
+            },
+            Object {
+              "f1": null,
+              "f2": null,
+              "id": 1,
+            },
+            Object {
+              "f1": "bar",
+              "f2": Object {
+                "a": "t1:bar",
+              },
+              "id": 2,
+            },
+          ],
+        }
+        `);
+      expect(response.errors).toBeUndefined();
+    });
+
+    test('handles null in required field correctly (with @require field non-nullable)', async () => {
+      const s1 = {
+        name: 'S1',
+        typeDefs: gql`
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String
+          }
+        `
+      }
+
+      const s2 = {
+        name: 'S2',
+        typeDefs: gql`
+          type Query {
+            getT1s: [T1]
+          }
+
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String @external
+            f2: T2! @requires(fields: "f1")
+          }
+
+          type T2 {
+            a: String
+          }
+        `
+      }
+
+      const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
+
+      const s1_data = [
+        { id: 0, f1: "foo" },
+        { id: 1, f1: null },
+        { id: 2, f1: "bar" },
+      ];
+
+      addResolversToSchema(serviceMap['S1'].schema, {
+        T1: {
+          __resolveReference(ref) {
+            return s1_data[ref.id];
+          },
+        },
+      });
+
+      addResolversToSchema(serviceMap['S2'].schema, {
+        Query: {
+          getT1s() {
+            return [{id: 0}, {id: 1}, {id: 2}];
+          },
+        },
+        T1: {
+          __resolveReference(ref) {
+            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+            return ref;
+          },
+          f2(o) {
+            return o.f1 === null ? null : { a: `t1:${o.f1}` };
+          }
+        }
+      });
+
+      const operation = parseOp(`
+        query {
+          getT1s {
+            id
+            f1
+            f2 {
+              a
+            }
+          }
+        }
+        `, schema);
+      const queryPlan = buildPlan(operation, queryPlanner);
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Sequence {
+            Fetch(service: "S2") {
+              {
+                getT1s {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S1") {
+                {
+                  ... on T1 {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f1
+                  }
+                }
+              },
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S2") {
+                {
+                  ... on T1 {
+                    __typename
+                    f1
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f2 {
+                      a
+                    }
+                  }
+                }
+              },
+            },
+          },
+        }
+      `);
+
+      const response = await executePlan(queryPlan, operation, undefined, schema, serviceMap);
+      // `null` should bubble up since `f2` is now non-nullable. But we should still get the `id: 0` response.
+      expect(response.data).toMatchInlineSnapshot(`
+        Object {
+          "getT1s": Array [
+            Object {
+              "f1": "foo",
+              "f2": Object {
+                "a": "t1:foo",
+              },
+              "id": 0,
+            },
+            null,
+            Object {
+              "f1": "bar",
+              "f2": Object {
+                "a": "t1:bar",
+              },
+              "id": 2,
+            },
+          ],
+        }
+        `);
+
+      // We returning `null` for f2 which isn't nullable, so it bubbled up and we should have an error
+      expect(response.errors?.map((e) => e.message)).toStrictEqual(['Cannot return null for non-nullable field T1.f2.']);
+    });
+
+    test('handles null in required field correctly (with non-nullable required field)', async () => {
+      const s1 = {
+        name: 'S1',
+        typeDefs: gql`
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String!
+          }
+        `
+      }
+
+      const s2 = {
+        name: 'S2',
+        typeDefs: gql`
+          type Query {
+            getT1s: [T1]
+          }
+
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String! @external
+            f2: T2 @requires(fields: "f1")
+          }
+
+          type T2 {
+            a: String
+          }
+        `
+      }
+
+      const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
+
+      const s1_data = [
+        { id: 0, f1: "foo" },
+        { id: 1, f1: null },
+        { id: 2, f1: "bar" },
+      ];
+
+      addResolversToSchema(serviceMap['S1'].schema, {
+        T1: {
+          __resolveReference(ref) {
+            return s1_data[ref.id];
+          },
+        },
+      });
+
+      addResolversToSchema(serviceMap['S2'].schema, {
+        Query: {
+          getT1s() {
+            return [{id: 0}, {id: 1}, {id: 2}];
+          },
+        },
+        T1: {
+          __resolveReference(ref) {
+            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+            return ref;
+          },
+          f2(o) {
+            return o.f1 === null ? null : { a: `t1:${o.f1}` };
+          }
+        }
+      });
+
+      const operation = parseOp(`
+        query {
+          getT1s {
+            id
+            f1
+            f2 {
+              a
+            }
+          }
+        }
+        `, schema);
+      const queryPlan = buildPlan(operation, queryPlanner);
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Sequence {
+            Fetch(service: "S2") {
+              {
+                getT1s {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S1") {
+                {
+                  ... on T1 {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f1
+                  }
+                }
+              },
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S2") {
+                {
+                  ... on T1 {
+                    __typename
+                    f1
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f2 {
+                      a
+                    }
+                  }
+                }
+              },
+            },
+          },
+        }
+      `);
+
+      const response = await executePlan(queryPlan, operation, undefined, schema, serviceMap);
+      // `null` should bubble up since `f2` is now non-nullable. But we should still get the `id: 0` response.
+      expect(response.data).toMatchInlineSnapshot(`
+        Object {
+          "getT1s": Array [
+            Object {
+              "f1": "foo",
+              "f2": Object {
+                "a": "t1:foo",
+              },
+              "id": 0,
+            },
+            null,
+            Object {
+              "f1": "bar",
+              "f2": Object {
+                "a": "t1:bar",
+              },
+              "id": 2,
+            },
+          ],
+        }
+        `);
+      expect(response.errors?.map((e) => e.message)).toStrictEqual(['Cannot return null for non-nullable field T1.f1.']);
+    });
+
+    test('handles errors in required field correctly (with nullable fields)', async () => {
+      const s1 = {
+        name: 'S1',
+        typeDefs: gql`
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String
+          }
+        `
+      }
+
+      const s2 = {
+        name: 'S2',
+        typeDefs: gql`
+          type Query {
+            getT1s: [T1]
+          }
+
+          type T1 @key(fields: "id") {
+            id: Int!
+            f1: String @external
+            f2: T2 @requires(fields: "f1")
+          }
+
+          type T2 {
+            a: String
+          }
+        `
+      }
+
+      const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
+
+      addResolversToSchema(serviceMap['S1'].schema, {
+        T1: {
+          __resolveReference(ref) {
+            return ref;
+          },
+          f1(o) {
+            switch (o.id) {
+              case 0: return "foo";
+              case 1: return [ "invalid" ]; // This will effectively throw
+              case 2: return "bar";
+              default: throw new Error('Not handled');
+            }
+          }
+        },
+      });
+
+      addResolversToSchema(serviceMap['S2'].schema, {
+        Query: {
+          getT1s() {
+            return [{id: 0}, {id: 1}, {id: 2}];
+          },
+        },
+        T1: {
+          __resolveReference(ref) {
+            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+            return ref;
+          },
+          f2(o) {
+            return o.f1 === null ? null : { a: `t1:${o.f1}` };
+          }
+        }
+      });
+
+      const operation = parseOp(`
+        query {
+          getT1s {
+            id
+            f1
+            f2 {
+              a
+            }
+          }
+        }
+        `, schema);
+      const queryPlan = buildPlan(operation, queryPlanner);
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Sequence {
+            Fetch(service: "S2") {
+              {
+                getT1s {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S1") {
+                {
+                  ... on T1 {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f1
+                  }
+                }
+              },
+            },
+            Flatten(path: "getT1s.@") {
+              Fetch(service: "S2") {
+                {
+                  ... on T1 {
+                    __typename
+                    f1
+                    id
+                  }
+                } =>
+                {
+                  ... on T1 {
+                    f2 {
+                      a
+                    }
+                  }
+                }
+              },
+            },
+          },
+        }
+      `);
+      const response = await executePlan(queryPlan, operation, undefined, schema, serviceMap);
+      expect(response.data).toMatchInlineSnapshot(`
+        Object {
+          "getT1s": Array [
+            Object {
+              "f1": "foo",
+              "f2": Object {
+                "a": "t1:foo",
+              },
+              "id": 0,
+            },
+            Object {
+              "f1": null,
+              "f2": null,
+              "id": 1,
+            },
+            Object {
+              "f1": "bar",
+              "f2": Object {
+                "a": "t1:bar",
+              },
+              "id": 2,
+            },
+          ],
+        }
+        `);
+      expect(response.errors?.map((e) => e.message)).toStrictEqual(['String cannot represent value: ["invalid"]']);
+    });
+  });
 });

--- a/gateway-js/src/__tests__/executeQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/executeQueryPlan.test.ts
@@ -2141,6 +2141,12 @@ describe('executeQueryPlan', () => {
 
   describe('@requires', () => {
     test('handles null in required field correctly (with nullable fields)', async () => {
+      const s1_data = [
+        { id: 0, f1: "foo" },
+        { id: 1, f1: null },
+        { id: 2, f1: "bar" },
+      ];
+
       const s1 = {
         name: 'S1',
         typeDefs: gql`
@@ -2148,7 +2154,14 @@ describe('executeQueryPlan', () => {
             id: Int!
             f1: String
           }
-        `
+        `,
+        resolvers: {
+          T1: {
+            __resolveReference(ref: {id: number}) {
+              return s1_data[ref.id];
+            },
+          },
+        }
       }
 
       const s2 = {
@@ -2167,41 +2180,26 @@ describe('executeQueryPlan', () => {
           type T2 {
             a: String
           }
-        `
+        `,
+        resolvers: {
+          Query: {
+            getT1s() {
+              return [{id: 0}, {id: 1}, {id: 2}];
+            },
+          },
+          T1: {
+            __resolveReference(ref: { id: number }) {
+              // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+              return ref;
+            },
+            f2(o: { f1: string }) {
+              return o.f1 === null ? null : { a: `t1:${o.f1}` };
+            }
+          }
+        }
       }
 
       const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
-
-      const s1_data = [
-        { id: 0, f1: "foo" },
-        { id: 1, f1: null },
-        { id: 2, f1: "bar" },
-      ];
-
-      addResolversToSchema(serviceMap['S1'].schema, {
-        T1: {
-          __resolveReference(ref) {
-            return s1_data[ref.id];
-          },
-        },
-      });
-
-      addResolversToSchema(serviceMap['S2'].schema, {
-        Query: {
-          getT1s() {
-            return [{id: 0}, {id: 1}, {id: 2}];
-          },
-        },
-        T1: {
-          __resolveReference(ref) {
-            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
-            return ref;
-          },
-          f2(o) {
-            return o.f1 === null ? null : { a: `t1:${o.f1}` };
-          }
-        }
-      });
 
       const operation = parseOp(`
         query {
@@ -2292,6 +2290,12 @@ describe('executeQueryPlan', () => {
     });
 
     test('handles null in required field correctly (with @require field non-nullable)', async () => {
+      const s1_data = [
+        { id: 0, f1: "foo" },
+        { id: 1, f1: null },
+        { id: 2, f1: "bar" },
+      ];
+
       const s1 = {
         name: 'S1',
         typeDefs: gql`
@@ -2299,7 +2303,14 @@ describe('executeQueryPlan', () => {
             id: Int!
             f1: String
           }
-        `
+        `,
+        resolvers: {
+          T1: {
+            __resolveReference(ref: { id: number }) {
+              return s1_data[ref.id];
+            },
+          },
+        }
       }
 
       const s2 = {
@@ -2318,41 +2329,26 @@ describe('executeQueryPlan', () => {
           type T2 {
             a: String
           }
-        `
+        `,
+        resolvers: {
+          Query: {
+            getT1s() {
+              return [{id: 0}, {id: 1}, {id: 2}];
+            },
+          },
+          T1: {
+            __resolveReference(ref: { id: number }) {
+              // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+              return ref;
+            },
+            f2(o: { f1: string }) {
+              return o.f1 === null ? null : { a: `t1:${o.f1}` };
+            }
+          }
+        }
       }
 
       const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
-
-      const s1_data = [
-        { id: 0, f1: "foo" },
-        { id: 1, f1: null },
-        { id: 2, f1: "bar" },
-      ];
-
-      addResolversToSchema(serviceMap['S1'].schema, {
-        T1: {
-          __resolveReference(ref) {
-            return s1_data[ref.id];
-          },
-        },
-      });
-
-      addResolversToSchema(serviceMap['S2'].schema, {
-        Query: {
-          getT1s() {
-            return [{id: 0}, {id: 1}, {id: 2}];
-          },
-        },
-        T1: {
-          __resolveReference(ref) {
-            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
-            return ref;
-          },
-          f2(o) {
-            return o.f1 === null ? null : { a: `t1:${o.f1}` };
-          }
-        }
-      });
 
       const operation = parseOp(`
         query {
@@ -2450,7 +2446,14 @@ describe('executeQueryPlan', () => {
             id: Int!
             f1: String!
           }
-        `
+        `,
+        resolvers: {
+          T1: {
+            __resolveReference(ref: { id: number}) {
+              return s1_data[ref.id];
+            },
+          },
+        }
       }
 
       const s2 = {
@@ -2469,7 +2472,23 @@ describe('executeQueryPlan', () => {
           type T2 {
             a: String
           }
-        `
+        `,
+        resolvers: {
+          Query: {
+            getT1s() {
+              return [{id: 0}, {id: 1}, {id: 2}];
+            },
+          },
+          T1: {
+            __resolveReference(ref: { id: number }) {
+              // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+              return ref;
+            },
+            f2(o: { f1: string }) {
+              return o.f1 === null ? null : { a: `t1:${o.f1}` };
+            }
+          }
+        }
       }
 
       const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
@@ -2479,31 +2498,6 @@ describe('executeQueryPlan', () => {
         { id: 1, f1: null },
         { id: 2, f1: "bar" },
       ];
-
-      addResolversToSchema(serviceMap['S1'].schema, {
-        T1: {
-          __resolveReference(ref) {
-            return s1_data[ref.id];
-          },
-        },
-      });
-
-      addResolversToSchema(serviceMap['S2'].schema, {
-        Query: {
-          getT1s() {
-            return [{id: 0}, {id: 1}, {id: 2}];
-          },
-        },
-        T1: {
-          __resolveReference(ref) {
-            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
-            return ref;
-          },
-          f2(o) {
-            return o.f1 === null ? null : { a: `t1:${o.f1}` };
-          }
-        }
-      });
 
       const operation = parseOp(`
         query {
@@ -2599,7 +2593,22 @@ describe('executeQueryPlan', () => {
             id: Int!
             f1: String
           }
-        `
+        `,
+        resolvers: {
+          T1: {
+            __resolveReference(ref: { id: number }) {
+              return ref;
+            },
+            f1(o: { id: number }) {
+              switch (o.id) {
+                case 0: return "foo";
+                case 1: return [ "invalid" ]; // This will effectively throw
+                case 2: return "bar";
+                default: throw new Error('Not handled');
+              }
+            }
+          },
+        }
       }
 
       const s2 = {
@@ -2618,43 +2627,26 @@ describe('executeQueryPlan', () => {
           type T2 {
             a: String
           }
-        `
+        `,
+        resolvers: {
+          Query: {
+            getT1s() {
+              return [{id: 0}, {id: 1}, {id: 2}];
+            },
+          },
+          T1: {
+            __resolveReference(ref: { id: number }) {
+              // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
+              return ref;
+            },
+            f2(o: { f1: string }) {
+              return o.f1 === null ? null : { a: `t1:${o.f1}` };
+            }
+          }
+        }
       }
 
       const { serviceMap, schema, queryPlanner} = getFederatedTestingSchema([ s1, s2 ]);
-
-      addResolversToSchema(serviceMap['S1'].schema, {
-        T1: {
-          __resolveReference(ref) {
-            return ref;
-          },
-          f1(o) {
-            switch (o.id) {
-              case 0: return "foo";
-              case 1: return [ "invalid" ]; // This will effectively throw
-              case 2: return "bar";
-              default: throw new Error('Not handled');
-            }
-          }
-        },
-      });
-
-      addResolversToSchema(serviceMap['S2'].schema, {
-        Query: {
-          getT1s() {
-            return [{id: 0}, {id: 1}, {id: 2}];
-          },
-        },
-        T1: {
-          __resolveReference(ref) {
-            // the ref has already the id and f1 is a require is triggered, and we resolve f2 below
-            return ref;
-          },
-          f2(o) {
-            return o.f1 === null ? null : { a: `t1:${o.f1}` };
-          }
-        }
-      });
 
       const operation = parseOp(`
         query {

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -489,7 +489,17 @@ function executeSelectionSet(
         const selections = (selection as QueryPlanFieldNode).selections;
 
         if (typeof source[responseName] === 'undefined') {
-          throw new Error(`Field "${responseName}" was not found in response.`);
+          // This method is called to collect the inputs/requires of a fetch. So, assuming query plans are correct
+          // (and we have not reason to assume otherwise here), all inputs should be fetched beforehand and the
+          // only reason for not finding one of the inputs is that we had an error fetching it _and_ that field
+          // is non-nullable (it it was nullable, error fetching the input would have make that input `null`; not
+          // having the input means the field is non-nullable so the whole entity had to be nullified/ignored,
+          // leading use to not have the field at all).
+          // In any case, we don't have all the necessary inputs for this particular entity and should ignore it.
+          // Note that an error has already been logged for whichever issue happen while fetching the inputs we're
+          // missing here, and that error had much more context, so no reason to log a duplicate (less useful) error
+          // here.
+          return null;
         }
         if (Array.isArray(source[responseName])) {
           result[responseName] = source[responseName].map((value: any) =>

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -714,4 +714,18 @@ export class ExternalTester {
   isFakeExternal(field: FieldDefinition<any> | InputFieldDefinition) {
     return this.fakeExternalFields.has(field.coordinate);
   }
+
+  selectsAnyExternalField(selectionSet: SelectionSet): boolean {
+    for (const selection of selectionSet.selections()) {
+      if (selection.kind === 'FieldSelection' && this.isExternal(selection.element().definition)) {
+        return true;
+      }
+      if (selection.selectionSet) {
+        if (this.selectsAnyExternalField(selection.selectionSet)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -31,6 +31,7 @@ import {
   ALL_SUBTYPING_RULES,
   externalDirectiveName,
   requiresDirectiveName,
+  ExternalTester,
 } from '@apollo/federation-internals';
 import { inspect } from 'util';
 import { DownCast, FieldCollection, subgraphEnteringTransition, SubgraphEnteringTransition, Transition, KeyResolution, RootTypeResolution } from './transition';
@@ -242,6 +243,12 @@ export class Edge {
  * that points to "reachable" types (reachable from any kind of operations).
  */
 export class QueryGraph {
+  // Because of the "fake externals" of type extension that we still support for fed1 backward compatibility, checking
+  // is a field is truly external or not is kind of expensive and that's why we have `ExternalTester` which is costly
+  // to build initially but then allow checking field cheaply. Anyway, we sometimes need those for the source schema
+  // of the query graph, and storing it here is convenient if a bit hacky. Those testers are lazily created.
+  private readonly externalTesters: Map<string, ExternalTester> = new Map();
+
   /**
    * Creates a new query graph.
    *
@@ -352,6 +359,16 @@ export class QueryGraph {
   verticesForType(typeName: string): Vertex[] {
     const indexes = this.typesToVertices.get(typeName);
     return indexes == undefined ? [] : indexes.map(i => this.vertices[i]);
+  }
+
+  externalTester(source: string) {
+    let tester = this.externalTesters.get(source);
+    if (!tester) {
+      const schema = this.sources.get(source);
+      assert(schema, () => `Unknown source: ${source}`);
+      tester = new ExternalTester(schema);
+    }
+    return tester;
   }
 }
 

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -361,7 +361,7 @@ export class QueryGraph {
     return indexes == undefined ? [] : indexes.map(i => this.vertices[i]);
   }
 
-  externalTester(source: string) {
+  externalTester(source: string): ExternalTester {
     let tester = this.externalTesters.get(source);
     if (!tester) {
       const schema = this.sources.get(source);

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -1652,7 +1652,7 @@ function inputsForRequire(graph: QueryGraph, entityType: ObjectType, edge: Edge,
   fullSelectionSet.mergeIn(edge.conditions!);
   if (includeKeyInputs) {
     const keyCondition = getLocallySatisfiableKey(graph, edge.head);
-    assert(keyCondition, () => `No key found for require on ${edge}`);
+    assert(keyCondition, () => `Due to @require, validation should have required a key to be present for ${edge}`);
     fullSelectionSet.mergeIn(keyCondition);
   }
   return [selectionOfElement(typeCast, fullSelectionSet), [typeCast]];

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -61,12 +61,12 @@ import {
   unsatisfiedConditionsResolution,
   cachingConditionResolver,
   ConditionResolver,
-  additionalKeyEdgeForRequireEdge,
   addConditionExclusion,
   SimultaneousPathsWithLazyIndirectPaths,
   simultaneousPathsToString,
   SimultaneousPaths,
   terminateWithNonRequestedTypenameField,
+  getLocallySatisfiableKey,
 } from "@apollo/query-graphs";
 import { DocumentNode, stripIgnoredCharacters, print, GraphQLError, parse } from "graphql";
 import { QueryPlan, ResponsePath, SequenceNode, PlanNode, ParallelNode, FetchNode, trimSelectionNodes } from "./QueryPlan";
@@ -663,6 +663,10 @@ class LazySelectionSet {
     } else {
       return this;
     }
+  }
+
+  toString() {
+    return this.forRead().toString();
   }
 }
 
@@ -1635,6 +1639,7 @@ function handleRequires(
     const newGroup = dependencyGraph.newKeyFetchGroup(group.subgraphName, mergeAt);
     newGroup.addDependencyOn(createdGroups);
     const [inputs, newPath] = inputsForRequire(dependencyGraph.federatedQueryGraph, entityType, edge);
+    debug.log(`Trying to add ${inputs} to ${newGroup}`);
     newGroup.addInputs(inputs);
     return [newGroup, mergeAt, newPath];
   }
@@ -1646,7 +1651,9 @@ function inputsForRequire(graph: QueryGraph, entityType: ObjectType, edge: Edge,
   fullSelectionSet.add(new FieldSelection(new Field(entityType.typenameField()!)));
   fullSelectionSet.mergeIn(edge.conditions!);
   if (includeKeyInputs) {
-    fullSelectionSet.mergeIn(additionalKeyEdgeForRequireEdge(graph, edge).conditions!);
+    const keyCondition = getLocallySatisfiableKey(graph, edge.head);
+    assert(keyCondition, () => `No key found for require on ${edge}`);
+    fullSelectionSet.mergeIn(keyCondition);
   }
   return [selectionOfElement(typeCast, fullSelectionSet), [typeCast]];
 }


### PR DESCRIPTION
This PR has the same fix than in https://github.com/apollographql/federation/pull/1305, but for `main`.

_However_, testing this also uncovered another issue with `@requires` on `main` (fed 2 code), and this PR also has this additional fix. So first commit is that "other" fix (but it includes all the tests), and second commit is the fix of https://github.com/apollographql/federation/pull/1305.
