### PR TITLE
Release @apollo/gateway@2.0.0-alpha.3, @apollo/composition@2.0.0-alpha.3, @apollo/query-planner@2.0.0-alpha.3, @apollo/query-graphs@2.0.0-alpha.3, @apollo/federation-internals@2.0.0-alpha.3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "apollo-federation-types",
  "deno_core",

--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG for `@apollo/composition`
 
-## vNEXT
+## v2.0.0-alpha.3
 
-> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Assign and document error codes for all errors [PR #1274](https://github.com/apollographql/federation/pull/1274).
 
 ## v2.0.0-alpha.2
 

--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for `@apollo/composition`
 
+## vNEXT
+
+- _Nothing yet! Stay tuned._
+
 ## v2.0.0-alpha.3
 
 - Assign and document error codes for all errors [PR #1274](https://github.com/apollographql/federation/pull/1274).

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG for `@apollo/gateway`
 
-## vNext
+## v2.0.0-alpha.3
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
@@ -12,7 +12,11 @@
     - Option #1: use the existing environment variable `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT` which will now be treated as a comma-separated list of URLs. 
     - Option #2: use the new `uplinkEndpoints`, which must be single URL or a comma-separated list of URLs for the Uplink End-points to be used, and `uplinkMaxRetries` which is how many times the Uplink URLs should be retried.
   - The old `schemaConfigDeliveryEndpoint` configuration value still work, but is deprecated and will be removed in a subsequent release.
-- Continue resolving when an `@external` reference cannot be resolved. [#376](https://github.com/apollographql/federation/issues/376)
+- Continue resolving when an `@external` reference cannot be resolved [#376](https://github.com/apollographql/federation/issues/376).
+- Fix issue reading some 0.x generated supergraphs [PR #1351](https://github.com/apollographql/federation/pull/1351).
+- Assign and document error codes for all errors [PR #1274](https://github.com/apollographql/federation/pull/1274).
+- Fix bug in handling of large number of query plan options [1316](https://github.com/apollographql/federation/pull/1316).
+- Remove unused dependency on `@apollographql/apollo-tools` [1304](https://github.com/apollographql/federation/pull/1304).
 
 ## v2.0.0-alpha.2
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG for `@apollo/gateway`
 
-## v2.0.0-alpha.3
-
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+
+## vNEXT
+
+- _Nothing yet! Stay tuned._
+
+## v2.0.0-alpha.3
 
 - RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1284](https://github.com/apollographql/federation/pull/1284)
 - __NOOP__: Fix OOB testing w.r.t. nock hygiene. Pushed error reporting endpoint responsibilities up into the gateway class, but there should be no effect on the runtime at all. [PR #1309](https://github.com/apollographql/federation/pull/1309)

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/harmonizer/Cargo.toml
+++ b/harmonizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harmonizer"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 authors = [ "Apollo <packages@apollographql.com>" ]
 edition = "2018"
 description = "Apollo Federation utility to compose a supergraph from subgraphs"

--- a/harmonizer/package.json
+++ b/harmonizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/harmonizer",
   "private": true,
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Apollo Federation Harmonizer JS Entrypoint",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for `@apollo/federation-internals`
 
+## vNEXT
+
+- _Nothing yet! Stay tuned._
+
 ## v2.0.0-alpha.3
 
 - Assign and document error codes for all errors [PR #1274](https://github.com/apollographql/federation/pull/1274).

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG for `@apollo/federation-internals`
 
-## vNEXT
+## v2.0.0-alpha.3
 
-> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Assign and document error codes for all errors [PR #1274](https://github.com/apollographql/federation/pull/1274).
+- Fix issue reading some 0.x generated supergraphs [PR #1351](https://github.com/apollographql/federation/pull/1351).
 
 ## v2.0.0-alpha.2
 

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -96,7 +96,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -125,7 +125,7 @@
     },
     "harmonizer": {
       "name": "@apollo/harmonizer",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -141,7 +141,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/core-schema": "^0.2.0",
@@ -21867,7 +21867,7 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -21882,7 +21882,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -21901,7 +21901,7 @@
     },
     "router-bridge": {
       "name": "@apollo/router-bridge",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/query-planner": "file:../query-planner-js",

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for `@apollo/query-graphs`
 
+## vNEXT
+
+- _Nothing yet! Stay tuned._
+
 ## v2.0.0-alpha.3
 
 - Fix issue with nested `@requires` directives [PR #1306](https://github.com/apollographql/federation/pull/1306).

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG for `@apollo/query-graphs`
 
-## vNEXT
+## v2.0.0-alpha.3
 
-> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Fix issue with nested `@requires` directives [PR #1306](https://github.com/apollographql/federation/pull/1306).
 
 ## v2.0.0-alpha.2
 

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG for `@apollo/query-planner`
 
-## v2.0.0-alpha.3
+## vNEXT
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+
+- _Nothing yet! Stay tuned._
+
+## v2.0.0-alpha.3
 
 - Fix bug in handling of large number of query plan options [1316](https://github.com/apollographql/federation/pull/1316).
 

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGELOG for `@apollo/query-planner`
 
-## vNEXT
+## v2.0.0-alpha.3
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+
+- Fix bug in handling of large number of query plan options [1316](https://github.com/apollographql/federation/pull/1316).
 
 ## v2.0.0-alpha.2
 

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/router-bridge/package.json
+++ b/router-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/router-bridge",
   "private": true,
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Apollo Router JS Bridge Entrypoint",
   "scripts": {
     "rollup": "rollup -c ./rollup.config.js"

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- _Nothing yet! Stay tuned._
+
 ## v2.0.0-alpha.2
 
 - __BREAKING__: Bump graphql peer dependency to `^15.7.0` [PR #1200](https://github.com/apollographql/federation/pull/1200)


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a release-x.y.z branch for an upcoming release. 🙌 The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR). Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. alpha, beta, rc) without affecting the main branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers. The main branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release. Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an -rc.x release suffix. Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the latest npm tag, this PR will be merged into main.