### PR TITLE
Add `resolvable` argument to `@key`

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -77,7 +77,7 @@ describe('composition', () => {
 
       directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
-      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
       enum core__Purpose {
         """
@@ -1833,7 +1833,7 @@ describe('composition', () => {
 
       directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
-      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
       enum core__Purpose {
         """

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -681,7 +681,8 @@ class Merger {
       } else {
         for (const key of keys) {
           const extension = key.ofExtension() || source.hasAppliedDirective(sourceMetadata.extendsDirective()) ? true : undefined;
-          dest.applyDirective(joinTypeDirective, { graph: name, key: key.arguments().fields, extension });
+          const { resolvable } = key.arguments();
+          dest.applyDirective(joinTypeDirective, { graph: name, key: key.arguments().fields, extension, resolvable });
         }
       }
     }

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- Adds an optional `resolvable` argument to the `@key` directive. [PR #1561](https://github.com/apollographql/federation/pull/1561).
 
 ## v2.0.0-alpha.6
 

--- a/gateway-js/src/__generated__/graphqlTypes.ts
+++ b/gateway-js/src/__generated__/graphqlTypes.ts
@@ -41,6 +41,8 @@ export type FetchError = {
   __typename?: 'FetchError';
   code: FetchErrorCode;
   message: Scalars['String'];
+  /** Minimum delay before the next fetch should occur, in seconds. */
+  minDelaySeconds: Scalars['Float'];
 };
 
 export enum FetchErrorCode {
@@ -111,16 +113,23 @@ export type RouterConfigResponse = FetchError | RouterConfigResult | Unchanged;
 
 export type RouterConfigResult = {
   __typename?: 'RouterConfigResult';
+  /** Variant-unique identifier. */
   id: Scalars['ID'];
   /** Messages that should be reported back to the operators of this router, eg through logs and/or monitoring. */
   messages: Array<Message>;
-  /** The configuration as core schema */
+  /** Minimum delay before the next fetch should occur, in seconds. */
+  minDelaySeconds: Scalars['Float'];
+  /** The configuration as core schema. */
   supergraphSDL: Scalars['String'];
 };
 
+/** Response indicating the router configuration available is not newer than the one passed in `ifAfterId`. */
 export type Unchanged = {
   __typename?: 'Unchanged';
+  /** Variant-unique identifier for the configuration that remains in place. */
   id: Scalars['ID'];
+  /** Minimum delay before the next fetch should occur, in seconds. */
+  minDelaySeconds: Scalars['Float'];
 };
 
 export type SupergraphSdlQueryVariables = Exact<{

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -147,7 +147,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated. 
     expect(secondCall[0]!.compositionId).toEqual(
-      '778ed1636b7b2ca13a078f577e093efb849b2eaf8dce2a9f813a4d66e1169bf5',
+      'be41610508728662796c2ccd71348603250b79a7f9854914ebfc771ac4ebcffb',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -101,7 +101,8 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
           subgraphType = schema.addType(newNamedType(type.kind, type.name));
         }
         if (args.key) {
-          const directive = subgraphType.applyDirective('key', {'fields': args.key});
+          const { resolvable } = args;
+          const directive = subgraphType.applyDirective('key', {'fields': args.key, resolvable});
           if (args.extension) {
             directive.setOfExtension(subgraphType.newExtension());
           }

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -529,7 +529,7 @@ export class FederationMetadata {
     return directive as DirectiveDefinition<TApplicationArgs>;
   }
 
-  keyDirective(): DirectiveDefinition<{fields: any}> {
+  keyDirective(): DirectiveDefinition<{fields: any, resolvable?: boolean}> {
     return this.getFederationDirective(keyDirectiveSpec.name);
   }
 

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -22,7 +22,10 @@ export const keyDirectiveSpec = createDirectiveSpecification({
   name:'key',
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE],
   repeatable: true,
-  argumentFct: (schema) => [fieldsArgument(schema)]
+  argumentFct: (schema) => [
+    fieldsArgument(schema),
+    { name: 'resolvable', type: schema.booleanType(), defaultValue: true },
+  ]
 });
 
 export const extendsDirectiveSpec = createDirectiveSpecification({

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -62,6 +62,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
     joinType.addArgument('key', joinFieldSet);
     if (!this.isV01()) {
       joinType.addArgument('extension', new NonNullType(schema.booleanType()), false);
+      joinType.addArgument('resolvable', new NonNullType(schema.booleanType()), true);
     }
 
     const joinField = this.addDirective(schema, 'field').addLocations(DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.INPUT_FIELD_DEFINITION);
@@ -132,7 +133,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
     return this.directive(schema, 'graph')!;
   }
 
-  typeDirective(schema: Schema): DirectiveDefinition<{graph: string, key?: string, extension?: boolean}> {
+  typeDirective(schema: Schema): DirectiveDefinition<{graph: string, key?: string, extension?: boolean, resolvable?: boolean}> {
     return this.directive(schema, 'type')!;
   }
 

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -592,6 +592,10 @@ function federateSubgraphs(subgraphs: QueryGraph[]): QueryGraph {
       v => {
         const type = v.type;
         for (const keyApplication of type.appliedDirectivesOf(keyDirective)) {
+          if (!(keyApplication.arguments().resolvable ?? true)) {
+            continue;
+          }
+
           // The @key directive creates an edge from every other subgraphs (having that type)
           // to the current subgraph. In other words, the fact this subgraph has a @key means
           // that the service of the current subgraph can be queried for the entity (through

--- a/subgraph-js/src/directives.ts
+++ b/subgraph-js/src/directives.ts
@@ -20,6 +20,7 @@ import {
   visit,
   GraphQLSchema,
   GraphQLList,
+  GraphQLBoolean,
 } from 'graphql';
 import { LinkImportType } from './types';
 
@@ -30,6 +31,10 @@ export const KeyDirective = new GraphQLDirective({
     fields: {
       type: new GraphQLNonNull(GraphQLString),
     },
+    resolvable: {
+      type: GraphQLBoolean,
+      defaultValue: true
+    }
   },
 });
 


### PR DESCRIPTION
This adds a new optional boolean `resolvable` argument to the `@key` directive. That argument default to `true` but if explicitly set to `false`, then the query planner does not assume that the key has an associated `__resolveReference`. In other words, this allow to mark some fields as keys of an entity but while declaring that the subgraph does not know how to resolve the entity based on those key.
This is useful for subgraph that want to "reference" an entity but don't want/can't easily resolve the entity. Before this patch, the same could be done by skipping the `@key` entirely in that case, but while doing so works in practice, it is less clear conceptually that the type is an entity type (at least looking at that subgraph).
Essentially, the goal of this patch is to make it so that we can always identify an entity type as type having a `@key` and this even when a subgraph do not need/want to have a resolver for said key.