### PR TITLE
Adds `@tag` definition automatically in `buildSubgraphSchema`

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Automatically add the `@tag` directive definition in `buildSubgraphSchema` (but still support it if the definition is present in the input document) [PR #1600](https://github.com/apollographql/federation/pull/1600).
+
 ## v2.0.0-preview.5
 
 - Fix propagation of `@tag` to the supergraph and allows @tag to be repeated. Additionally, merged directives (only `@tag` and `@deprecated` currently) are not allowed on external fields anymore [PR #1592](https://github.com/apollographql/federation/pull/1592).

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Automatically add the `@tag` directive definition in `buildSubgraphSchema` (but still support it if the definition is present in the input document) [PR #1600](https://github.com/apollographql/federation/pull/1600).
 
 ## v2.0.0-preview.5
 

--- a/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
@@ -518,6 +518,50 @@ extend type User @key(fields: "email") {
 }
 `);
     });
+
+    describe('@tag directive', () => {
+      const query = `query GetServiceDetails {
+        _service {
+          sdl
+        }
+      }`;
+
+      const validateTag = async (header: string) => {
+        const schema = buildSubgraphSchema(gql`${header}
+          type User @key(fields: "email") @tag(name: "tagOnType") {
+            email: String @tag(name: "tagOnField")
+          }
+
+          interface Thing @tag(name: "tagOnInterface") {
+            name: String
+          }
+
+          union UserButAUnion @tag(name: "tagOnUnion") = User
+        `);
+
+        const { data, errors } = await graphql({ schema, source: query });
+        expect(errors).toBeUndefined();
+        expect((data?._service as any).sdl).toEqual(`${header}type User @key(fields: "email") @tag(name: "tagOnType") {
+  email: String @tag(name: "tagOnField")
+}
+
+interface Thing @tag(name: "tagOnInterface") {
+  name: String
+}
+
+union UserButAUnion @tag(name: "tagOnUnion") = User
+`);
+      };
+
+      it('adds it for fed1 schema', async () => {
+        await validateTag('');
+      });
+
+      it('adds it for fed2 schema', async () => {
+        await validateTag('extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])\n\n');
+      });
+
+    });
   });
 });
 

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -18,8 +18,6 @@ describe('printSubgraphSchema', () => {
 
       directive @transform(from: String!) on FIELD
 
-      directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
-
       directive @cacheControl(maxAge: Int, scope: CacheControlScope, inheritMaxAge: Boolean) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
       enum CacheControlScope {
@@ -102,8 +100,6 @@ describe('printSubgraphSchema', () => {
       directive @stream on FIELD
 
       directive @transform(from: String!) on FIELD
-
-      directive @tag(name: String!) repeatable on INTERFACE | FIELD_DEFINITION | OBJECT | UNION
 
       type Query {
         _entities(representations: [_Any!]!): [_Entity]!

--- a/subgraph-js/src/directives.ts
+++ b/subgraph-js/src/directives.ts
@@ -110,21 +110,11 @@ export const federationDirectives = [
   ProvidesDirective,
   ShareableDirective,
   LinkDirective,
+  TagDirective,
 ];
 
 export function isFederationDirective(directive: GraphQLDirective): boolean {
   return federationDirectives.some(({ name }) => name === directive.name);
-}
-
-export const otherKnownDirectives = [TagDirective];
-
-export const knownSubgraphDirectives = [
-  ...federationDirectives,
-  ...otherKnownDirectives,
-];
-
-export function isKnownSubgraphDirective(directive: GraphQLDirective): boolean {
-  return knownSubgraphDirectives.some(({ name }) => name === directive.name);
 }
 
 export type ASTNodeWithDirectives =


### PR DESCRIPTION
This patch makes `@tag` behave like any other federation directive in
`subgraph-js`/`buildSubgraphSchema`, that is, its definition is
automatically added to the schema.

But because we want to be "backward compatible", this patch also
ensure that federation directive definitions are not added by
`buildSugraphSchema` if the input document already defined a directive
with that name. Do note that while `subrgaph-js` has no validation
that such user definition of a federation directive is "correct",
this is ok because composition does do such validation and will
reject an invalid definition.

A consequence of this patch is that the `@tag` definition is not
outputed by `printSubgraphSchema` (like for other federation
directives), but it's very doubtful any external user would have
relied on this behaviour in the first place (and it's very easy
to adapt in the off chance someone does).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
