### PR TITLE
Release @apollo/gateway@2.0.0-preview.1

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -8,6 +8,14 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 - _Nothing yet! Stay tuned._
 
+## v2.0.0-preview.1
+
+- No-op publish to account for publishing difficulties.
+
+## v2.0.0-preview.0
+
+- Initial "preview" release.
+
 ## v2.0.0-alpha.6
 
 - No direct changes, only transitive updates to `@apollo/query-graphs` and `@apollo/federation-internals`.

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,12 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- _Nothing yet.  Stay tuned!_
+
+## v2.0.0-preview.1
+
+- No-op publish to account for publishing difficulties.
+
 ## v2.0.0-preview.0
 
 - Fix merging of arguments by composition [PR #1567](https://github.com/apollographql/federation/pull/1567).

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - _Nothing yet! Stay tuned!_
 
+## v2.0.0-preview.1
+
+- No-op publish to account for publishing difficulties.
+
+## v2.0.0-preview.0
+
+- Initial "preview" release.
+
 ## v2.0.0-alpha.6
 
 - Avoid incomplete subgraphs when extracting them from the supergraph. [PR #1511](https://github.com/apollographql/federation/pull/1511)

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-preview.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -81,7 +81,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-preview.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "graphql-tag": "^2.12.6",
@@ -90,7 +90,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-preview.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -152,7 +152,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-preview.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/core-schema": "^0.2.2",
@@ -19783,7 +19783,7 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-preview.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -19799,7 +19799,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-preview.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -19817,7 +19817,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-preview.1",
       "license": "MIT",
       "engines": {
         "node": ">=12.13.0 <17.0"

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - _Nothing yet! Stay tuned._
 
+## v2.0.0-preview.1
+
+- No-op publish to account for publishing difficulties.
+
+## v2.0.0-preview.0
+
+- Initial "preview" release.
+
 ## v2.0.0-alpha.6
 
 - No direct changes, only transitive updates to `@apollo/federation-internals`.

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -8,6 +8,14 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 - _Nothing yet! Stay tuned!_
 
+## v2.0.0-preview.1
+
+- No-op publish to account for publishing difficulties.
+
+## v2.0.0-preview.0
+
+- Initial "preview" release.
+
 ## v2.0.0-alpha.6
 
 - Avoid incomplete subgraphs when extracting them from the supergraph. [PR #1511](https://github.com/apollographql/federation/pull/1511) (via fix to `@apollo/federation-internals`)

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -8,6 +8,14 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 - _Nothing yet! Stay tuned._
 
+## v2.0.0-preview.1
+
+- No-op publish to account for publishing difficulties.
+
+## v2.0.0-preview.0
+
+- Initial "preview" release.
+
 ## v2.0.0-alpha.6
 
 - No direct changes.  Just bumping to maintain version alignment with other v2.0.0 alpha packages.

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌   The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.