### PR TITLE
Use optional syntax to avoid array in call to buildSubgraphSchema

### DIFF
--- a/docs/source/api/apollo-subgraph.mdx
+++ b/docs/source/api/apollo-subgraph.mdx
@@ -8,13 +8,14 @@ api_reference: true
 This API reference documents the exports from the `@apollo/subgraph` package.
 
 ## `buildSubgraphSchema`
+
 > This method previously existed in the `@apollo/federation` package and was renamed from `buildFederatedSchema` after @apollo/federation v0.28.0 (the previous name still works but might be removed in a future release).
 
-A function that takes an array of GraphQL schema modules and returns a federation-ready schema based on those modules:
+A function that takes a schema module object (or an array of them) and returns a federation-ready subgraph schema:
 
 ```js{2}
 const server = new ApolloServer({
-  schema: buildSubgraphSchema([{ typeDefs, resolvers }])
+  schema: buildSubgraphSchema({ typeDefs, resolvers })
 });
 ```
 
@@ -45,11 +46,11 @@ Each schema module is an object with the following format:
 
 ###### `modules`
 
-`Array`
+`Object` or `Array`
 </td>
 <td>
 
-**Required.** An array of schema module objects with the structure shown above.
+**Required.** A schema module object (or an array of them) with the structure shown above.
 </td>
 </tr>
 </tbody>
@@ -84,7 +85,7 @@ const resolvers = {
 };
 
 const server = new ApolloServer({
-  schema: buildSubgraphSchema([{ typeDefs, resolvers }])
+  schema: buildSubgraphSchema({ typeDefs, resolvers })
 });
 ```
 

--- a/docs/source/quickstart-pt-3.mdx
+++ b/docs/source/quickstart-pt-3.mdx
@@ -35,7 +35,7 @@ Finally, modify your `ApolloServer` constructor by passing it a `schema` option 
 
 ```js:title=index.js
 const server = new ApolloServer({
-  schema: buildSubgraphSchema([{ typeDefs, resolvers }])
+  schema: buildSubgraphSchema({ typeDefs, resolvers })
 });
 ```
 

--- a/docs/source/subgraphs.mdx
+++ b/docs/source/subgraphs.mdx
@@ -105,7 +105,7 @@ Finally, we use the `buildSubgraphSchema` function from the `@apollo/subgraph` p
 
 ```js:title=index.js
 const server = new ApolloServer({
-  schema: buildSubgraphSchema([{ typeDefs, resolvers }])
+  schema: buildSubgraphSchema({ typeDefs, resolvers })
 });
 
 server.listen(4001).then(({ url }) => {
@@ -148,7 +148,7 @@ const resolvers = {
 }
 
 const server = new ApolloServer({
-  schema: buildSubgraphSchema([{ typeDefs, resolvers }])
+  schema: buildSubgraphSchema({ typeDefs, resolvers })
 });
 
 server.listen(4001).then(({ url }) => {
@@ -293,7 +293,7 @@ class DeprecatedDirective extends SchemaDirectiveVisitor {
 const directives = {
   deprecated: DeprecatedDirective
 };
-let schema = buildSubgraphSchema([{ typeDefs, resolvers }]);
+let schema = buildSubgraphSchema({ typeDefs, resolvers });
 
 SchemaDirectiveVisitor.visitSchemaDirectives(schema, directives);
 


### PR DESCRIPTION
Small PR for whenever you're around