### PR TITLE
fix(subgraph): Fix `GraphQLResolverMap` types - allow `args` fields to be typed by users

### DIFF
--- a/federation-integration-testsuite-js/src/resolverMap.ts
+++ b/federation-integration-testsuite-js/src/resolverMap.ts
@@ -10,10 +10,10 @@ export interface GraphQLResolverMap<TContext = {}> {
   [typeName: string]:
     | {
         [fieldName: string]:
-          | GraphQLFieldResolver<any, TContext>
+          | GraphQLFieldResolver<any, TContext, any>
           | {
               requires?: string;
-              resolve: GraphQLFieldResolver<any, TContext>;
+              resolve: GraphQLFieldResolver<any, TContext, any>;
             };
       }
     | GraphQLScalarType

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Use specific error classes when throwing errors due Apollo Uplink being unreacheable or returning an invalid response [PR #1473](https://github.com/apollographql/federation/pull/1473)
+- Improve typings for `GraphQLResolverMap` which previously prevented users from typing their `args` parameter on a resolver correctly. [PR #1499](https://github.com/apollographql/federation/pull/1499)
 
 ## v0.48.0
 

--- a/gateway-js/src/schema-helper/resolverMap.ts
+++ b/gateway-js/src/schema-helper/resolverMap.ts
@@ -10,10 +10,10 @@ export interface GraphQLResolverMap<TContext = {}> {
   [typeName: string]:
     | {
         [fieldName: string]:
-          | GraphQLFieldResolver<any, TContext>
+          | GraphQLFieldResolver<any, TContext, any>
           | {
               requires?: string;
-              resolve: GraphQLFieldResolver<any, TContext>;
+              resolve: GraphQLFieldResolver<any, TContext, any>;
             };
       }
     | GraphQLScalarType

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Improve typings for `GraphQLResolverMap` which previously prevented users from typing their `args` parameter on a resolver correctly. [PR #1499](https://github.com/apollographql/federation/pull/1499)
 
 ## v0.3.0
 

--- a/subgraph-js/src/schema-helper/resolverMap.ts
+++ b/subgraph-js/src/schema-helper/resolverMap.ts
@@ -10,10 +10,10 @@ export interface GraphQLResolverMap<TContext = {}> {
   [typeName: string]:
     | {
         [fieldName: string]:
-          | GraphQLFieldResolver<any, TContext>
+          | GraphQLFieldResolver<any, TContext, any>
           | {
               requires?: string;
-              resolve: GraphQLFieldResolver<any, TContext>;
+              resolve: GraphQLFieldResolver<any, TContext, any>;
             };
       }
     | GraphQLScalarType


### PR DESCRIPTION
The current typings are restrictive for the `TArgs` field. Users
who wish to use `graphql@^15.8.0` will encounter a default of
`{ [key: string]: any }` type for the `args` parameter, which will
effectively prevent them from typing their `args` parameter correctly.

As demonstrated in the thread:
https://community.apollographql.com/t/buildsubgraphschema-typescript-typing-conflict-with-resolver/2716/3

Changing the type of `TArgs` to `any` is effectively the same change that
v16 moves to (defaulting to `any` instead of the above mentioned object-y
type).

Reported by @Axel-p
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
