### PR TITLE
Fix operation names

### DIFF
--- a/gateway-js/src/__tests__/build-query-plan.feature
+++ b/gateway-js/src/__tests__/build-query-plan.feature
@@ -1009,8 +1009,8 @@ Scenario: supports basic, single-service mutation
         "password"
       ],
       "operationKind": "mutation",
-      "operation": "mutation Login_accounts_0($username:String!$password:String!){login(username:$username password:$password){id}}",
-      "operationName": "Login_accounts_0"
+      "operation": "mutation Login__accounts__0($username:String!$password:String!){login(username:$username password:$password){id}}",
+      "operationName": "Login__accounts__0"
     }
   }
   """
@@ -1044,8 +1044,8 @@ Scenario: supports mutations with a cross-service request
             "password"
           ],
           "operationKind": "mutation",
-          "operation": "mutation Login_accounts_0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "Login_accounts_0"
+          "operation": "mutation Login__accounts__0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "Login__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -1073,8 +1073,8 @@ Scenario: supports mutations with a cross-service request
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Login_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "Login_reviews_1"
+            "operation": "query Login__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "Login__reviews__1"
           }
         },
         {
@@ -1106,8 +1106,8 @@ Scenario: supports mutations with a cross-service request
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Login_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "Login_product_2"
+            "operation": "query Login__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "Login__product__2"
           }
         }
       ]
@@ -1142,8 +1142,8 @@ Scenario: returning across service boundaries
             "body"
           ],
           "operationKind": "mutation",
-          "operation": "mutation Review_reviews_0($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
-          "operationName": "Review_reviews_0"
+          "operation": "mutation Review__reviews__0($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
+          "operationName": "Review__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -1171,8 +1171,8 @@ Scenario: returning across service boundaries
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Review_product_1($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
-            "operationName": "Review_product_1"
+            "operation": "query Review__product__1($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
+            "operationName": "Review__product__1"
           }
         }
       ]
@@ -1219,8 +1219,8 @@ Scenario: supports multiple root mutations
             "password"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_accounts_0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "LoginAndReview_accounts_0"
+          "operation": "mutation LoginAndReview__accounts__0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "LoginAndReview__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -1248,8 +1248,8 @@ Scenario: supports multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "LoginAndReview_reviews_1"
+            "operation": "query LoginAndReview__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "LoginAndReview__reviews__1"
           }
         },
         {
@@ -1281,8 +1281,8 @@ Scenario: supports multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "LoginAndReview_product_2"
+            "operation": "query LoginAndReview__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "LoginAndReview__product__2"
           }
         },
         {
@@ -1293,8 +1293,8 @@ Scenario: supports multiple root mutations
             "body"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_3($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
-          "operationName": "LoginAndReview_reviews_3"
+          "operation": "mutation LoginAndReview__reviews__3($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
+          "operationName": "LoginAndReview__reviews__3"
         },
         {
           "kind": "Flatten",
@@ -1322,8 +1322,8 @@ Scenario: supports multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_4($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
-            "operationName": "LoginAndReview_product_4"
+            "operation": "query LoginAndReview__product__4($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
+            "operationName": "LoginAndReview__product__4"
           }
         }
       ]
@@ -1378,8 +1378,8 @@ Scenario: multiple root mutations with correct service order
             "updatedReview"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_0($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}",
-          "operationName": "LoginAndReview_reviews_0"
+          "operation": "mutation LoginAndReview__reviews__0($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}",
+          "operationName": "LoginAndReview__reviews__0"
         },
         {
           "kind": "Fetch",
@@ -1389,8 +1389,8 @@ Scenario: multiple root mutations with correct service order
             "password"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_accounts_1($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "LoginAndReview_accounts_1"
+          "operation": "mutation LoginAndReview__accounts__1($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "LoginAndReview__accounts__1"
         },
         {
           "kind": "Flatten",
@@ -1418,8 +1418,8 @@ Scenario: multiple root mutations with correct service order
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_reviews_2($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "LoginAndReview_reviews_2"
+            "operation": "query LoginAndReview__reviews__2($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "LoginAndReview__reviews__2"
           }
         },
         {
@@ -1451,8 +1451,8 @@ Scenario: multiple root mutations with correct service order
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "LoginAndReview_product_3"
+            "operation": "query LoginAndReview__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "LoginAndReview__product__3"
           }
         },
         {
@@ -1462,8 +1462,8 @@ Scenario: multiple root mutations with correct service order
             "reviewId"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_4($reviewId:ID!){deleteReview(id:$reviewId)}",
-          "operationName": "LoginAndReview_reviews_4"
+          "operation": "mutation LoginAndReview__reviews__4($reviewId:ID!){deleteReview(id:$reviewId)}",
+          "operationName": "LoginAndReview__reviews__4"
         }
       ]
     }

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -3,7 +3,7 @@ import { composeServices } from '@apollo/composition';
 import { asFed2SubgraphDocument, assert, buildSchema, operationFromDocument, Schema, ServiceDefinition } from '@apollo/federation-internals';
 import gql from 'graphql-tag';
 import { MAX_COMPUTED_PLANS } from '../buildPlan';
-import { FetchNode } from '../QueryPlan';
+import { FetchNode, FlattenNode, SequenceNode } from '../QueryPlan';
 import { FieldNode, OperationDefinitionNode, parse } from 'graphql';
 
 expect.addSnapshotSerializer(astSerializer);
@@ -1062,6 +1062,143 @@ describe('@requires', () => {
       }
     `);
   })
+});
+
+describe('fetch operation names', () => {
+  test('handle subgraph with - in the name', () => {
+    const subgraph1 = {
+      name: 'S1',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: 'non-graphql-name',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          x: Int
+        }
+      `
+    }
+
+    const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+    const operation = operationFromDocument(api, gql`
+      query myOp {
+        t {
+          x
+        }
+      }
+    `);
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "S1") {
+            {
+              t {
+                __typename
+                id
+              }
+            }
+          },
+          Flatten(path: "t") {
+            Fetch(service: "non-graphql-name") {
+              {
+                ... on T {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T {
+                  x
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+    const fetch = ((plan.node as SequenceNode).nodes[1] as FlattenNode).node as FetchNode;
+    expect(fetch.operation).toMatch(/^query myOp__non_graphqlname__1.*/i);
+  });
+
+  test('handle very non-graph subgraph name', () => {
+    const subgraph1 = {
+      name: 'S1',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: '42!',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          x: Int
+        }
+      `
+    }
+
+    const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+    const operation = operationFromDocument(api, gql`
+      query myOp {
+        t {
+          x
+        }
+      }
+    `);
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "S1") {
+            {
+              t {
+                __typename
+                id
+              }
+            }
+          },
+          Flatten(path: "t") {
+            Fetch(service: "42!") {
+              {
+                ... on T {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T {
+                  x
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+    const fetch = ((plan.node as SequenceNode).nodes[1] as FlattenNode).node as FetchNode;
+    
+    expect(fetch.operation).toMatch(/^query myOp___42__1.*/i);
+  });
 });
 
 test('Correctly handle case where there is too many plans to consider', () => {

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -1196,7 +1196,7 @@ describe('fetch operation names', () => {
       }
     `);
     const fetch = ((plan.node as SequenceNode).nodes[1] as FlattenNode).node as FetchNode;
-    
+
     expect(fetch.operation).toMatch(/^query myOp___42__1.*/i);
   });
 });

--- a/query-planner-js/src/__tests__/features/basic/abstract-types.feature
+++ b/query-planner-js/src/__tests__/features/basic/abstract-types.feature
@@ -23,8 +23,8 @@ Scenario: handles an abstract type from the base service
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn upc price}...on Furniture{upc name price}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn upc price}...on Furniture{upc name price}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -44,8 +44,8 @@ Scenario: handles an abstract type from the base service
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_books_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-            "operationName": "GetProduct_books_1"
+            "operation": "query GetProduct__books__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+            "operationName": "GetProduct__books__1"
           }
         },
         {
@@ -68,8 +68,8 @@ Scenario: handles an abstract type from the base service
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
-            "operationName": "GetProduct_product_2"
+            "operation": "query GetProduct__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
+            "operationName": "GetProduct__product__2"
           }
         }
       ]
@@ -98,8 +98,8 @@ Scenario: can request fields on extended interfaces
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename sku}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename sku}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -127,8 +127,8 @@ Scenario: can request fields on extended interfaces
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_inventory_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{inStock}...on Furniture{inStock}}}",
-            "operationName": "GetProduct_inventory_1"
+            "operation": "query GetProduct__inventory__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{inStock}...on Furniture{inStock}}}",
+            "operationName": "GetProduct__inventory__1"
           }
         }
       ]
@@ -160,8 +160,8 @@ Scenario: can request fields on extended types that implement an interface
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename sku}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename sku}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -189,8 +189,8 @@ Scenario: can request fields on extended types that implement an interface
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_inventory_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{inStock}...on Furniture{inStock isHeavy}}}",
-            "operationName": "GetProduct_inventory_1"
+            "operation": "query GetProduct__inventory__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{inStock}...on Furniture{inStock isHeavy}}}",
+            "operationName": "GetProduct__inventory__1"
           }
         }
       ]
@@ -225,8 +225,8 @@ Scenario: prunes unfilled type conditions
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename sku}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename sku}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -254,8 +254,8 @@ Scenario: prunes unfilled type conditions
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_inventory_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{inStock isCheckedOut}...on Furniture{inStock isHeavy}}}",
-            "operationName": "GetProduct_inventory_1"
+            "operation": "query GetProduct__inventory__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{inStock isCheckedOut}...on Furniture{inStock isHeavy}}}",
+            "operationName": "GetProduct__inventory__1"
           }
         }
       ]
@@ -291,8 +291,8 @@ Scenario: fetches interfaces returned from other services
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUserAndProducts_accounts_0{me{__typename id}}",
-          "operationName": "GetUserAndProducts_accounts_0"
+          "operation": "query GetUserAndProducts__accounts__0{me{__typename id}}",
+          "operationName": "GetUserAndProducts__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -312,8 +312,8 @@ Scenario: fetches interfaces returned from other services
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetUserAndProducts_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
-            "operationName": "GetUserAndProducts_reviews_1"
+            "operation": "query GetUserAndProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
+            "operationName": "GetUserAndProducts__reviews__1"
           }
         },
         {
@@ -337,8 +337,8 @@ Scenario: fetches interfaces returned from other services
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query GetUserAndProducts_books_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title}}}",
-                "operationName": "GetUserAndProducts_books_2"
+                "operation": "query GetUserAndProducts__books__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title}}}",
+                "operationName": "GetUserAndProducts__books__2"
               }
             },
             {
@@ -367,8 +367,8 @@ Scenario: fetches interfaces returned from other services
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query GetUserAndProducts_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{price}...on Furniture{price}}}",
-                "operationName": "GetUserAndProducts_product_3"
+                "operation": "query GetUserAndProducts__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{price}...on Furniture{price}}}",
+                "operationName": "GetUserAndProducts__product__3"
               }
             }
           ]
@@ -406,8 +406,8 @@ Scenario: fetches composite fields from a foreign type casted to an interface [@
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUserAndProducts_accounts_0{me{__typename id}}",
-          "operationName": "GetUserAndProducts_accounts_0"
+          "operation": "query GetUserAndProducts__accounts__0{me{__typename id}}",
+          "operationName": "GetUserAndProducts__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -427,8 +427,8 @@ Scenario: fetches composite fields from a foreign type casted to an interface [@
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetUserAndProducts_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
-            "operationName": "GetUserAndProducts_reviews_1"
+            "operation": "query GetUserAndProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
+            "operationName": "GetUserAndProducts__reviews__1"
           }
         },
         {
@@ -460,8 +460,8 @@ Scenario: fetches composite fields from a foreign type casted to an interface [@
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query GetUserAndProducts_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{price}...on Furniture{price}}}",
-                "operationName": "GetUserAndProducts_product_2"
+                "operation": "query GetUserAndProducts__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{price}...on Furniture{price}}}",
+                "operationName": "GetUserAndProducts__product__2"
               }
             },
             {
@@ -485,8 +485,8 @@ Scenario: fetches composite fields from a foreign type casted to an interface [@
                     ],
                     "variableUsages": [],
                     "operationKind": "query",
-                    "operation": "query GetUserAndProducts_books_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-                    "operationName": "GetUserAndProducts_books_3"
+                    "operation": "query GetUserAndProducts__books__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+                    "operationName": "GetUserAndProducts__books__3"
                   }
                 },
                 {
@@ -509,8 +509,8 @@ Scenario: fetches composite fields from a foreign type casted to an interface [@
                     ],
                     "variableUsages": [],
                     "operationKind": "query",
-                    "operation": "query GetUserAndProducts_product_4($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
-                    "operationName": "GetUserAndProducts_product_4"
+                    "operation": "query GetUserAndProducts__product__4($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
+                    "operationName": "GetUserAndProducts__product__4"
                   }
                 }
               ]
@@ -545,8 +545,8 @@ Scenario: allows for extending an interface from another service with fields
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -574,8 +574,8 @@ Scenario: allows for extending an interface from another service with fields
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{body}}...on Furniture{reviews{body}}}}",
-            "operationName": "GetProduct_reviews_1"
+            "operation": "query GetProduct__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{body}}...on Furniture{reviews{body}}}}",
+            "operationName": "GetProduct__reviews__1"
           }
         }
       ]
@@ -618,8 +618,8 @@ Scenario: handles unions from the same service
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUserAndProducts_accounts_0{me{__typename id}}",
-          "operationName": "GetUserAndProducts_accounts_0"
+          "operation": "query GetUserAndProducts__accounts__0{me{__typename id}}",
+          "operationName": "GetUserAndProducts__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -639,8 +639,8 @@ Scenario: handles unions from the same service
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetUserAndProducts_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
-            "operationName": "GetUserAndProducts_reviews_1"
+            "operation": "query GetUserAndProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
+            "operationName": "GetUserAndProducts__reviews__1"
           }
         },
         {
@@ -669,8 +669,8 @@ Scenario: handles unions from the same service
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetUserAndProducts_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{price}...on Furniture{price brand{__typename ...on Ikea{asile}...on Amazon{referrer}}}}}",
-            "operationName": "GetUserAndProducts_product_2"
+            "operation": "query GetUserAndProducts__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{price}...on Furniture{price brand{__typename ...on Ikea{asile}...on Amazon{referrer}}}}}",
+            "operationName": "GetUserAndProducts__product__2"
           }
         }
       ]

--- a/query-planner-js/src/__tests__/features/basic/aliases.feature
+++ b/query-planner-js/src/__tests__/features/basic/aliases.feature
@@ -23,8 +23,8 @@ Scenario: supports simple aliases
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{name title:name}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{name title:name}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -44,8 +44,8 @@ Scenario: supports simple aliases
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_books_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-            "operationName": "GetProduct_books_1"
+            "operation": "query GetProduct__books__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+            "operationName": "GetProduct__books__1"
           }
         },
         {
@@ -68,8 +68,8 @@ Scenario: supports simple aliases
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title:name name}}}",
-            "operationName": "GetProduct_product_2"
+            "operation": "query GetProduct__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title:name name}}}",
+            "operationName": "GetProduct__product__2"
           }
         }
       ]
@@ -105,8 +105,8 @@ Scenario: supports aliases of root fields on subservices
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename upc name title:name}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename upc name title:name}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Parallel",
@@ -137,8 +137,8 @@ Scenario: supports aliases of root fields on subservices
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query GetProduct_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{body}productReviews:reviews{body}}...on Furniture{reviews{body}productReviews:reviews{body}}}}",
-                "operationName": "GetProduct_reviews_1"
+                "operation": "query GetProduct__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{body}productReviews:reviews{body}}...on Furniture{reviews{body}productReviews:reviews{body}}}}",
+                "operationName": "GetProduct__reviews__1"
               }
             },
             {
@@ -162,8 +162,8 @@ Scenario: supports aliases of root fields on subservices
                     ],
                     "variableUsages": [],
                     "operationKind": "query",
-                    "operation": "query GetProduct_books_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-                    "operationName": "GetProduct_books_2"
+                    "operation": "query GetProduct__books__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+                    "operationName": "GetProduct__books__2"
                   }
                 },
                 {
@@ -186,8 +186,8 @@ Scenario: supports aliases of root fields on subservices
                     ],
                     "variableUsages": [],
                     "operationKind": "query",
-                    "operation": "query GetProduct_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{title:name name}}}",
-                    "operationName": "GetProduct_product_3"
+                    "operation": "query GetProduct__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{title:name name}}}",
+                    "operationName": "GetProduct__product__3"
                   }
                 }
               ]
@@ -231,8 +231,8 @@ Scenario: supports aliases of nested fields on subservices
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename upc name title:name}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{__typename upc name title:name}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Parallel",
@@ -263,8 +263,8 @@ Scenario: supports aliases of nested fields on subservices
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query GetProduct_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{content:body body}productReviews:reviews{body reviewer:author{name:username}}}...on Furniture{reviews{content:body body}productReviews:reviews{body reviewer:author{name:username}}}}}",
-                "operationName": "GetProduct_reviews_1"
+                "operation": "query GetProduct__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{content:body body}productReviews:reviews{body reviewer:author{name:username}}}...on Furniture{reviews{content:body body}productReviews:reviews{body reviewer:author{name:username}}}}}",
+                "operationName": "GetProduct__reviews__1"
               }
             },
             {
@@ -288,8 +288,8 @@ Scenario: supports aliases of nested fields on subservices
                     ],
                     "variableUsages": [],
                     "operationKind": "query",
-                    "operation": "query GetProduct_books_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-                    "operationName": "GetProduct_books_2"
+                    "operation": "query GetProduct__books__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+                    "operationName": "GetProduct__books__2"
                   }
                 },
                 {
@@ -312,8 +312,8 @@ Scenario: supports aliases of nested fields on subservices
                     ],
                     "variableUsages": [],
                     "operationKind": "query",
-                    "operation": "query GetProduct_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{title:name name}}}",
-                    "operationName": "GetProduct_product_3"
+                    "operation": "query GetProduct__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{title:name name}}}",
+                    "operationName": "GetProduct__product__3"
                   }
                 }
               ]

--- a/query-planner-js/src/__tests__/features/basic/boolean.feature
+++ b/query-planner-js/src/__tests__/features/basic/boolean.feature
@@ -26,8 +26,8 @@ Scenario: supports @skip when a boolean condition is met
           "serviceName": "reviews",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetReviewers_reviews_0{topReviews{body author@skip(if:true){__typename id}}}",
-          "operationName": "GetReviewers_reviews_0"
+          "operation": "query GetReviewers__reviews__0{topReviews{body author@skip(if:true){__typename id}}}",
+          "operationName": "GetReviewers__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -47,8 +47,8 @@ Scenario: supports @skip when a boolean condition is met
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviewers_accounts_1($representations:[_Any!]!){_entities(representations:$representations){...on User@skip(if:true){name{first}}}}",
-            "operationName": "GetReviewers_accounts_1"
+            "operation": "query GetReviewers__accounts__1($representations:[_Any!]!){_entities(representations:$representations){...on User@skip(if:true){name{first}}}}",
+            "operationName": "GetReviewers__accounts__1"
           }
         }
       ]
@@ -77,8 +77,8 @@ Scenario: supports @skip when a boolean condition is met (variable driven)
       "serviceName": "reviews",
       "variableUsages": ["skip"],
       "operationKind": "query",
-      "operation": "query GetReviewers_reviews_0($skip:Boolean!=true){topReviews{body author@skip(if:$skip){username}}}",
-      "operationName": "GetReviewers_reviews_0"
+      "operation": "query GetReviewers__reviews__0($skip:Boolean!=true){topReviews{body author@skip(if:$skip){username}}}",
+      "operationName": "GetReviewers__reviews__0"
     }
   }
   """
