### PR TITLE
Experimentation: using the gateway or router as subgraph

### DIFF
--- a/composition-js/src/compose.ts
+++ b/composition-js/src/compose.ts
@@ -7,9 +7,14 @@ import {
   ServiceDefinition,
   subgraphsFromServiceList,
   ERRORS,
+  UnionType,
+  FieldDefinition,
+  ObjectType,
+  NonNullType,
+  ListType,
 } from "@apollo/federation-internals";
 import { GraphQLError } from "graphql";
-import { buildFederatedQueryGraph, buildSupergraphAPIQueryGraph } from "@apollo/query-graphs";
+import { buildFederatedQueryGraph, buildSupergraphAPIQueryGraph, buildSubgraphAPIQueryGraph } from "@apollo/query-graphs";
 import { mergeSubgraphs } from "./merging";
 import { validateGraphComposition } from "./validate";
 import { CompositionHint } from "./hints";
@@ -62,6 +67,88 @@ export function compose(subgraphs: Subgraphs): CompositionResult {
   };
 }
 
+export function composeSubgraph(subgraphs: Subgraphs): CompositionResult {
+  const mergeResult = mergeSubgraphs(subgraphs);
+  if (mergeResult.errors) {
+    return { errors: mergeResult.errors };
+  }
+
+  const supergraphSchema = mergeResult.supergraph;
+
+  // the generated supergraph does not have the _Any type, and once we're
+  // here it is already constructed so we can't add a type
+  // I hardcoded it in internals-js/src/definitions.ts:1091
+  // there's probably a better solution, especially considering that
+  // creating the ferederatedQueryGraph fails whe trying to add _Any too
+  // (fixed by removing the error throw in internals-js/src/definitions.ts:1264
+  // oh, well...)
+  const _any = supergraphSchema.type("_Any")!
+
+  var _entity = new UnionType("_Entity")
+  supergraphSchema.addType(_entity)
+  var query
+
+  // we loop over the object types and look for federated ones to build the
+  // _Entity union
+  // we also get the query object for later
+  for (const t of supergraphSchema.types()) {
+    if(t.kind == "ObjectType" && !t.isQueryRootType()) {
+      console.log("got object:"+t.name)
+      for(const f of t.allFields()) {
+        console.log(f)
+      }
+      for(const di of t.appliedDirectives) {
+        console.log(di)
+        if(di.name == "join__type") {
+          _entity.addType(t)
+        }
+      }
+    }
+    if(t.kind == "ObjectType" && t.isQueryRootType()) {
+      query = t
+    }
+  }
+
+  // building the _entities query manually
+  //_entities(representations: [_Any!]!): [_Entity]!
+  var _entities = new FieldDefinition<ObjectType>("_entities")
+
+  console.log(_any)
+
+  const repArg = new NonNullType(new ListType(new NonNullType(_any)))
+  console.log(repArg.toString())
+
+  const _entitiesType =  new NonNullType(new ListType(_entity))
+
+  query?.addField(_entities, _entitiesType)
+  _entities.addArgument("representations", repArg)
+  console.log(_entities)
+
+  const supergraphQueryGraph = buildSubgraphAPIQueryGraph(supergraphSchema);
+  const federatedQueryGraph = buildFederatedQueryGraph(supergraphSchema, false);
+  const validationResult = validateGraphComposition(supergraphQueryGraph, federatedQueryGraph);
+  if (validationResult.errors) {
+    return { errors: validationResult.errors.map(e => ERRORS.SATISFIABILITY_ERROR.err({ message: e.message })) };
+  }
+
+  // printSchema calls validateOptions, which can throw
+  let supergraphSdl;
+  try {
+    supergraphSdl = printSchema(
+      supergraphSchema,
+      orderPrintedDefinitions(defaultPrintOptions)
+    );
+  } catch (err) {
+    return { errors: [err] };
+  }
+
+  return {
+    schema: supergraphSchema,
+    supergraphSdl,
+    hints: mergeResult.hints
+  };
+}
+
 export function composeServices(services: ServiceDefinition[]): CompositionResult  {
   const subgraphs = subgraphsFromServiceList(services);
   if (Array.isArray(subgraphs)) {
@@ -71,4 +158,17 @@ export function composeServices(services: ServiceDefinition[]): CompositionResul
     return { errors: subgraphs };
   }
   return compose(subgraphs);
+}
+
+
+
+export function composeSubgraphFromServices(services: ServiceDefinition[]): CompositionResult  {
+  const subgraphs = subgraphsFromServiceList(services);
+  if (Array.isArray(subgraphs)) {
+    // Errors in subgraphs are not truly "composition" errors, but it's probably still the best place
+    // to surface them in this case. Not that `subgraphsFromServiceList` do ensure the errors will
+    // include the subgraph name in their message.
+    return { errors: subgraphs };
+  }
+  return composeSubgraph(subgraphs);
 }

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -1091,6 +1091,9 @@ export class Schema {
     Element.prototype['setParent'].call(this._schemaDefinition, this);
     builtIns.addBuiltInTypes(this);
     builtIns.addBuiltInDirectives(this);
+    // horrible hack to manually add the _Any type so we can use it later to build the _entities query
+    const _any = new ScalarType("_Any", false)
+    this.addType(_any);
     this.isConstructed = true;
   }
 
