### PR TITLE
Create specific error class to signal uplink fetcher errors

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Use specific error classes when throwing errors due Apollo Uplink being unreacheable or returning an invalid response [PR #1473](https://github.com/apollographql/federation/pull/1473)
 
 ## v2.0.0-alpha.5
 
@@ -35,9 +35,7 @@ Some defensive code around gateway shutdown has been removed which was only rele
 
 [#1246](https://github.com/apollographql/federation/pull/1246)
 
-Upgrading graphql dependency to `16.2.0` [PR #1129](https://github.com/apollographql/federation/pull/1129).
-
-Use specific error classes when throwing errors due Apollo Uplink being unreacheable or returning an invalid response [PR #1473](https://github.com/apollographql/federation/pull/1473)
+- Upgrading graphql dependency to `16.2.0` [PR #1129](https://github.com/apollographql/federation/pull/1129).
 
 ## v2.0.0-alpha.3
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -30,6 +30,8 @@ Some defensive code around gateway shutdown has been removed which was only rele
 
 Upgrading graphql dependency to `16.2.0` [PR #1129](https://github.com/apollographql/federation/pull/1129).
 
+Use specific error classes when throwing errors due Apollo Uplink being unreacheable or returning an invalid response [PR #1473](https://github.com/apollographql/federation/pull/1473)
+
 ## v2.0.0-alpha.3
 
 - RemoteGraphQLDataSource will now use `make-fetch-happen` by default rather than `node-fetch` [PR #1284](https://github.com/apollographql/federation/pull/1284)

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -1127,3 +1127,6 @@ export {
   SupergraphSdlHook,
   SupergraphManager
 } from './config';
+
+export { UplinkFetcherError } from "./supergraphManagers"
+

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -1,6 +1,7 @@
 import {
   loadSupergraphSdlFromStorage,
-  loadSupergraphSdlFromUplinks
+  loadSupergraphSdlFromUplinks,
+  UplinkFetcherError,
 } from '../loadSupergraphSdlFromStorage';
 import { getDefaultFetcher } from '../../..';
 import {
@@ -86,8 +87,10 @@ describe('loadSupergraphSdlFromStorage', () => {
         compositionId: "originalId-1234",
         maxRetries: 1
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred while fetching your schema from Apollo: 500 Internal Server Error"`,
+    ).rejects.toThrowError(
+      new UplinkFetcherError(
+        "An error occurred while fetching your schema from Apollo: 500 Internal Server Error",
+      )
     );
   })
 
@@ -105,8 +108,10 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 200 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected token I in JSON at position 0"`,
+      ).rejects.toThrowError(
+        new UplinkFetcherError(
+          "An error occurred while fetching your schema from Apollo: 200 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected token I in JSON at position 0"
+        )
       );
     });
 
@@ -129,7 +134,9 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowError(message);
+      ).rejects.toThrowError(
+        new UplinkFetcherError(`An error occurred while fetching your schema from Apollo: \n${message}`)
+      );
     });
 
     it("throws on non-OK status codes when `errors` isn't present in a JSON response", async () => {
@@ -146,8 +153,10 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 500 Internal Server Error"`,
+      ).rejects.toThrowError(
+        new UplinkFetcherError(
+          "An error occurred while fetching your schema from Apollo: 500 Internal Server Error"
+        )
       );
     });
 
@@ -166,8 +175,10 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input"`,
+      ).rejects.toThrowError(
+        new UplinkFetcherError(
+          "An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input",
+        )
       );
     });
 
@@ -185,8 +196,10 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input"`,
+      ).rejects.toThrowError(
+        new UplinkFetcherError(
+          "An error occurred while fetching your schema from Apollo: 400 invalid json response body at https://example1.cloud-config-url.com/cloudconfig/ reason: Unexpected end of JSON input",
+        )
       );
     });
 
