### PR TITLE
Update Apollo Gateway readme usage with Introspect and Compose

### DIFF
--- a/gateway-js/README.md
+++ b/gateway-js/README.md
@@ -10,13 +10,15 @@ For complete documentation, see the [Apollo Gateway API reference](https://www.a
 
 ```js
 const { ApolloServer } = require("apollo-server");
-const { ApolloGateway } = require("@apollo/gateway");
+const { ApolloGateway, IntrospectAndCompose } = require("@apollo/gateway");
 
 const gateway = new ApolloGateway({
-  serviceList: [
-    { name: "accounts", url: "http://localhost:4001/graphql" },
-    // List of federation-capable GraphQL endpoints...
-  ]
+  supergraphSdl: new IntrospectAndCompose({
+    subgraphs: [
+       { name: "accounts", url: "http://localhost:4001/graphql" }
+       // List of federation-capable GraphQL endpoints...
+    ],
+  }),
 });
 
 const server = new ApolloServer({ gateway });


### PR DESCRIPTION
In @apollo/gateway version 0.46.0 and later,IntrospectAndCompose is the new drop-in replacement for the serviceList option.

This PR updates the Readme example on session with the correctly use.

The current example will result in the following warning :

> The `serviceList` option is deprecated and will be removed in a future version of `@apollo/gateway`. Please migrate to its replacement `IntrospectAndCompose`. More information on `IntrospectAndCompose` can be found in the documentation.

### Docs

* https://www.apollographql.com/docs/federation/gateway/#composing-subgraphs-with-introspectandcompose
* https://www.apollographql.com/docs/federation/api/apollo-gateway/#class-introspectandcompose