### PR TITLE
Improve validation and error messages around @link and federation directives

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -2257,6 +2257,5 @@ describe('composition', () => {
         validateError(composeServices([subgraphA, asFed2Service(subgraphB)]));
       });
     });
-
   });
 });

--- a/internals-js/src/__tests__/coreSpec.test.ts
+++ b/internals-js/src/__tests__/coreSpec.test.ts
@@ -1,0 +1,100 @@
+import { DocumentNode, GraphQLError } from "graphql";
+import gql from "graphql-tag";
+import { buildSubgraph } from "../federation";
+import { errorCauses } from "../definitions";
+import { assert } from "../utils";
+
+function expectErrors(
+  subgraphDefs: DocumentNode,
+  expectedErrorMessages: string[],
+) {
+  let thrownError: Error | undefined = undefined;
+  expect(() => {
+    try {
+      // Note: we use buildSubgraph because currently it's the only one that does auto-magic import of
+      // directive definition, and we don't want to bother with adding the @link definition to every
+      // example.
+      buildSubgraph('S', '', subgraphDefs)
+    } catch (e) {
+      // Kind-of ugly, but if Jest has a better option, I haven't found it.
+      thrownError = e;
+      throw e;
+    }
+  }).toThrow(GraphQLError);
+
+  assert(thrownError, 'Should have thrown');
+  const causes = errorCauses(thrownError);
+  assert(causes, 'Should have some causes');
+  // Note: all the received message with start with "[S] <rest of message>", so the `slice` below
+  // strips the extra prefix. This avoid leaking the subgraph name to leak to the tests themselves.
+  expect(causes.map((e) => e.message.slice(4))).toStrictEqual(expectedErrorMessages);
+}
+
+describe('@link(import:) argument', () => {
+  test('errors on misformed values', () => {
+    const schema = gql`
+      extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.0",
+        import: [
+          2,
+          { foo: "bar" },
+          { name: "@key", badName: "foo"},
+          { name: 42 },
+          { as: "bar" },
+         ]
+      )
+
+      type Query {
+        q: Int
+      }
+    `;
+
+    expectErrors(schema, [
+      'Invalid sub-value 2 for @link(import:) argument: values should be either strings or input object values of the form { name: "<importedElement>", as: "<alias>" }.',
+      'Unknown field "foo" for sub-value {foo: "bar"} of @link(import:) argument.',
+      'Unknown field "badName" for sub-value {name: "@key", badName: "foo"} of @link(import:) argument.',
+      'Invalid value for the "name" field for sub-value {name: 42} of @link(import:) argument: must be a string.',
+      'Invalid sub-value {as: "bar"} for @link(import:) argument: missing mandatory "name" field.',
+    ]);
+  });
+
+  test('errors on mismatch between name and alias', () => {
+    const schema = gql`
+      extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.0",
+        import: [
+          { name: "@key", as: "myKey" },
+          { name: "FieldSet", as: "@fieldSet" },
+        ]
+      )
+
+      type Query {
+        q: Int
+      }
+    `;
+
+    expectErrors(schema, [
+      'Invalid @link import renaming: directive "@key" imported name should start with a \'@\' character, but got "myKey".',
+      'Invalid @link import renaming: type "FieldSet" imported name should not start with a \'@\' character, but got "@fieldSet" (or, if @FieldSet is a directive, then it should be referred to with a \'@\').',
+    ]);
+  });
+
+  test('errors on importing unknown elements for known features', () => {
+    const schema = gql`
+      extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.0",
+        import: [ "@foo", "key", { name: "@sharable" } ]
+      )
+
+      type Query {
+        q: Int
+      }
+    `;
+
+    expectErrors(schema, [
+      'Cannot import unknown element "@foo".',
+      'Cannot import unknown element "key". Did you mean directive "@key"?',
+      'Cannot import unknown element "@sharable\". Did you mean "@shareable"?',
+    ]);
+  });
+});

