### PR TITLE
Fix merging of arguments

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -1436,6 +1436,34 @@ describe('composition', () => {
         ['EXTERNAL_MISSING_ON_BASE', 'Field "A.f" is marked @external on all the subgraphs in which it is listed (subgraph "subgraphB").'],
       ]);
     });
+
+    it('errors if a mandatory argument is not in all subgraphs', () => {
+      const subgraphA = {
+        typeDefs: gql`
+          type Query {
+            q(a: Int!): String @shareable
+          }
+        `,
+        name: 'subgraphA',
+      };
+
+      const subgraphB = {
+        typeDefs: gql`
+          type Query {
+            q: String @shareable
+          }
+        `,
+        name: 'subgraphB',
+      };
+
+      const result = composeAsFed2Subgraphs([subgraphA, subgraphB]);
+
+      expect(result.errors).toBeDefined();
+      expect(errors(result)).toStrictEqual([
+        ['REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH',
+          'Argument "Query.q(a:)" is required in some subgraphs but does not appear in all subgraphs: it is required in subgraph "subgraphA" but does not appear in subgraph "subgraphB"']
+      ]);
+    });
   });
 
   describe('post-merge validation', () => {

--- a/composition-js/src/__tests__/hints.test.ts
+++ b/composition-js/src/__tests__/hints.test.ts
@@ -365,10 +365,9 @@ test('hints on enum value not being in all subgraphs', () => {
   );
 })
 
-test('hints on type system directives having inconsistent repeatable', () => {
-  // Note that the code currently only merge a handful of hard-coded type system directive, so we have
-  // to use of the known names. We use 'tag'.
-
+// Skipped for now because we don't merge any type system directives and so
+// this cannot be properly tested.
+test.skip('hints on type system directives having inconsistent repeatable', () => {
   const subgraph1 = gql`
     type Query {
       a: Int
@@ -389,7 +388,9 @@ test('hints on type system directives having inconsistent repeatable', () => {
   );
 })
 
-test('hints on type system directives having inconsistent locations', () => {
+// Skipped for now because we don't merge any type system directives and so
+// this cannot be properly tested.
+test.skip('hints on type system directives having inconsistent locations', () => {
   // Same as above, we kind of have to use tag.
   const subgraph1 = gql`
     type Query {

--- a/composition-js/src/hints.ts
+++ b/composition-js/src/hints.ts
@@ -115,12 +115,10 @@ export const hintInconsistentDescription = new HintID(
   'the element with inconsistent description'
 );
 
-// Note that we keep the hint somewhat generic, but it is currently only used for execution directive so we specify
-// this in the description for clarity.
 export const hintInconsistentArgumentPresence = new HintID(
   'InconsistentArgumentPresence',
-  'Indicates that an argument of an execution directive definition is not present in all subgraphs '
-  + 'and will not be part of the supergraph',
+  'Indicates that an (optional) argument (of a field or directive definition) is not present in all subgraphs '
+  + ' and will not be part of the supergraph',
   'the argument with mismatched types'
 );
 

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -49,6 +49,7 @@ The following errors may be raised by composition:
 | `PROVIDES_INVALID_FIELDS` | The `fields` argument of a `@provides` directive is invalid (it has invalid syntax, includes unknown fields, ...). | 2.0.0 |  |
 | `PROVIDES_ON_NON_OBJECT_FIELD` | A `@provides` directive is used to mark a field whose base type is not an object type. | 2.0.0 |  |
 | `PROVIDES_UNSUPPORTED_ON_INTERFACE` | A `@provides` directive is used on an interface, which is not (yet) supported. | 2.0.0 |  |
+| `REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH` | An argument of a field or directive definition is mandatory in some subgraphs, but the argument is not defined in all subgraphs that define the field or directive definition. | 2.0.0 |  |
 | `REQUIRES_FIELDS_HAS_ARGS` | The `fields` argument of a `@requires` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `REQUIRES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@requires` directive includes a field that is not marked as `@external`. | 0.x |  |
 | `REQUIRES_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@requires` directive is not a string. | 2.0.0 |  |

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -147,7 +147,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated. 
     expect(secondCall[0]!.compositionId).toEqual(
-      'be41610508728662796c2ccd71348603250b79a7f9854914ebfc771ac4ebcffb',
+      'ce2a5aa4525435780c32e19001e9fb337041a66f3c8cb7dc3e8617e97bc8610e',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -301,6 +301,11 @@ const INVALID_LINK_DIRECTIVE_USAGE = makeCodeDefinition(
   'An application of the @link directive is invalid/does not respect the specification.'
 );
 
+const REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH = makeCodeDefinition(
+  'REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH',
+  'An argument of a field or directive definition is mandatory in some subgraphs, but the argument is not defined in all subgraphs that define the field or directive definition.'
+);
+
 const SATISFIABILITY_ERROR = makeCodeDefinition(
   'SATISFIABILITY_ERROR',
   'Subgraphs can be merged, but the resulting supergraph API would have queries that cannot be satisfied by those subgraphs.',
@@ -359,6 +364,7 @@ export const ERRORS = {
   INTERFACE_FIELD_IMPLEM_TYPE_MISMATCH,
   INVALID_FIELD_SHARING,
   INVALID_LINK_DIRECTIVE_USAGE,
+  REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH,
   SATISFIABILITY_ERROR,
 };
 


### PR DESCRIPTION
We shouldn't merge arguments unless they appear in all subgraphs, orthis lead to unclear semantic if those argument are passed by the end user.

I'll also note that the pre-existing behaviour, which was adding arguments to the supergraph if it appeared in any subgraph was potentially leading to errors when decoding the supergraph because we didn't kept information of where the argument was defined and as a result we sometimes inferred that an argument was in a subgraph that didn't have the argument type. Long story short, if we only include argument that are in all subgraphs (that have the field/directive definition), we solve that problem as well.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