@@ -109,8 +109,8 @@ Scenario: supports @skip when a boolean condition is not met
           "serviceName": "reviews",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetReviewers_reviews_0{topReviews{body author@skip(if:false){__typename id}}}",
-          "operationName": "GetReviewers_reviews_0"
+          "operation": "query GetReviewers__reviews__0{topReviews{body author@skip(if:false){__typename id}}}",
+          "operationName": "GetReviewers__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -130,8 +130,8 @@ Scenario: supports @skip when a boolean condition is not met
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviewers_accounts_1($representations:[_Any!]!){_entities(representations:$representations){...on User@skip(if:false){name{first}}}}",
-            "operationName": "GetReviewers_accounts_1"
+            "operation": "query GetReviewers__accounts__1($representations:[_Any!]!){_entities(representations:$representations){...on User@skip(if:false){name{first}}}}",
+            "operationName": "GetReviewers__accounts__1"
           }
         }
       ]
@@ -165,8 +165,8 @@ Scenario: supports @skip when a boolean condition is not met (variable driven)
           "serviceName": "reviews",
           "variableUsages": ["skip"],
           "operationKind": "query",
-          "operation": "query GetReviewers_reviews_0($skip:Boolean!){topReviews{body author@skip(if:$skip){__typename id}}}",
-          "operationName": "GetReviewers_reviews_0"
+          "operation": "query GetReviewers__reviews__0($skip:Boolean!){topReviews{body author@skip(if:$skip){__typename id}}}",
+          "operationName": "GetReviewers__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -186,8 +186,8 @@ Scenario: supports @skip when a boolean condition is not met (variable driven)
             ],
             "variableUsages": ["skip"],
             "operationKind": "query",
