### PR TITLE
Add demand control for uplink

### DIFF
--- a/docs/source/api/apollo-gateway.mdx
+++ b/docs/source/api/apollo-gateway.mdx
@@ -274,6 +274,19 @@ Provide this field **only** if you are using managed federation.
 </td>
 </tr>
 
+###### `fallbackPollIntervalInMs` (managed mode only)
+
+`number`
+</td>
+<td>
+
+Specify this option as a fallback if Uplink fails to provide a polling interval. This will also take effect if `fallbackPollIntervalInMs` is greater than the Uplink defined interval. 
+
+</td>
+</tr>
+
+<tr>
+<td>
 
 <tr>
 <td>

--- a/docs/source/api/apollo-gateway.mdx
+++ b/docs/source/api/apollo-gateway.mdx
@@ -274,6 +274,10 @@ Provide this field **only** if you are using managed federation.
 </td>
 </tr>
 
+
+<tr>
+<td>
+
 ###### `fallbackPollIntervalInMs` (managed mode only)
 
 `number`
@@ -285,8 +289,6 @@ Specify this option as a fallback if Uplink fails to provide a polling interval.
 </td>
 </tr>
 
-<tr>
-<td>
 
 <tr>
 <td>

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet.  Stay tuned!_
+- Respect the `minDelaySeconds` returning from Uplink when polling and retrying to fetch the supergraph schema from Uplink [PR #1564](https://github.com/apollographql/federation/pull/1564)
 
 ## v2.0.0-preview.2
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - Respect the `minDelaySeconds` returning from Uplink when polling and retrying to fetch the supergraph schema from Uplink [PR #1564](https://github.com/apollographql/federation/pull/1564)
+- Remove the previously deprecated `experimental_pollInterval` config option and deprecate `pollIntervalInMs` in favour of `fallbackPollIntervalInMs` (for managed mode only). [PR #1564](https://github.com/apollographql/federation/pull/1564)
 
 ## v2.0.0-preview.2
 

--- a/gateway-js/src/__generated__/graphqlTypes.ts
+++ b/gateway-js/src/__generated__/graphqlTypes.ts
@@ -139,7 +139,7 @@ export type SupergraphSdlQueryVariables = Exact<{
 }>;
 
 
-export type SupergraphSdlQuery = { __typename?: 'Query', routerConfig: { __typename: 'FetchError', code: FetchErrorCode, message: string } | { __typename: 'RouterConfigResult', id: string, supergraphSdl: string } | { __typename: 'Unchanged' } };
+export type SupergraphSdlQuery = { __typename?: 'Query', routerConfig: { __typename: 'FetchError', code: FetchErrorCode, message: string } | { __typename: 'RouterConfigResult', id: string, minDelaySeconds: number, supergraphSdl: string } | { __typename: 'Unchanged' } };
 
 export type OobReportMutationVariables = Exact<{
   input?: InputMaybe<ApiMonitoringReport>;

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -137,7 +137,7 @@ describe('lifecycle hooks', () => {
 
     const [firstCall, secondCall] = mockDidUpdate.mock.calls;
 
-    // Note that we've composing our usual test fixtures here 
+    // Note that we've composing our usual test fixtures here
     const expectedFirstId = createHash('sha256').update(getTestingSupergraphSdl()).digest('hex');
     expect(firstCall[0]!.compositionId).toEqual(expectedFirstId);
     // first call should have no second "previous" argument
@@ -145,7 +145,7 @@ describe('lifecycle hooks', () => {
 
     // Note that this assertion is a tad fragile in that every time we modify
     // the supergraph (even just formatting differences), this ID will change
-    // and this test will have to updated. 
+    // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
       '3ca7f295b11b070d1e1b56a698cbfabb70cb2b5912a4ff0ecae2fb91e8709838',
     );
@@ -183,7 +183,7 @@ describe('lifecycle hooks', () => {
     );
   });
 
-  it('registers schema change callbacks when experimental_pollInterval is set for unmanaged configs', async () => {
+  it('registers schema change callbacks when pollIntervalInMs is set for unmanaged configs', async () => {
     const experimental_updateServiceDefinitions: Experimental_UpdateServiceDefinitions =
       jest.fn(async (_config) => {
         return { serviceDefinitions, isNewSchema: true };

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -444,15 +444,4 @@ describe('deprecation warnings', () => {
       'The `schemaConfigDeliveryEndpoint` option is deprecated and will be removed in a future version of `@apollo/gateway`. Please migrate to the equivalent (array form) `uplinkEndpoints` configuration option.',
     );
   });
-
-  it('warns with `experimental_pollInterval` option set', async () => {
-    new ApolloGateway({
-      experimental_pollInterval: 10000,
-      logger,
-    });
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      'The `experimental_pollInterval` option is deprecated and will be removed in a future version of `@apollo/gateway`. Please migrate to the equivalent `pollIntervalInMs` configuration option.',
-    );
-  });
 });

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -165,7 +165,7 @@ export interface ManagedGatewayConfig extends GatewayConfigBase {
    */
   uplinkEndpoints?: string[];
   uplinkMaxRetries?: number;
-    /**
+  /**
    * @deprecated use `fallbackPollIntervalInMs` instead
    */
   pollIntervalInMs?: number;

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -126,11 +126,6 @@ interface GatewayConfigBase {
   // experimental observability callbacks
   experimental_didResolveQueryPlan?: Experimental_DidResolveQueryPlanCallback;
   experimental_didUpdateSupergraph?: Experimental_DidUpdateSupergraphCallback;
-  /**
-   * @deprecated use `pollIntervalInMs` instead
-   */
-  experimental_pollInterval?: number;
-  pollIntervalInMs?: number;
   experimental_approximateQueryPlanStoreMiB?: number;
   experimental_autoFragmentization?: boolean;
   fetcher?: typeof fetch;
@@ -151,6 +146,7 @@ export interface ServiceListGatewayConfig extends GatewayConfigBase {
     | ((
         service: ServiceEndpointDefinition,
       ) => Promise<HeadersInit> | HeadersInit);
+  pollIntervalInMs?: number;
 }
 
 export interface ManagedGatewayConfig extends GatewayConfigBase {
@@ -169,6 +165,11 @@ export interface ManagedGatewayConfig extends GatewayConfigBase {
    */
   uplinkEndpoints?: string[];
   uplinkMaxRetries?: number;
+    /**
+   * @deprecated use `fallbackPollIntervalInMs` instead
+   */
+  pollIntervalInMs?: number;
+  fallbackPollIntervalInMs?: number;
 }
 
 // TODO(trevor:removeServiceList): migrate users to `supergraphSdl` function option
@@ -177,6 +178,7 @@ interface ManuallyManagedServiceDefsGatewayConfig extends GatewayConfigBase {
    * @deprecated: use `supergraphSdl` instead (either as a `SupergraphSdlHook` or `SupergraphManager`)
    */
   experimental_updateServiceDefinitions: Experimental_UpdateServiceDefinitions;
+  pollIntervalInMs?: number;
 }
 
 // TODO(trevor:removeServiceList): migrate users to `supergraphSdl` function option
@@ -186,6 +188,7 @@ interface ExperimentalManuallyManagedSupergraphSdlGatewayConfig
    * @deprecated: use `supergraphSdl` instead (either as a `SupergraphSdlHook` or `SupergraphManager`)
    */
   experimental_updateSupergraphSdl: Experimental_UpdateSupergraphSdl;
+  pollIntervalInMs?: number;
 }
 
 export function isManuallyManagedSupergraphSdlGatewayConfig(
@@ -239,7 +242,7 @@ type ManuallyManagedGatewayConfig =
   | ManuallyManagedServiceDefsGatewayConfig
   | ExperimentalManuallyManagedSupergraphSdlGatewayConfig
   | ManuallyManagedSupergraphSdlGatewayConfig
-  // TODO(trevor:removeServiceList
+  // TODO(trevor:removeServiceList)
   | ServiceListGatewayConfig;
 
 // TODO(trevor:removeServiceList)
@@ -323,6 +326,7 @@ export function isManagedConfig(
   return (
     'schemaConfigDeliveryEndpoint' in config ||
     'uplinkEndpoints' in config ||
+    'fallbackPollIntervalInMs' in config ||
     (!isLocalConfig(config) &&
       !isStaticSupergraphSdlConfig(config) &&
       !isManuallyManagedConfig(config))

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -81,6 +81,7 @@ export interface ServiceDefinitionUpdate {
 export interface SupergraphSdlUpdate {
   id: string;
   supergraphSdl: string;
+  minDelaySeconds?: number;
 }
 
 export function isSupergraphSdlUpdate(

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -202,7 +202,7 @@ export class ApolloGateway implements GraphQLService {
 
     if (isManagedConfig(this.config)) {
       this.pollIntervalInMs =
-      this.config.fallbackPollIntervalInMs ?? this.config.pollIntervalInMs;
+        this.config.fallbackPollIntervalInMs ?? this.config.pollIntervalInMs;
     } else if (isServiceListConfig(this.config)) {
       this.pollIntervalInMs = this.config?.pollIntervalInMs;
     }
@@ -430,7 +430,6 @@ export class ApolloGateway implements GraphQLService {
       schema: this.schema!,
       executor: this.executor,
     };
-
   }
 
   private getUplinkEndpoints(config: ManagedGatewayConfig) {

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -398,8 +398,7 @@ describe("loadSupergraphSdlFromUplinks", () => {
   });
 
   it("Waits the correct time before retrying", async () => {
-    //jest.useFakeTimers();
-    //jest.spyOn(global, 'setTimeout');
+    jest.spyOn(global, 'setTimeout');
 
     mockSupergraphSdlRequest('originalId-1234', mockCloudConfigUrl1).reply(500);
     mockSupergraphSdlRequestIfAfter('originalId-1234', mockCloudConfigUrl2).reply(
@@ -414,23 +413,23 @@ describe("loadSupergraphSdlFromUplinks", () => {
         },
       }),
     );
-
     const fetcher = getDefaultFetcher();
+
     await loadSupergraphSdlFromUplinks({
       graphRef,
       apiKey,
       endpoints: [mockCloudConfigUrl1, mockCloudConfigUrl2],
       errorReportingEndpoint: undefined,
-      fetcher,
+      fetcher: fetcher,
       compositionId: "originalId-1234",
       maxRetries: 1,
       roundRobinSeed: 0,
       earliestFetchTime: new Date(Date.now() + 1000),
     });
-    //jest.runAllTimers();
-    //jest.useRealTimers();
-    expect(setTimeout).toHaveBeenCalledTimes(2);
-    expect(setTimeout).toHaveBeenLastCalledWith(1)
+
+    // test what setTimeout was called with like this to deal with time jitter
+    expect((setTimeout as unknown as jest.MockedFn<typeof setTimeout>).mock.calls[1][1]).toBeLessThanOrEqual(1000);
+    expect((setTimeout as unknown as jest.MockedFn<typeof setTimeout>).mock.calls[1][1]).toBeGreaterThanOrEqual(900);
   });
 });
 

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -398,7 +398,7 @@ describe("loadSupergraphSdlFromUplinks", () => {
   });
 
   it("Waits the correct time before retrying", async () => {
-    jest.spyOn(global, 'setTimeout');
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
 
     mockSupergraphSdlRequest('originalId-1234', mockCloudConfigUrl1).reply(500);
     mockSupergraphSdlRequestIfAfter('originalId-1234', mockCloudConfigUrl2).reply(
@@ -427,9 +427,12 @@ describe("loadSupergraphSdlFromUplinks", () => {
       earliestFetchTime: new Date(Date.now() + 1000),
     });
 
-    // test what setTimeout was called with like this to deal with time jitter
-    expect((setTimeout as unknown as jest.MockedFn<typeof setTimeout>).mock.calls[1][1]).toBeLessThanOrEqual(1000);
-    expect((setTimeout as unknown as jest.MockedFn<typeof setTimeout>).mock.calls[1][1]).toBeGreaterThanOrEqual(900);
+    // test if setTimeout was called with a value in range to deal with time jitter
+    const setTimeoutCall = timeoutSpy.mock.calls[1][1];
+    expect(setTimeoutCall).toBeLessThanOrEqual(1000);
+    expect(setTimeoutCall).toBeGreaterThanOrEqual(900);
+
+    timeoutSpy.mockRestore();
   });
 });
 

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/__tests__/loadSupergraphSdlFromStorage.test.ts
@@ -65,6 +65,7 @@ describe('loadSupergraphSdlFromStorage', () => {
       compositionId: "originalId-1234",
       maxRetries: 1,
       roundRobinSeed: 0,
+      earliestFetchTime: null,
     });
 
     expect(result).toMatchObject({
@@ -88,6 +89,7 @@ describe('loadSupergraphSdlFromStorage', () => {
         compositionId: "originalId-1234",
         maxRetries: 1,
         roundRobinSeed: 0,
+        earliestFetchTime: null,
       }),
     ).rejects.toThrowError(
       new UplinkFetcherError(
@@ -388,6 +390,7 @@ describe("loadSupergraphSdlFromUplinks", () => {
       compositionId: "id-1234",
       maxRetries: 5,
       roundRobinSeed: 0,
+      earliestFetchTime: null,
     });
 
     expect(result).toBeNull();

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
@@ -6,7 +6,7 @@ import { SubgraphHealthCheckFunction, SupergraphSdlUpdateFunction } from '../..'
 import { loadSupergraphSdlFromUplinks } from './loadSupergraphSdlFromStorage';
 
 export interface UplinkFetcherOptions {
-  pollIntervalInMs: number;
+  fallbackPollIntervalInMs: number;
   subgraphHealthCheck?: boolean;
   graphRef: string;
   apiKey: string;
@@ -132,7 +132,7 @@ export class UplinkFetcher implements SupergraphManager {
       }
 
       this.poll();
-    }, this.minDelayMs ? Math.max(this.minDelayMs, this.config.pollIntervalInMs) : this.config.pollIntervalInMs);
+    }, this.minDelayMs ? Math.max(this.minDelayMs, this.config.fallbackPollIntervalInMs) : this.config.fallbackPollIntervalInMs);
   }
 
   private logUpdateFailure(e: any) {

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
@@ -13,6 +13,7 @@ export const SUPERGRAPH_SDL_QUERY = /* GraphQL */`#graphql
       ... on RouterConfigResult {
         id
         supergraphSdl: supergraphSDL
+        minDelaySeconds
       }
       ... on FetchError {
         code
@@ -176,9 +177,10 @@ export async function loadSupergraphSdlFromStorage({
     const {
       id,
       supergraphSdl,
+      minDelaySeconds,
       // messages,
     } = routerConfig;
-    return { id, supergraphSdl: supergraphSdl! };
+    return { id, supergraphSdl: supergraphSdl!, minDelaySeconds };
   } else if (routerConfig.__typename === 'FetchError') {
     // FetchError case
     const { code, message } = routerConfig;

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/loadSupergraphSdlFromStorage.ts
@@ -57,6 +57,7 @@ export async function loadSupergraphSdlFromUplinks({
   compositionId,
   maxRetries,
   roundRobinSeed,
+  earliestFetchTime,
 }: {
   graphRef: string;
   apiKey: string;
@@ -66,6 +67,7 @@ export async function loadSupergraphSdlFromUplinks({
   compositionId: string | null;
   maxRetries: number,
   roundRobinSeed: number,
+  earliestFetchTime: Date | null
 }) : Promise<SupergraphSdlUpdate | null> {
   // This Promise resolves with either an updated supergraph or null if no change.
   // This Promise can reject in the case that none of the retries are successful,
@@ -82,6 +84,10 @@ export async function loadSupergraphSdlFromUplinks({
       }),
     {
       retries: maxRetries,
+      onRetry: async () => {
+        const delayMS = earliestFetchTime ? earliestFetchTime.getTime() - Date.now(): 0;
+        if (delayMS > 0) await new Promise(resolve => setTimeout(resolve, delayMS));
+      }
     },
   );
 


### PR DESCRIPTION
Implements https://github.com/mdg-private/planning/issues/727

This PR uses the new `minDelaySeconds` returned by uplink to set the polling interval instead of gateways polling every 10 seconds by default configurable on the gateway side. If no `minDelaySeconds` is provided by uplink, `pollIntervalInMs` will still be used.



<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