@@ -204,8 +217,10 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 413 Payload Too Large"`,
+      ).rejects.toThrowError(
+        new UplinkFetcherError(
+          "An error occurred while fetching your schema from Apollo: 413 Payload Too Large",
+        )
       );
     });
 
@@ -223,8 +238,10 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 422 Unprocessable Entity"`,
+      ).rejects.toThrowError(
+        new UplinkFetcherError(
+          "An error occurred while fetching your schema from Apollo: 422 Unprocessable Entity",
+        )
       );
     });
 
@@ -242,8 +259,10 @@ describe('loadSupergraphSdlFromStorage', () => {
           fetcher,
           compositionId: null,
         }),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"An error occurred while fetching your schema from Apollo: 408 Request Timeout"`,
+      ).rejects.toThrowError(
+        new UplinkFetcherError(
+          "An error occurred while fetching your schema from Apollo: 408 Request Timeout",
+        )
       );
     });
   });
@@ -263,8 +282,10 @@ describe('loadSupergraphSdlFromStorage', () => {
         fetcher,
         compositionId: null,
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred while fetching your schema from Apollo: 504 Gateway Timeout"`,
+    ).rejects.toThrowError(
+      new UplinkFetcherError(
+        "An error occurred while fetching your schema from Apollo: 504 Gateway Timeout",
+      )
     );
   });
 
@@ -282,8 +303,10 @@ describe('loadSupergraphSdlFromStorage', () => {
         fetcher,
         compositionId: null,
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred while fetching your schema from Apollo: request to https://example1.cloud-config-url.com/cloudconfig/ failed, reason: no response"`,
+    ).rejects.toThrowError(
+      new UplinkFetcherError(
+        "An error occurred while fetching your schema from Apollo: request to https://example1.cloud-config-url.com/cloudconfig/ failed, reason: no response",
+      )
     );
   });
 
@@ -301,8 +324,10 @@ describe('loadSupergraphSdlFromStorage', () => {
         fetcher,
         compositionId: null,
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred while fetching your schema from Apollo: 502 Bad Gateway"`,
+    ).rejects.toThrowError(
+      new UplinkFetcherError(
+        "An error occurred while fetching your schema from Apollo: 502 Bad Gateway",
+      )
     );
   });
 
@@ -320,8 +345,10 @@ describe('loadSupergraphSdlFromStorage', () => {
         fetcher,
         compositionId: null,
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred while fetching your schema from Apollo: 503 Service Unavailable"`,
+    ).rejects.toThrowError(
+      new UplinkFetcherError(
+        "An error occurred while fetching your schema from Apollo: 503 Service Unavailable",
+      )
     );
   });
 

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
@@ -4,6 +4,7 @@ import resolvable from '@josephg/resolvable';
 import { SupergraphManager, SupergraphSdlHookOptions } from '../../config';
 import { SubgraphHealthCheckFunction, SupergraphSdlUpdateFunction } from '../..';
 import { loadSupergraphSdlFromUplinks } from './loadSupergraphSdlFromStorage';
