### PR TITLE
Specify which role for API key

### DIFF
--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -56,7 +56,7 @@ APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT=https://uplink.api.apollographql.com/
 
 ## 4. Connect the gateway to Studio
 
-Like your subgraphs, your gateway uses an API key to identify itself to Studio.
+Like your subgraphs, your gateway uses an API key (Graph Admin role) to identify itself to Studio.
 
 <ObtainGraphApiKey />
 


### PR DESCRIPTION
I dont know if this is accurate but I could not find the answer to the question "which role does the API key need to have for a gateway using managed federation