### PR TITLE
fix: owned types are marked as extension when GraphQL `v16` is used

### DIFF
--- a/subgraph-js/src/printSubgraphSchema.ts
+++ b/subgraph-js/src/printSubgraphSchema.ts
@@ -178,22 +178,25 @@ function printImplementedInterfaces(
     : '';
 }
 
-function printObject(type: GraphQLObjectType): string {
-  // Apollo change: print `extend` keyword on type extensions.
-  //
-  // The implementation assumes that an owned type will have fields defined
-  // since that is required for a valid schema. Types that are *only*
-  // extensions will not have fields on the astNode since that ast doesn't
-  // exist.
-  //
-  // XXX revist extension checking
-  const isExtension =
-    type.extensionASTNodes && type.astNode && !type.astNode.fields;
+/**
+ * Method that checks if a type is an extension
+ *
+ * The implementation assumes that an owned type will have fields defined
+ * since that is required for a valid schema. Types that are *only* extensions will:
+ *  - have the `extensionASTNodes` defined and with at least 1 field. This is because prior GraphQL v16
+ *    the `extensionASTNodes` property was undefined, where now it comes as an empty {@link Array}
+ *  - not have fields on the `astNode` since that Abstract Syntax Tree doesn't exist;
+ * @param type
+ */
+function checksIfTypeIsExtension(type: GraphQLObjectType) {
+  return type.extensionASTNodes?.length && type.astNode && !type.astNode.fields;
+}
 
+function printObject(type: GraphQLObjectType): string {
   return (
     printDescription(type) +
     // Apollo addition: print `extend` keyword on type extensions
-    (isExtension ? 'extend ' : '') +
+    (checksIfTypeIsExtension(type) ? 'extend ' : '') +
     `type ${type.name}` +
     printImplementedInterfaces(type) +
     // Apollo addition: print @key usages
@@ -205,17 +208,10 @@ function printObject(type: GraphQLObjectType): string {
 }
 
 function printInterface(type: GraphQLInterfaceType): string {
-  // Apollo change: print `extend` keyword on type extensions.
-  // See printObject for assumptions made.
-  //
-  // XXX revist extension checking
-  const isExtension =
-    type.extensionASTNodes && type.astNode && !type.astNode.fields;
-
   return (
     printDescription(type) +
     // Apollo change: print `extend` keyword on interface extensions
-    (isExtension ? 'extend ' : '') +
+    (checksIfTypeIsExtension(type) ? 'extend ' : '') +
     `interface ${type.name}` +
     printImplementedInterfaces(type) +
     printFederationDirectives(type) +

--- a/subgraph-js/src/printSubgraphSchema.ts
+++ b/subgraph-js/src/printSubgraphSchema.ts
@@ -192,9 +192,8 @@ function printImplementedInterfaces(
 function checksIfTypeIsExtension(type: GraphQLObjectType | GraphQLInterfaceType): boolean {
   return (
       Array.isArray(type.extensionASTNodes) &&
-      type.extensionASTNodes?.length &&
-      type.astNode &&
-      !type.astNode.fields
+      !!type.extensionASTNodes?.length &&
+      !type.astNode?.fields
   );
 }
 

--- a/subgraph-js/src/printSubgraphSchema.ts
+++ b/subgraph-js/src/printSubgraphSchema.ts
@@ -189,7 +189,7 @@ function printImplementedInterfaces(
  * @param type
  * @return boolean
  */
-function checksIfTypeIsExtension(type: GraphQLObjectType): boolean {
+function checksIfTypeIsExtension(type: GraphQLObjectType | GraphQLInterfaceType): boolean {
   return (
       Array.isArray(type.extensionASTNodes) &&
       type.extensionASTNodes?.length &&

--- a/subgraph-js/src/printSubgraphSchema.ts
+++ b/subgraph-js/src/printSubgraphSchema.ts
@@ -187,9 +187,15 @@ function printImplementedInterfaces(
  *    the `extensionASTNodes` property was undefined, where now it comes as an empty {@link Array}
  *  - not have fields on the `astNode` since that Abstract Syntax Tree doesn't exist;
  * @param type
+ * @return boolean
  */
-function checksIfTypeIsExtension(type: GraphQLObjectType) {
-  return type.extensionASTNodes?.length && type.astNode && !type.astNode.fields;
+function checksIfTypeIsExtension(type: GraphQLObjectType): boolean {
+  return (
+      Array.isArray(type.extensionASTNodes) &&
+      type.extensionASTNodes?.length &&
+      type.astNode &&
+      !type.astNode.fields
+  );
 }
 
 function printObject(type: GraphQLObjectType): string {


### PR DESCRIPTION
This PR is meant to fix the issues in which types are wrongly set as extensions when GraphQL `v16` is used.

**Issue**
[printSubgraphSchema.ts:190](https://github.com/apollographql/federation/blob/main/subgraph-js/src/printSubgraphSchema.ts#L190) (@apollo/subgraph) checks if the `extensionASTNodes` field is defined in order to determine if a type should be extended or not. GraphQL `v15` [sets it as `undefined`](https://github.com/graphql/graphql-js/blob/15.x.x/src/type/definition.js#L753) while GraphQL `v16` [always includes](https://github.com/graphql/graphql-js/blob/main/src/type/definition.ts#L770) `extensionASTNodes` in all `GraphQLObjectType` as `[]`.

**Fix**
I order to fix this we had to also check the length of the array, not only just if it's defined.

This will also fix: [#2029](https://github.com/nestjs/graphql/issues/2029).

_Let me know if you need more details. We will provide any information in order to speed up the process of releasing the fix as this is a **major issue** for consumers that are using **Federation**._