-            "operation": "query GetReviewers_accounts_1($representations:[_Any!]!$skip:Boolean!){_entities(representations:$representations){...on User@skip(if:$skip){name{first}}}}",
-            "operationName": "GetReviewers_accounts_1"
+            "operation": "query GetReviewers__accounts__1($representations:[_Any!]!$skip:Boolean!){_entities(representations:$representations){...on User@skip(if:$skip){name{first}}}}",
+            "operationName": "GetReviewers__accounts__1"
           }
         }
       ]
@@ -216,8 +216,8 @@ Scenario: supports @include when a boolean condition is not met
       "serviceName": "reviews",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetReviewers_reviews_0{topReviews{body author@include(if:false){username}}}",
-      "operationName": "GetReviewers_reviews_0"
+      "operation": "query GetReviewers__reviews__0{topReviews{body author@include(if:false){username}}}",
+      "operationName": "GetReviewers__reviews__0"
     }
   }
   """
@@ -243,8 +243,8 @@ Scenario: supports @include when a boolean condition is not met (variable driven
       "serviceName": "reviews",
       "variableUsages": ["include"],
       "operationKind": "query",
-      "operation": "query GetReviewers_reviews_0($include:Boolean!=false){topReviews{body author@include(if:$include){username}}}",
-      "operationName": "GetReviewers_reviews_0"
+      "operation": "query GetReviewers__reviews__0($include:Boolean!=false){topReviews{body author@include(if:$include){username}}}",
+      "operationName": "GetReviewers__reviews__0"
     }
   }
   """
