### PR TITLE
Update broken links from Apollo Subgraph Readme

### DIFF
--- a/subgraph-js/README.md
+++ b/subgraph-js/README.md
@@ -1,8 +1,8 @@
-# `Apollo Subgraph Utilities`
+# `Apollo Subgraph`
 
-This package provides utilities for creating GraphQL microservices, which can be combined into a single endpoint through tools like [Apollo Gateway](https://github.com/apollographql/apollo-server/tree/main/packages/apollo-gateway).
+This package provides utilities for creating GraphQL microservices, which can be combined into a single endpoint through tools like [Apollo Gateway](https://github.com/apollographql/federation/tree/main/gateway-js).
 
-For complete documentation, see the [Apollo Subgraph API reference](https://www.apollographql.com/docs/apollo-server/api/apollo-subgraph/).
+For complete documentation, see the [Apollo Subgraph API reference](https://www.apollographql.com/docs/federation/subgraphs/).
 
 ## Usage
 
@@ -36,5 +36,9 @@ const resolvers = {
 
 const server = new ApolloServer({
   schema: buildSubgraphSchema([{ typeDefs, resolvers }])
+});
+
+server.listen(4001).then(({ url }) => {
+    console.log(`🚀 Server ready at ${url}`);
 });
 ```


### PR DESCRIPTION
Update broken links from readme

| From                                                                             | To                                                                 |
|----------------------------------------------------------------------------------|--------------------------------------------------------------------|
| https://github.com/apollographql/apollo-server/tree/main/packages/apollo-gateway | https://github.com/apollographql/federation/tree/main/gateway-js\| |
| https://www.apollographql.com/docs/apollo-server/api/apollo-subgraph             | https://www.apollographql.com/docs/federation/subgraphs/           |

https://www.npmjs.com/package/@apollo/subgraph - we had this problem accessing through the readme presented in NPM