### PR TITLE
Update allowed Gatsby versions for Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -106,13 +106,13 @@
       "matchPackageNames": ["react", "react-dom"],
       "allowedVersions": "16.x",
     },
-    // The current Apollo Gatsby theme does not support gatsby v3
+    // The current Apollo Gatsby theme does not support gatsby v4
     {
       "matchPaths": [
         "docs/package.json"
       ],
       "matchPackageNames": ["gatsby"],
-      "allowedVersions": "2.x",
+      "allowedVersions": "3.x",
     },
   ]
 }


### PR DESCRIPTION
This PR bumps the allowed versions for Gatsby in Renovate to v3, following the recent update to the docs theme to support v3.