@@ -275,8 +275,8 @@ Scenario: supports @include when a boolean condition is met
           "serviceName": "reviews",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetReviewers_reviews_0{topReviews{body author@include(if:true){__typename id}}}",
-          "operationName": "GetReviewers_reviews_0"
+          "operation": "query GetReviewers__reviews__0{topReviews{body author@include(if:true){__typename id}}}",
+          "operationName": "GetReviewers__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -296,8 +296,8 @@ Scenario: supports @include when a boolean condition is met
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviewers_accounts_1($representations:[_Any!]!){_entities(representations:$representations){...on User@include(if:true){name{first}}}}",
-            "operationName": "GetReviewers_accounts_1"
+            "operation": "query GetReviewers__accounts__1($representations:[_Any!]!){_entities(representations:$representations){...on User@include(if:true){name{first}}}}",
+            "operationName": "GetReviewers__accounts__1"
           }
         }
       ]
@@ -333,8 +333,8 @@ Scenario: supports @include when a boolean condition is met (variable driven)
           "serviceName": "reviews",
           "variableUsages": ["include"],
           "operationKind": "query",
-          "operation": "query GetReviewers_reviews_0($include:Boolean!){topReviews{body author@include(if:$include){__typename id}}}",
-          "operationName": "GetReviewers_reviews_0"
+          "operation": "query GetReviewers__reviews__0($include:Boolean!){topReviews{body author@include(if:$include){__typename id}}}",
+          "operationName": "GetReviewers__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -354,8 +354,8 @@ Scenario: supports @include when a boolean condition is met (variable driven)
             ],
             "variableUsages": ["include"],
             "operationKind": "query",
-            "operation": "query GetReviewers_accounts_1($representations:[_Any!]!$include:Boolean!){_entities(representations:$representations){...on User@include(if:$include){name{first}}}}",
-            "operationName": "GetReviewers_accounts_1"
+            "operation": "query GetReviewers__accounts__1($representations:[_Any!]!$include:Boolean!){_entities(representations:$representations){...on User@include(if:$include){name{first}}}}",
+            "operationName": "GetReviewers__accounts__1"
           }
         }
       ]

--- a/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
+++ b/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
@@ -1009,8 +1009,8 @@ Scenario: supports basic, single-service mutation
         "password"
       ],
       "operationKind": "mutation",
-      "operation": "mutation Login_accounts_0($username:String!$password:String!){login(username:$username password:$password){id}}",
-      "operationName": "Login_accounts_0"
+      "operation": "mutation Login__accounts__0($username:String!$password:String!){login(username:$username password:$password){id}}",
+      "operationName": "Login__accounts__0"
     }
   }
   """
@@ -1044,8 +1044,8 @@ Scenario: supports mutations with a cross-service request
             "password"
           ],
           "operationKind": "mutation",
-          "operation": "mutation Login_accounts_0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "Login_accounts_0"
+          "operation": "mutation Login__accounts__0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "Login__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -1073,8 +1073,8 @@ Scenario: supports mutations with a cross-service request
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Login_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "Login_reviews_1"
+            "operation": "query Login__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "Login__reviews__1"
           }
         },
         {
@@ -1106,8 +1106,8 @@ Scenario: supports mutations with a cross-service request
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Login_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "Login_product_2"
+            "operation": "query Login__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "Login__product__2"
           }
         }
       ]
@@ -1142,8 +1142,8 @@ Scenario: returning across service boundaries
             "body"
           ],
           "operationKind": "mutation",
-          "operation": "mutation Review_reviews_0($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
-          "operationName": "Review_reviews_0"
+          "operation": "mutation Review__reviews__0($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
+          "operationName": "Review__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -1171,8 +1171,8 @@ Scenario: returning across service boundaries
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Review_product_1($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
-            "operationName": "Review_product_1"
+            "operation": "query Review__product__1($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
+            "operationName": "Review__product__1"
           }
         }
       ]
@@ -1219,8 +1219,8 @@ Scenario: supports multiple root mutations
             "password"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_accounts_0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "LoginAndReview_accounts_0"
+          "operation": "mutation LoginAndReview__accounts__0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "LoginAndReview__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -1248,8 +1248,8 @@ Scenario: supports multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "LoginAndReview_reviews_1"
+            "operation": "query LoginAndReview__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "LoginAndReview__reviews__1"
           }
         },
         {
@@ -1281,8 +1281,8 @@ Scenario: supports multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "LoginAndReview_product_2"
+            "operation": "query LoginAndReview__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "LoginAndReview__product__2"
           }
         },
         {
@@ -1293,8 +1293,8 @@ Scenario: supports multiple root mutations
             "body"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_3($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
-          "operationName": "LoginAndReview_reviews_3"
+          "operation": "mutation LoginAndReview__reviews__3($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
+          "operationName": "LoginAndReview__reviews__3"
         },
         {
           "kind": "Flatten",
@@ -1322,8 +1322,8 @@ Scenario: supports multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_4($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
-            "operationName": "LoginAndReview_product_4"
+            "operation": "query LoginAndReview__product__4($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
+            "operationName": "LoginAndReview__product__4"
           }
         }
       ]
@@ -1378,8 +1378,8 @@ Scenario: multiple root mutations with correct service order
             "updatedReview"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_0($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}",
-          "operationName": "LoginAndReview_reviews_0"
+          "operation": "mutation LoginAndReview__reviews__0($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}",
+          "operationName": "LoginAndReview__reviews__0"
         },
         {
           "kind": "Fetch",
@@ -1389,8 +1389,8 @@ Scenario: multiple root mutations with correct service order
             "password"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_accounts_1($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "LoginAndReview_accounts_1"
+          "operation": "mutation LoginAndReview__accounts__1($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "LoginAndReview__accounts__1"
         },
         {
           "kind": "Flatten",
@@ -1418,8 +1418,8 @@ Scenario: multiple root mutations with correct service order
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_reviews_2($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "LoginAndReview_reviews_2"
+            "operation": "query LoginAndReview__reviews__2($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "LoginAndReview__reviews__2"
           }
         },
         {
@@ -1451,8 +1451,8 @@ Scenario: multiple root mutations with correct service order
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "LoginAndReview_product_3"
+            "operation": "query LoginAndReview__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "LoginAndReview__product__3"
           }
         },
         {
@@ -1462,8 +1462,8 @@ Scenario: multiple root mutations with correct service order
             "reviewId"
           ],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_4($reviewId:ID!){deleteReview(id:$reviewId)}",
-          "operationName": "LoginAndReview_reviews_4"
+          "operation": "mutation LoginAndReview__reviews__4($reviewId:ID!){deleteReview(id:$reviewId)}",
+          "operationName": "LoginAndReview__reviews__4"
         }
       ]
     }
@@ -1495,8 +1495,8 @@ Scenario: supports arrays
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query MergeArrays_accounts_0{me{__typename id metadata{description address}}}",
-          "operationName": "MergeArrays_accounts_0"
+          "operation": "query MergeArrays__accounts__0{me{__typename id metadata{description address}}}",
+          "operationName": "MergeArrays__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -1534,8 +1534,8 @@ Scenario: supports arrays
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query MergeArrays_inventory_1($representations:[_Any!]!){_entities(representations:$representations){...on User{goodDescription}}}",
-            "operationName": "MergeArrays_inventory_1"
+            "operation": "query MergeArrays__inventory__1($representations:[_Any!]!){_entities(representations:$representations){...on User{goodDescription}}}",
+            "operationName": "MergeArrays__inventory__1"
           }
         }
       ]

--- a/query-planner-js/src/__tests__/features/basic/custom-directives.feature
+++ b/query-planner-js/src/__tests__/features/basic/custom-directives.feature
@@ -18,8 +18,8 @@ Scenario: successfully passes directives along in requests to an underlying serv
       "serviceName": "reviews",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetReviewers_reviews_0{topReviews{body@stream}}",
-      "operationName": "GetReviewers_reviews_0"
+      "operation": "query GetReviewers__reviews__0{topReviews{body@stream}}",
+      "operationName": "GetReviewers__reviews__0"
     }
   }
   """
