### PR TITLE
fix(subgraph): Conditionally print @specifiedBy directive on scalars correctly

### DIFF
--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNEXT
 
+> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+
 - Make sure scalars don't print a `specifiedBy` directive unless specified in the subgraph. [PR #1463](https://github.com/apollographql/federation/pull/1463)
 
 ## v2.0.0-alpha.2

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## vNEXT
 
-> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
-
-- _Nothing yet! Stay tuned._
+- Make sure scalars don't have the `specifiedBy` directive unless specified in the schema.
 
 ## v2.0.0-alpha.2
 

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNEXT
 
-- Make sure scalars don't have the `specifiedBy` directive unless specified in the schema.
+- Make sure scalars don't print a `specifiedBy` directive unless specified in the subgraph. [PR #1463](https://github.com/apollographql/federation/pull/1463)
 
 ## v2.0.0-alpha.2
 

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -79,9 +79,9 @@ describe('printSubgraphSchema', () => {
   });
 
   it('prints a scalar without a directive correctly', () => {
-    const schema = gql`scalar JSON`
+    const schema = gql`scalar JSON`;
     const subgraphSchema = buildSubgraphSchema(schema);
-    
+
     expect(printSubgraphSchema(subgraphSchema)).toMatchInlineSnapshot(`
       "scalar JSON
 

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -1,6 +1,7 @@
 import { fixtures } from 'apollo-federation-integration-testsuite';
 import { buildSubgraphSchema } from '../buildSubgraphSchema';
 import { printSubgraphSchema } from '../printSubgraphSchema';
+import gql from 'graphql-tag';
 
 describe('printSubgraphSchema', () => {
   it('prints a subgraph correctly', () => {
@@ -72,6 +73,20 @@ describe('printSubgraphSchema', () => {
         id: ID! @external
         name: String @external
         userAccount(id: ID! = 1): User @requires(fields: \\"name\\")
+      }
+      "
+    `);
+  });
+
+  it('prints a scalar without a directive correctly', () => {
+    const schema = gql`scalar JSON`
+    const subgraphSchema = buildSubgraphSchema(schema);
+    
+    expect(printSubgraphSchema(subgraphSchema)).toMatchInlineSnapshot(`
+      "scalar JSON
+
+      type Query {
+        _service: _Service!
       }
       "
     `);

--- a/subgraph-js/src/printSubgraphSchema.ts
+++ b/subgraph-js/src/printSubgraphSchema.ts
@@ -380,7 +380,7 @@ function printSpecifiedByURL(scalar: GraphQLScalarType): string {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const value = (scalar as any).specifiedByUrl ?? scalar.specifiedByURL;
 
-  if (value === null) {
+  if (value == null) {
     return '';
   }
   const astValue = print({


### PR DESCRIPTION
When having a schema with scalars
```
scalar Date
scalar JSON
scalar HexColour
```

We end up in a situation where the scalar is `undefined` instead of `null`.

Because of that when we try to get the `sdl` we receive the `@specifiedBy` tag with an object attached to it.

```
query getIntrospection {
  _service {
    sdl
  }
}
```

![image](https://user-images.githubusercontent.com/5627330/152002454-09778fea-63e0-4c80-bc5d-295424976606.png)


This PR should fix that by weakly comparing `undefined == null`, I am happy to do a more strict comparison.