### PR TITLE
Creation of @override directive along with relevant tests

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -10,6 +10,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 - Optimize composition validation when many entities spans many subgraphs [PR #1653](https://github.com/apollographql/federation/pull/1653).
 - Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
+- Adds support for the `@override` directive on fields to indicate that a field should be moved from one subgraph to another. [PR #1484](https://github.com/apollographql/federation/pull/1484)
 
 ## v2.0.0-preview.8
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -74,7 +74,7 @@ describe('composition', () => {
         query: Query
       }
 
-      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -2025,7 +2025,7 @@ describe('composition', () => {
         query: Query
       }
 
-      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4,18 +4,18 @@ import gql from 'graphql-tag';
 import './matchers';
 import { print } from 'graphql';
 
-function assertCompositionSuccess(r: CompositionResult): asserts r is CompositionSuccess {
+export function assertCompositionSuccess(r: CompositionResult): asserts r is CompositionSuccess {
   if (r.errors) {
     throw new Error(`Expected composition to succeed but got errors:\n${r.errors.join('\n\n')}`);
   }
 }
 
-function errors(r: CompositionResult): [string, string][] {
+export function errors(r: CompositionResult): [string, string][] {
   return r.errors?.map(e => [e.extensions.code as string, e.message]) ?? [];
 }
 
 // Returns [the supergraph schema, its api schema, the extracted subgraphs]
-function schemas(result: CompositionSuccess): [Schema, Schema, Subgraphs] {
+export function schemas(result: CompositionSuccess): [Schema, Schema, Subgraphs] {
   // Note that we could user `result.schema`, but reparsing to ensure we don't lose anything with printing/parsing.
   const schema = buildSchema(result.supergraphSdl);
   expect(schema.isCoreSchema()).toBeTruthy();
@@ -74,7 +74,7 @@ describe('composition', () => {
         query: Query
       }
 
-      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -2025,7 +2025,7 @@ describe('composition', () => {
         query: Query
       }
 
-      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 

--- a/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
+++ b/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
@@ -15,7 +15,7 @@ function errors(r: CompositionResult): [string, string][] {
 
 // Returns [the supergraph schema, its api schema, the extracted subgraphs]
 function schemas(result: CompositionSuccess): [Schema, Schema, Subgraphs] {
-  // Note that we could user `result.schema`, but reparsing to ensure we don't lose anything with printing/parsing.
+  // Note that we could user `result.schema`, but re-parsing to ensure we don't lose anything with printing/parsing.
   const schema = buildSchema(result.supergraphSdl);
   expect(schema.isCoreSchema()).toBeTruthy();
   return [schema, schema.toAPISchema(), extractSubgraphsFromSupergraph(schema)];

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -168,7 +168,7 @@ describe("composition involving @override directive", () => {
         @join__type(graph: SUBGRAPH2, key: \\"id\\")
       {
         id: ID!
-        b: B @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, external: true)
+        b: B @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, usedOverridden: true)
       }"
     `);
 
@@ -239,7 +239,7 @@ describe("composition involving @override directive", () => {
         @join__type(graph: SUBGRAPH2, key: \\"id\\")
       {
         id: ID!
-        b: B @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, external: true)
+        b: B @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, usedOverridden: true)
       }"
     `);
 
@@ -300,7 +300,7 @@ describe("composition involving @override directive", () => {
         @join__type(graph: SUBGRAPH2, key: \\"k\\")
       {
         k: ID
-        x: Int @join__field(graph: SUBGRAPH1, external: true) @join__field(graph: SUBGRAPH2, override: \\"Subgraph1\\")
+        x: Int @join__field(graph: SUBGRAPH1, usedOverridden: true) @join__field(graph: SUBGRAPH2, override: \\"Subgraph1\\")
       }"
     `);
   });
@@ -464,7 +464,7 @@ describe("composition involving @override directive", () => {
         @join__type(graph: SUBGRAPH1, key: \\"k\\")
         @join__type(graph: SUBGRAPH2, key: \\"k\\")
       {
-        k: ID @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, external: true)
+        k: ID @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, usedOverridden: true)
         a: Int @join__field(graph: SUBGRAPH1)
         b: Int @join__field(graph: SUBGRAPH2)
       }"
@@ -502,9 +502,6 @@ describe("composition involving @override directive", () => {
 
     const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
     expect(result.errors).toBeDefined();
-    // TODO: Those error messages might be currently a tad confusing for the user, because it essentially says that "k" is external
-    // in Subgraph2, but if a user looks at its subgraph, it's not external. Ideally, we should amend those message to recognize
-    // and indicate that the field is external _because_ it is overridden 
     expect(result.errors?.map(e => e.message)).toMatchStringArray([
       `
       The following supergraph API query:
@@ -515,8 +512,8 @@ describe("composition involving @override directive", () => {
       }
       cannot be satisfied by the subgraphs because:
       - from subgraph "Subgraph2":
-        - field "T.k" is not resolvable because marked @external.
-        - cannot move to subgraph "Subgraph1" using @key(fields: "k") of "T", the key field(s) cannot be resolved from subgraph "Subgraph2".
+        - field "T.k" is not resolvable because it is overridden by subgraph "Subgraph1".
+        - cannot move to subgraph "Subgraph1" using @key(fields: "k") of "T", the key field(s) cannot be resolved from subgraph "Subgraph2" (note that some of those key fields are overridden in "Subgraph2").
       `,
       `
       The following supergraph API query:
@@ -528,7 +525,7 @@ describe("composition involving @override directive", () => {
       cannot be satisfied by the subgraphs because:
       - from subgraph "Subgraph2":
         - cannot find field "T.a".
-        - cannot move to subgraph "Subgraph1" using @key(fields: "k") of "T", the key field(s) cannot be resolved from subgraph "Subgraph2".
+        - cannot move to subgraph "Subgraph1" using @key(fields: "k") of "T", the key field(s) cannot be resolved from subgraph "Subgraph2" (note that some of those key fields are overridden in "Subgraph2").
       `
     ]);
   });
@@ -616,7 +613,7 @@ describe("composition involving @override directive", () => {
         @join__type(graph: SUBGRAPH1)
         @join__type(graph: SUBGRAPH2)
       {
-        k: ID @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, external: true)
+        k: ID @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, usedOverridden: true)
         a: Int @join__field(graph: SUBGRAPH1)
         b: Int @join__field(graph: SUBGRAPH2)
       }"

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -424,30 +424,14 @@ describe("composition involving @override directive", () => {
     };
 
     const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
-    assertCompositionSuccess(result);
-
-    const typeT = result.schema.type("T");
-    expect(printType(typeT!)).toMatchInlineSnapshot(`
-      "type T
-        @join__type(graph: SUBGRAPH1, key: \\"k\\")
-        @join__type(graph: SUBGRAPH2, key: \\"k\\")
-      {
-        k: ID
-        a: Int @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\")
-      }"
-    `);
-
-    const [_, api] = schemas(result);
-    expect(printSchema(api)).toMatchString(`
-      type Query {
-        t: T
-      }
-
-      type T {
-        k: ID
-        a: Int
-      }
-    `);
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toStrictEqual([
+      [
+        'FIELD_TYPE_MISMATCH',
+        'Field "T.a" has incompatible types across subgraphs: it has type "Int" in subgraph "Subgraph1" but type "String" in subgraph "Subgraph2"'
+      ]
+    ]);
   });
 
   it("override field that is a key in another type", () => {

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -394,44 +394,6 @@ describe("composition involving @override directive", () => {
     `);
   });
 
-  it("override with @external on overridden field", () => {
-    const subgraph1 = {
-      name: "Subgraph1",
-      url: "https://Subgraph1",
-      typeDefs: gql`
-        type Query {
-          t: T
-        }
-
-        type T @key(fields: "k") {
-          k: ID @override(from: "Subgraph2")
-          a: Int
-        }
-      `,
-    };
-
-    const subgraph2 = {
-      name: "Subgraph2",
-      url: "https://Subgraph2",
-      typeDefs: gql`
-        type T @key(fields: "k") {
-          k: ID @external
-          b: Int
-        }
-      `,
-    };
-
-    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
-    expect(result.errors?.length).toBe(1);
-    expect(result.errors).toBeDefined();
-    expect(errors(result)).toStrictEqual([
-      [
-        "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
-        `@override cannot be used on field "T.k" on subgraph "Subgraph1" since "T.k" on "Subgraph2" is marked with directive "@external"`,
-      ],
-    ]);
-  });
-
   it("override with @provides on overridden field", () => {
     const subgraph1 = {
       name: "Subgraph1",

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -1,0 +1,561 @@
+import { printSchema, printType } from "@apollo/federation-internals";
+import gql from "graphql-tag";
+import "./matchers";
+import {
+  assertCompositionSuccess,
+  schemas,
+  errors,
+  composeAsFed2Subgraphs,
+} from "./compose.test";
+
+describe("composition involving @override directive", () => {
+  it.skip("@override whole type", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") @override(from: "Subgraph2") {
+          k: ID
+          a: Int
+          b: Int
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          a: Int
+          c: Int
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    assertCompositionSuccess(result);
+
+    const typeT = result.schema.type("T");
+    expect(printType(typeT!)).toMatchInlineSnapshot(`
+      "type T
+        @join__type(graph: SUBGRAPH1, key: \\"k\\")
+        @join__type(graph: SUBGRAPH2, key: \\"k\\")
+      {
+        k: ID
+        a: Int
+        b: Int
+      }"
+    `);
+  });
+
+  it("@override single field.", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID
+          a: Int @override(from: "Subgraph2")
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          a: Int
+          b: Int
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    assertCompositionSuccess(result);
+
+    const typeT = result.schema.type("T");
+    expect(printType(typeT!)).toMatchInlineSnapshot(`
+      "type T
+        @join__type(graph: SUBGRAPH1, key: \\"k\\")
+        @join__type(graph: SUBGRAPH2, key: \\"k\\")
+      {
+        k: ID
+        a: Int @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\")
+        b: Int @join__field(graph: SUBGRAPH2)
+      }"
+    `);
+
+    const [_, api] = schemas(result);
+    expect(printSchema(api)).toMatchString(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        k: ID
+        a: Int
+        b: Int
+      }
+    `);
+  });
+
+  it("override from self error", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID
+          a: Int @override(from: "Subgraph1")
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toStrictEqual([
+      [
+        "OVERRIDE_FROM_SELF_ERROR",
+        `Source and destination subgraphs "Subgraph1" are the same for overridden field "T.a"`,
+      ],
+    ]);
+  });
+
+  it.skip("override in both type and field error", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") @override(from: "Subgraph2") {
+          k: ID
+          a: Int @override(from: "Subgraph2")
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          a: Int
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toStrictEqual([
+      [
+        "OVERRIDE_ON_BOTH_FIELD_AND_TYPE",
+        `Field "T.a" on subgraph "Subgraph1" is marked with @override directive on both the field and the type`,
+      ],
+    ]);
+  });
+
+  it("multiple override error", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID
+          a: Int @override(from: "Subgraph2")
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          a: Int @override(from: "Subgraph1")
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    // TODO: This test really should not cause the shareable error to be raised, but to fix it would be a bit of a pain, so punting
+    // for now
+    expect(result.errors?.length).toBe(3);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toStrictEqual([
+      [
+        "OVERRIDE_SOURCE_HAS_OVERRIDE",
+        `Field "T.a" on subgraph "Subgraph1" is also marked with directive @override in subgraph "Subgraph2". Only one @override directive is allowed per field.`,
+      ],
+      [
+        "OVERRIDE_SOURCE_HAS_OVERRIDE",
+        `Field "T.a" on subgraph "Subgraph2" is also marked with directive @override in subgraph "Subgraph1". Only one @override directive is allowed per field.`,
+      ],
+      [
+        "INVALID_FIELD_SHARING",
+        `Non-shareable field "T.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1" and "Subgraph2" and defined as non-shareable in all of them`,
+      ],
+    ]);
+  });
+
+  it("override @key field", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID @override(from: "Subgraph2")
+          a: Int
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          b: Int
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    assertCompositionSuccess(result);
+
+    const typeT = result.schema.type("T");
+    expect(printType(typeT!)).toMatchInlineSnapshot(`
+      "type T
+        @join__type(graph: SUBGRAPH1, key: \\"k\\")
+        @join__type(graph: SUBGRAPH2, key: \\"k\\")
+      {
+        k: ID @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, external: true)
+        a: Int @join__field(graph: SUBGRAPH1)
+        b: Int @join__field(graph: SUBGRAPH2)
+      }"
+    `);
+  });
+
+  it("override field with change to type definition", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID
+          a: Int @override(from: "Subgraph2")
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          a: String
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    assertCompositionSuccess(result);
+
+    const typeT = result.schema.type("T");
+    expect(printType(typeT!)).toMatchInlineSnapshot(`
+      "type T
+        @join__type(graph: SUBGRAPH1, key: \\"k\\")
+        @join__type(graph: SUBGRAPH2, key: \\"k\\")
+      {
+        k: ID
+        a: Int @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\")
+      }"
+    `);
+
+    const [_, api] = schemas(result);
+    expect(printSchema(api)).toMatchString(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        k: ID
+        a: Int
+      }
+    `);
+  });
+
+  it("override field that is a key in another type", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "e { k }") {
+          e: E
+        }
+
+        type E {
+          k: ID @override(from: "Subgraph2")
+          a: Int
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "e { k }") {
+          e: E
+          x: Int
+        }
+
+        type E {
+          k: ID
+          b: Int
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    assertCompositionSuccess(result);
+
+    const typeE = result.schema.type("E");
+    expect(printType(typeE!)).toMatchInlineSnapshot(`
+      "type E
+        @join__type(graph: SUBGRAPH1)
+        @join__type(graph: SUBGRAPH2)
+      {
+        k: ID @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\") @join__field(graph: SUBGRAPH2, external: true)
+        a: Int @join__field(graph: SUBGRAPH1)
+        b: Int @join__field(graph: SUBGRAPH2)
+      }"
+    `);
+
+    const typeT = result.schema.type("T");
+    expect(printType(typeT!)).toMatchInlineSnapshot(`
+      "type T
+        @join__type(graph: SUBGRAPH1, key: \\"e { k }\\")
+        @join__type(graph: SUBGRAPH2, key: \\"e { k }\\")
+      {
+        e: E
+        x: Int @join__field(graph: SUBGRAPH2)
+      }"
+    `);
+  });
+
+  it("override with @external on overridden field", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID @override(from: "Subgraph2")
+          a: Int
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID @external
+          b: Int
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toStrictEqual([
+      [
+        "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
+        `@override cannot be used on field "T.k" on subgraph "Subgraph1" since "T.k" on "Subgraph2" is marked with directive "@external"`,
+      ],
+    ]);
+  });
+
+  it("override with @provides on overridden field", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID
+          u: U @override(from: "Subgraph2")
+        }
+
+        type U @key(fields: "id") {
+          id: ID
+          name: String
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          u: U @provides(fields: "name")
+        }
+
+        extend type U @key(fields: "id") {
+          id: ID
+          name: String @external
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    // expect(result.errors?.length).toBe(1);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toContainEqual([
+      "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
+      `@override cannot be used on field "T.u" on subgraph "Subgraph1" since "T.u" on "Subgraph1" is marked with directive "@provides"`,
+    ]);
+  });
+
+  it("override with @requires on overridden field", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID
+          id: ID
+          u: U @override(from: "Subgraph2")
+        }
+
+        type U @key(fields: "id") {
+          id: ID
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          id: ID @external
+          u: U @requires(fields: "id")
+        }
+
+        extend type U @key(fields: "id") {
+          id: ID
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    // expect(result.errors?.length).toBe(1);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toContainEqual([
+      "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
+      `@override cannot be used on field "T.u" on subgraph "Subgraph1" since "T.u" on "Subgraph1" is marked with directive "@requires"`,
+    ]);
+  });
+
+  it("override with @external on overriding field", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      url: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "k") {
+          k: ID @override(from: "Subgraph2") @external
+          a: Int
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      url: "https://Subgraph2",
+      typeDefs: gql`
+        type T @key(fields: "k") {
+          k: ID
+          b: Int
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toContainEqual([
+      "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
+      `@override cannot be used on field "T.k" on subgraph "Subgraph1" since "T.k" on "Subgraph1" is marked with directive "@external"`,
+    ]);
+  });
+});

--- a/composition-js/src/hints.ts
+++ b/composition-js/src/hints.ts
@@ -122,6 +122,24 @@ export const hintInconsistentArgumentPresence = new HintID(
   'the argument with mismatched types'
 );
 
+export const hintFromSubgraphDoesNotExist = new HintID(
+  'FromSubgraphDoesNotExist',
+  'Source subgraph specified by @override directive does not exist',
+  'the argument with non-existent subgraph'
+);
+
+export const hintOverriddenFieldCanBeRemoved = new HintID(
+  'OverriddenFieldCanBeRemoved',
+  'Field has been overridden by another subgraph. Consider removing.',
+  'the overridden field'
+);
+
+export const hintOverrideDirectiveCanBeRemoved = new HintID(
+  'OverrideDirectiveCanBeRemoved',
+  'Field with @override directive no longer exists in source subgraph, the directive can be safely removed',
+  'the field with the override directive'
+);
+
 export class CompositionHint {
   public readonly nodes?: readonly SubgraphASTNode[];
 

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1011,10 +1011,7 @@ class Merger {
       } else if (subgraphsWithOverride.includes(sourceSubgraphName)) {
         this.errors.push(ERRORS.OVERRIDE_SOURCE_HAS_OVERRIDE.err({
           message: `Field "${coordinate}" on subgraph "${subgraphName}" is also marked with directive @override in subgraph "${sourceSubgraphName}". Only one @override directive is allowed per field.`,
-          nodes: [
-            overrideDirective?.sourceAST,
-            subgraphMap[sourceSubgraphName].overrideDirective?.sourceAST,
-          ].filter((ast): ast is ASTNode => ast !== undefined),
+          nodes: sourceASTs(overrideDirective, subgraphMap[sourceSubgraphName].overrideDirective)
         }));
       } else if (subgraphMap[sourceSubgraphName] === undefined) {
         this.hints.push(new CompositionHint(
@@ -1038,11 +1035,8 @@ class Merger {
           assert(conflictingDirective !== undefined, 'conflictingDirective should not be undefined');
           this.errors.push(ERRORS.OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE.err({
             message: `@override cannot be used on field "${fromField?.coordinate}" on subgraph "${subgraphName}" since "${fromField?.coordinate}" on "${subgraph}" is marked with directive "@${conflictingDirective.name}"`,
-            nodes: [
-              overrideDirective?.sourceAST,
-              conflictingDirective.sourceAST,
-            ].filter((ast): ast is ASTNode => ast !== undefined),
-            }));
+            nodes: sourceASTs(overrideDirective, conflictingDirective)
+          }));
         } else {
           // if we get here, then the @override directive is valid
           // if the field being overridden is used, then we need to add an @external directive

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1061,7 +1061,15 @@ class Merger {
           // if we get here, then the @override directive is valid
           // if the field being overridden is used, then we need to add an @external directive
           assert(fromField, 'fromField should not be undefined');
-          if (this.metadata(fromIdx).isFieldUsed(fromField)) {
+          if (this.isExternal(fromIdx, fromField)) {
+            // The from field is explcitely marked external by the user (which means it is "used" and cannot be completely
+            // removed) so the @override can be removed.
+            this.hints.push(new CompositionHint(
+              hintOverrideDirectiveCanBeRemoved,
+              `Field "${coordinate}" on subgraph "${subgraphName}" is not resolved anymore by the from subgraph (it is marked "@external" in "${sourceSubgraphName}"). The @override directive can be removed.`,
+              coordinate,
+            ));
+          } else if (this.metadata(fromIdx).isFieldUsed(fromField)) {
             result.setExternal(fromIdx);
             this.hints.push(new CompositionHint(
               hintOverriddenFieldCanBeRemoved,

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -917,14 +917,12 @@ class Merger {
     subgraphName,
     fromIdx,
     fromField,
-    fromSubgraphName
   }: {
     idx: number;
     field: FieldDefinition<any> | undefined;
     subgraphName: string;
     fromIdx: number;
     fromField: FieldDefinition<any> | undefined;
-    fromSubgraphName: string;
   }): { result: boolean, conflictingDirective?: DirectiveDefinition, subgraph?: string } {
     const fromMetadata = this.metadata(fromIdx);
     for (const directive of [fromMetadata.requiresDirective(), fromMetadata.providesDirective()]) {
@@ -941,13 +939,6 @@ class Merger {
         result: true,
         conflictingDirective: fromMetadata.externalDirective(),
         subgraph: subgraphName,
-      };
-    }
-    if (fromField && this.isExternal(fromIdx, fromField)) {
-      return {
-        result: true,
-        conflictingDirective: fromMetadata.externalDirective(),
-        subgraph: fromSubgraphName,
       };
     }
     return { result: false };
@@ -1029,7 +1020,6 @@ class Merger {
           subgraphName,
           fromIdx: this.names.indexOf(sourceSubgraphName),
           fromField: sources[fromIdx],
-          fromSubgraphName: sourceSubgraphName,
         });
         if (hasIncompatible) {
           assert(conflictingDirective !== undefined, 'conflictingDirective should not be undefined');

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -48,7 +48,6 @@ The following errors may be raised by composition:
 | `NON_REPEATABLE_DIRECTIVE_ARGUMENTS_MISMATCH` | A non-repeatable directive is applied to a schema element in different subgraphs but with arguments that are different. | 2.0.0 |  |
 | `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
 | `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
-| `OVERRIDE_ON_BOTH_FIELD_AND_TYPE` | Field and type are both marked with @override directive. This is not currently supported. | 2.0.0 |  |
 | `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
 | `PROVIDES_FIELDS_HAS_ARGS` | The `fields` argument of a `@provides` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `PROVIDES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@provides` directive includes a field that is not marked as `@external`. | 0.x |  |

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -46,6 +46,10 @@ The following errors may be raised by composition:
 | `MERGED_DIRECTIVE_APPLICATION_ON_EXTERNAL` | In a subgraph, a field is both marked @external and has a merged directive applied to it | 2.0.0 |  |
 | `NO_QUERIES` | None of the composed subgraphs expose any query. | 2.0.0 |  |
 | `NON_REPEATABLE_DIRECTIVE_ARGUMENTS_MISMATCH` | A non-repeatable directive is applied to a schema element in different subgraphs but with arguments that are different. | 2.0.0 |  |
+| `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
+| `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
+| `OVERRIDE_ON_BOTH_FIELD_AND_TYPE` | Field and type are both marked with @override directive. This is not currently supported. | 2.0.0 |  |
+| `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
 | `PROVIDES_FIELDS_HAS_ARGS` | The `fields` argument of a `@provides` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `PROVIDES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@provides` directive includes a field that is not marked as `@external`. | 0.x |  |
 | `PROVIDES_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@provides` directive is not a string. | 2.0.0 |  |

--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -83,6 +83,7 @@ export const typeDefs = gql`
     id: ID!
     name: String @external
     userAccount(id: ID! = "1"): User @requires(fields: "name")
+    description: String
   }
 `;
 

--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -83,7 +83,7 @@ export const typeDefs = gql`
     id: ID!
     name: String @external
     userAccount(id: ID! = "1"): User @requires(fields: "name")
-    description: String
+    description: String  @override(from: "books")
   }
 `;
 

--- a/federation-integration-testsuite-js/src/fixtures/books.ts
+++ b/federation-integration-testsuite-js/src/fixtures/books.ts
@@ -28,6 +28,7 @@ export const typeDefs = gql`
   type Library @key(fields: "id") {
     id: ID!
     name: String
+    description: String @override(from: "accounts")
   }
 
   # FIXME: turn back on when unions are supported in composition

--- a/federation-integration-testsuite-js/src/fixtures/books.ts
+++ b/federation-integration-testsuite-js/src/fixtures/books.ts
@@ -28,7 +28,7 @@ export const typeDefs = gql`
   type Library @key(fields: "id") {
     id: ID!
     name: String
-    description: String @override(from: "accounts")
+    description: String
   }
 
   # FIXME: turn back on when unions are supported in composition

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -1,4 +1,7 @@
-import { astSerializer, queryPlanSerializer } from 'apollo-federation-integration-testsuite';
+import {
+  astSerializer,
+  queryPlanSerializer,
+} from 'apollo-federation-integration-testsuite';
 import { getFederatedTestingSchema } from './execution-utils';
 import { QueryPlan, QueryPlanner } from '@apollo/query-planner';
 import { Schema, parseOperation } from '@apollo/federation-internals';
@@ -6,14 +9,13 @@ import { Schema, parseOperation } from '@apollo/federation-internals';
 expect.addSnapshotSerializer(astSerializer);
 expect.addSnapshotSerializer(queryPlanSerializer);
 
-
 describe('buildQueryPlan', () => {
   let schema: Schema;
   let queryPlanner: QueryPlanner;
 
   const buildPlan = (operation: string): QueryPlan => {
     return queryPlanner.buildQueryPlan(parseOperation(schema, operation));
-  }
+  };
 
   beforeEach(() => {
     expect(
@@ -515,7 +517,7 @@ describe('buildQueryPlan', () => {
 
   describe(`when requesting a composite field with subfields from another service`, () => {
     it(`should add key fields to the parent selection set and use a dependent fetch`, () => {
-       const operationString = `#graphql
+      const operationString = `#graphql
         query {
           topReviews {
             body
@@ -1164,6 +1166,33 @@ describe('buildQueryPlan', () => {
                     text
                   }
                 }
+              }
+            }
+          },
+        }
+      `);
+    });
+  });
+
+  describe('overridden fields and type', () => {
+    it(`query plan of overridden field`, () => {
+      const operationString = `#graphql
+        query {
+          library (id: "3") {
+            name
+            description
+          }
+        }
+      `;
+
+      const queryPlan = buildPlan(operationString);
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Fetch(service: "books") {
+            {
+              library(id: 3) {
+                name
+                description
               }
             }
           },

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -1188,13 +1188,31 @@ describe('buildQueryPlan', () => {
       const queryPlan = buildPlan(operationString);
       expect(queryPlan).toMatchInlineSnapshot(`
         QueryPlan {
-          Fetch(service: "books") {
-            {
-              library(id: 3) {
-                name
-                description
+          Sequence {
+            Fetch(service: "books") {
+              {
+                library(id: 3) {
+                  __typename
+                  id
+                  name
+                }
               }
-            }
+            },
+            Flatten(path: "library") {
+              Fetch(service: "accounts") {
+                {
+                  ... on Library {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on Library {
+                    description
+                  }
+                }
+              },
+            },
           },
         }
       `);

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -147,7 +147,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
-      '3a799fc2690d4e0e2766002f8c583b4b796d2e6732f12da9bfafab782fc01240',
+      '7fdce3c97bf56a17fa73ca7d7575c406165df1e7f9e0cce010d957a27bbb01e4',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -147,7 +147,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
-      '7fdce3c97bf56a17fa73ca7d7575c406165df1e7f9e0cce010d957a27bbb01e4',
+      '730a2fe4036db8e2c847096ba2a62f78ff8f3c08c9ee092a5b1b37e1aa00ef5a',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -5,6 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
 - Add missing `includeDeprecated` argument for `args` and `inputFields` when defining introspection fields [PR #1584](https://github.com/apollographql/federation/pull/1584)
+- Adds support for the `@override` directive on fields to indicate that a field should be moved from one subgraph to another. [PR #1484](https://github.com/apollographql/federation/pull/1484)
 
 ## v2.0.0-preview.8
 

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -549,7 +549,7 @@ describe('@core/@link handling', () => {
 
     directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-    directive @federation__external on OBJECT | FIELD_DEFINITION
+    directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
 
     directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -680,7 +680,7 @@ describe('@core/@link handling', () => {
           k: ID!
         }
 
-        directive @federation__external on OBJECT | FIELD_DEFINITION
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
       `,
     ];
 
@@ -777,7 +777,7 @@ describe('@core/@link handling', () => {
         k: ID!
       }
 
-      directive @federation__external on OBJECT | FIELD_DEFINITION | SCHEMA
+      directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION | SCHEMA
     `;
 
     // @external is not allowed on 'schema' and likely never will.

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -559,6 +559,8 @@ describe('@core/@link handling', () => {
 
     directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
+    directive @federation__override(from: String!) on FIELD_DEFINITION
+
     type T
       @key(fields: "k")
     {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -384,7 +384,7 @@ export class DirectiveTargetElement<T extends DirectiveTargetElement<T>> {
 }
 
 export function sourceASTs(...elts: ({ sourceAST?: ASTNode } | undefined)[]): ASTNode[] {
-  return elts.map(elt => elt?.sourceAST).filter(elt => elt !== undefined) as ASTNode[];
+  return elts.map(elt => elt?.sourceAST).filter((elt): elt is ASTNode => elt !== undefined);
 }
 
 // Not exposed: mostly about avoid code duplication between SchemaElement and Directive (which is not a SchemaElement as it can't

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -369,11 +369,6 @@ const OVERRIDE_SOURCE_HAS_OVERRIDE = makeCodeDefinition(
   'Field which is overridden to another subgraph is also marked @override.',
 );
 
-const OVERRIDE_ON_BOTH_FIELD_AND_TYPE = makeCodeDefinition(
-  'OVERRIDE_ON_BOTH_FIELD_AND_TYPE',
-  'Field and type are both marked with @override directive. This is not currently supported.',
-);
-
 const OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE = makeCodeDefinition(
   'OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE',
   'The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires.',
@@ -441,7 +436,6 @@ export const ERRORS = {
   OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE,
   OVERRIDE_FROM_SELF_ERROR,
   OVERRIDE_SOURCE_HAS_OVERRIDE,
-  OVERRIDE_ON_BOTH_FIELD_AND_TYPE,
 };
 
 const codeDefByCode = Object.values(ERRORS).reduce((obj: {[code: string]: ErrorCodeDefinition}, codeDef: ErrorCodeDefinition) => { obj[codeDef.code] = codeDef; return obj; }, {});

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -359,6 +359,26 @@ const SATISFIABILITY_ERROR = makeCodeDefinition(
   'Subgraphs can be merged, but the resulting supergraph API would have queries that cannot be satisfied by those subgraphs.',
 );
 
+const OVERRIDE_FROM_SELF_ERROR = makeCodeDefinition(
+  'OVERRIDE_FROM_SELF_ERROR',
+  'Field with `@override` directive has "from" location that references its own subgraph.',
+);
+
+const OVERRIDE_SOURCE_HAS_OVERRIDE = makeCodeDefinition(
+  'OVERRIDE_SOURCE_HAS_OVERRIDE',
+  'Field which is overridden to another subgraph is also marked @override.',
+);
+
+const OVERRIDE_ON_BOTH_FIELD_AND_TYPE = makeCodeDefinition(
+  'OVERRIDE_ON_BOTH_FIELD_AND_TYPE',
+  'Field and type are both marked with @override directive. This is not currently supported.',
+);
+
+const OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE = makeCodeDefinition(
+  'OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE',
+  'The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires.',
+);
+
 export const ERROR_CATEGORIES = {
   DIRECTIVE_FIELDS_MISSING_EXTERNAL,
   DIRECTIVE_UNSUPPORTED_ON_INTERFACE,
@@ -418,6 +438,10 @@ export const ERRORS = {
   REFERENCED_INACCESSIBLE,
   REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH,
   SATISFIABILITY_ERROR,
+  OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE,
+  OVERRIDE_FROM_SELF_ERROR,
+  OVERRIDE_SOURCE_HAS_OVERRIDE,
+  OVERRIDE_ON_BOTH_FIELD_AND_TYPE,
 };
 
 const codeDefByCode = Object.values(ERRORS).reduce((obj: {[code: string]: ErrorCodeDefinition}, codeDef: ErrorCodeDefinition) => { obj[codeDef.code] = codeDef; return obj; }, {});

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -181,6 +181,12 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
               if (args.external) {
                 subgraphField.applyDirective(subgraph.metadata().externalDirective());
               }
+              if (args.usedOverridden) {
+                subgraphField.applyDirective(subgraph.metadata().externalDirective(), {'reason': '[overridden]'});
+              }
+              if (args.override) {
+                subgraphField.applyDirective(subgraph.metadata().overrideDirective(), {'from': args.override});
+              }
             }
           }
         }

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -52,7 +52,7 @@ import {
   ERRORS,
   withModifiedErrorMessage,
 } from "./error";
-import { computeShareables } from "./sharing";
+import { computeKeys, computeShareables } from "./precompute";
 import {
   CoreSpecDefinition,
   FeatureVersion,
@@ -71,6 +71,7 @@ import {
   externalDirectiveSpec,
   extendsDirectiveSpec,
   shareableDirectiveSpec,
+  overrideDirectiveSpec,
   FEDERATION2_SPEC_DIRECTIVES,
   ALL_FEDERATION_DIRECTIVES_DEFAULT_NAMES,
   FEDERATION2_ONLY_SPEC_DIRECTIVES,
@@ -262,21 +263,21 @@ function validateAllFieldSet<TParent extends SchemaElement<any, any>>(
   }
 }
 
-export function collectUsedExternalFieldsCoordinates(metadata: FederationMetadata): Set<string> {
-  const usedExternalCoordinates = new Set<string>();
+export function collectUsedFields(metadata: FederationMetadata): Set<FieldDefinition<CompositeType>> {
+  const usedFields = new Set<FieldDefinition<CompositeType>>();
 
   // Collects all external fields used by a key, requires or provides
   collectUsedExternaFieldsForDirective<CompositeType>(
     metadata,
     metadata.keyDirective(),
     type => type,
-    usedExternalCoordinates,
+    usedFields,
   );
   collectUsedExternaFieldsForDirective<FieldDefinition<CompositeType>>(
     metadata,
     metadata.requiresDirective(),
     field => field.parent!,
-    usedExternalCoordinates,
+    usedFields,
   );
   collectUsedExternaFieldsForDirective<FieldDefinition<CompositeType>>(
     metadata,
@@ -285,7 +286,7 @@ export function collectUsedExternalFieldsCoordinates(metadata: FederationMetadat
       const type = baseType(field.type!);
       return isCompositeType(type) ? type : undefined;
     },
-    usedExternalCoordinates,
+    usedFields,
   );
 
   // Collects all external fields used to satisfy an interface constraint
@@ -295,20 +296,20 @@ export function collectUsedExternalFieldsCoordinates(metadata: FederationMetadat
       for (const runtimeType of runtimeTypes) {
         const implemField = runtimeType.field(field.name);
         if (implemField && metadata.isFieldExternal(implemField)) {
-          usedExternalCoordinates.add(implemField.coordinate);
+          usedFields.add(implemField);
         }
       }
     }
   }
 
-  return usedExternalCoordinates;
+  return usedFields;
 }
 
 function collectUsedExternaFieldsForDirective<TParent extends SchemaElement<any, any>>(
   metadata: FederationMetadata,
   definition: DirectiveDefinition<{fields: any}>,
   targetTypeExtractor: (element: TParent) => CompositeType | undefined,
-  usedExternalCoordinates: Set<string>
+  usedExternalCoordinates: Set<FieldDefinition<CompositeType>>
 ) {
   for (const application of definition.applications()) {
     const type = targetTypeExtractor(application.parent! as TParent);
@@ -327,7 +328,7 @@ function collectUsedExternaFieldsForDirective<TParent extends SchemaElement<any,
       includeInterfaceFieldsImplementations: true,
       validate: false,
     }).filter((field) => metadata.isFieldExternal(field))
-      .forEach((field) => usedExternalCoordinates.add(field.coordinate));
+      .forEach((field) => usedExternalCoordinates.add(field));
   }
 }
 
@@ -336,13 +337,12 @@ function collectUsedExternaFieldsForDirective<TParent extends SchemaElement<any,
  * interface implementation. Otherwise, the field declaration is somewhat useless.
  */
 function validateAllExternalFieldsUsed(metadata: FederationMetadata, errorCollector: GraphQLError[]): void {
-  const allUsedExternals = collectUsedExternalFieldsCoordinates(metadata);
   for (const type of metadata.schema.types()) {
     if (!isObjectType(type) && !isInterfaceType(type)) {
       continue;
     }
     for (const field of type.fields()) {
-      if (!metadata.isFieldExternal(field) || allUsedExternals.has(field.coordinate)) {
+      if (!metadata.isFieldExternal(field) || metadata.isFieldUsed(field)) {
         continue;
       }
 
@@ -425,6 +425,8 @@ function formatFieldsToReturnType([type, implems]: [string, FieldDefinition<Obje
 export class FederationMetadata {
   private _externalTester?: ExternalTester;
   private _sharingPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
+  private _keysPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
+  private _fieldUsedPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
   private _isFed2Schema?: boolean;
 
   constructor(readonly schema: Schema) {
@@ -433,7 +435,9 @@ export class FederationMetadata {
   private onInvalidate() {
     this._externalTester = undefined;
     this._sharingPredicate = undefined;
+    this._keysPredicate = undefined;
     this._isFed2Schema = undefined;
+    this._fieldUsedPredicate = undefined;
   }
 
   isFed2Schema(): boolean {
@@ -462,6 +466,25 @@ export class FederationMetadata {
     return this._sharingPredicate;
   }
 
+  private keysPredicate(): (field: FieldDefinition<CompositeType>) => boolean {
+    if (!this._keysPredicate) {
+      this._keysPredicate = computeKeys(this.schema);
+    }
+    return this._keysPredicate;
+  }
+
+  private fieldUsedPredicate(): (field: FieldDefinition<CompositeType>) => boolean {
+    if (!this._fieldUsedPredicate) {
+      const usedFields = Array.from(collectUsedFields(this));
+      this._fieldUsedPredicate = (field: FieldDefinition<CompositeType>) => !!usedFields.find((f) => f.coordinate === field.coordinate);
+    }
+    return this._fieldUsedPredicate;
+  }
+
+  isFieldUsed(field: FieldDefinition<CompositeType>): boolean {
+    return this.fieldUsedPredicate()(field);
+  }
+
   isFieldExternal(field: FieldDefinition<any> | InputFieldDefinition) {
     return this.externalTester().isExternal(field);
   }
@@ -484,6 +507,10 @@ export class FederationMetadata {
 
   isFieldShareable(field: FieldDefinition<any>): boolean {
     return this.sharingPredicate()(field);
+  }
+
+  isKeyField(field: FieldDefinition<any>): boolean {
+    return this.keysPredicate()(field);
   }
 
   federationDirectiveNameInSchema(name: string): string {
@@ -533,6 +560,10 @@ export class FederationMetadata {
     return this.getFederationDirective(keyDirectiveSpec.name);
   }
 
+  overrideDirective(): DirectiveDefinition<{from: string}> {
+    return this.getFederationDirective(overrideDirectiveSpec.name);
+  }
+
   extendsDirective(): DirectiveDefinition<Record<string, never>> {
     return this.getFederationDirective(extendsDirectiveSpec.name);
   }
@@ -562,7 +593,7 @@ export class FederationMetadata {
   }
 
   allFederationDirectives(): DirectiveDefinition[] {
-    const baseDirectives = [
+    const baseDirectives: DirectiveDefinition<any>[] = [
       this.keyDirective(),
       this.externalDirective(),
       this.requiresDirective(),
@@ -571,7 +602,7 @@ export class FederationMetadata {
       this.extendsDirective(),
     ];
     return this.isFed2Schema()
-      ? baseDirectives.concat(this.shareableDirective(), this.inaccessibleDirective())
+      ? baseDirectives.concat(this.shareableDirective(), this.inaccessibleDirective(), this.overrideDirective())
       : baseDirectives;
   }
 
@@ -804,7 +835,7 @@ export class FederationBlueprint extends SchemaBlueprint {
         }
       } else {
         return withModifiedErrorMessage(
-          error, 
+          error,
           `${error.message} If you meant the "@${unknownDirectiveName}" federation 2 directive, note that this schema is a federation 1 schema. To be a federation 2 schema, it needs to @link to the federation specifcation v2.`
         );
       }
@@ -813,7 +844,7 @@ export class FederationBlueprint extends SchemaBlueprint {
       const suggestions = suggestionList(unknownDirectiveName, FEDERATION2_ONLY_SPEC_DIRECTIVES.map((spec) => spec.name));
       if (suggestions.length > 0) {
         return withModifiedErrorMessage(
-          error, 
+          error,
           `${error.message}${didYouMean(suggestions.map((s) => '@' + s))} If so, note that ${suggestions.length === 1 ? 'it is a federation 2 directive' : 'they are federation 2 directives'} but this schema is a federation 1 one. To be a federation 2 schema, it needs to @link to the federation specifcation v2.`
         );
       }
@@ -876,7 +907,7 @@ export function setSchemaAsFed2Subgraph(schema: Schema) {
 
 // This is the full @link declaration as added by `asFed2SubgraphDocument`. It's here primarily for uses by tests that print and match
 // subgraph schema to avoid having to update 20+ tests every time we use a new directive or the order of import changes ...
-export const FEDERATION2_LINK_WTH_FULL_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible"])';
+export const FEDERATION2_LINK_WTH_FULL_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override"])';
 
 export function asFed2SubgraphDocument(document: DocumentNode): DocumentNode {
   const fed2LinkExtension: SchemaExtensionNode = {

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -544,7 +544,7 @@ export class FederationMetadata {
     return this.getFederationDirective(extendsDirectiveSpec.name);
   }
 
-  externalDirective(): DirectiveDefinition<Record<string, never>> {
+  externalDirective(): DirectiveDefinition<{reason: string}> {
     return this.getFederationDirective(externalDirectiveSpec.name);
   }
 

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -475,14 +475,14 @@ export class FederationMetadata {
 
   private fieldUsedPredicate(): (field: FieldDefinition<CompositeType>) => boolean {
     if (!this._fieldUsedPredicate) {
-      const usedFields = Array.from(collectUsedFields(this));
-      this._fieldUsedPredicate = (field: FieldDefinition<CompositeType>) => !!usedFields.find((f) => f.coordinate === field.coordinate);
+      const usedFields = collectUsedFields(this);
+      this._fieldUsedPredicate = (field: FieldDefinition<CompositeType>) => !!usedFields.has(field);
     }
     return this._fieldUsedPredicate;
   }
 
   isFieldUsed(field: FieldDefinition<CompositeType>): boolean {
-    return this.fieldUsedPredicate()(field);
+    return this.fieldUsedPredicate()(field) || this.keysPredicate()(field);
   }
 
   isFieldExternal(field: FieldDefinition<any> | InputFieldDefinition) {
@@ -507,10 +507,6 @@ export class FederationMetadata {
 
   isFieldShareable(field: FieldDefinition<any>): boolean {
     return this.sharingPredicate()(field);
-  }
-
-  isKeyField(field: FieldDefinition<any>): boolean {
-    return this.keysPredicate()(field);
   }
 
   federationDirectiveNameInSchema(name: string): string {
@@ -593,7 +589,7 @@ export class FederationMetadata {
   }
 
   allFederationDirectives(): DirectiveDefinition[] {
-    const baseDirectives: DirectiveDefinition<any>[] = [
+    const baseDirectives: DirectiveDefinition[] = [
       this.keyDirective(),
       this.externalDirective(),
       this.requiresDirective(),

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -52,7 +52,7 @@ import {
   ERRORS,
   withModifiedErrorMessage,
 } from "./error";
-import { computeKeys, computeShareables } from "./precompute";
+import { computeShareables } from "./precompute";
 import {
   CoreSpecDefinition,
   FeatureVersion,
@@ -267,20 +267,17 @@ export function collectUsedFields(metadata: FederationMetadata): Set<FieldDefini
   const usedFields = new Set<FieldDefinition<CompositeType>>();
 
   // Collects all external fields used by a key, requires or provides
-  collectUsedExternaFieldsForDirective<CompositeType>(
-    metadata,
+  collectUsedFieldsForDirective<CompositeType>(
     metadata.keyDirective(),
     type => type,
     usedFields,
   );
-  collectUsedExternaFieldsForDirective<FieldDefinition<CompositeType>>(
-    metadata,
+  collectUsedFieldsForDirective<FieldDefinition<CompositeType>>(
     metadata.requiresDirective(),
     field => field.parent!,
     usedFields,
   );
-  collectUsedExternaFieldsForDirective<FieldDefinition<CompositeType>>(
-    metadata,
+  collectUsedFieldsForDirective<FieldDefinition<CompositeType>>(
     metadata.providesDirective(),
     field => {
       const type = baseType(field.type!);
@@ -305,11 +302,10 @@ export function collectUsedFields(metadata: FederationMetadata): Set<FieldDefini
   return usedFields;
 }
 
-function collectUsedExternaFieldsForDirective<TParent extends SchemaElement<any, any>>(
-  metadata: FederationMetadata,
+function collectUsedFieldsForDirective<TParent extends SchemaElement<any, any>>(
   definition: DirectiveDefinition<{fields: any}>,
   targetTypeExtractor: (element: TParent) => CompositeType | undefined,
-  usedExternalCoordinates: Set<FieldDefinition<CompositeType>>
+  usedFieldDefs: Set<FieldDefinition<CompositeType>>
 ) {
   for (const application of definition.applications()) {
     const type = targetTypeExtractor(application.parent! as TParent);
@@ -327,8 +323,7 @@ function collectUsedExternaFieldsForDirective<TParent extends SchemaElement<any,
       directive: application as Directive<any, {fields: any}>,
       includeInterfaceFieldsImplementations: true,
       validate: false,
-    }).filter((field) => metadata.isFieldExternal(field))
-      .forEach((field) => usedExternalCoordinates.add(field));
+    }).forEach((field) => usedFieldDefs.add(field));
   }
 }
 
@@ -425,7 +420,6 @@ function formatFieldsToReturnType([type, implems]: [string, FieldDefinition<Obje
 export class FederationMetadata {
   private _externalTester?: ExternalTester;
   private _sharingPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
-  private _keysPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
   private _fieldUsedPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
   private _isFed2Schema?: boolean;
 
@@ -435,7 +429,6 @@ export class FederationMetadata {
   private onInvalidate() {
     this._externalTester = undefined;
     this._sharingPredicate = undefined;
-    this._keysPredicate = undefined;
     this._isFed2Schema = undefined;
     this._fieldUsedPredicate = undefined;
   }
@@ -466,13 +459,6 @@ export class FederationMetadata {
     return this._sharingPredicate;
   }
 
-  private keysPredicate(): (field: FieldDefinition<CompositeType>) => boolean {
-    if (!this._keysPredicate) {
-      this._keysPredicate = computeKeys(this.schema);
-    }
-    return this._keysPredicate;
-  }
-
   private fieldUsedPredicate(): (field: FieldDefinition<CompositeType>) => boolean {
     if (!this._fieldUsedPredicate) {
       const usedFields = collectUsedFields(this);
@@ -482,7 +468,7 @@ export class FederationMetadata {
   }
 
   isFieldUsed(field: FieldDefinition<CompositeType>): boolean {
-    return this.keysPredicate()(field) || this.fieldUsedPredicate()(field);
+    return this.fieldUsedPredicate()(field);
   }
 
   isFieldExternal(field: FieldDefinition<any> | InputFieldDefinition) {

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -482,7 +482,7 @@ export class FederationMetadata {
   }
 
   isFieldUsed(field: FieldDefinition<CompositeType>): boolean {
-    return this.fieldUsedPredicate()(field) || this.keysPredicate()(field);
+    return this.keysPredicate()(field) || this.fieldUsedPredicate()(field);
   }
 
   isFieldExternal(field: FieldDefinition<any> | InputFieldDefinition) {

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -286,13 +286,13 @@ export function collectUsedFields(metadata: FederationMetadata): Set<FieldDefini
     usedFields,
   );
 
-  // Collects all external fields used to satisfy an interface constraint
+  // Collects all fields used to satisfy an interface constraint
   for (const itfType of metadata.schema.types<InterfaceType>('InterfaceType')) {
     const runtimeTypes = itfType.possibleRuntimeTypes();
     for (const field of itfType.fields()) {
       for (const runtimeType of runtimeTypes) {
         const implemField = runtimeType.field(field.name);
-        if (implemField && metadata.isFieldExternal(implemField)) {
+        if (implemField) {
           usedFields.add(implemField);
         }
       }
@@ -341,13 +341,11 @@ function validateAllExternalFieldsUsed(metadata: FederationMetadata, errorCollec
         continue;
       }
 
-      if (!isFieldSatisfyingInterface(field)) {
-        errorCollector.push(ERRORS.EXTERNAL_UNUSED.err({
-          message: `Field "${field.coordinate}" is marked @external but is not used in any federation directive (@key, @provides, @requires) or to satisfy an interface;`
-          + ' the field declaration has no use and should be removed (or the field should not be @external).',
-          nodes: field.sourceAST,
-        }));
-      }
+      errorCollector.push(ERRORS.EXTERNAL_UNUSED.err({
+        message: `Field "${field.coordinate}" is marked @external but is not used in any federation directive (@key, @provides, @requires) or to satisfy an interface;`
+        + ' the field declaration has no use and should be removed (or the field should not be @external).',
+        nodes: field.sourceAST,
+      }));
     }
   }
 }
@@ -363,10 +361,6 @@ function validateNoExternalOnInterfaceFields(metadata: FederationMetadata, error
       }
     }
   }
-}
-
-function isFieldSatisfyingInterface(field: FieldDefinition<ObjectType | InterfaceType>): boolean {
-  return field.parent.interfaces().some(itf => itf.field(field.name));
 }
 
 /**

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -41,9 +41,10 @@ export const extendsDirectiveSpec = createDirectiveSpecification({
 export const externalDirectiveSpec = createDirectiveSpecification({
   name:'external',
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
-  argumentFct: (schema) => {
-    return [{ name: 'reason', type: schema.stringType() }];
-  },
+  argumentFct: (schema) => ({
+    args: [{ name: 'reason', type: schema.stringType() }],
+    errors: [],
+  }),
 });
 
 export const requiresDirectiveSpec = createDirectiveSpecification({

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -41,6 +41,9 @@ export const extendsDirectiveSpec = createDirectiveSpecification({
 export const externalDirectiveSpec = createDirectiveSpecification({
   name:'external',
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
+  argumentFct: (schema) => {
+    return [{ name: 'reason', type: schema.stringType() }];
+  },
 });
 
 export const requiresDirectiveSpec = createDirectiveSpecification({

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -66,6 +66,15 @@ export const shareableDirectiveSpec = createDirectiveSpecification({
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
 });
 
+export const overrideDirectiveSpec = createDirectiveSpecification({
+  name: 'override',
+  locations: [DirectiveLocation.FIELD_DEFINITION],
+  argumentFct: (schema) => ({
+    args: [{ name: 'from', type: new NonNullType(schema.stringType()) }],
+    errors: [],
+  }),
+});
+
 function fieldsArgument(schema: Schema): ArgumentSpecification {
   return { name: 'fields', type: fieldSetType(schema) };
 }
@@ -79,6 +88,7 @@ function fieldSetType(schema: Schema): InputType {
 export const FEDERATION2_ONLY_SPEC_DIRECTIVES = [
   shareableDirectiveSpec,
   inaccessibleDirectiveSpec,
+  overrideDirectiveSpec,
 ];
 
 // Note that this is only used for federation 2+ (federation 1 adds the same directive, but not through a core spec).

--- a/internals-js/src/index.ts
+++ b/internals-js/src/index.ts
@@ -16,3 +16,4 @@ export * from './supergraphs';
 export * from './extractSubgraphsFromSupergraph';
 export * from './error';
 export * from './schemaUpgrader';
+export * from './suggestions';

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -74,6 +74,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
     if (!this.isV01()) {
       joinField.addArgument('type', schema.stringType());
       joinField.addArgument('external', schema.booleanType());
+      joinField.addArgument('override', schema.stringType());
     }
 
     if (!this.isV01()) {
@@ -159,7 +160,14 @@ export class JoinSpecDefinition extends FeatureDefinition {
     return this.directive(schema, 'implements');
   }
 
-  fieldDirective(schema: Schema): DirectiveDefinition<{graph: string, requires?: string, provides?: string, type?: string, external?: boolean}> {
+  fieldDirective(schema: Schema): DirectiveDefinition<{
+    graph: string,
+    requires?: string,
+    provides?: string,
+    override?: string,
+    type?: string,
+    external?: boolean,
+  }> {
     return this.directive(schema, 'field')!;
   }
 

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -75,6 +75,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
       joinField.addArgument('type', schema.stringType());
       joinField.addArgument('external', schema.booleanType());
       joinField.addArgument('override', schema.stringType());
+      joinField.addArgument('usedOverridden', schema.booleanType());
     }
 
     if (!this.isV01()) {
@@ -167,6 +168,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
     override?: string,
     type?: string,
     external?: boolean,
+    usedOverridden?: boolean,
   }> {
     return this.directive(schema, 'field')!;
   }

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -862,6 +862,21 @@ export class SelectionSet {
   }
 }
 
+export function allFieldDefinitionsInSelectionSet(selection: SelectionSet): FieldDefinition<CompositeType>[] {
+  const stack = Array.from(selection.selections());
+  const allFields: FieldDefinition<CompositeType>[] = [];
+  while (stack.length > 0) {
+    const selection = stack.pop()!;
+    if (selection.kind === 'FieldSelection') {
+      allFields.push(selection.field.definition);
+    }
+    if (selection.selectionSet) {
+      stack.push(...selection.selectionSet.selections());
+    }
+  }
+  return allFields;
+}
+
 export function selectionSetOfElement(element: OperationElement, subSelection?: SelectionSet): SelectionSet {
   const selectionSet = new SelectionSet(element.parentType);
   selectionSet.add(selectionOfElement(element, subSelection));

--- a/internals-js/src/precompute.ts
+++ b/internals-js/src/precompute.ts
@@ -10,30 +10,6 @@ import {
   Schema,
 } from ".";
 
-export const computeKeys = (schema: Schema) => {
-  const metadata = federationMetadata(schema);
-  assert(metadata, 'Schema should be a federation subgraph');
-  const fields: Set<string> = new Set();
-
-  const keyDirective = metadata.keyDirective();
-  const addKeyFields = (type: CompositeType) => {
-    for (const key of type.appliedDirectivesOf(keyDirective)) {
-      collectTargetFields({
-        parentType: type,
-        directive: key,
-        includeInterfaceFieldsImplementations: true,
-        validate: false,
-      }).forEach((f) => fields.add(f.coordinate));
-    }
-  };
-
-  for (const type of schema.types<ObjectType>('ObjectType')) {
-    addKeyFields(type);
-  }
-
-  return (field: FieldDefinition<any>) => fields.has(field.coordinate);
-};
-
 export function computeShareables(schema: Schema): (field: FieldDefinition<CompositeType>) => boolean {
   const metadata = federationMetadata(schema);
   assert(metadata, 'Schema should be a federation subgraph');

--- a/internals-js/src/suggestions.ts
+++ b/internals-js/src/suggestions.ts
@@ -5,7 +5,7 @@ import { mapKeys } from './utils';
  * Given an invalid input string and a list of valid options, returns a filtered
  * list of valid options sorted based on their similarity with the input.
  */
-export function suggestionList(input: string, options: string[]): string[] {
+export function suggestionList(input: string, options: readonly string[]): string[] {
   const optionsByDistance = new Map<string, number>();
 
   const threshold = Math.floor(input.length * 0.4) + 1;

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -40,7 +40,7 @@ import { preComputeNonTrivialFollowupEdges } from './nonTrivialEdgePrecomputing'
 // We use our federation reserved subgraph name to avoid risk of conflict with other subgraph names (wouldn't be a huge
 // deal, but safer that way). Using something short like `_` is also on purpose: it makes it stand out in debug messages
 // without taking space.
-const FEDERATED_GRAPH_ROOT_SOURCE = FEDERATION_RESERVED_SUBGRAPH_NAME;
+export const FEDERATED_GRAPH_ROOT_SOURCE = FEDERATION_RESERVED_SUBGRAPH_NAME;
 const FEDERATED_GRAPH_ROOT_SCHEMA = new Schema();
 
 export function federatedGraphRootTypeName(rootKind: SchemaRootKind): string {

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
+- Adds support for the `@override` directive on fields to indicate that a field should be moved from one subgraph to another. [PR #1484](https://github.com/apollographql/federation/pull/1484)
 
 ## v2.0.0-preview.8
 

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
+- Adds support for the `@override` directive on fields to indicate that a field should be moved from one subgraph to another. [PR #1484](https://github.com/apollographql/federation/pull/1484)
 
 ## v2.0.0-preview.8
 

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -12,7 +12,7 @@ describe('printSubgraphSchema', () => {
         mutation: Mutation
       }
 
-      extend schema @link(url: \\"https://specs.apollo.dev/federation/v2.0\\", import: [\\"@key\\", \\"@requires\\", \\"@provides\\", \\"@external\\", \\"@tag\\", \\"@extends\\", \\"@shareable\\", \\"@inaccessible\\"])
+      extend schema @link(url: \\"https://specs.apollo.dev/federation/v2.0\\", import: [\\"@key\\", \\"@requires\\", \\"@provides\\", \\"@external\\", \\"@tag\\", \\"@extends\\", \\"@shareable\\", \\"@inaccessible\\", \\"@override\\"])
 
       directive @stream on FIELD
 
@@ -73,6 +73,7 @@ describe('printSubgraphSchema', () => {
         id: ID!
         name: String @external
         userAccount(id: ID! = 1): User @requires(fields: \\"name\\")
+        description: String
       }
       "
     `);
@@ -97,7 +98,7 @@ describe('printSubgraphSchema', () => {
   it('prints reviews subgraph correctly', () => {
     const schema = buildSubgraphSchema(fixtures[5].typeDefs);
     expect(printSubgraphSchema(schema)).toMatchInlineSnapshot(`
-      "extend schema @link(url: \\"https://specs.apollo.dev/federation/v2.0\\", import: [\\"@key\\", \\"@requires\\", \\"@provides\\", \\"@external\\", \\"@tag\\", \\"@extends\\", \\"@shareable\\", \\"@inaccessible\\"])
+      "extend schema @link(url: \\"https://specs.apollo.dev/federation/v2.0\\", import: [\\"@key\\", \\"@requires\\", \\"@provides\\", \\"@external\\", \\"@tag\\", \\"@extends\\", \\"@shareable\\", \\"@inaccessible\\", \\"@override\\"])
 
       directive @stream on FIELD
 

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -73,7 +73,7 @@ describe('printSubgraphSchema', () => {
         id: ID!
         name: String @external
         userAccount(id: ID! = 1): User @requires(fields: \\"name\\")
-        description: String
+        description: String @override(from: \\"books\\")
       }
       "
     `);

--- a/subgraph-js/src/directives.ts
+++ b/subgraph-js/src/directives.ts
@@ -120,6 +120,16 @@ export const InaccessibleDirective = new GraphQLDirective({
   ],
 });
 
+export const OverrideDirective = new GraphQLDirective({
+  name: 'override',
+  locations: [DirectiveLocation.FIELD_DEFINITION],
+  args: {
+    from: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+});
+
 export const federationDirectives = [
   KeyDirective,
   ExtendsDirective,
@@ -130,6 +140,7 @@ export const federationDirectives = [
   LinkDirective,
   TagDirective,
   InaccessibleDirective,
+  OverrideDirective,
 ];
 
 export function isFederationDirective(directive: GraphQLDirective): boolean {


### PR DESCRIPTION
There are three new hints and two new errors to deal with some of the error conditions. Note that `override` can be defined both at the object as well as the field level.