@@ -50,8 +50,8 @@ Scenario: successfully passes directives and their variables along in requests t
           "serviceName": "reviews",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetReviewers_reviews_0{topReviews{body@stream author@transform(from:\"JSON\"){__typename id}}}",
-          "operationName": "GetReviewers_reviews_0"
+          "operation": "query GetReviewers__reviews__0{topReviews{body@stream author@transform(from:\"JSON\"){__typename id}}}",
+          "operationName": "GetReviewers__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -71,8 +71,8 @@ Scenario: successfully passes directives and their variables along in requests t
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviewers_accounts_1($representations:[_Any!]!){_entities(representations:$representations){...on User{name@stream{first}}}}",
-            "operationName": "GetReviewers_accounts_1"
+            "operation": "query GetReviewers__accounts__1($representations:[_Any!]!){_entities(representations:$representations){...on User{name@stream{first}}}}",
+            "operationName": "GetReviewers__accounts__1"
           }
         }
       ]

--- a/query-planner-js/src/__tests__/features/basic/execution-style.feature
+++ b/query-planner-js/src/__tests__/features/basic/execution-style.feature
@@ -24,16 +24,16 @@ Scenario: supports parallel root fields
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUserAndReviews_accounts_0{me{username}}",
-          "operationName": "GetUserAndReviews_accounts_0"
+          "operation": "query GetUserAndReviews__accounts__0{me{username}}",
+          "operationName": "GetUserAndReviews__accounts__0"
         },
         {
           "kind": "Fetch",
           "serviceName": "reviews",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUserAndReviews_reviews_1{topReviews{body}}",
-          "operationName": "GetUserAndReviews_reviews_1"
+          "operation": "query GetUserAndReviews__reviews__1{topReviews{body}}",
+          "operationName": "GetUserAndReviews__reviews__1"
         }
       ]
     }

--- a/query-planner-js/src/__tests__/features/basic/fragments.feature
+++ b/query-planner-js/src/__tests__/features/basic/fragments.feature
@@ -14,7 +14,7 @@ Scenario: supports inline fragments (one level)
     """
   Then query plan
     """
-    {"kind":"QueryPlan","node":{"kind":"Fetch","serviceName":"accounts","variableUsages":[],"operationKind": "query","operation":"query GetUser_accounts_0{me{username}}","operationName":"GetUser_accounts_0"}}
+    {"kind":"QueryPlan","node":{"kind":"Fetch","serviceName":"accounts","variableUsages":[],"operationKind": "query","operation":"query GetUser__accounts__0{me{username}}","operationName":"GetUser__accounts__0"}}
     """
 
 # important things: calls [accounts, reviews, products, books]
@@ -56,8 +56,8 @@ Scenario: supports inline fragments (multi level)
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUser_accounts_0{me{__typename id username}}",
-          "operationName": "GetUser_accounts_0"
+          "operation": "query GetUser__accounts__0{me{__typename id username}}",
+          "operationName": "GetUser__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -77,8 +77,8 @@ Scenario: supports inline fragments (multi level)
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetUser_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
-            "operationName": "GetUser_reviews_1"
+            "operation": "query GetUser__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}}}}}",
+            "operationName": "GetUser__reviews__1"
           }
         },
         {
@@ -102,8 +102,8 @@ Scenario: supports inline fragments (multi level)
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query GetUser_books_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title}}}",
-                "operationName": "GetUser_books_2"
+                "operation": "query GetUser__books__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title}}}",
+                "operationName": "GetUser__books__2"
               }
             },
             {
@@ -124,8 +124,8 @@ Scenario: supports inline fragments (multi level)
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query GetUser_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
-                "operationName": "GetUser_product_3"
+                "operation": "query GetUser__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
+                "operationName": "GetUser__product__3"
               }
             }
           ]
@@ -157,8 +157,8 @@ Scenario: supports named fragments (one level)
       "serviceName": "accounts",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetUser_accounts_0{me{username}}",
-      "operationName": "GetUser_accounts_0"
+      "operation": "query GetUser__accounts__0{me{username}}",
+      "operationName": "GetUser__accounts__0"
     }
   }
   """
@@ -192,8 +192,8 @@ Scenario: supports multiple named fragments (one level, mixed ordering)
       "serviceName": "accounts",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetUser_accounts_0{me{username name{first}}}",
