### PR TITLE
chore(gateway): Fix OOB testing strategy (`main`)

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- __NOOP__: Fix OOB testing w.r.t. nock hygiene. Pushed error reporting endpoint responsibilities up into the gateway class, but there should be no effect on the runtime at all. [PR #1309](https://github.com/apollographql/federation/pull/1309)
+
 ## v2.0.0-alpha.2
 
 - Conditional schema update based on ifAfterId [PR #1152](https://github.com/apollographql/federation/pull/1152)

--- a/gateway-js/src/__tests__/gateway/reporting.test.ts
+++ b/gateway-js/src/__tests__/gateway/reporting.test.ts
@@ -12,6 +12,7 @@ import { ApolloGateway } from '../..';
 import { Plugin, Config, Refs } from 'pretty-format';
 import { Report, Trace } from 'apollo-reporting-protobuf';
 import { fixtures } from 'apollo-federation-integration-testsuite';
+import { nockAfterEach, nockBeforeEach } from '../nockAssertions';
 
 // Normalize specific fields that change often (eg timestamps) to static values,
 // to make snapshot testing viable.  (If these helpers are more generally
@@ -89,7 +90,6 @@ describe('reporting', () => {
   let gatewayServer: ApolloServer;
   let gatewayUrl: string;
   let reportPromise: Promise<any>;
-  let nockScope: nock.Scope;
 
   beforeEach(async () => {
     let reportResolver: (report: any) => void;
@@ -97,7 +97,8 @@ describe('reporting', () => {
       reportResolver = resolve;
     });
 
-    nockScope = nock('https://usage-reporting.api.apollographql.com')
+    nockBeforeEach();
+    nock('https://usage-reporting.api.apollographql.com')
       .post('/api/ingress/traces')
       .reply(200, (_: any, requestBody: string) => {
         reportResolver(requestBody);
@@ -137,7 +138,8 @@ describe('reporting', () => {
     if (gatewayServer) {
       await gatewayServer.stop();
     }
-    nockScope.done();
+
+    nockAfterEach();
   });
 
   it(`queries three services`, async () => {

--- a/gateway-js/src/__tests__/integration/networkRequests.test.ts
+++ b/gateway-js/src/__tests__/integration/networkRequests.test.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import gql from 'graphql-tag';
 import { DocumentNode, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import mockedEnv from 'mocked-env';
@@ -26,6 +25,7 @@ import {
   reviews,
 } from 'apollo-federation-integration-testsuite';
 import { getTestingSupergraphSdl } from '../execution-utils';
+import { nockAfterEach, nockBeforeEach } from '../nockAssertions';
 
 type GenericFunction = (...args: unknown[]) => unknown;
 export interface MockService {
@@ -63,7 +63,7 @@ let gateway: ApolloGateway | null = null;
 let cleanUp: (() => void) | null = null;
 
 beforeEach(() => {
-  if (!nock.isActive()) nock.activate();
+  nockBeforeEach();
 
   const warn = jest.fn();
   const debug = jest.fn();
@@ -79,9 +79,8 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  expect(nock.isDone()).toBeTruthy();
-  nock.cleanAll();
-  nock.restore();
+  nockAfterEach();
+
   if (gateway) {
     await gateway.stop();
     gateway = null;

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -11,15 +11,26 @@ import {
   mockSupergraphSdlRequestIfAfterUnchanged,
 } from './integration/nockMocks';
 import mockedEnv from 'mocked-env';
+import nock from 'nock';
 
 describe('loadSupergraphSdlFromStorage', () => {
   let cleanUp: (() => void) | null = null;
 
-  afterAll(async () => {
+  beforeEach(() => {
+    if (!nock.isActive()) {
+      nock.activate();
+    }
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
     if (cleanUp) {
       cleanUp();
       cleanUp = null;
     }
+
+    expect(nock.activeMocks()).toEqual([]);
+    expect(nock.isDone()).toBe(true);
   });
 
   it('fetches Supergraph SDL as expected', async () => {

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -10,12 +10,9 @@ import {
   mockSupergraphSdlRequestSuccess,
   mockSupergraphSdlRequestIfAfterUnchanged,
 } from './integration/nockMocks';
-import mockedEnv from 'mocked-env';
 import nock from 'nock';
 
 describe('loadSupergraphSdlFromStorage', () => {
-  let cleanUp: (() => void) | null = null;
-
   beforeEach(() => {
     if (!nock.isActive()) {
       nock.activate();
@@ -24,11 +21,6 @@ describe('loadSupergraphSdlFromStorage', () => {
   });
 
   afterEach(() => {
-    if (cleanUp) {
-      cleanUp();
-      cleanUp = null;
-    }
-
     expect(nock.activeMocks()).toEqual([]);
     expect(nock.isDone()).toBe(true);
   });
@@ -512,13 +504,8 @@ describe('loadSupergraphSdlFromStorage', () => {
       );
     });
 
-    it('throws on 400 status response and successfully submits an out of band error', async () => {
-      cleanUp = mockedEnv({
-        APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-      });
-
+    it('throws on 400 status response and does not submit an out of band error', async () => {
       mockSupergraphSdlRequest().reply(400);
-      mockOutOfBandReportRequestSuccess();
 
       const fetcher = getDefaultFetcher();
       await expect(
@@ -526,6 +513,7 @@ describe('loadSupergraphSdlFromStorage', () => {
           graphRef,
           apiKey,
           endpoint: mockCloudConfigUrl,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
@@ -535,10 +523,6 @@ describe('loadSupergraphSdlFromStorage', () => {
     });
 
     it('throws on 413 status response and successfully submits an out of band error', async () => {
-      cleanUp = mockedEnv({
-        APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-      });
-
       mockSupergraphSdlRequest().reply(413);
       mockOutOfBandReportRequestSuccess();
 
@@ -548,6 +532,7 @@ describe('loadSupergraphSdlFromStorage', () => {
           graphRef,
           apiKey,
           endpoint: mockCloudConfigUrl,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
@@ -557,10 +542,6 @@ describe('loadSupergraphSdlFromStorage', () => {
     });
 
     it('throws on 422 status response and successfully submits an out of band error', async () => {
-      cleanUp = mockedEnv({
-        APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-      });
-
       mockSupergraphSdlRequest().reply(422);
       mockOutOfBandReportRequestSuccess();
 
@@ -570,6 +551,7 @@ describe('loadSupergraphSdlFromStorage', () => {
           graphRef,
           apiKey,
           endpoint: mockCloudConfigUrl,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
@@ -579,10 +561,6 @@ describe('loadSupergraphSdlFromStorage', () => {
     });
 
     it('throws on 408 status response and successfully submits an out of band error', async () => {
-      cleanUp = mockedEnv({
-        APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-      });
-
       mockSupergraphSdlRequest().reply(408);
       mockOutOfBandReportRequestSuccess();
 
@@ -592,6 +570,7 @@ describe('loadSupergraphSdlFromStorage', () => {
           graphRef,
           apiKey,
           endpoint: mockCloudConfigUrl,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
@@ -602,10 +581,6 @@ describe('loadSupergraphSdlFromStorage', () => {
   });
 
   it('throws on 504 status response and successfully submits an out of band error', async () => {
-    cleanUp = mockedEnv({
-      APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-    });
-
     mockSupergraphSdlRequest().reply(504);
     mockOutOfBandReportRequestSuccess();
 
@@ -615,6 +590,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         graphRef,
         apiKey,
         endpoint: mockCloudConfigUrl,
+        errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
       }),
@@ -624,10 +600,6 @@ describe('loadSupergraphSdlFromStorage', () => {
   });
 
   it('throws when there is no response and successfully submits an out of band error', async () => {
-    cleanUp = mockedEnv({
-      APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-    });
-
     mockSupergraphSdlRequest().replyWithError('no response');
     mockOutOfBandReportRequestSuccess();
 
@@ -637,6 +609,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         graphRef,
         apiKey,
         endpoint: mockCloudConfigUrl,
+        errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
       }),
@@ -646,10 +619,6 @@ describe('loadSupergraphSdlFromStorage', () => {
   });
 
   it('throws on 502 status response and successfully submits an out of band error', async () => {
-    cleanUp = mockedEnv({
-      APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-    });
-
     mockSupergraphSdlRequest().reply(502);
     mockOutOfBandReportRequestSuccess();
 
@@ -659,6 +628,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         graphRef,
         apiKey,
         endpoint: mockCloudConfigUrl,
+        errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
       }),
@@ -668,10 +638,6 @@ describe('loadSupergraphSdlFromStorage', () => {
   });
 
   it('throws on 503 status response and successfully submits an out of band error', async () => {
-    cleanUp = mockedEnv({
-      APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT: mockOutOfBandReporterUrl,
-    });
-
     mockSupergraphSdlRequest().reply(503);
     mockOutOfBandReportRequestSuccess();
 
@@ -681,6 +647,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         graphRef,
         apiKey,
         endpoint: mockCloudConfigUrl,
+        errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
       }),

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -10,20 +10,11 @@ import {
   mockSupergraphSdlRequestSuccess,
   mockSupergraphSdlRequestIfAfterUnchanged,
 } from './integration/nockMocks';
-import nock from 'nock';
+import { nockAfterEach, nockBeforeEach } from './nockAssertions';
 
 describe('loadSupergraphSdlFromStorage', () => {
-  beforeEach(() => {
-    if (!nock.isActive()) {
-      nock.activate();
-    }
-    nock.cleanAll();
-  });
-
-  afterEach(() => {
-    expect(nock.activeMocks()).toEqual([]);
-    expect(nock.isDone()).toBe(true);
-  });
+  beforeEach(nockBeforeEach);
+  afterEach(nockAfterEach);
 
   it('fetches Supergraph SDL as expected', async () => {
     mockSupergraphSdlRequestSuccess();

--- a/gateway-js/src/__tests__/nockAssertions.ts
+++ b/gateway-js/src/__tests__/nockAssertions.ts
@@ -1,0 +1,20 @@
+import nock from 'nock';
+
+// Ensures an active and clean nock before every test
+export function nockBeforeEach() {
+  if (!nock.isActive()) {
+    nock.activate();
+  }
+  // Cleaning _before_ each test ensures that any mocks from a previous test
+  // which failed don't affect the current test.
+  nock.cleanAll();
+}
+
+// Ensures a test is complete (all expected requests were run) and a clean
+// global state after each test.
+export function nockAfterEach() {
+  // unmock HTTP interceptor
+  nock.restore();
+  // effectively nock.isDone() but with more helpful messages in test failures
+  expect(nock.activeMocks()).toEqual([]);
+};

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -184,6 +184,8 @@ export class ApolloGateway implements GraphQLService {
   private fetcher: typeof fetch;
   private compositionId?: string;
   private state: GatewayState;
+  private errorReportingEndpoint: string | undefined =
+    process.env.APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT ?? undefined;
 
   // Observe query plan, service info, and operation info prior to execution.
   // The information made available here will give insight into the resulting
@@ -920,6 +922,7 @@ export class ApolloGateway implements GraphQLService {
       graphRef: this.apolloConfig!.graphRef!,
       apiKey: this.apolloConfig!.key!,
       endpoint: this.schemaConfigDeliveryEndpoint!,
+      errorReportingEndpoint: this.errorReportingEndpoint,
       fetcher: this.fetcher,
       compositionId: this.compositionId ?? null,
     });

--- a/gateway-js/src/outOfBandReporter.ts
+++ b/gateway-js/src/outOfBandReporter.ts
@@ -27,102 +27,100 @@ interface OobReportMutationFailure {
   data?: OobReportMutation;
   errors: GraphQLError[];
 }
-export class OutOfBandReporter {
-  static endpoint: string | null = process.env.APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT || null;
 
-  async submitOutOfBandReportIfConfigured({
-    error,
-    request,
-    response,
-    startedAt,
-    endedAt,
-    tags,
-    fetcher,
-  }: {
-    error: Error;
-    request: Request;
-    response?: Response;
-    startedAt: Date;
-    endedAt: Date;
-    tags?: string[];
-    fetcher: typeof fetch;
-  }) {
+export async function submitOutOfBandReportIfConfigured({
+  error,
+  request,
+  endpoint,
+  response,
+  startedAt,
+  endedAt,
+  tags,
+  fetcher,
+}: {
+  error: Error;
+  request: Request;
+  endpoint: string | undefined;
+  response?: Response;
+  startedAt: Date;
+  endedAt: Date;
+  tags?: string[];
+  fetcher: typeof fetch;
+}) {
+  // don't send report if the endpoint url is not configured
+  if (!endpoint) {
+    return;
+  }
 
-    // don't send report if the endpoint url is not configured
-    if (!OutOfBandReporter.endpoint) {
-      return;
+  let errorCode: ErrorCode;
+  if (!response) {
+    errorCode = ErrorCode.ConnectionFailed;
+  } else {
+    // possible error situations to check against
+    switch (response.status) {
+      case 400:
+      case 413:
+      case 422:
+        errorCode = ErrorCode.InvalidBody;
+        break;
+      case 408:
+      case 504:
+        errorCode = ErrorCode.Timeout;
+        break;
+      case 502:
+      case 503:
+        errorCode = ErrorCode.ConnectionFailed;
+        break;
+      default:
+        errorCode = ErrorCode.Other;
     }
+  }
 
-    let errorCode: ErrorCode;
-    if (!response) {
-      errorCode = ErrorCode.ConnectionFailed;
-    } else {
-      // possible error situations to check against
-      switch (response.status) {
-        case 400:
-        case 413:
-        case 422:
-          errorCode = ErrorCode.InvalidBody;
-          break;
-        case 408:
-        case 504:
-          errorCode = ErrorCode.Timeout;
-          break;
-        case 502:
-        case 503:
-          errorCode = ErrorCode.ConnectionFailed;
-          break;
-        default:
-          errorCode = ErrorCode.Other;
-      }
-    }
+  const responseBody: string | undefined = await response?.text();
 
-    const responseBody: string | undefined = await response?.text();
-
-    const variables: OobReportMutationVariables = {
-      input: {
-        error: {
-          code: errorCode,
-          message: error.message,
-        },
-        request: {
-          url: request.url,
-          body: await request.text(),
-        },
-        response: response
-          ? {
-              httpStatusCode: response.status,
-              body: responseBody,
-            }
-          : null,
-        startedAt: startedAt.toISOString(),
-        endedAt: endedAt.toISOString(),
-        tags: tags,
+  const variables: OobReportMutationVariables = {
+    input: {
+      error: {
+        code: errorCode,
+        message: error.message,
       },
-    };
+      request: {
+        url: request.url,
+        body: await request.text(),
+      },
+      response: response
+        ? {
+            httpStatusCode: response.status,
+            body: responseBody,
+          }
+        : null,
+      startedAt: startedAt.toISOString(),
+      endedAt: endedAt.toISOString(),
+      tags: tags,
+    },
+  };
 
-    try {
-      const oobResponse = await fetcher(OutOfBandReporter.endpoint, {
-        method: 'POST',
-        body: JSON.stringify({
-          query: OUT_OF_BAND_REPORTER_QUERY,
-          variables,
-        }),
-        headers: {
-          'apollographql-client-name': name,
-          'apollographql-client-version': version,
-          'user-agent': `${name}/${version}`,
-          'content-type': 'application/json',
-        },
-      });
-      const parsedResponse: OobReportMutationResult = await oobResponse.json();
-      if (!parsedResponse?.data?.reportError) {
-        throw new Error(
-          `Out-of-band error reporting failed: ${oobResponse.status} ${oobResponse.statusText}`,
-        );
-      }
-    } catch (e) {
-      throw new Error(`Out-of-band error reporting failed: ${e.message ?? e}`);
+  try {
+    const oobResponse = await fetcher(endpoint, {
+      method: 'POST',
+      body: JSON.stringify({
+        query: OUT_OF_BAND_REPORTER_QUERY,
+        variables,
+      }),
+      headers: {
+        'apollographql-client-name': name,
+        'apollographql-client-version': version,
+        'user-agent': `${name}/${version}`,
+        'content-type': 'application/json',
+      },
+    });
+    const parsedResponse: OobReportMutationResult = await oobResponse.json();
+    if (!parsedResponse?.data?.reportError) {
+      throw new Error(
+        `Out-of-band error reporting failed: ${oobResponse.status} ${oobResponse.statusText}`,
+      );
     }
+  } catch (e) {
+    throw new Error(`Out-of-band error reporting failed: ${e.message ?? e}`);
   }
 }


### PR DESCRIPTION
While reviewing https://github.com/apollographql/federation/pull/1283, I encountered a couple testing smells that got me digging a bit. There are some issues around nock testing hygiene (checking for doneness!) which, when addressed, revealed a few things:

Most reporting mocks weren't actually being exercised. This is because the static property on `OutOfBandReporter` class would resolve the env variable once for all tests, and never again (it was always null 😢). I decided the static property + `process.env` combo wasn't very test friendly, so I pushed the responsibility of that up to the gateway (where other env variables are also handled).

Fortunately for us, all but one of the tests were passing after I made these changes. The `400` case is failing, because only throw in that case (and don't submit an error report). I imagine the expectation is that we _do_ send the report. Will confirm with @Y-Guo and fix if needed.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
