### PR TITLE
Avoid incomplete subgraph when extracting from supergraph

### DIFF
--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -243,7 +243,7 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
           break;
         case 'UnionType':
           if (type.membersCount() === 0) {
-            type.remove();
+            type.removeRecursive();
           }
           break;
       }


### PR DESCRIPTION
This is a small followup to #1351: the patch removed object/interface types recursively as it should, but typo-ed union types only calling `remove` instead of `removeRecursive`.
I didn't notice it at the time because while I added a union type test, it wasn't actually exercise the part of the code I though it was.
This PR fixes that problem and adds a proper test (keeping the other union test because while it didn't test what I though it was, it still tests something useful (namely that the `removeRecursive` on object types correctly recurse to unions)).