### PR TITLE
fix(gateway): Resolve gateway retry issues (`UplinkFetcher failed to update...`) (`version-0.x`)

### DIFF
--- a/docs/source/api/apollo-gateway.mdx
+++ b/docs/source/api/apollo-gateway.mdx
@@ -267,7 +267,7 @@ Provide this field **only** if you are using managed federation _and_ your use c
 
 The maximum number of times the gateway retries a failed poll request to Apollo Uplink, cycling through its list of [`uplinkEndpoints`](#uplinkendpoints).
 
-The default value is three times your number of `uplinkEndpoints` (i.e., `6` in almost all cases).
+The default value is to try each of your uplinkEndpoints three times (i.e., 5 retries with the default list of two endpoints).
 
 Provide this field **only** if you are using managed federation.
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Use specific error classes when throwing errors due Apollo Uplink being unreacheable or returning an invalid response [PR #1473](https://github.com/apollographql/federation/pull/1473)
+- __FIX__ Correct retry logic while fetching the supergraph schema from Uplink [PR #1503](https://github.com/apollographql/federation/pull/1503)
 
 ## v0.48.0
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -38,6 +38,7 @@
     "apollo-server-errors": "^2.5.0 || ^3.0.0",
     "apollo-server-types": "^0.9.0 || ^3.0.0",
     "apollo-utilities": "^1.3.0",
+    "async-retry": "^1.3.3",
     "loglevel": "^1.6.1",
     "make-fetch-happen": "^8.0.0",
     "pretty-format": "^27.4.6",

--- a/gateway-js/src/__tests__/integration/nockMocks.ts
+++ b/gateway-js/src/__tests__/integration/nockMocks.ts
@@ -121,9 +121,10 @@ export function mockSupergraphSdlRequestSuccessIfAfter(
 }
 
 export function mockSupergraphSdlRequestIfAfterUnchanged(
-    ifAfter: string | null = null,
+  ifAfter: string | null = null,
+  url: string = mockCloudConfigUrl1,
 ) {
-  return mockSupergraphSdlRequestIfAfter(ifAfter).reply(
+  return mockSupergraphSdlRequestIfAfter(ifAfter, url).reply(
       200,
       JSON.stringify({
         data: {

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -400,7 +400,7 @@ export class ApolloGateway implements GraphQLService {
           apiKey: this.apolloConfig!.key!,
           uplinkEndpoints,
           maxRetries:
-            this.config.uplinkMaxRetries ?? uplinkEndpoints.length * 3,
+            this.config.uplinkMaxRetries ?? uplinkEndpoints.length * 3 - 1, // -1 for the initial request
           subgraphHealthCheck: this.config.serviceHealthCheck,
           fetcher: this.fetcher,
           logger: this.logger,

--- a/gateway-js/src/supergraphManagers/LegacyFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/LegacyFetcher/index.ts
@@ -222,7 +222,7 @@ export class LegacyFetcher implements SupergraphManager {
 
   private logUpdateFailure(e: any) {
     this.config.logger?.error(
-      'UplinkFetcher failed to update supergraph with the following error: ' +
+      'LegacyFetcher failed to update supergraph with the following error: ' +
         (e.message ?? e),
     );
   }

--- a/gateway-js/src/supergraphManagers/LocalCompose/index.ts
+++ b/gateway-js/src/supergraphManagers/LocalCompose/index.ts
@@ -76,7 +76,7 @@ export class LocalCompose implements SupergraphManager {
 
   private logUpdateFailure(e: any) {
     this.config.logger?.error(
-      'UplinkFetcher failed to update supergraph with the following error: ' +
+      'LocalCompose failed to update supergraph with the following error: ' +
         (e.message ?? e),
     );
   }

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -63,7 +63,8 @@ describe('loadSupergraphSdlFromStorage', () => {
       errorReportingEndpoint: undefined,
       fetcher,
       compositionId: "originalId-1234",
-      maxRetries: 1
+      maxRetries: 1,
+      roundRobinSeed: 0,
     });
 
     expect(result).toMatchObject({
@@ -85,7 +86,8 @@ describe('loadSupergraphSdlFromStorage', () => {
         errorReportingEndpoint: undefined,
         fetcher,
         compositionId: "originalId-1234",
-        maxRetries: 1
+        maxRetries: 1,
+        roundRobinSeed: 0,
       }),
     ).rejects.toThrowError(
       new UplinkFetcherError(

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -368,3 +368,36 @@ describe('loadSupergraphSdlFromStorage', () => {
   });
 });
 
+
+describe("loadSupergraphSdlFromUplinks", () => {
+  beforeEach(nockBeforeEach);
+  afterEach(nockAfterEach);
+
+  it("doesn't retry in the unchanged / null case", async () => {
+    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl1);
+
+    // These mocks ensure we get through the test without other unrelated errors
+    // but also prove the bad behavior exists. TODO: remove when the code is
+    // corrected (this test won't pass otherwise).
+    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl2);
+    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl1);
+    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl2);
+    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl1);
+    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl2);
+
+    const fetcher = jest.fn(getDefaultFetcher());
+    const result = await loadSupergraphSdlFromUplinks({
+      graphRef,
+      apiKey,
+      endpoints: [mockCloudConfigUrl1, mockCloudConfigUrl2],
+      errorReportingEndpoint: mockOutOfBandReporterUrl,
+      fetcher: fetcher as any,
+      compositionId: "id-1234",
+      maxRetries: 5,
+    });
+
+    expect(result).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -396,6 +396,7 @@ describe("loadSupergraphSdlFromUplinks", () => {
       fetcher: fetcher as any,
       compositionId: "id-1234",
       maxRetries: 5,
+      roundRobinSeed: 0,
     });
 
     expect(result).toBeNull();

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -378,15 +378,6 @@ describe("loadSupergraphSdlFromUplinks", () => {
   it("doesn't retry in the unchanged / null case", async () => {
     mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl1);
 
-    // These mocks ensure we get through the test without other unrelated errors
-    // but also prove the bad behavior exists. TODO: remove when the code is
-    // corrected (this test won't pass otherwise).
-    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl2);
-    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl1);
-    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl2);
-    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl1);
-    mockSupergraphSdlRequestIfAfterUnchanged("id-1234", mockCloudConfigUrl2);
-
     const fetcher = jest.fn(getDefaultFetcher());
     const result = await loadSupergraphSdlFromUplinks({
       graphRef,

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
@@ -82,7 +82,7 @@ export class UplinkFetcher implements SupergraphManager {
       fetcher: this.config.fetcher,
       compositionId: this.compositionId ?? null,
       maxRetries: this.config.maxRetries,
-      roundRobinSeed: this.fetchCount,
+      roundRobinSeed: this.fetchCount++,
     });
 
     if (!result) {

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
@@ -30,6 +30,7 @@ export class UplinkFetcher implements SupergraphManager {
   private errorReportingEndpoint: string | undefined =
     process.env.APOLLO_OUT_OF_BAND_REPORTER_ENDPOINT ?? undefined;
   private compositionId?: string;
+  private fetchCount: number = 0;
 
   constructor(options: UplinkFetcherOptions) {
     this.config = options;
@@ -81,6 +82,7 @@ export class UplinkFetcher implements SupergraphManager {
       fetcher: this.config.fetcher,
       compositionId: this.compositionId ?? null,
       maxRetries: this.config.maxRetries,
+      roundRobinSeed: this.fetchCount,
     });
 
     if (!result) {

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
@@ -39,8 +39,6 @@ const { name, version } = require('../../../package.json');
 
 const fetchErrorMsg = "An error occurred while fetching your schema from Apollo: ";
 
-let fetchCounter = 0;
-
 export class UplinkFetcherError extends Error {
   constructor(message: string) {
     super(message);
@@ -56,6 +54,7 @@ export async function loadSupergraphSdlFromUplinks({
   fetcher,
   compositionId,
   maxRetries,
+  roundRobinSeed,
 }: {
   graphRef: string;
   apiKey: string;
@@ -63,7 +62,8 @@ export async function loadSupergraphSdlFromUplinks({
   errorReportingEndpoint: string | undefined,
   fetcher: typeof fetch;
   compositionId: string | null;
-  maxRetries: number
+  maxRetries: number,
+  roundRobinSeed: number,
 }) : Promise<SupergraphSdlUpdate | null> {
   let retries = 0;
   let lastException = null;
@@ -73,10 +73,10 @@ export async function loadSupergraphSdlFromUplinks({
       result = await loadSupergraphSdlFromStorage({
         graphRef,
         apiKey,
-        endpoint: endpoints[fetchCounter++ % endpoints.length],
+        endpoint: endpoints[roundRobinSeed++ % endpoints.length],
         errorReportingEndpoint,
         fetcher,
-        compositionId
+        compositionId,
       });
     } catch (e) {
       lastException = e;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@rollup/plugin-commonjs": "21.0.1",
         "@rollup/plugin-json": "4.1.0",
         "@rollup/plugin-node-resolve": "13.1.3",
+        "@types/async-retry": "^1.4.3",
         "@types/bunyan": "1.8.8",
         "@types/deep-equal": "1.0.1",
         "@types/jest": "27.4.0",
@@ -110,6 +111,7 @@
         "apollo-server-errors": "^2.5.0 || ^3.0.0",
         "apollo-server-types": "^0.9.0 || ^3.0.0",
         "apollo-utilities": "^1.3.0",
+        "async-retry": "^1.3.3",
         "loglevel": "^1.6.1",
         "make-fetch-happen": "^8.0.0",
         "pretty-format": "^27.4.6",
@@ -4098,6 +4100,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/async-retry": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.3.tgz",
+      "integrity": "sha512-B3C9QmmNULVPL2uSJQ088eGWTNPIeUk35hca6CV8rRDJ8GXuQJP5CCVWA1ZUCrb9xYP7Js/RkLqnNNwKhe+Zsw==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -4387,6 +4398,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "dev": true
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
@@ -20585,6 +20602,7 @@
         "apollo-server-errors": "^2.5.0 || ^3.0.0",
         "apollo-server-types": "^0.9.0 || ^3.0.0",
         "apollo-utilities": "^1.3.0",
+        "async-retry": "^1.3.3",
         "loglevel": "^1.6.1",
         "make-fetch-happen": "^8.0.0",
         "pretty-format": "^27.4.6",
@@ -23719,6 +23737,15 @@
         "@types/node": "*"
       }
     },
+    "@types/async-retry": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.3.tgz",
+      "integrity": "sha512-B3C9QmmNULVPL2uSJQ088eGWTNPIeUk35hca6CV8rRDJ8GXuQJP5CCVWA1ZUCrb9xYP7Js/RkLqnNNwKhe+Zsw==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -24008,6 +24035,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.10",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@rollup/plugin-commonjs": "21.0.1",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.1.3",
+    "@types/async-retry": "^1.4.3",
     "@types/bunyan": "1.8.8",
     "@types/deep-equal": "1.0.1",
     "@types/jest": "27.4.0",


### PR DESCRIPTION
Currently the gateway implements incorrect retry logic. The `null` response case (no schema change found) is handled as a retry-able result (or failure case) when really it should be handled as a success and result in completing the current retry sequence with no errors thrown.

It's worth mentioning that this issue should have never affected gateway load/startup (only update), since the gateway has no `ifAfterId` to send to our server and thus should never expect an `Unchanged` result from its initial request. It should also have never affected gateway _updates_ since in the update case the result would be non-null and escape the retry case. All this is to say, gateway function should have been unaffected due to this issue, but it did log errors even from the happy path (successful retry after an error).

Additionally, this PR introduces the `async-retry` package which wraps the retry logic for us and handles exponential backoff.
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