-      "operationName": "GetUser_accounts_0"
+      "operation": "query GetUser__accounts__0{me{username name{first}}}",
+      "operationName": "GetUser__accounts__0"
     }
   }
   """
@@ -229,8 +229,8 @@ Scenario: supports multiple named fragments (multi level, mixed ordering)
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUser_accounts_0{me{__typename id username}}",
-          "operationName": "GetUser_accounts_0"
+          "operation": "query GetUser__accounts__0{me{__typename id username}}",
+          "operationName": "GetUser__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -250,8 +250,8 @@ Scenario: supports multiple named fragments (multi level, mixed ordering)
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetUser_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}",
-            "operationName": "GetUser_reviews_1"
+            "operation": "query GetUser__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}",
+            "operationName": "GetUser__reviews__1"
           }
         }
       ]
@@ -288,8 +288,8 @@ Scenario: supports variables within fragments
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetUser_accounts_0{me{__typename id username}}",
-          "operationName": "GetUser_accounts_0"
+          "operation": "query GetUser__accounts__0{me{__typename id username}}",
+          "operationName": "GetUser__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -309,8 +309,8 @@ Scenario: supports variables within fragments
             ],
             "variableUsages": ["format"],
             "operationKind": "query",
-            "operation": "query GetUser_reviews_1($representations:[_Any!]!$format:Boolean){_entities(representations:$representations){...on User{reviews{body(format:$format)}}}}",
-            "operationName": "GetUser_reviews_1"
+            "operation": "query GetUser__reviews__1($representations:[_Any!]!$format:Boolean){_entities(representations:$representations){...on User{reviews{body(format:$format)}}}}",
+            "operationName": "GetUser__reviews__1"
           }
         }
       ]
@@ -338,8 +338,8 @@ Scenario: supports root fragments
       "serviceName": "accounts",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetUser_accounts_0{me{username}}",
-      "operationName": "GetUser_accounts_0"
+      "operation": "query GetUser__accounts__0{me{username}}",
+      "operationName": "GetUser__accounts__0"
     }
   }
   """
@@ -365,5 +365,5 @@ Scenario: supports directives on inline fragments (https://github.com/apollograp
   """
   Then query plan
   """
-  {"kind":"QueryPlan","node":{"kind":"Fetch","serviceName":"product","variableUsages":[],"operationKind": "query","operation":"query GetVehicle_product_0{vehicle(id:\"rav4\"){__typename ...on Car@fragmentDirective{price thing{__typename ...on Ikea{asile}}}...on Van{price@stream}}}","operationName":"GetVehicle_product_0"}}
+  {"kind":"QueryPlan","node":{"kind":"Fetch","serviceName":"product","variableUsages":[],"operationKind": "query","operation":"query GetVehicle__product__0{vehicle(id:\"rav4\"){__typename ...on Car@fragmentDirective{price thing{__typename ...on Ikea{asile}}}...on Van{price@stream}}}","operationName":"GetVehicle__product__0"}}
   """

--- a/query-planner-js/src/__tests__/features/basic/mutations.feature
+++ b/query-planner-js/src/__tests__/features/basic/mutations.feature
@@ -25,8 +25,8 @@ Scenario: supports mutations
           "serviceName": "accounts",
           "variableUsages": ["username", "password"],
           "operationKind": "mutation",
-          "operation": "mutation Login_accounts_0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "Login_accounts_0"
+          "operation": "mutation Login__accounts__0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "Login__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -46,8 +46,8 @@ Scenario: supports mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Login_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "Login_reviews_1"
+            "operation": "query Login__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "Login__reviews__1"
           }
         },
         {
@@ -68,8 +68,8 @@ Scenario: supports mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Login_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "Login_product_2"
+            "operation": "query Login__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "Login__product__2"
           }
         }
       ]
@@ -100,8 +100,8 @@ Scenario: mutations across service boundaries
           "serviceName": "reviews",
           "variableUsages": ["upc", "body"],
           "operationKind": "mutation",
-          "operation": "mutation Review_reviews_0($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
-          "operationName": "Review_reviews_0"
+          "operation": "mutation Review__reviews__0($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
+          "operationName": "Review__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -121,8 +121,8 @@ Scenario: mutations across service boundaries
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query Review_product_1($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
-            "operationName": "Review_product_1"
+            "operation": "query Review__product__1($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
+            "operationName": "Review__product__1"
           }
         }
       ]
@@ -166,8 +166,8 @@ Scenario: multiple root mutations
           "serviceName": "accounts",
           "variableUsages": ["username", "password"],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_accounts_0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "LoginAndReview_accounts_0"
+          "operation": "mutation LoginAndReview__accounts__0($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "LoginAndReview__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -187,8 +187,8 @@ Scenario: multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "LoginAndReview_reviews_1"
+            "operation": "query LoginAndReview__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "LoginAndReview__reviews__1"
           }
         },
         {
@@ -209,8 +209,8 @@ Scenario: multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "LoginAndReview_product_2"
+            "operation": "query LoginAndReview__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "LoginAndReview__product__2"
           }
         },
         {
@@ -218,8 +218,8 @@ Scenario: multiple root mutations
           "serviceName": "reviews",
           "variableUsages": ["upc", "body"],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_3($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
-          "operationName": "LoginAndReview_reviews_3"
+          "operation": "mutation LoginAndReview__reviews__3($upc:String!$body:String!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{__typename upc}}}",
+          "operationName": "LoginAndReview__reviews__3"
         },
         {
           "kind": "Flatten",
@@ -239,8 +239,8 @@ Scenario: multiple root mutations
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_4($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
-            "operationName": "LoginAndReview_product_4"
+            "operation": "query LoginAndReview__product__4($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}",
+            "operationName": "LoginAndReview__product__4"
           }
         }
       ]
@@ -291,16 +291,16 @@ Scenario: multiple root mutations with correct service order
           "serviceName": "reviews",
           "variableUsages": ["upc", "body", "updatedReview"],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_0($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}",
-          "operationName": "LoginAndReview_reviews_0"
+          "operation": "mutation LoginAndReview__reviews__0($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(input:{upc:$upc body:$body}){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}",
+          "operationName": "LoginAndReview__reviews__0"
         },
         {
           "kind": "Fetch",
           "serviceName": "accounts",
           "variableUsages": ["username", "password"],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_accounts_1($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
-          "operationName": "LoginAndReview_accounts_1"
+          "operation": "mutation LoginAndReview__accounts__1($username:String!$password:String!){login(username:$username password:$password){__typename id}}",
+          "operationName": "LoginAndReview__accounts__1"
         },
         {
           "kind": "Flatten",
@@ -320,8 +320,8 @@ Scenario: multiple root mutations with correct service order
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_reviews_2($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
-            "operationName": "LoginAndReview_reviews_2"
+            "operation": "query LoginAndReview__reviews__2($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}",
+            "operationName": "LoginAndReview__reviews__2"
           }
         },
         {
@@ -342,8 +342,8 @@ Scenario: multiple root mutations with correct service order
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query LoginAndReview_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
-            "operationName": "LoginAndReview_product_3"
+            "operation": "query LoginAndReview__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}",
+            "operationName": "LoginAndReview__product__3"
           }
         },
         {
@@ -351,8 +351,8 @@ Scenario: multiple root mutations with correct service order
           "serviceName": "reviews",
           "variableUsages": ["reviewId"],
           "operationKind": "mutation",
-          "operation": "mutation LoginAndReview_reviews_4($reviewId:ID!){deleteReview(id:$reviewId)}",
-          "operationName": "LoginAndReview_reviews_4"
+          "operation": "mutation LoginAndReview__reviews__4($reviewId:ID!){deleteReview(id:$reviewId)}",
+          "operationName": "LoginAndReview__reviews__4"
         }
       ]
     }

--- a/query-planner-js/src/__tests__/features/basic/provides.feature
+++ b/query-planner-js/src/__tests__/features/basic/provides.feature
@@ -20,8 +20,8 @@ Scenario: does not have to go to another service when field is given
       "serviceName": "reviews",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetReviewers_reviews_0{topReviews{author{username}}}",
-      "operationName": "GetReviewers_reviews_0"
+      "operation": "query GetReviewers__reviews__0{topReviews{author{username}}}",
+      "operationName": "GetReviewers__reviews__0"
     }
   }
   """
@@ -53,8 +53,8 @@ Scenario: does not load fields provided even when going to other service
           "serviceName": "reviews",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetReviewers_reviews_0{topReviews{author{__typename id username}}}",
-          "operationName": "GetReviewers_reviews_0"
+          "operation": "query GetReviewers__reviews__0{topReviews{author{__typename id username}}}",
+          "operationName": "GetReviewers__reviews__0"
         },
         {
           "kind": "Flatten",
@@ -74,8 +74,8 @@ Scenario: does not load fields provided even when going to other service
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviewers_accounts_1($representations:[_Any!]!){_entities(representations:$representations){...on User{name{first}}}}",
-            "operationName": "GetReviewers_accounts_1"
+            "operation": "query GetReviewers__accounts__1($representations:[_Any!]!){_entities(representations:$representations){...on User{name{first}}}}",
+            "operationName": "GetReviewers__accounts__1"
           }
         }
       ]

