### PR TITLE
Clenfest/make_fetch_happen_backport

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## v0.45.0
 
+- RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1284](https://github.com/apollographql/federation/pull/1284)
 - __NOOP__: Fix OOB testing w.r.t. nock hygiene. Pushed error reporting endpoint responsibilities up into the gateway class, but there should be no effect on the runtime at all. [PR #1309](https://github.com/apollographql/federation/pull/1309)
 - __BREAKING__: Remove legacy GCS fetcher for schema updates. If you're currently opted-in to the backwards compatibility provided by setting `schemaConfigDeliveryEndpoint: null`, you may be affected by this update. Please see the PR for additional details. [PR #1225](https://github.com/apollographql/federation/pull/1225)
 - __Multi-cloud Uplink capability__ [PR #1283](https://github.com/apollographql/federation/pull/1283): now, by default two separate Uplink services will be used for schema fetching, the system will round-robin and if one service fails, a retry will occur and the other service will be called. 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix sending queries to service for type they don't know [PR #864](https://github.com/apollographql/federation/pull/864).
 
-- RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1284](https://github.com/apollographql/federation/pull/1284)
+- RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1380](https://github.com/apollographql/federation/pull/1380)
 
 ## v0.45.1
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,13 +6,14 @@
 
 - Fix sending queries to service for type they don't know [PR #864](https://github.com/apollographql/federation/pull/864).
 
+- RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1284](https://github.com/apollographql/federation/pull/1284)
+
 ## v0.45.1
 
 - Continue resolving when an `@external` reference cannot be resolved. [#376](https://github.com/apollographql/federation/issues/376)
 
 ## v0.45.0
 
-- RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1284](https://github.com/apollographql/federation/pull/1284)
 - __NOOP__: Fix OOB testing w.r.t. nock hygiene. Pushed error reporting endpoint responsibilities up into the gateway class, but there should be no effect on the runtime at all. [PR #1309](https://github.com/apollographql/federation/pull/1309)
 - __BREAKING__: Remove legacy GCS fetcher for schema updates. If you're currently opted-in to the backwards compatibility provided by setting `schemaConfigDeliveryEndpoint: null`, you may be affected by this update. Please see the PR for additional details. [PR #1225](https://github.com/apollographql/federation/pull/1225)
 - __Multi-cloud Uplink capability__ [PR #1283](https://github.com/apollographql/federation/pull/1283): now, by default two separate Uplink services will be used for schema fetching, the system will round-robin and if one service fails, a retry will occur and the other service will be called. 

--- a/gateway-js/src/__mocks__/make-fetch-happen-fetcher.ts
+++ b/gateway-js/src/__mocks__/make-fetch-happen-fetcher.ts
@@ -20,6 +20,7 @@ interface MakeFetchHappenMock extends jest.MockedFunction<typeof fetch> {
 }
 
 const mockMakeFetchHappen = jest.fn(fetcher) as unknown as MakeFetchHappenMock;
+const defaults = () => mockMakeFetchHappen;
 
 mockMakeFetchHappen.mockResponseOnce = (
   data?: BodyInit,
@@ -47,7 +48,8 @@ mockMakeFetchHappen.mockJSONResponseOnce = (
 };
 
 const makeFetchMock = {
-  makeFetchHappenFetcher: mockMakeFetchHappen,
+  fetch: mockMakeFetchHappen,
+  defaults,
 };
 
 jest.doMock('make-fetch-happen', () => makeFetchMock);

--- a/gateway-js/src/__tests__/gateway/buildService.test.ts
+++ b/gateway-js/src/__tests__/gateway/buildService.test.ts
@@ -1,4 +1,4 @@
-import { fetch } from '../../__mocks__/apollo-server-env';
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 
 import { RemoteGraphQLDataSource } from '../../datasources/RemoteGraphQLDataSource';

--- a/gateway-js/src/__tests__/gateway/composedSdl.test.ts
+++ b/gateway-js/src/__tests__/gateway/composedSdl.test.ts
@@ -1,6 +1,6 @@
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import { ApolloGateway } from '@apollo/gateway';
 import { ApolloServer } from 'apollo-server';
-import { fetch } from '../../__mocks__/apollo-server-env';
 import { getTestingSupergraphSdl } from '../execution-utils';
 
 async function getSupergraphSdlGatewayServer() {

--- a/gateway-js/src/__tests__/gateway/executor.test.ts
+++ b/gateway-js/src/__tests__/gateway/executor.test.ts
@@ -1,8 +1,8 @@
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import gql from 'graphql-tag';
 import { ApolloGateway } from '../../';
 import { fixtures } from 'apollo-federation-integration-testsuite';
 import { Logger } from 'apollo-server-types';
-import { fetch } from '../../__mocks__/apollo-server-env';
 
 let logger: {
   warn: jest.MockedFunction<Logger['warn']>,

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -17,18 +17,24 @@ import { isObject } from '../utilities/predicates';
 import { GraphQLDataSource, GraphQLDataSourceProcessOptions, GraphQLDataSourceRequestKind } from './types';
 import createSHA from 'apollo-server-core/dist/utils/createSHA';
 import { parseCacheControlHeader } from './parseCacheControlHeader';
-
+import fetcher from 'make-fetch-happen';
 export class RemoteGraphQLDataSource<
   TContext extends Record<string, any> = Record<string, any>,
 > implements GraphQLDataSource<TContext>
 {
-  fetcher: typeof fetch = fetch;
+  fetcher: typeof fetch;
 
   constructor(
     config?: Partial<RemoteGraphQLDataSource<TContext>> &
       object &
       ThisType<RemoteGraphQLDataSource<TContext>>,
   ) {
+    this.fetcher = fetcher.defaults({
+      // although this is the default, we want to take extra care and be very
+      // explicity to ensure that mutations cannot be retried. please leave this
+      // intact.
+      retry: false,
+    });
     if (config) {
       return Object.assign(this, config);
     }

--- a/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -1,5 +1,5 @@
-import { fetch } from '../../__mocks__/apollo-server-env';
-import { makeFetchHappenFetcher } from '../../__mocks__/make-fetch-happen-fetcher';
+import { fetch as customFetcher } from '../../__mocks__/apollo-server-env';
+import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 
 import {
   ApolloError,
@@ -263,8 +263,8 @@ describe('fetcher', () => {
     expect(data).toEqual({ injected: true });
   });
 
-  it('supports a custom fetcher, like `make-fetch-happen`', async () => {
-    const injectedFetch = makeFetchHappenFetcher.mockJSONResponseOnce({
+  it('supports a custom fetcher, like `node-fetch`', async () => {
+    const injectedFetch = customFetcher.mockJSONResponseOnce({
       data: { me: 'james' },
     });
     const DataSource = new RemoteGraphQLDataSource({


### PR DESCRIPTION
RemoteGraphQLDataSource uses make-fetch-happen by default (0.x backport
Fixes #1379