### PR TITLE
Fix adding descriptions to type extensions

### DIFF
--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -427,6 +427,10 @@ test('handling of descriptions', () => {
       pages: Int @Important
     }
 
+    extend type Book {
+      author: String
+    }
+
     type DVD implements Product {
       id: ID!
       description: String!

--- a/internals-js/src/buildSchema.ts
+++ b/internals-js/src/buildSchema.ts
@@ -299,7 +299,9 @@ function buildNamedTypeInner(
       const enumType = type as EnumType;
       for (const enumVal of definitionNode.values ?? []) {
         const v = enumType.addValue(enumVal.name.value);
-        v.description = enumVal.description?.value;
+        if (enumVal.description) {
+          v.description = enumVal.description.value;
+        }
         v.setOfExtension(extension);
         buildAppliedDirectives(enumVal, v);
       }
@@ -315,7 +317,9 @@ function buildNamedTypeInner(
       break;
   }
   buildAppliedDirectives(definitionNode, type, extension);
-  type.description = definitionNode.description?.value;
+  if (definitionNode.description) {
+    type.description = definitionNode.description.value;
+  }
   type.sourceAST = definitionNode;
 }
 


### PR DESCRIPTION
If a schema had both a type definition and a correspdonding type
extension, the printing code was mistakenly printing the description of
the type definition on the type extension as well. But since description
are not syntactically valid on type extension in graphQL, this leads to
syntactic errors.

More precisely, an input schema like:
```graphql
""" I'm a type """
type T {
  a: Int
}

extend type T {
  b: Int
}
```
was (before this patch) mistakenly printed as:
```graphql
""" I'm a type """
type T {
  a: Int
}

""" I'm a type """
extend type T {
  b: Int
}
```
which is syntactically invalid due to the description on the type
extension.

Note: the patch also fix a related additional issue where the presence
of type extension might have the type definition description ignored due
a lack of conditional when setting descriptions in `buildSchema`.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