--- a/query-planner-js/src/__tests__/features/basic/requires.feature
+++ b/query-planner-js/src/__tests__/features/basic/requires.feature
@@ -28,8 +28,8 @@ Scenario: supports passing additional fields defined by a requires
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetReviwedBookNames_accounts_0{me{__typename id}}",
-          "operationName": "GetReviwedBookNames_accounts_0"
+          "operation": "query GetReviwedBookNames__accounts__0{me{__typename id}}",
+          "operationName": "GetReviwedBookNames__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -49,8 +49,8 @@ Scenario: supports passing additional fields defined by a requires
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviwedBookNames_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}",
-            "operationName": "GetReviwedBookNames_reviews_1"
+            "operation": "query GetReviwedBookNames__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}}}}}}",
+            "operationName": "GetReviwedBookNames__reviews__1"
           }
         },
         {
@@ -71,8 +71,8 @@ Scenario: supports passing additional fields defined by a requires
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviwedBookNames_books_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-            "operationName": "GetReviwedBookNames_books_2"
+            "operation": "query GetReviwedBookNames__books__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+            "operationName": "GetReviwedBookNames__books__2"
           }
         },
         {
@@ -95,8 +95,8 @@ Scenario: supports passing additional fields defined by a requires
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetReviwedBookNames_product_3($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
-            "operationName": "GetReviwedBookNames_product_3"
+            "operation": "query GetReviwedBookNames__product__3($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
+            "operationName": "GetReviwedBookNames__product__3"
           }
         }
       ]

--- a/query-planner-js/src/__tests__/features/basic/single-service.feature
+++ b/query-planner-js/src/__tests__/features/basic/single-service.feature
@@ -36,8 +36,8 @@ Scenario: does not remove __typename if that is all that is requested on an enti
       "serviceName": "accounts",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetUser_accounts_0{me{__typename}}",
-      "operationName": "GetUser_accounts_0"
+      "operation": "query GetUser__accounts__0{me{__typename}}",
+      "operationName": "GetUser__accounts__0"
     }
   }
   """
@@ -62,8 +62,8 @@ Scenario: does not remove __typename if that is all that is requested on a value
       "serviceName": "accounts",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetUser_accounts_0{me{account{__typename}}}",
-      "operationName": "GetUser_accounts_0"
+      "operation": "query GetUser__accounts__0{me{account{__typename}}}",
+      "operationName": "GetUser__accounts__0"
     }
   }
   """
@@ -88,8 +88,8 @@ Scenario: does not remove __typename if that is all that is requested on a union
       "serviceName": "accounts",
       "variableUsages": [],
       "operationKind": "query",
