### PR TITLE
docs: add router results to algolia search

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
         // algoliaIndexName: 'federation',
         algoliaFilters: [
           'docset:federation',
-          ['docset:server', 'docset:rover', 'docset:studio'],
+          ['docset:server', 'docset:rover', 'docset:router', 'docset:studio'],
         ],
         subtitle: 'Federation',
         description: 'A guide to using Apollo Federation',


### PR DESCRIPTION
This PR adds the router docset to the `algoliaFilters` so that results for router docs will be surfaced when a user is in the federation docs.