@@ -1264,7 +1267,11 @@ export class Schema {
     const existing = this.type(type.name);
     // Like for directive, we let use shadow built-in types, but validation will ensure the definition is compatible.
     if (existing && !existing.isBuiltIn) {
-      throw error(`Type ${type} already exists in this schema`);
+      // horrible hack to avoid an error when trying to add the _Any type, because
+      // I added it manually at graph creation
+      //throw error(`Type ${type} already exists in this schema`);
+      console.log(`Type ${type} already exists in this schema`)
+      return type;
     }
     if (type.isAttached()) {
       // For convenience, let's not error out on adding an already added type.

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -521,6 +521,13 @@ export function buildSupergraphAPIQueryGraph(supergraph: Schema): QueryGraph {
 }
 
 /**
+ * Builds a "subgraph API" query graph based on the provided supergraph schema.
+ */
+ export function buildSubgraphAPIQueryGraph(supergraph: Schema): QueryGraph {
+  return buildQueryGraph("supergraph", supergraph);
+}
+
+/**
  * Builds a "federated" query graph based on the provided supergraph schema.
  *
  * A "federated" query graph is one that is used to reason about queries made by a

--- a/query-planner-js/src/__tests__/buildSubgraphPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildSubgraphPlan.test.ts
@@ -1,0 +1,142 @@
+import { astSerializer, queryPlanSerializer, QueryPlanner } from '@apollo/query-planner';
+import { composeSubgraphFromServices } from '@apollo/composition';
+import { /*assert,*/ buildSchema, operationFromDocument, Schema, ServiceDefinition } from '@apollo/federation-internals';
+import gql from 'graphql-tag';
+/*
+import { MAX_COMPUTED_PLANS } from '../buildPlan';
+import { FetchNode } from '../QueryPlan';
+import { FieldNode, OperationDefinitionNode, parse } from 'graphql';
+*/
+
+expect.addSnapshotSerializer(astSerializer);
+expect.addSnapshotSerializer(queryPlanSerializer);
+
+function composeAndCreatePlanner(...services: ServiceDefinition[]): [Schema, QueryPlanner] {
+  const compositionResults = composeSubgraphFromServices(services);
+  expect(compositionResults.errors).toBeUndefined();
+  return [
+    compositionResults.schema!.toAPISchema(),
+    new QueryPlanner(buildSchema(compositionResults.supergraphSdl!))
+  ];
+}
+
+test("look at me I'm the subgraph now", () => {
+  const subgraph1 = {
+    name: 'Subgraph1',
+    typeDefs: gql`
+      type Query {
+        me: User!
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        prop1: String
+      }
+    `
+  }
+
+  const subgraph2 = {
+    name: 'Subgraph2',
+    typeDefs: gql`
+      type Query {
+        me: User!
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        prop2: String
+      }
+    `
+  }
+
+  const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+  const operation = operationFromDocument(api, gql`
+  query($representations:[_Any!]!){
+    _entities(representations:$representations){
+      ...on User{
+        prop1
+      }
+    }
+  }
+  `);
+
+  const plan = queryPlanner.buildQueryPlan(operation);
+  expect(plan).toMatchInlineSnapshot(`
+    QueryPlan {
+      Fetch(service: "Subgraph1") {
+        {
+          __typename
+          ... on User {
+            prop1
+          }
+        }
+      },
+    }
+  `);
+});
+
+test("look at me I'm the federated subgraph now", () => {
+  const subgraph1 = {
+    name: 'Subgraph1',
+    typeDefs: gql`
+      type Query {
+        me: User!
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        prop1: String
+      }
+    `
+  }
+
+  const subgraph2 = {
+    name: 'Subgraph2',
+    typeDefs: gql`
+      type Query {
+        me: User!
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        prop2: String
+      }
+    `
+  }
+
+  const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+  const operation = operationFromDocument(api, gql`
+  query($representations:[_Any!]!){
+    _entities(representations:$representations){
+      ...on User{
+        prop1
+        prop2
+      }
+    }
+  }
+  `);
+
+  const plan = queryPlanner.buildQueryPlan(operation);
+  expect(plan).toMatchInlineSnapshot(`
+    QueryPlan {
+      Parallel {
+        Fetch(service: "Subgraph1") {
+          {
+            __typename
+            ... on User {
+              prop1
+            }
+          }
+        },
+        Fetch(service: "Subgraph2") {
+          {
+            __typename
+            ... on User {
+              prop2
+            }
+          }
+        },
+      },
+    }
+  `);
+});


### PR DESCRIPTION
This is a test to see if we can convince the query planner to act as a
subgraph. This would allow the gateway or the router to sit in front of
one or multiple subgraphs, with potential benefits:
- have an authorization layer where the main gateway and the subgraph
  gateway can coordinate to avoid exposing the subgraph directly
- make a datasource or subgraph plugin to convert the entity query to a
  normal query if we're in front of a non federated graph
- make trees of routers if we want to expose different subsets of the
  subgraphs, or have edge routers calling into the real router

The idea is to take the supergraph created from the list of
subgraphs, manually create the _Entity type that unifies all the
federated types, and create the _entities query that will use it.

When receiving an _entities query, the query plan somehow understands
that it has must forward it to the subgraph. It can even dispatch
subqueries to multiple subgraphs depending on the requested fields.
I have no ideas why :D but it suggests a clean implementation would not
be too far.