--- a/internals-js/src/buildSchema.ts
+++ b/internals-js/src/buildSchema.ts
@@ -46,7 +46,8 @@ import {
   UnionType,
   InputObjectType,
   EnumType,
-  Extension
+  Extension,
+  ErrGraphQLValidationFailed,
 } from "./definitions";
 
 function buildValue(value?: ValueNode): any {
@@ -66,6 +67,7 @@ export function buildSchemaFromAST(
   documentNode: DocumentNode,
   options?: BuildSchemaOptions,
 ): Schema {
+  const errors: GraphQLError[] = [];
   const schema = new Schema(options?.blueprint);
   // We do a first pass to add all empty types and directives definition. This ensure any reference on one of
   // those can be resolved in the 2nd pass, regardless of the order of the definitions in the AST.
@@ -77,13 +79,13 @@ export function buildSchemaFromAST(
   // populated (and at this point, we don't really know the name of the `@core` directive since it can be renamed, so
   // we just handle all directives).
   for (const directiveDefinitionNode of directiveDefinitions) {
-    buildDirectiveDefinitionInner(directiveDefinitionNode, schema.directive(directiveDefinitionNode.name.value)!);
+    buildDirectiveDefinitionInner(directiveDefinitionNode, schema.directive(directiveDefinitionNode.name.value)!, errors);
   }
   for (const schemaDefinition of schemaDefinitions) {
-    buildSchemaDefinitionInner(schemaDefinition, schema.schemaDefinition);
+    buildSchemaDefinitionInner(schemaDefinition, schema.schemaDefinition, errors);
   }
   for (const schemaExtension of schemaExtensions) {
-    buildSchemaDefinitionInner(schemaExtension, schema.schemaDefinition, schema.schemaDefinition.newExtension());
+    buildSchemaDefinitionInner(schemaExtension, schema.schemaDefinition, errors, schema.schemaDefinition.newExtension());
   }
 
   schema.blueprint.onDirectiveDefinitionAndSchemaParsed(schema);
@@ -92,14 +94,15 @@ export function buildSchemaFromAST(
     switch (definitionNode.kind) {
       case 'OperationDefinition':
       case 'FragmentDefinition':
-        throw new GraphQLError("Invalid executable definition found while building schema", definitionNode);
+        errors.push(new GraphQLError("Invalid executable definition found while building schema", definitionNode));
+        continue;
       case 'ScalarTypeDefinition':
       case 'ObjectTypeDefinition':
       case 'InterfaceTypeDefinition':
       case 'UnionTypeDefinition':
       case 'EnumTypeDefinition':
       case 'InputObjectTypeDefinition':
-        buildNamedTypeInner(definitionNode, schema.type(definitionNode.name.value)!, schema.blueprint);
+        buildNamedTypeInner(definitionNode, schema.type(definitionNode.name.value)!, schema.blueprint, errors);
         break;
       case 'ScalarTypeExtension':
       case 'ObjectTypeExtension':
@@ -110,9 +113,18 @@ export function buildSchemaFromAST(
         const toExtend = schema.type(definitionNode.name.value)!;
         const extension = toExtend.newExtension();
         extension.sourceAST = definitionNode;
-        buildNamedTypeInner(definitionNode, toExtend, schema.blueprint, extension);
+        buildNamedTypeInner(definitionNode, toExtend, schema.blueprint, errors, extension);
         break;
     }
+  }
+
+  // Note: we could try calling `schema.validate()` regardless of errors building the schema and merge the resulting
+  // errors, and there is some subset of cases where this be a tad more convenient (as the user would get all the errors
+  // at once), but in most cases a bunch of the errors thrown by `schema.validate()` would actually be consequences of
+  // the schema not be properly built in the first place and those errors would be confusing to the user. And avoiding
+  // confusing users probably trumps a rare minor convenience.
+  if (errors.length > 0) {
+    throw ErrGraphQLValidationFailed(errors);
   }
 
   if (options?.validate ?? true) {
@@ -187,13 +199,13 @@ function getReferencedType(node: NamedTypeNode, schema: Schema): NamedType {
   return type;
 }
 
-function withNodeAttachedToError(operation: () => void, node: ASTNode) {
+function withNodeAttachedToError(operation: () => void, node: ASTNode, errors: GraphQLError[]) {
   try {
     operation();
   } catch (e) {
     if (e instanceof GraphQLError) {
       const allNodes: ASTNode | ASTNode[] = e.nodes ? [node, ...e.nodes] : node;
-      throw new GraphQLError(
+      errors.push(new GraphQLError(
         e.message,
         allNodes,
         e.source,
@@ -201,7 +213,7 @@ function withNodeAttachedToError(operation: () => void, node: ASTNode) {
         e.path,
         e,
         e.extensions
-      );
+      ));
     } else {
       throw e;
     }
@@ -211,31 +223,39 @@ function withNodeAttachedToError(operation: () => void, node: ASTNode) {
 function buildSchemaDefinitionInner(
   schemaNode: SchemaDefinitionNode | SchemaExtensionNode,
   schemaDefinition: SchemaDefinition,
+  errors: GraphQLError[],
   extension?: Extension<SchemaDefinition>
 ) {
   for (const opTypeNode of schemaNode.operationTypes ?? []) {
     withNodeAttachedToError(
       () => schemaDefinition.setRoot(opTypeNode.operation, opTypeNode.type.name.value).setOfExtension(extension),
-      opTypeNode);
+      opTypeNode,
+      errors,
+    );
   }
   schemaDefinition.sourceAST = schemaNode;
   if ('description' in schemaNode) {
     schemaDefinition.description = schemaNode.description?.value;
   }
-  buildAppliedDirectives(schemaNode, schemaDefinition, extension);
+  buildAppliedDirectives(schemaNode, schemaDefinition, errors, extension);
 }
 
 function buildAppliedDirectives(
   elementNode: NodeWithDirectives,
   element: SchemaElement<any, any>,
+  errors: GraphQLError[],
   extension?: Extension<any>
 ) {
   for (const directive of elementNode.directives ?? []) {
-    withNodeAttachedToError(() => {
-      const d = element.applyDirective(directive.name.value, buildArgs(directive));
-      d.setOfExtension(extension);
-      d.sourceAST = directive;
-    }, directive);
+    withNodeAttachedToError(
+      () => {
+        const d = element.applyDirective(directive.name.value, buildArgs(directive));
+        d.setOfExtension(extension);
+        d.sourceAST = directive;
+      },
+      directive,
+      errors,
+    );
   }
 }
 
@@ -251,6 +271,7 @@ function buildNamedTypeInner(
   definitionNode: DefinitionNode & NodeWithDirectives & NodeWithDescription,
   type: NamedType,
   blueprint: SchemaBlueprint,
+  errors: GraphQLError[],
   extension?: Extension<any>,
 ) {
   switch (definitionNode.kind) {
@@ -265,18 +286,20 @@ function buildNamedTypeInner(
         }
         const field = fieldBasedType.addField(fieldNode.name.value);
         field.setOfExtension(extension);
-        buildFieldDefinitionInner(fieldNode, field);
+        buildFieldDefinitionInner(fieldNode, field, errors);
       }
       for (const itfNode of definitionNode.interfaces ?? []) {
         withNodeAttachedToError(
           () => {
             const itfName = itfNode.name.value;
             if (fieldBasedType.implementsInterface(itfName)) {
-              throw new GraphQLError(`Type ${type} can only implement ${itfName} once.`);
+              throw new GraphQLError(`Type "${type}" can only implement "${itfName}" once.`);
             }
             fieldBasedType.addImplementedInterface(itfName).setOfExtension(extension);
           },
-          itfNode);
+          itfNode,
+          errors,
+        );
       }
       break;
     case 'UnionTypeDefinition':
@@ -287,11 +310,13 @@ function buildNamedTypeInner(
           () => {
             const name = namedType.name.value;
             if (unionType.hasTypeMember(name)) {
-              throw new GraphQLError(`Union type ${unionType} can only include type ${name} once.`);
+              throw new GraphQLError(`Union type "${unionType}" can only include type "${name}" once.`);
             }
             unionType.addType(name).setOfExtension(extension);
           },
-          namedType);
+          namedType,
+          errors,
+        );
       }
       break;
     case 'EnumTypeDefinition':
@@ -303,7 +328,7 @@ function buildNamedTypeInner(
           v.description = enumVal.description.value;
         }
         v.setOfExtension(extension);
-        buildAppliedDirectives(enumVal, v);
+        buildAppliedDirectives(enumVal, v, errors);
       }
       break;
     case 'InputObjectTypeDefinition':
@@ -312,41 +337,47 @@ function buildNamedTypeInner(
       for (const fieldNode of definitionNode.fields ?? []) {
         const field = inputObjectType.addField(fieldNode.name.value);
         field.setOfExtension(extension);
-        buildInputFieldDefinitionInner(fieldNode, field);
+        buildInputFieldDefinitionInner(fieldNode, field, errors);
       }
       break;
   }
-  buildAppliedDirectives(definitionNode, type, extension);
+  buildAppliedDirectives(definitionNode, type, errors, extension);
   if (definitionNode.description) {
     type.description = definitionNode.description.value;
   }
   type.sourceAST = definitionNode;
 }
 
-function buildFieldDefinitionInner(fieldNode: FieldDefinitionNode, field: FieldDefinition<any>) {
+function buildFieldDefinitionInner(
+  fieldNode: FieldDefinitionNode,
+  field: FieldDefinition<any>,
+  errors: GraphQLError[],
+) {
   const type = buildTypeReferenceFromAST(fieldNode.type, field.schema());
-  field.type = ensureOutputType(type, field.coordinate, fieldNode);
+  field.type = validateOutputType(type, field.coordinate, fieldNode, errors);
   for (const inputValueDef of fieldNode.arguments ?? []) {
-    buildArgumentDefinitionInner(inputValueDef, field.addArgument(inputValueDef.name.value));
+    buildArgumentDefinitionInner(inputValueDef, field.addArgument(inputValueDef.name.value), errors);
   }
-  buildAppliedDirectives(fieldNode, field);
+  buildAppliedDirectives(fieldNode, field, errors);
   field.description = fieldNode.description?.value;
   field.sourceAST = fieldNode;
 }
 
-function ensureOutputType(type: Type, what: string, node: ASTNode): OutputType {
+function validateOutputType(type: Type, what: string, node: ASTNode, errors: GraphQLError[]): OutputType | undefined {
   if (isOutputType(type)) {
     return type;
   } else {
-    throw new GraphQLError(`The type of ${what} must be Output Type but got: ${type}, a ${type.kind}.`, node);
+    errors.push(new GraphQLError(`The type of "${what}" must be Output Type but got "${type}", a ${type.kind}.`, node));
+    return undefined;
   }
 }
 
-function ensureInputType(type: Type, what: string, node: ASTNode): InputType {
+function validateInputType(type: Type, what: string, node: ASTNode, errors: GraphQLError[]): InputType | undefined {
   if (isInputType(type)) {
     return type;
   } else {
-    throw new GraphQLError(`The type of ${what} must be Input Type but got: ${type}, a ${type.kind}.`, node);
+    errors.push(new GraphQLError(`The type of "${what}" must be Input Type but got "${type}", a ${type.kind}.`, node));
+    return undefined;
   }
 }
 
@@ -369,27 +400,39 @@ function buildTypeReferenceFromAST(typeNode: TypeNode, schema: Schema): Type {
   }
 }
 
-function buildArgumentDefinitionInner(inputNode: InputValueDefinitionNode, arg: ArgumentDefinition<any>) {
+function buildArgumentDefinitionInner(
+  inputNode: InputValueDefinitionNode,
+  arg: ArgumentDefinition<any>,
+  errors: GraphQLError[],
+) {
   const type = buildTypeReferenceFromAST(inputNode.type, arg.schema());
-  arg.type = ensureInputType(type, arg.coordinate, inputNode);
+  arg.type = validateInputType(type, arg.coordinate, inputNode, errors);
   arg.defaultValue = buildValue(inputNode.defaultValue);
-  buildAppliedDirectives(inputNode, arg);
+  buildAppliedDirectives(inputNode, arg, errors);
   arg.description = inputNode.description?.value;
   arg.sourceAST = inputNode;
 }
 
-function buildInputFieldDefinitionInner(fieldNode: InputValueDefinitionNode, field: InputFieldDefinition) {
+function buildInputFieldDefinitionInner(
+  fieldNode: InputValueDefinitionNode,
+  field: InputFieldDefinition,
+  errors: GraphQLError[],
+) {
   const type = buildTypeReferenceFromAST(fieldNode.type, field.schema());
-  field.type = ensureInputType(type, field.coordinate, fieldNode);
+  field.type = validateInputType(type, field.coordinate, fieldNode, errors);
   field.defaultValue = buildValue(fieldNode.defaultValue);
-  buildAppliedDirectives(fieldNode, field);
+  buildAppliedDirectives(fieldNode, field, errors);
   field.description = fieldNode.description?.value;
   field.sourceAST = fieldNode;
 }
 
-function buildDirectiveDefinitionInner(directiveNode: DirectiveDefinitionNode, directive: DirectiveDefinition) {
+function buildDirectiveDefinitionInner(
+  directiveNode: DirectiveDefinitionNode,
+  directive: DirectiveDefinition,
+  errors: GraphQLError[],
+) {
   for (const inputValueDef of directiveNode.arguments ?? []) {
-    buildArgumentDefinitionInner(inputValueDef, directive.addArgument(inputValueDef.name.value));
+    buildArgumentDefinitionInner(inputValueDef, directive.addArgument(inputValueDef.name.value), errors);
   }
   directive.repeatable = directiveNode.repeatable;
   const locations = directiveNode.locations.map(({ value }) => value as DirectiveLocation);

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -39,6 +39,8 @@ import { SDLValidationRule } from "graphql/validation/ValidationContext";
 import { specifiedSDLRules } from "graphql/validation/specifiedRules";
 import { validateSchema } from "./validate";
 import { createDirectiveSpecification, createScalarTypeSpecification, DirectiveSpecification, TypeSpecification } from "./directiveAndTypeSpecification";
+import { didYouMean, suggestionList } from "./suggestions";
+import { withModifiedErrorMessage } from "./error";
 
 const validationErrorCode = 'GraphQLValidationFailed';
 
@@ -505,7 +507,10 @@ export abstract class SchemaElement<TOwnType extends SchemaElement<any, TParent>
         this.checkUpdate();
         const def = this.schema().directive(nameOrDefOrDirective) ?? this.schema().blueprint.onMissingDirectiveDefinition(this.schema(), nameOrDefOrDirective);
         if (!def) {
-          throw new GraphQLError(`Cannot apply unknown directive "@${nameOrDefOrDirective}"`);
+          throw this.schema().blueprint.onGraphQLJSValidationError(
+            this.schema(),
+            new GraphQLError(`Unknown directive "@${nameOrDefOrDirective}".`)
+          );
         }
         name = nameOrDefOrDirective;
       } else {
@@ -856,6 +861,38 @@ export class SchemaBlueprint {
 
   validationRules(): readonly SDLValidationRule[] {
     return specifiedSDLRules;
+  }
+
+  /**
+   * Allows to intercept some graphQL-js error messages when we can provide additional guidance to users.
+   */
+  onGraphQLJSValidationError(schema: Schema, error: GraphQLError): GraphQLError {
+    // For now, the main additional guidance we provide is around directives, where we could provide additional help in 2 main ways:
+    // - if a directive name is likely misspelled (somehow, graphQL-js has methods to offer suggestions on likely mispelling, but don't use this (at the
+    //   time of this writting) for directive names).
+    // - for fed 2 schema, if a federation directive is refered under it's "default" naming but is not properly imported (not enforced
+    //   in the method but rather in the `FederationBlueprint`).
+    //
+    // Note that intercepting/parsing error messages to modify them is never ideal, but pragmatically, it's probably better than rewriting the relevant
+    // rules entirely (in that later case, our "copied" rule would stop getting any potential graphQL-js made improvements for instance). And while such
+    // parsing is fragile, in that it'll break if the original message change, we have unit tests to surface any such breakage so it's not really a risk.
+    const matcher = /^Unknown directive "@(?<directive>[_A-Za-z][_0-9A-Za-z]*)"\.$/.exec(error.message);
+    const name = matcher?.groups?.directive;
+    if (!name) {
+      return error;
+    }
+
+    const allDefinedDirectiveNames = schema.allDirectives().map((d) => d.name);
+    const suggestions = suggestionList(name, allDefinedDirectiveNames);
+    if (suggestions.length === 0) {
+      return this.onUnknownDirectiveValidationError(schema, name, error);
+    } else {
+      return withModifiedErrorMessage(error, `${error.message}${didYouMean(suggestions.map((s) => '@' + s))}`);
+    }
+  }
+
+  onUnknownDirectiveValidationError(_schema: Schema, _unknownDirectiveName: string, error: GraphQLError): GraphQLError {
+    return error;
   }
 }
 
@@ -1311,7 +1348,7 @@ export class Schema {
 
     // TODO: we check that all types are properly set (aren't undefined) in `validateSchema`, but `validateSDL` will error out beforehand. We should
     // probably extract that part of `validateSchema` and run `validateSDL` conditionally on that first check.
-    let errors = validateSDL(this.toAST(), undefined, this.blueprint.validationRules());
+    let errors = validateSDL(this.toAST(), undefined, this.blueprint.validationRules()).map((e) => this.blueprint.onGraphQLJSValidationError(this, e));
     errors = errors.concat(validateSchema(this));
 
     // We avoid adding federation-specific validations if the base schema is not proper graphQL as the later can easily trigger

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -968,7 +968,7 @@ export class CoreFeatures {
     if (existing) {
       throw error(`Duplicate inclusion of feature ${url.identity}`);
     }
-    const imports = extractCoreFeatureImports(typedDirective);
+    const imports = extractCoreFeatureImports(url, typedDirective);
     const feature = new CoreFeature(url, args.as ?? url.name, directive, imports, args.for);
     this.add(feature);
     directive.schema().blueprint.onAddedCoreFeature(directive.schema(), feature);
@@ -1440,7 +1440,7 @@ export class SchemaDefinition extends SchemaElement<SchemaDefinition, Schema>  {
       const schemaDirective = applied as Directive<SchemaDefinition, CoreOrLinkDirectiveArgs>;
       const args = schemaDirective.arguments();
       const url = FeatureUrl.parse((args.url ?? args.feature)!);
-      const imports = extractCoreFeatureImports(schemaDirective);
+      const imports = extractCoreFeatureImports(url, schemaDirective);
       const core = new CoreFeature(url, args.as ?? url.name, schemaDirective, imports, args.for);
       Schema.prototype['markAsCoreSchema'].call(schema, core);
     } else if (coreFeatures) {

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -105,6 +105,20 @@ export function errorCodeDef(e: GraphQLError | string): ErrorCodeDefinition | un
   return code ? codeDefByCode[code] : undefined;
 }
 
+export function withModifiedErrorMessage(e: GraphQLError, newMessage: string): GraphQLError {
+  return new GraphQLError(
+    newMessage,
+    {
+      nodes: e.nodes,
+      source: e.source,
+      positions: e.positions,
+      path: e.path,
+      originalError: e.originalError,
+      extensions: e.extensions
+    }
+  );
+}
+
 const INVALID_GRAPHQL = makeCodeDefinition(
   'INVALID_GRAPHQL',
   'A schema is invalid GraphQL: it violates one of the rule of the specification.'

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -786,13 +786,13 @@ export class FederationBlueprint extends SchemaBlueprint {
         if (directiveNameInSchema.startsWith(federationFeature.nameInSchema + '__')) {
           // There is no import for that directive
           return withModifiedErrorMessage(
-            error, 
+            error,
             `${error.message} If you meant the "@${unknownDirectiveName}" federation directive, you should use fully-qualified name "@${directiveNameInSchema}" or add "@${unknownDirectiveName}" to the \`import\` argument of the @link to the federation specification.`
           );
         } else {
           // There's an import, but it's renamed
           return withModifiedErrorMessage(
-            error, 
+            error,
             `${error.message} If you meant the "@${unknownDirectiveName}" federation directive, you should use "@${directiveNameInSchema}" as it is imported under that name in the @link to the federation specification of this schema.`
           );
         }

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -78,16 +78,27 @@ function fieldSetType(schema: Schema): InputType {
   return new NonNullType(metadata.fieldSetType());
 }
 
+export const FEDERATION2_ONLY_SPEC_DIRECTIVES = [
+  shareableDirectiveSpec,
+];
+
 // Note that this is only used for federation 2+ (federation 1 adds the same directive, but not through a core spec).
 export const FEDERATION2_SPEC_DIRECTIVES = [
   keyDirectiveSpec,
   requiresDirectiveSpec,
   providesDirectiveSpec,
   externalDirectiveSpec,
-  shareableDirectiveSpec,
   tagDirectiveSpec,
   extendsDirectiveSpec, // TODO: should we stop supporting that?
+  ...FEDERATION2_ONLY_SPEC_DIRECTIVES,
 ];
+
+// Note that this is meant to contain _all_ federation directive names ever supported, regardless of which version.
+// But currently, fed2 directives are a superset of fed1's so ... (but this may change if we stop supporting `@extends`
+// in fed2).
+export const ALL_FEDERATION_DIRECTIVES_DEFAULT_NAMES = FEDERATION2_SPEC_DIRECTIVES.map((spec) => spec.name);
+
+
 
 export const FEDERATION_SPEC_TYPES = [
   fieldSetTypeSpec,

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -13,6 +13,7 @@ import { DirectiveLocation } from "graphql";
 import { assert } from "./utils";
 import { tagLocations } from "./tagSpec";
 import { federationMetadata } from "./federation";
+import { registerKnownFeature } from "./knownCoreFeatures";
 
 export const federationIdentity = 'https://specs.apollo.dev/federation';
 
@@ -88,9 +89,11 @@ export const FEDERATION2_SPEC_DIRECTIVES = [
   requiresDirectiveSpec,
   providesDirectiveSpec,
   externalDirectiveSpec,
+  // This is here to preserve the order of this array prior of the introduction of this constant. And that's done because
+  // changing the order would require changing the outputs of a bunch of tests (not a big deal, just annoying).
+  ...FEDERATION2_ONLY_SPEC_DIRECTIVES,
   tagDirectiveSpec,
   extendsDirectiveSpec, // TODO: should we stop supporting that?
-  ...FEDERATION2_ONLY_SPEC_DIRECTIVES,
 ];
 
 // Note that this is meant to contain _all_ federation directive names ever supported, regardless of which version.
@@ -119,7 +122,15 @@ export class FederationSpecDefinition extends FeatureDefinition {
       directive.checkOrAdd(schema, feature.directiveNameInSchema(directive.name));
     }
   }
+
+  allElementNames(): string[] {
+    return FEDERATION2_SPEC_DIRECTIVES.map((spec) => `@${spec.name}`).concat([
+      fieldSetTypeSpec.name,
+    ])
+  }
 }
 
 export const FEDERATION_VERSIONS = new FeatureDefinitions<FederationSpecDefinition>(federationIdentity)
   .add(new FederationSpecDefinition(new FeatureVersion(2, 0)));
+
+registerKnownFeature(FEDERATION_VERSIONS);

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -8,6 +8,7 @@ import {
   Schema,
 } from "./definitions";
 import { GraphQLError, DirectiveLocation } from "graphql";
+import { registerKnownFeature } from "./knownCoreFeatures";
 
 export const inaccessibleIdentity = 'https://specs.apollo.dev/inaccessible';
 
@@ -28,10 +29,16 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
   inaccessibleDirective(schema: Schema): DirectiveDefinition<Record<string, never>> {
     return this.directive(schema, 'inaccessible')!;
   }
+
+  allElementNames(): string[] {
+    return ['@inaccessible'];
+  }
 }
 
 export const INACCESSIBLE_VERSIONS = new FeatureDefinitions<InaccessibleSpecDefinition>(inaccessibleIdentity)
   .add(new InaccessibleSpecDefinition(new FeatureVersion(0, 1)));
+
+registerKnownFeature(INACCESSIBLE_VERSIONS);
 
 export function removeInaccessibleElements(schema: Schema) {
   const coreFeatures = schema.coreFeatures;

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -8,6 +8,7 @@ import {
   NonNullType,
 } from "./definitions";
 import { Subgraph, Subgraphs } from "./federation";
+import { registerKnownFeature } from './knownCoreFeatures';
 import { MultiMap } from "./utils";
 
 export const joinIdentity = 'https://specs.apollo.dev/join';
@@ -90,6 +91,22 @@ export class JoinSpecDefinition extends FeatureDefinition {
     }
   }
 
+  allElementNames(): string[] {
+    const names = [
+      'graph',
+      'Graph',
+      'FieldSet',
+      '@type',
+      '@field',
+    ];
+    if (this.isV01()) {
+      names.push('@owner');
+    } else {
+      names.push('@implements');
+    }
+    return names;
+  }
+
   populateGraphEnum(schema: Schema, subgraphs: Subgraphs): Map<string, string> {
     // Duplicate enum values can occur due to sanitization and must be accounted for
     // collect the duplicates in an array so we can uniquify them in a second pass.
@@ -160,3 +177,5 @@ export class JoinSpecDefinition extends FeatureDefinition {
 export const JOIN_VERSIONS = new FeatureDefinitions<JoinSpecDefinition>(joinIdentity)
   .add(new JoinSpecDefinition(new FeatureVersion(0, 1)))
   .add(new JoinSpecDefinition(new FeatureVersion(0, 2)));
+
+registerKnownFeature(JOIN_VERSIONS);

--- a/internals-js/src/knownCoreFeatures.ts
+++ b/internals-js/src/knownCoreFeatures.ts
@@ -1,0 +1,13 @@
+import { FeatureDefinition, FeatureDefinitions, FeatureUrl } from "./coreSpec";
+
+const registeredFeatures: Map<string, FeatureDefinitions> = new Map();
+
+export function registerKnownFeature(definitions: FeatureDefinitions) {
+  if (!registeredFeatures.has(definitions.identity)) {
+    registeredFeatures.set(definitions.identity, definitions);
+  }
+}
+
+export function coreFeatureDefinitionIfKnown(url: FeatureUrl): FeatureDefinition | undefined {
+  return registeredFeatures.get(url.identity)?.find(url.version);
+}

--- a/internals-js/src/tagSpec.ts
+++ b/internals-js/src/tagSpec.ts
@@ -2,6 +2,7 @@ import { DirectiveLocation, GraphQLError } from "graphql";
 import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
 import { DirectiveDefinition, NonNullType, Schema } from "./definitions";
 import { ERRORS } from "./error";
+import { registerKnownFeature } from "./knownCoreFeatures";
 import { sameType } from "./types";
 
 export const tagIdentity = 'https://specs.apollo.dev/tag';
@@ -43,7 +44,13 @@ export class TagSpecDefinition extends FeatureDefinition {
     }
     return undefined;
   }
+
+  allElementNames(): string[] {
+    return ["@tag"];
+  }
 }
 
 export const TAG_VERSIONS = new FeatureDefinitions<TagSpecDefinition>(tagIdentity)
   .add(new TagSpecDefinition(new FeatureVersion(0, 1)));
+
+registerKnownFeature(TAG_VERSIONS);


### PR DESCRIPTION
Validation is currently pretty light around the new `@link(import:)` argument and it's easy to run into unhelpful error is you try to pass invalid values. There is also no validation of the imported name, so if you try to import a directive/name that doesn't exists, you get no errors and it's very easy to miss a typo for instance. But also, users coming from fed1 where name imports are not a thing are likely to forgot to add the directive they want to use to `import` a bunch of time initially, and (before this patch) you get a fairly laconic error message like `Unknown directive "@key"` (and if you're brand new to `@link`, this may not click as "I forgot to import" right away).

Anyway, this commit tries to improve the user experience around all this by:
1. providing suggestions if you typo a directive name
2. providing additional guidance is you try to use a fed2 directive but it's a fed1 schema, or you haven't imported it.
3. properly validating the `@link(import:)` argument
4. for known features (mostly matter for the `federation` one right now, but the code handles all "known" features), it ensures the imported names are known name for that feature.