### PR TITLE
feat(gateway): Allow configuration of multiple Uplink URLs `version-0.x` (duped from #1283)

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - __NOOP__: Fix OOB testing w.r.t. nock hygiene. Pushed error reporting endpoint responsibilities up into the gateway class, but there should be no effect on the runtime at all. [PR #1309](https://github.com/apollographql/federation/pull/1309)
 - __BREAKING__: Remove legacy GCS fetcher for schema updates. If you're currently opted-in to the backwards compatibility provided by setting `schemaConfigDeliveryEndpoint: null`, you may be affected by this update. Please see the PR for additional details. [PR #1225](https://github.com/apollographql/federation/pull/1225)
+- __Multi-cloud Uplink capability__ [PR #1283](https://github.com/apollographql/federation/pull/1283): now, by default two separate Uplink services will be used for schema fetching, the system will round-robin and if one service fails, a retry will occur and the other service will be called. 
+  - The Uplink URLs are `https://uplink.api.apollographql.com/` (GCP) and `https://aws.uplink.api.apollographql.com/` (AWS). 
+  - To override these defaults and configure what Uplink services, there are two options: 
+    - Option #1: use the existing environment variable `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT` which will now be treated as a comma-separated list of URLs. 
+    - Option #2: use the new `uplinkEndpoints`, which must be single URL or a comma-separated list of URLs for the Uplink End-points to be used, and `uplinkMaxRetries` which is how many times the Uplink URLs should be retried.
+  - The old `schemaConfigDeliveryEndpoint` configuration value still work, but is deprecated and will be removed in a subsequent release.
 
 ## v0.44.0
 

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -7,7 +7,9 @@ import {
   mockSdlQuerySuccess,
   mockSupergraphSdlRequestSuccess,
   mockApolloConfig,
-  mockCloudConfigUrl,
+  mockCloudConfigUrl1,
+  mockCloudConfigUrl2,
+  mockCloudConfigUrl3,
 } from './nockMocks';
 import { getTestingSupergraphSdl } from '../execution-utils';
 import { MockService } from './networkRequests.test';
@@ -110,7 +112,26 @@ describe('gateway configuration warnings', () => {
 
     gateway = new ApolloGateway({
       logger,
-      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      uplinkEndpoints: [mockCloudConfigUrl1],
+    });
+
+    await gateway.load(mockApolloConfig);
+
+    await gateway.stop();
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringMatching(
+        /A local gateway configuration is overriding a managed federation configuration/,
+      ),
+    );
+  });
+
+  it('deprecated conflicting configurations are not warned about when absent', async () => {
+    mockSupergraphSdlRequestSuccess();
+
+    gateway = new ApolloGateway({
+      logger,
+      schemaConfigDeliveryEndpoint: mockCloudConfigUrl1,
     });
 
     await gateway.load(mockApolloConfig);
@@ -307,11 +328,30 @@ describe('gateway config / env behavior', () => {
 
       gateway = new ApolloGateway({
         logger,
+        uplinkEndpoints: [mockCloudConfigUrl1, mockCloudConfigUrl2, mockCloudConfigUrl3],
+      });
+
+      expect(gateway['uplinkEndpoints']).toEqual(
+        [mockCloudConfigUrl1, mockCloudConfigUrl2, mockCloudConfigUrl3],
+      );
+
+      gateway = null;
+    });
+  });
+
+  describe('deprecated schema config delivery endpoint configuration', () => {
+    it('A code config overrides the env variable', async () => {
+      cleanUp = mockedEnv({
+        APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT: 'env-config',
+      });
+
+      gateway = new ApolloGateway({
+        logger,
         schemaConfigDeliveryEndpoint: 'code-config',
       });
 
-      expect(gateway['schemaConfigDeliveryEndpoint']).toEqual(
-        'code-config',
+      expect(gateway['uplinkEndpoints']).toEqual(
+        ['code-config'],
       );
 
       gateway = null;

--- a/gateway-js/src/__tests__/integration/networkRequests.test.ts
+++ b/gateway-js/src/__tests__/integration/networkRequests.test.ts
@@ -11,7 +11,7 @@ import {
   mockSupergraphSdlRequestSuccess,
   mockSupergraphSdlRequest,
   mockApolloConfig,
-  mockCloudConfigUrl,
+  mockCloudConfigUrl1,
   mockSupergraphSdlRequestIfAfter,
   mockSupergraphSdlRequestSuccessIfAfter,
 } from './nockMocks';
@@ -104,7 +104,7 @@ it('Fetches Supergraph SDL from remote storage', async () => {
 
   gateway = new ApolloGateway({
     logger,
-    schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+    uplinkEndpoints: [mockCloudConfigUrl1],
   });
 
   await gateway.load(mockApolloConfig);
@@ -114,7 +114,7 @@ it('Fetches Supergraph SDL from remote storage', async () => {
 
 it('Fetches Supergraph SDL from remote storage using a configured env variable', async () => {
   cleanUp = mockedEnv({
-    APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT: mockCloudConfigUrl,
+    APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT: mockCloudConfigUrl1,
   });
   mockSupergraphSdlRequestSuccess();
 
@@ -148,7 +148,7 @@ it('Updates Supergraph SDL from remote storage', async () => {
 
   gateway = new ApolloGateway({
     logger,
-    schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+    uplinkEndpoints: [mockCloudConfigUrl1],
   });
   // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
   gateway.experimental_pollInterval = 100;
@@ -167,7 +167,8 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      uplinkEndpoints: [mockCloudConfigUrl1],
+      uplinkMaxRetries: 0
     });
 
     await expect(
@@ -195,7 +196,8 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      uplinkEndpoints: [mockCloudConfigUrl1],
+      uplinkMaxRetries: 0
     });
 
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
@@ -228,7 +230,8 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      uplinkEndpoints: [mockCloudConfigUrl1],
+      uplinkMaxRetries: 0
     });
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
     gateway.experimental_pollInterval = 100;
@@ -265,7 +268,7 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      uplinkEndpoints: [mockCloudConfigUrl1],
     });
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
     gateway.experimental_pollInterval = 100;
@@ -295,7 +298,7 @@ describe('Supergraph SDL update failures', () => {
 
     gateway = new ApolloGateway({
       logger,
-      schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+      uplinkEndpoints: [mockCloudConfigUrl1],
     });
     // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
     gateway.experimental_pollInterval = 100;
@@ -339,7 +342,7 @@ it('Rollsback to a previous schema when triggered', async () => {
 
   gateway = new ApolloGateway({
     logger,
-    schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+    uplinkEndpoints: [mockCloudConfigUrl1],
   });
   // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
   gateway.experimental_pollInterval = 100;
@@ -423,7 +426,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        uplinkEndpoints: [mockCloudConfigUrl1],
       });
       // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
       gateway.experimental_pollInterval = 100;
@@ -446,7 +449,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        uplinkEndpoints: [mockCloudConfigUrl1],
       });
 
       // This is the ideal, but our version of Jest has a bug with printing error snapshots.
@@ -506,7 +509,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        uplinkEndpoints: [mockCloudConfigUrl1],
       });
       // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
       gateway.experimental_pollInterval = 100;
@@ -549,7 +552,7 @@ describe('Downstream service health checks', () => {
       gateway = new ApolloGateway({
         serviceHealthCheck: true,
         logger,
-        schemaConfigDeliveryEndpoint: mockCloudConfigUrl,
+        uplinkEndpoints: [mockCloudConfigUrl1],
       });
       // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
       gateway.experimental_pollInterval = 100;

--- a/gateway-js/src/__tests__/integration/nockMocks.ts
+++ b/gateway-js/src/__tests__/integration/nockMocks.ts
@@ -64,14 +64,20 @@ function gatewayNock(url: Parameters<typeof nock>[0]): nock.Scope {
   });
 }
 
-export const mockCloudConfigUrl =
-  'https://example.cloud-config-url.com/cloudconfig/';
+export const mockCloudConfigUrl1 =
+  'https://example1.cloud-config-url.com/cloudconfig/';
+
+export const mockCloudConfigUrl2 =
+  'https://example2.cloud-config-url.com/cloudconfig/';
+
+export const mockCloudConfigUrl3 =
+  'https://example3.cloud-config-url.com/cloudconfig/';
 
 export const mockOutOfBandReporterUrl =
   'https://example.outofbandreporter.com/monitoring/';
 
-export function mockSupergraphSdlRequestIfAfter(ifAfter: string | null) {
-  return gatewayNock(mockCloudConfigUrl).post('/', {
+export function mockSupergraphSdlRequestIfAfter(ifAfter: string | null, url: string = mockCloudConfigUrl1) {
+  return gatewayNock(url).post('/', {
     query: SUPERGRAPH_SDL_QUERY,
     variables: {
       ref: graphRef,
@@ -81,8 +87,8 @@ export function mockSupergraphSdlRequestIfAfter(ifAfter: string | null) {
   });
 }
 
-export function mockSupergraphSdlRequest(ifAfter: string | null = null) {
-  return mockSupergraphSdlRequestIfAfter(ifAfter);
+export function mockSupergraphSdlRequest(ifAfter: string | null = null, url: string = mockCloudConfigUrl1) {
+  return mockSupergraphSdlRequestIfAfter(ifAfter, url);
 }
 
 export function mockSupergraphSdlRequestSuccessIfAfter(

--- a/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -1,15 +1,21 @@
-import { loadSupergraphSdlFromStorage } from '../loadSupergraphSdlFromStorage';
+import {
+  loadSupergraphSdlFromStorage,
+  loadSupergraphSdlFromUplinks
+} from '../loadSupergraphSdlFromStorage';
 import { getDefaultFetcher } from '../..';
 import {
   graphRef,
   apiKey,
-  mockCloudConfigUrl,
-  mockSupergraphSdlRequest,
+  mockCloudConfigUrl1,
+  mockCloudConfigUrl2,
   mockOutOfBandReporterUrl,
+  mockSupergraphSdlRequest,
   mockOutOfBandReportRequestSuccess,
   mockSupergraphSdlRequestSuccess,
   mockSupergraphSdlRequestIfAfterUnchanged,
+  mockSupergraphSdlRequestIfAfter
 } from './integration/nockMocks';
+import { getTestingSupergraphSdl } from "./execution-utils";
 import { nockAfterEach, nockBeforeEach } from './nockAssertions';
 
 describe('loadSupergraphSdlFromStorage', () => {
@@ -18,331 +24,72 @@ describe('loadSupergraphSdlFromStorage', () => {
 
   it('fetches Supergraph SDL as expected', async () => {
     mockSupergraphSdlRequestSuccess();
-
     const fetcher = getDefaultFetcher();
     const result = await loadSupergraphSdlFromStorage({
       graphRef,
       apiKey,
-      endpoint: mockCloudConfigUrl,
+      endpoint: mockCloudConfigUrl1,
+      errorReportingEndpoint: undefined,
       fetcher,
       compositionId: null,
+    });
+    expect(result).toMatchObject({
+      id: 'originalId-1234',
+      supergraphSdl: getTestingSupergraphSdl(),
+    });
+  });
 
+  it('Queries alternate Uplink URL if first one fails', async () => {
+    mockSupergraphSdlRequest('originalId-1234', mockCloudConfigUrl1).reply(500);
+    mockSupergraphSdlRequestIfAfter('originalId-1234', mockCloudConfigUrl2).reply(
+      200,
+      JSON.stringify({
+        data: {
+          routerConfig: {
+            __typename: 'RouterConfigResult',
+            id: 'originalId-1234',
+            supergraphSdl: getTestingSupergraphSdl()
+          },
+        },
+      }),
+    );
+
+    const fetcher = getDefaultFetcher();
+    const result = await loadSupergraphSdlFromUplinks({
+      graphRef,
+      apiKey,
+      endpoints: [mockCloudConfigUrl1, mockCloudConfigUrl2],
+      errorReportingEndpoint: undefined,
+      fetcher,
+      compositionId: "originalId-1234",
+      maxRetries: 1
     });
 
-    expect(result).toMatchInlineSnapshot(`
-      Object {
-        "id": "originalId-1234",
-        "supergraphSdl": "schema
-        @core(feature: \\"https://specs.apollo.dev/core/v0.2\\"),
-        @core(feature: \\"https://specs.apollo.dev/join/v0.1\\", for: EXECUTION),
-        @core(feature: \\"https://specs.apollo.dev/tag/v0.1\\")
-      {
-        query: Query
-        mutation: Mutation
-      }
-
-      directive @core(as: String, feature: String!, for: core__Purpose) repeatable on SCHEMA
-
-      directive @join__field(graph: join__Graph, provides: join__FieldSet, requires: join__FieldSet) on FIELD_DEFINITION
-
-      directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-
-      directive @join__owner(graph: join__Graph!) on INTERFACE | OBJECT
-
-      directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on INTERFACE | OBJECT
-
-      directive @stream on FIELD
-
-      directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
-
-      directive @transform(from: String!) on FIELD
-
-      union AccountType
-        @tag(name: \\"from-accounts\\")
-      = PasswordAccount | SMSAccount
-
-      type Amazon {
-        referrer: String
-      }
-
-      union Body = Image | Text
-
-      type Book implements Product
-        @join__owner(graph: BOOKS)
-        @join__type(graph: BOOKS, key: \\"isbn\\")
-        @join__type(graph: INVENTORY, key: \\"isbn\\")
-        @join__type(graph: PRODUCT, key: \\"isbn\\")
-        @join__type(graph: REVIEWS, key: \\"isbn\\")
-      {
-        details: ProductDetailsBook @join__field(graph: PRODUCT)
-        inStock: Boolean @join__field(graph: INVENTORY)
-        isCheckedOut: Boolean @join__field(graph: INVENTORY)
-        isbn: String! @join__field(graph: BOOKS)
-        metadata: [MetadataOrError] @join__field(graph: BOOKS)
-        name(delimeter: String = \\" \\"): String @join__field(graph: PRODUCT, requires: \\"title year\\")
-        price: String @join__field(graph: PRODUCT)
-        relatedReviews: [Review!]! @join__field(graph: REVIEWS, requires: \\"similarBooks{isbn}\\")
-        reviews: [Review] @join__field(graph: REVIEWS)
-        similarBooks: [Book]! @join__field(graph: BOOKS)
-        sku: String! @join__field(graph: PRODUCT)
-        title: String @join__field(graph: BOOKS)
-        upc: String! @join__field(graph: PRODUCT)
-        year: Int @join__field(graph: BOOKS)
-      }
-
-      union Brand = Amazon | Ikea
-
-      enum CacheControlScope {
-        PRIVATE
-        PUBLIC
-      }
-
-      type Car implements Vehicle
-        @join__owner(graph: PRODUCT)
-        @join__type(graph: PRODUCT, key: \\"id\\")
-        @join__type(graph: REVIEWS, key: \\"id\\")
-      {
-        description: String @join__field(graph: PRODUCT)
-        id: String! @join__field(graph: PRODUCT)
-        price: String @join__field(graph: PRODUCT)
-        retailPrice: String @join__field(graph: REVIEWS, requires: \\"price\\")
-      }
-
-      type Error {
-        code: Int
-        message: String
-      }
-
-      type Furniture implements Product
-        @join__owner(graph: PRODUCT)
-        @join__type(graph: PRODUCT, key: \\"upc\\")
-        @join__type(graph: PRODUCT, key: \\"sku\\")
-        @join__type(graph: INVENTORY, key: \\"sku\\")
-        @join__type(graph: REVIEWS, key: \\"upc\\")
-      {
-        brand: Brand @join__field(graph: PRODUCT)
-        details: ProductDetailsFurniture @join__field(graph: PRODUCT)
-        inStock: Boolean @join__field(graph: INVENTORY)
-        isHeavy: Boolean @join__field(graph: INVENTORY)
-        metadata: [MetadataOrError] @join__field(graph: PRODUCT)
-        name: String @join__field(graph: PRODUCT)
-        price: String @join__field(graph: PRODUCT)
-        reviews: [Review] @join__field(graph: REVIEWS)
-        sku: String! @join__field(graph: PRODUCT)
-        upc: String! @join__field(graph: PRODUCT)
-      }
-
-      type Ikea {
-        asile: Int
-      }
-
-      type Image implements NamedObject {
-        attributes: ImageAttributes!
-        name: String!
-      }
-
-      type ImageAttributes {
-        url: String!
-      }
-
-      scalar JSON @specifiedBy(url: \\"https://json-spec.dev\\")
-
-      type KeyValue {
-        key: String!
-        value: String!
-      }
-
-      type Library
-        @join__owner(graph: BOOKS)
-        @join__type(graph: BOOKS, key: \\"id\\")
-        @join__type(graph: ACCOUNTS, key: \\"id\\")
-      {
-        id: ID! @join__field(graph: BOOKS)
-        name: String @join__field(graph: BOOKS)
-        userAccount(id: ID! = 1): User @join__field(graph: ACCOUNTS, requires: \\"name\\")
-      }
-
-      union MetadataOrError = Error | KeyValue
-
-      type Mutation {
-        deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
-        login(password: String!, userId: String @deprecated(reason: \\"Use username instead\\"), username: String!): User @join__field(graph: ACCOUNTS)
-        reviewProduct(input: ReviewProduct!): Product @join__field(graph: REVIEWS)
-        updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
-      }
-
-      type Name {
-        first: String
-        last: String
-      }
-
-      interface NamedObject {
-        name: String!
-      }
-
-      type PasswordAccount
-        @join__owner(graph: ACCOUNTS)
-        @join__type(graph: ACCOUNTS, key: \\"email\\")
-      {
-        email: String! @join__field(graph: ACCOUNTS)
-      }
-
-      interface Product
-        @tag(name: \\"from-reviews\\")
-      {
-        details: ProductDetails
-        inStock: Boolean
-        name: String
-        price: String
-        reviews: [Review]
-        sku: String!
-        upc: String!
-      }
-
-      interface ProductDetails {
-        country: String
-      }
-
-      type ProductDetailsBook implements ProductDetails {
-        country: String
-        pages: Int
-      }
-
-      type ProductDetailsFurniture implements ProductDetails {
-        color: String
-        country: String
-      }
-
-      type Query {
-        body: Body! @join__field(graph: DOCUMENTS)
-        book(isbn: String!): Book @join__field(graph: BOOKS)
-        books: [Book] @join__field(graph: BOOKS)
-        library(id: ID!): Library @join__field(graph: BOOKS)
-        me: User @join__field(graph: ACCOUNTS)
-        product(upc: String!): Product @join__field(graph: PRODUCT)
-        topCars(first: Int = 5): [Car] @join__field(graph: PRODUCT)
-        topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCT)
-        topReviews(first: Int = 5): [Review] @join__field(graph: REVIEWS)
-        user(id: ID!): User @join__field(graph: ACCOUNTS)
-        vehicle(id: String!): Vehicle @join__field(graph: PRODUCT)
-      }
-
-      type Review
-        @join__owner(graph: REVIEWS)
-        @join__type(graph: REVIEWS, key: \\"id\\")
-      {
-        author: User @join__field(graph: REVIEWS, provides: \\"username\\")
-        body(format: Boolean = false): String @join__field(graph: REVIEWS)
-        id: ID! @join__field(graph: REVIEWS)
-        metadata: [MetadataOrError] @join__field(graph: REVIEWS)
-        product: Product @join__field(graph: REVIEWS)
-      }
-
-      input ReviewProduct {
-        body: String!
-        stars: Int @deprecated(reason: \\"Stars are no longer in use\\")
-        upc: String!
-      }
-
-      type SMSAccount
-        @join__owner(graph: ACCOUNTS)
-        @join__type(graph: ACCOUNTS, key: \\"number\\")
-      {
-        number: String @join__field(graph: ACCOUNTS)
-      }
-
-      type Text implements NamedObject {
-        attributes: TextAttributes!
-        name: String!
-      }
-
-      type TextAttributes {
-        bold: Boolean
-        text: String
-      }
-
-      union Thing = Car | Ikea
-
-      input UpdateReviewInput {
-        body: String
-        id: ID!
-      }
-
-      type User
-        @join__owner(graph: ACCOUNTS)
-        @join__type(graph: ACCOUNTS, key: \\"id\\")
-        @join__type(graph: ACCOUNTS, key: \\"username name{first last}\\")
-        @join__type(graph: INVENTORY, key: \\"id\\")
-        @join__type(graph: PRODUCT, key: \\"id\\")
-        @join__type(graph: REVIEWS, key: \\"id\\")
-        @tag(name: \\"from-accounts\\")
-        @tag(name: \\"from-reviews\\")
-      {
-        account: AccountType @join__field(graph: ACCOUNTS)
-        birthDate(locale: String): String @join__field(graph: ACCOUNTS) @tag(name: \\"admin\\") @tag(name: \\"dev\\")
-        goodAddress: Boolean @join__field(graph: REVIEWS, requires: \\"metadata{address}\\")
-        goodDescription: Boolean @join__field(graph: INVENTORY, requires: \\"metadata{description}\\")
-        id: ID! @join__field(graph: ACCOUNTS) @tag(name: \\"accounts\\") @tag(name: \\"on-external\\")
-        metadata: [UserMetadata] @join__field(graph: ACCOUNTS)
-        name: Name @join__field(graph: ACCOUNTS)
-        numberOfReviews: Int! @join__field(graph: REVIEWS)
-        reviews: [Review] @join__field(graph: REVIEWS)
-        ssn: String @join__field(graph: ACCOUNTS)
-        thing: Thing @join__field(graph: PRODUCT)
-        username: String @join__field(graph: ACCOUNTS)
-        vehicle: Vehicle @join__field(graph: PRODUCT)
-      }
-
-      type UserMetadata {
-        address: String
-        description: String
-        name: String
-      }
-
-      type Van implements Vehicle
-        @join__owner(graph: PRODUCT)
-        @join__type(graph: PRODUCT, key: \\"id\\")
-        @join__type(graph: REVIEWS, key: \\"id\\")
-      {
-        description: String @join__field(graph: PRODUCT)
-        id: String! @join__field(graph: PRODUCT)
-        price: String @join__field(graph: PRODUCT)
-        retailPrice: String @join__field(graph: REVIEWS, requires: \\"price\\")
-      }
-
-      interface Vehicle {
-        description: String
-        id: String!
-        price: String
-        retailPrice: String
-      }
-
-      enum core__Purpose {
-        \\"\\"\\"
-        \`EXECUTION\` features provide metadata necessary to for operation execution.
-        \\"\\"\\"
-        EXECUTION
-
-        \\"\\"\\"
-        \`SECURITY\` features provide metadata necessary to securely resolve fields.
-        \\"\\"\\"
-        SECURITY
-      }
-
-      scalar join__FieldSet
-
-      enum join__Graph {
-        ACCOUNTS @join__graph(name: \\"accounts\\" url: \\"https://accounts.api.com\\")
-        BOOKS @join__graph(name: \\"books\\" url: \\"https://books.api.com\\")
-        DOCUMENTS @join__graph(name: \\"documents\\" url: \\"https://documents.api.com\\")
-        INVENTORY @join__graph(name: \\"inventory\\" url: \\"https://inventory.api.com\\")
-        PRODUCT @join__graph(name: \\"product\\" url: \\"https://product.api.com\\")
-        REVIEWS @join__graph(name: \\"reviews\\" url: \\"https://reviews.api.com\\")
-      }
-      ",
-      }
-    `);
+    expect(result).toMatchObject({
+      id: 'originalId-1234',
+      supergraphSdl: getTestingSupergraphSdl(),
+    });
   });
+
+  it('Throws error if all Uplink URLs fail', async () => {
+    mockSupergraphSdlRequest("originalId-1234", mockCloudConfigUrl1).reply(500);
+    mockSupergraphSdlRequestIfAfter("originalId-1234", mockCloudConfigUrl2).reply(500);
+
+    const fetcher = getDefaultFetcher();
+    await expect(
+      loadSupergraphSdlFromUplinks({
+        graphRef,
+        apiKey,
+        endpoints: [mockCloudConfigUrl1, mockCloudConfigUrl2],
+        errorReportingEndpoint: undefined,
+        fetcher,
+        compositionId: "originalId-1234",
+        maxRetries: 1
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"An error occurred while fetching your schema from Apollo: 500 Internal Server Error"`,
+    );
+  })
 
   describe('errors', () => {
     it('throws on a malformed response', async () => {
@@ -353,13 +100,13 @@ describe('loadSupergraphSdlFromStorage', () => {
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
-
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 200 invalid json response body at https://example.cloud-config-url.com/cloudconfig/ reason: Unexpected token I in JSON at position 0"`,
+        `"An error occurred while fetching your schema from Apollo: 200 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected token I in JSON at position 0"`,
       );
     });
 
@@ -377,7 +124,8 @@ describe('loadSupergraphSdlFromStorage', () => {
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
@@ -386,13 +134,15 @@ describe('loadSupergraphSdlFromStorage', () => {
 
     it("throws on non-OK status codes when `errors` isn't present in a JSON response", async () => {
       mockSupergraphSdlRequest().reply(500);
+      mockOutOfBandReportRequestSuccess();
 
       const fetcher = getDefaultFetcher();
       await expect(
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
@@ -411,16 +161,18 @@ describe('loadSupergraphSdlFromStorage', () => {
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
+          errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input"`,
+        `"An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input"`,
       );
     });
 
     it('throws on 400 status response and does not submit an out of band error', async () => {
+
       mockSupergraphSdlRequest().reply(400);
 
       const fetcher = getDefaultFetcher();
@@ -428,13 +180,13 @@ describe('loadSupergraphSdlFromStorage', () => {
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
           errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input"`,
+        `"An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input"`,
       );
     });
 
@@ -447,7 +199,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
           errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
@@ -466,7 +218,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
           errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
@@ -485,7 +237,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         loadSupergraphSdlFromStorage({
           graphRef,
           apiKey,
-          endpoint: mockCloudConfigUrl,
+          endpoint: mockCloudConfigUrl1,
           errorReportingEndpoint: mockOutOfBandReporterUrl,
           fetcher,
           compositionId: null,
@@ -497,6 +249,7 @@ describe('loadSupergraphSdlFromStorage', () => {
   });
 
   it('throws on 504 status response and successfully submits an out of band error', async () => {
+
     mockSupergraphSdlRequest().reply(504);
     mockOutOfBandReportRequestSuccess();
 
@@ -505,7 +258,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       loadSupergraphSdlFromStorage({
         graphRef,
         apiKey,
-        endpoint: mockCloudConfigUrl,
+        endpoint: mockCloudConfigUrl1,
         errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
@@ -524,13 +277,13 @@ describe('loadSupergraphSdlFromStorage', () => {
       loadSupergraphSdlFromStorage({
         graphRef,
         apiKey,
-        endpoint: mockCloudConfigUrl,
+        endpoint: mockCloudConfigUrl1,
         errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred while fetching your schema from Apollo: request to https://example.cloud-config-url.com/cloudconfig/ failed, reason: no response"`,
+      `"An error occurred while fetching your schema from Apollo: request to https://example1.cloud-config-url.com/cloudconfig/ failed, reason: no response"`,
     );
   });
 
@@ -543,7 +296,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       loadSupergraphSdlFromStorage({
         graphRef,
         apiKey,
-        endpoint: mockCloudConfigUrl,
+        endpoint: mockCloudConfigUrl1,
         errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
@@ -562,7 +315,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       loadSupergraphSdlFromStorage({
         graphRef,
         apiKey,
-        endpoint: mockCloudConfigUrl,
+        endpoint: mockCloudConfigUrl1,
         errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: null,
@@ -579,10 +332,12 @@ describe('loadSupergraphSdlFromStorage', () => {
     const result = await loadSupergraphSdlFromStorage({
         graphRef,
         apiKey,
-        endpoint: mockCloudConfigUrl,
+        endpoint: mockCloudConfigUrl1,
+        errorReportingEndpoint: mockOutOfBandReporterUrl,
         fetcher,
         compositionId: "id-1234",
     });
     expect(result).toBeNull();
   });
 });
+

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -140,7 +140,9 @@ export interface ManagedGatewayConfig extends GatewayConfigBase {
    * This configuration option shouldn't be used unless by recommendation from
    * Apollo staff.
    */
-  schemaConfigDeliveryEndpoint?: string;
+  schemaConfigDeliveryEndpoint?: string; // deprecated
+  uplinkEndpoints?: string[];
+  uplinkMaxRetries?: number;
 }
 
 interface ManuallyManagedServiceDefsGatewayConfig extends GatewayConfigBase {


### PR DESCRIPTION
See #1283 for original PR by @snoopdave. Description below is copied directly from the original.
This PR duplicates the work which has landed on `main` over to `version-0.x`
---
This PR adds two new configuration fields to the existing ManagedGatewayConfig interface:
  uplinkEndpoints?: string[];
  uplinkMaxRetries?: number;

If uplinkEndpoints is not set and there is an existing setting for schemaDeliveryMaxRetries (deprecated) it will be honored.

Also, the existing env variable APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT is now treated as a comma-separated list of Uplink URLS.

uplinkMaxRetries will default to three times the number of entries in the end-points array.

If you specify more than one Uplink URL, the loadSupergraphSdlFromUplinks() logic will round-robin retry and will return the first result it receives.
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
