### PR TITLE
router-bridge: use npm ci in the build.rs process

### DIFF
--- a/router-bridge/build.rs
+++ b/router-bridge/build.rs
@@ -18,7 +18,7 @@ fn update_bridge() {
 
     assert!(Command::new(&npm)
         .current_dir(&repo_dir)
-        .args(&["install"])
+        .args(&["ci"])
         .status()
         .unwrap()
         .success());


### PR DESCRIPTION
fixes apollographql/federation-rs#29 

Use npm ci instead of npm install in the build.rs process, to make sure we're using the tested dependencies, and avoir surprises if one of them doesn't respect semver.