### PR TITLE
diffTypeNodes will now return any[] as type for `kind` field

### DIFF
--- a/federation-js/src/composition/utils.ts
+++ b/federation-js/src/composition/utils.ts
@@ -638,7 +638,7 @@ export function diffTypeNodes(
       ? []
       : [firstNode.name.value, secondNode.name.value];
 
-  const kindDiff: typeof Kind[keyof typeof Kind][] =
+  const kindDiff: any[] =
     firstNode.kind === secondNode.kind ? [] : [firstNode.kind, secondNode.kind];
 
   return {

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- `diffTypeNodes` function will now return any[] as the type on the kind field. This may result in casting being necessary for some clients.
 
 ## v0.49.0
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- `diffTypeNodes` function will now return any[] as the type on the kind field. This may result in casting being necessary for some clients.
+- `diffTypeNodes` function will now return any[] as the type on the kind field. This may result in casting being necessary for some clients. [PR #1636](https://github.com/apollographql/federation/pull/1636)
 
 ## v0.49.0
 


### PR DESCRIPTION
`diffTypeNodes` will now return any[] as type for `kind` field

I'm a little concerned that this may introduce a need for casting for customers that previously didn't exist, but in order to continue to support graphql-js@15 and 16 I think it's necessary.