### PR TITLE
diffTypeNodes return type causing problems with graphql15

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- Fixes typing incompatibility issue with graphql15. [PR #1585](https://github.com/apollographql/federation/pull/1585)
+- Fixes type incompatibility issue with graphql15. [PR #1585](https://github.com/apollographql/federation/pull/1585)
 
 ## v0.35.3
 

--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Fixes typing incompatibility issue with graphql15. [PR #1585](https://github.com/apollographql/federation/pull/1585)
 
 ## v0.35.3
 

--- a/federation-js/src/composition/utils.ts
+++ b/federation-js/src/composition/utils.ts
@@ -638,7 +638,7 @@ export function diffTypeNodes(
       ? []
       : [firstNode.name.value, secondNode.name.value];
 
-  const kindDiff =
+  const kindDiff: Kind[keyof Kind][] =
     firstNode.kind === secondNode.kind ? [] : [firstNode.kind, secondNode.kind];
 
   return {

--- a/federation-js/src/composition/utils.ts
+++ b/federation-js/src/composition/utils.ts
@@ -638,7 +638,7 @@ export function diffTypeNodes(
       ? []
       : [firstNode.name.value, secondNode.name.value];
 
-  const kindDiff: Kind[keyof Kind][] =
+  const kindDiff: typeof Kind[keyof typeof Kind][] =
     firstNode.kind === secondNode.kind ? [] : [firstNode.kind, secondNode.kind];
 
   return {


### PR DESCRIPTION
Fixes #1538 

Change return type on `diffTypeNodes` so that the Kind is explicit rather than implicit. I tested this by running the following super advanced program:

```typescript
import { defaultRootOperationNameLookup, compositionHasErrors, isStringValueNode, findDirectivesOnNode } from '@apollo/federation';
console.log('hello');
```

It failed on the old version, but seems to work with the new version. I don't totally understand why the old version is failing, so another set of eyes would be helpful, especially if we think there could be other areas of the code where this might be an issue.