-      "operation": "query GetUser_accounts_0{me{accountType{__typename}}}",
-      "operationName": "GetUser_accounts_0"
+      "operation": "query GetUser__accounts__0{me{accountType{__typename}}}",
+      "operationName": "GetUser__accounts__0"
     }
   }
   """

--- a/query-planner-js/src/__tests__/features/basic/value-types.feature
+++ b/query-planner-js/src/__tests__/features/basic/value-types.feature
@@ -47,8 +47,8 @@ Scenario: resolves value types within their respective services
           "serviceName": "product",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query ProducsWithMetadata_product_0{topProducts(first:10){__typename ...on Book{__typename isbn upc}...on Furniture{__typename upc metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}}",
-          "operationName": "ProducsWithMetadata_product_0"
+          "operation": "query ProducsWithMetadata__product__0{topProducts(first:10){__typename ...on Book{__typename isbn upc}...on Furniture{__typename upc metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}}",
+          "operationName": "ProducsWithMetadata__product__0"
         },
         {
           "kind": "Parallel",
@@ -79,8 +79,8 @@ Scenario: resolves value types within their respective services
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query ProducsWithMetadata_reviews_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}...on Furniture{reviews{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}}}",
-                "operationName": "ProducsWithMetadata_reviews_1"
+                "operation": "query ProducsWithMetadata__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}...on Furniture{reviews{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}}}",
+                "operationName": "ProducsWithMetadata__reviews__1"
               }
             },
             {
@@ -101,8 +101,8 @@ Scenario: resolves value types within their respective services
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query ProducsWithMetadata_books_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}}",
-                "operationName": "ProducsWithMetadata_books_2"
+                "operation": "query ProducsWithMetadata__books__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}}",
+                "operationName": "ProducsWithMetadata__books__2"
               }
             }
           ]

--- a/query-planner-js/src/__tests__/features/basic/variables.feature
+++ b/query-planner-js/src/__tests__/features/basic/variables.feature
@@ -22,8 +22,8 @@ Scenario: passes variables to root fields
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{name}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String!){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{name}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -43,8 +43,8 @@ Scenario: passes variables to root fields
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_books_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-            "operationName": "GetProduct_books_1"
+            "operation": "query GetProduct__books__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+            "operationName": "GetProduct__books__1"
           }
         },
         {
@@ -67,8 +67,8 @@ Scenario: passes variables to root fields
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
-            "operationName": "GetProduct_product_2"
+            "operation": "query GetProduct__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
+            "operationName": "GetProduct__product__2"
           }
         }
       ]
@@ -98,8 +98,8 @@ Scenario: supports default variables in a variable definition
           "serviceName": "product",
           "variableUsages": ["upc"],
           "operationKind": "query",
-          "operation": "query GetProduct_product_0($upc:String=\"1\"){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{name}}}",
-          "operationName": "GetProduct_product_0"
+          "operation": "query GetProduct__product__0($upc:String=\"1\"){product(upc:$upc){__typename ...on Book{__typename isbn}...on Furniture{name}}}",
+          "operationName": "GetProduct__product__0"
         },
         {
           "kind": "Flatten",
@@ -119,8 +119,8 @@ Scenario: supports default variables in a variable definition
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_books_1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
-            "operationName": "GetProduct_books_1"
+            "operation": "query GetProduct__books__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{title year}}}",
+            "operationName": "GetProduct__books__1"
           }
         },
         {
@@ -143,8 +143,8 @@ Scenario: supports default variables in a variable definition
             ],
             "variableUsages": [],
             "operationKind": "query",
-            "operation": "query GetProduct_product_2($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
-            "operationName": "GetProduct_product_2"
+            "operation": "query GetProduct__product__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
+            "operationName": "GetProduct__product__2"
           }
         }
       ]
@@ -176,8 +176,8 @@ Scenario: passes variables to nested services
           "serviceName": "accounts",
           "variableUsages": [],
           "operationKind": "query",
-          "operation": "query GetProductsForUser_accounts_0{me{__typename id}}",
-          "operationName": "GetProductsForUser_accounts_0"
+          "operation": "query GetProductsForUser__accounts__0{me{__typename id}}",
+          "operationName": "GetProductsForUser__accounts__0"
         },
         {
           "kind": "Flatten",
@@ -197,8 +197,8 @@ Scenario: passes variables to nested services
             ],
             "variableUsages": ["format"],
             "operationKind": "query",
-            "operation": "query GetProductsForUser_reviews_1($representations:[_Any!]!$format:Boolean){_entities(representations:$representations){...on User{reviews{body(format:$format)}}}}",
-            "operationName": "GetProductsForUser_reviews_1"
+            "operation": "query GetProductsForUser__reviews__1($representations:[_Any!]!$format:Boolean){_entities(representations:$representations){...on User{reviews{body(format:$format)}}}}",
+            "operationName": "GetProductsForUser__reviews__1"
           }
         }
       ]
@@ -233,8 +233,8 @@ Scenario: works with default variables in the schema
           "serviceName": "books",
           "variableUsages": ["libraryId"],
           "operationKind": "query",
-          "operation": "query LibraryUser_books_0($libraryId:ID!){library(id:$libraryId){__typename id name}}",
-          "operationName": "LibraryUser_books_0"
+          "operation": "query LibraryUser__books__0($libraryId:ID!){library(id:$libraryId){__typename id name}}",
+          "operationName": "LibraryUser__books__0"
         },
         {
           "kind": "Flatten",
@@ -255,8 +255,8 @@ Scenario: works with default variables in the schema
             ],
             "variableUsages": ["userId"],
             "operationKind": "query",
-            "operation": "query LibraryUser_accounts_1($representations:[_Any!]!$userId:ID){_entities(representations:$representations){...on Library{userAccount(id:$userId){id name{first}}}}}",
-            "operationName": "LibraryUser_accounts_1"
+            "operation": "query LibraryUser__accounts__1($representations:[_Any!]!$userId:ID){_entities(representations:$representations){...on Library{userAccount(id:$userId){id name{first}}}}}",
+            "operationName": "LibraryUser__accounts__1"
           }
         }
       ]

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -833,7 +833,6 @@ class FetchGroup {
           operationName,
         );
 
-    try {
     const fetchNode: FetchNode = {
       kind: 'Fetch',
       serviceName: this.subgraphName,
@@ -851,11 +850,6 @@ class FetchGroup {
         path: this.mergeAt!,
         node: fetchNode,
       };
-    } catch (e) {
-      console.log(`Got ${e} with ${operation}`);
-      console.log(print(operationToDocument(operation)));
-      throw e;
-    }
   }
 
   toString(): string {

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -617,6 +617,22 @@ function splitTopLevelFields(selectionSet: SelectionSet): SelectionSet[] {
   });
 }
 
+function toValidGraphQLName(subgraphName: string): string {
+  // We have almost no limitations on subgraph names, so we cannot use them inside query names
+  // without some cleaning up. GraphQL names can only be: [_A-Za-z][_0-9A-Za-z]*.
+  // To do so, we:
+  //  1. replace '-' by '_' because the former is not allowed but it's probably pretty
+  //   common and using the later should be fairly readable.
+  //  2. remove any character in what remains that is not allowed.
+  //  3. Unsure the first character is not a number, and if it is, add a leading `_`.
+  // Note that this could theoretically lead to substantial changes to the name but should
+  // work well in practice (and if it's a huge problem for someone, we can change it).
+  const sanitized = subgraphName
+    .replace('-', '_')
+    .replace(/[^_0-9A-Za-z]/i, '');
+  return sanitized.match(/^[0-9].*/i) ? '_' + sanitized : sanitized;
+}
+
 function fetchGroupToPlanProcessor(
   variableDefinitions: VariableDefinitions,
   fragments?: NamedFragments,
@@ -624,7 +640,7 @@ function fetchGroupToPlanProcessor(
 ): FetchGroupProcessor<PlanNode, PlanNode, PlanNode | undefined> {
   let counter = 0;
   return {
-    onFetchGroup: (group: FetchGroup) => group.toPlanNode(variableDefinitions, fragments, operationName ? `${operationName}_${group.subgraphName}_${counter++}` : undefined),
+    onFetchGroup: (group: FetchGroup) => group.toPlanNode(variableDefinitions, fragments, operationName ? `${operationName}__${toValidGraphQLName(group.subgraphName)}__${counter++}` : undefined),
     reduceParallel: (values: PlanNode[]) => flatWrap('Parallel', values),
     reduceSequence: (values: PlanNode[]) => flatWrap('Sequence', values),
     finalize: (roots: PlanNode[], rootsAreParallel) => roots.length == 0 ? undefined : flatWrap(rootsAreParallel ? 'Parallel' : 'Sequence', roots)
@@ -817,6 +833,7 @@ class FetchGroup {
           operationName,
         );
 
+    try {
     const fetchNode: FetchNode = {
       kind: 'Fetch',
       serviceName: this.subgraphName,
@@ -834,6 +851,11 @@ class FetchGroup {
         path: this.mergeAt!,
         node: fetchNode,
       };
+    } catch (e) {
+      console.log(`Got ${e} with ${operation}`);
+      console.log(print(operationToDocument(operation)));
+      throw e;
+    }
   }
 
   toString(): string {


### PR DESCRIPTION
This is a followup to #1550: as mentioned in my last comment, that PR adds the subgraph names to the operation name, but we unfortunately allow near anything as a subgraph name, and so in particular we can have subgraph names that are invalid graphQL names. in which case the query plan we generate ends up invalid.

This PR "sanitize" the subgraph name (the other part we use for the operation name is the name of the original query, but we know _that_ is a valid graphQL name by definition). It also switch from a single `_` to `__` to separate the elements from the generate operation names so it's a bit clearer if some underscores are already used for either the original query name or the subgraph name.