+export { UplinkFetcherError } from "./loadSupergraphSdlFromStorage"
 
 export interface UplinkFetcherOptions {
   pollIntervalInMs: number;

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
@@ -4,7 +4,6 @@ import resolvable from '@josephg/resolvable';
 import { SupergraphManager, SupergraphSdlHookOptions } from '../../config';
 import { SubgraphHealthCheckFunction, SupergraphSdlUpdateFunction } from '../..';
 import { loadSupergraphSdlFromUplinks } from './loadSupergraphSdlFromStorage';
-export { UplinkFetcherError } from "./loadSupergraphSdlFromStorage"
 
 export interface UplinkFetcherOptions {
   pollIntervalInMs: number;

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
@@ -139,7 +139,7 @@ export async function loadSupergraphSdlFromStorage({
       fetcher,
     });
 
-    throw new Error(fetchErrorMsg + (e.message ?? e));
+    throw new UplinkFetcherError(fetchErrorMsg + (e.message ?? e));
   }
 
   const endTime = new Date();
@@ -150,7 +150,7 @@ export async function loadSupergraphSdlFromStorage({
       response = await result.json();
     } catch (e) {
       // Bad response
-      throw new Error(fetchErrorMsg + result.status + ' ' + e.message ?? e);
+      throw new UplinkFetcherError(fetchErrorMsg + result.status + ' ' + e.message ?? e);
     }
 
     if ('errors' in response) {
@@ -162,7 +162,7 @@ export async function loadSupergraphSdlFromStorage({
     }
   } else {
     await submitOutOfBandReportIfConfigured({
-      error: new Error(fetchErrorMsg + result.status + ' ' + result.statusText),
+      error: new UplinkFetcherError(fetchErrorMsg + result.status + ' ' + result.statusText),
       request,
       endpoint: errorReportingEndpoint,
       response: result,
@@ -170,7 +170,7 @@ export async function loadSupergraphSdlFromStorage({
       endedAt: endTime,
       fetcher,
     });
-    throw new Error(fetchErrorMsg + result.status + ' ' + result.statusText);
+    throw new UplinkFetcherError(fetchErrorMsg + result.status + ' ' + result.statusText);
   }
 
   const { routerConfig } = response.data;
@@ -184,10 +184,10 @@ export async function loadSupergraphSdlFromStorage({
   } else if (routerConfig.__typename === 'FetchError') {
     // FetchError case
     const { code, message } = routerConfig;
-    throw new Error(`${code}: ${message}`);
+    throw new UplinkFetcherError(`${code}: ${message}`);
   } else if (routerConfig.__typename === 'Unchanged') {
     return null;
   } else {
-    throw new Error('Programming error: unhandled response failure');
+    throw new UplinkFetcherError('Programming error: unhandled response failure');
   }
 }

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
@@ -41,6 +41,13 @@ const fetchErrorMsg = "An error occurred while fetching your schema from Apollo:
 
 let fetchCounter = 0;
 
+export class UplinkFetcherError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UplinkFetcherError';
+  }
+}
+
 export async function loadSupergraphSdlFromUplinks({
   graphRef,
   apiKey,
@@ -147,7 +154,7 @@ export async function loadSupergraphSdlFromStorage({
     }
 
     if ('errors' in response) {
-      throw new Error(
+      throw new UplinkFetcherError(
         [fetchErrorMsg, ...response.errors.map((error) => error.message)].join(
           '\n',
         ),

--- a/gateway-js/src/supergraphManagers/index.ts
+++ b/gateway-js/src/supergraphManagers/index.ts
@@ -1,4 +1,4 @@
 export { LocalCompose } from './LocalCompose';
 export { LegacyFetcher } from './LegacyFetcher';
 export { IntrospectAndCompose } from './IntrospectAndCompose';
-export { UplinkFetcher } from './UplinkFetcher';
+export { UplinkFetcher, UplinkFetcherError } from './UplinkFetcher';

--- a/gateway-js/src/supergraphManagers/index.ts
+++ b/gateway-js/src/supergraphManagers/index.ts
@@ -1,4 +1,5 @@
 export { LocalCompose } from './LocalCompose';
 export { LegacyFetcher } from './LegacyFetcher';
 export { IntrospectAndCompose } from './IntrospectAndCompose';
-export { UplinkFetcher, UplinkFetcherError } from './UplinkFetcher';
+export { UplinkFetcher } from './UplinkFetcher';
+export { UplinkFetcherError } from './UplinkFetcher/loadSupergraphSdlFromStorage'


### PR DESCRIPTION
Hello there,

As described in #1439, we are suggesting here to use a specific class when throwing errors while fetching the schema from Apollo Uplink.

This should allow us to capture those errors using the specific class name, instead of relying on the actual message.

I've decided to transform all the errors in that file (since they are all related to the same process of fetching the schema). Also, please let me know if you think the error class should be placed somewhere else, so we don't need to export it up to the top

Thank you!

Fixes 