### PR TITLE
Start a docs production deploy when docs changes get merged

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,16 @@
+name: Deploy docs to production
+
+on:
+  push:
+    branches:
+      - main
+      - version-0.x
+    paths:
+      - docs/**
+
+jobs:
+  publish:
+    uses: apollographql/docs/.github/workflows/publish.yml@main
+    secrets:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
 
 [context.deploy-preview.build]
   base = "docs"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
+  ignore = "git diff --quiet HEAD^ HEAD ."
   command = """\
   cd ../
   rm -rf monodocs


### PR DESCRIPTION
This PR adds a workflow that kicks off a production build of the docs on Netlify when docs changes get merged to main (or version branches).