### PR TITLE
Add support for tag v0.2

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/federation-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## vNEXT
+
+> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
+
 ## v2.0.0-preview.8
 
 NOTE: Be sure to upgrade the gateway _before_ re-composing/deploying with this version. See below and the changelog for `@apollo/gateway`.

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -1323,7 +1323,7 @@ describe('composition', () => {
 
       expect(result.errors).toBeDefined();
       expect(errors(result)).toStrictEqual([
-        ['DIRECTIVE_DEFINITION_INVALID', '[subgraphA] Found invalid @tag directive definition. Please ensure the directive definition in your schema\'s definitions matches the following:\n\tdirective @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION'],
+        ['DIRECTIVE_DEFINITION_INVALID', '[subgraphA] Found invalid @tag directive definition. Please ensure the directive definition in your schema\'s definitions matches the following:\n\tdirective @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION'],
       ]);
     });
 

--- a/federation-integration-testsuite-js/src/fixtures/accounts.ts
+++ b/federation-integration-testsuite-js/src/fixtures/accounts.ts
@@ -11,9 +11,15 @@ export const typeDefs = gql`
     | INTERFACE
     | OBJECT
     | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
 
-  enum CacheControlScope {
-    PUBLIC
+  enum CacheControlScope @tag(name: "from-reviews") {
+    PUBLIC @tag(name: "from-reviews")
     PRIVATE
   }
 
@@ -23,7 +29,7 @@ export const typeDefs = gql`
     inheritMaxAge: Boolean
   ) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
-  scalar JSON @specifiedBy(url: "https://json-spec.dev")
+  scalar JSON @tag(name: "from-reviews") @specifiedBy(url: "https://json-spec.dev")
 
   schema {
     query: RootQuery
@@ -55,7 +61,7 @@ export const typeDefs = gql`
     id: ID! @tag(name: "accounts")
     name: Name @cacheControl(inheritMaxAge: true)
     username: String @shareable # Provided by the 'reviews' subgraph
-    birthDate(locale: String): String @tag(name: "admin") @tag(name: "dev")
+    birthDate(locale: String @tag(name: "admin")): String @tag(name: "admin") @tag(name: "dev")
     account: AccountType
     metadata: [UserMetadata]
     ssn: String

--- a/federation-integration-testsuite-js/src/fixtures/reviews.ts
+++ b/federation-integration-testsuite-js/src/fixtures/reviews.ts
@@ -11,6 +11,12 @@ export const typeDefs = gql`
     | FIELD_DEFINITION
     | OBJECT
     | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
 
   type Query {
     topReviews(first: Int = 5): [Review]
@@ -24,9 +30,9 @@ export const typeDefs = gql`
     metadata: [MetadataOrError]
   }
 
-  input UpdateReviewInput {
+  input UpdateReviewInput @tag(name: "from-reviews") {
     id: ID!
-    body: String
+    body: String @tag(name: "from-reviews")
   }
 
   type UserMetadata {
@@ -43,7 +49,7 @@ export const typeDefs = gql`
   }
 
   interface Product @tag(name: "from-reviews") {
-    reviews: [Review]
+    reviews: [Review] @tag(name: "from-reviews")
   }
 
   type Furniture implements Product @key(fields: "upc") {
@@ -82,13 +88,13 @@ export const typeDefs = gql`
 
   type Mutation {
     reviewProduct(input: ReviewProduct!): Product
-    updateReview(review: UpdateReviewInput!): Review
+    updateReview(review: UpdateReviewInput! @tag(name: "from-reviews")): Review
     deleteReview(id: ID!): Boolean
   }
 
   # Value type
-  type KeyValue @shareable {
-    key: String!
+  type KeyValue @shareable @tag(name: "from-reviews") {
+    key: String! @tag(name: "from-reviews")
     value: String!
   }
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## vNEXT
+
+> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Adds support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
+
 ## v2.0.0-preview.8
 
 NOTE: Be sure to update to this version of gateway _before_ upgrading composition. See below and the changelog for `@apollo/composition`.

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -147,7 +147,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
-      'cf96012e98a17d3739f90afed59ef6a5d969d42a5780f9a069a790f2a959d711',
+      '2111ffa6e04caa88d5422b503f72192bfd644910fb4b56a73e0531ec79d5ea92',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/gateway-js/src/core/__tests__/core.test.ts
+++ b/gateway-js/src/core/__tests__/core.test.ts
@@ -31,7 +31,7 @@ describe('core v0.1', () => {
 
       directive @tag(
         name: String!
-      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
       enum CacheControlScope {
         PRIVATE
@@ -87,7 +87,7 @@ describe('core v0.1', () => {
 
       directive @tag(
         name: String!
-      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
       enum CacheControlScope {
         PRIVATE
@@ -124,7 +124,7 @@ describe('core v0.2', () => {
       schema
         @core(feature: "https://specs.apollo.dev/core/v0.2")
         @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
-        @core(feature: "https://specs.apollo.dev/tag/v0.1") {
+        @core(feature: "https://specs.apollo.dev/tag/v0.2") {
         query: Query
       }
 
@@ -151,7 +151,7 @@ describe('core v0.2', () => {
 
       directive @tag(
         name: String!
-      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
       enum CacheControlScope {
         PRIVATE
@@ -193,7 +193,7 @@ describe('core v0.2', () => {
       schema
         @core(feature: "https://specs.apollo.dev/core/v0.2")
         @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
-        @core(feature: "https://specs.apollo.dev/tag/v0.1")
+        @core(feature: "https://specs.apollo.dev/tag/v0.2")
         @core(feature: "https://specs.apollo.dev/unsupported-feature/v0.1") {
         query: Query
       }
@@ -221,7 +221,7 @@ describe('core v0.2', () => {
 
       directive @tag(
         name: String!
-      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
       enum CacheControlScope {
         PRIVATE
@@ -293,7 +293,7 @@ describe('core v0.2', () => {
 
       directive @tag(
         name: String!
-      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
       enum CacheControlScope {
         PRIVATE
@@ -369,7 +369,7 @@ describe('core v0.2', () => {
 
       directive @tag(
         name: String!
-      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+      ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
       enum CacheControlScope {
         PRIVATE

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG for `@apollo/federation-internals`
 
-## vNext
+## vNEXT
 
-- Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
+> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
 
 ## v2.0.0-preview.8
 

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -385,7 +385,7 @@ function isFieldSatisfyingInterface(field: FieldDefinition<ObjectType | Interfac
  */
 function validateInterfaceRuntimeImplementationFieldsTypes(
   itf: InterfaceType,
-  metadata: FederationMetadata, 
+  metadata: FederationMetadata,
   errorCollector: GraphQLError[],
 ): void {
   const requiresDirective = federationMetadata(itf.schema())?.requiresDirective();
@@ -630,7 +630,7 @@ export class FederationBlueprint extends SchemaBlueprint {
     // Historically, federation 1 has accepted invalid schema, including some where the Query type included
     // the definition of `_entities` (so `_entities(representations: [_Any!]!): [_Entity]!`) but _without_
     // defining the `_Any` or `_Entity` type. So while we want to be stricter for fed2 (so this kind of
-    // really weird case can be fixed), we want fed2 to accept as much fed1 schema as possible. 
+    // really weird case can be fixed), we want fed2 to accept as much fed1 schema as possible.
     //
     // So, to avoid this problem, we ignore the _entities and _service fields if we parse them from
     // a fed1 input schema. Those will be added back anyway (along with the proper types) post-parsing.

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -11,7 +11,7 @@ import {
 } from "./directiveAndTypeSpecification";
 import { DirectiveLocation } from "graphql";
 import { assert } from "./utils";
-import { tagLocations } from "./tagSpec";
+import { TAG_VERSIONS } from "./tagSpec";
 import { federationMetadata } from "./federation";
 import { registerKnownFeature } from "./knownCoreFeatures";
 import { inaccessibleLocations } from "./inaccessibleSpec";
@@ -63,7 +63,7 @@ export const shareableDirectiveSpec = createDirectiveSpecification({
 
 export const tagDirectiveSpec = createDirectiveSpecification({
   name:'tag',
-  locations: tagLocations,
+  locations: TAG_VERSIONS.latest().tagLocations,
   repeatable: true,
   argumentFct: (schema) => {
     return [{ name: 'name', type: new NonNullType(schema.stringType()) }];

--- a/internals-js/src/supergraphs.ts
+++ b/internals-js/src/supergraphs.ts
@@ -12,6 +12,7 @@ const SUPPORTED_FEATURES = new Set([
   'https://specs.apollo.dev/join/v0.1',
   'https://specs.apollo.dev/join/v0.2',
   'https://specs.apollo.dev/tag/v0.1',
+  'https://specs.apollo.dev/tag/v0.2',
   'https://specs.apollo.dev/inaccessible/v0.1',
 ]);
 

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
-## vNext
+## vNEXT
 
-- Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
+> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
 
 ## v2.0.0-preview.8
 

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
-## vNext
+## vNEXT
 
-- Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
+> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
 
 ## v2.0.0-preview.8
 

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -20,12 +20,12 @@ describe('printSubgraphSchema', () => {
 
       directive @cacheControl(maxAge: Int, scope: CacheControlScope, inheritMaxAge: Boolean) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
-      enum CacheControlScope {
-        PUBLIC
+      enum CacheControlScope @tag(name: \\"from-reviews\\") {
+        PUBLIC @tag(name: \\"from-reviews\\")
         PRIVATE
       }
 
-      scalar JSON @specifiedBy(url: \\"https://json-spec.dev\\")
+      scalar JSON @specifiedBy(url: \\"https://json-spec.dev\\") @tag(name: \\"from-reviews\\")
 
       type RootQuery {
         _entities(representations: [_Any!]!): [_Entity]!
@@ -54,7 +54,7 @@ describe('printSubgraphSchema', () => {
         id: ID! @tag(name: \\"accounts\\")
         name: Name
         username: String @shareable
-        birthDate(locale: String): String @tag(name: \\"admin\\") @tag(name: \\"dev\\")
+        birthDate(locale: String @tag(name: \\"admin\\")): String @tag(name: \\"admin\\") @tag(name: \\"dev\\")
         account: AccountType
         metadata: [UserMetadata]
         ssn: String
@@ -79,7 +79,9 @@ describe('printSubgraphSchema', () => {
   });
 
   it('prints a scalar without a directive correctly', () => {
-    const schema = gql`scalar JSON`;
+    const schema = gql`
+      scalar JSON
+    `;
     const subgraphSchema = buildSubgraphSchema(schema);
 
     expect(printSubgraphSchema(subgraphSchema)).toMatchInlineSnapshot(`
@@ -115,9 +117,9 @@ describe('printSubgraphSchema', () => {
         metadata: [MetadataOrError]
       }
 
-      input UpdateReviewInput {
+      input UpdateReviewInput @tag(name: \\"from-reviews\\") {
         id: ID!
-        body: String
+        body: String @tag(name: \\"from-reviews\\")
       }
 
       type UserMetadata {
@@ -134,7 +136,7 @@ describe('printSubgraphSchema', () => {
       }
 
       interface Product @tag(name: \\"from-reviews\\") {
-        reviews: [Review]
+        reviews: [Review] @tag(name: \\"from-reviews\\")
       }
 
       type Furniture implements Product @key(fields: \\"upc\\") {
@@ -173,12 +175,12 @@ describe('printSubgraphSchema', () => {
 
       type Mutation {
         reviewProduct(input: ReviewProduct!): Product
-        updateReview(review: UpdateReviewInput!): Review
+        updateReview(review: UpdateReviewInput! @tag(name: \\"from-reviews\\")): Review
         deleteReview(id: ID!): Boolean
       }
 
-      type KeyValue @shareable {
-        key: String!
+      type KeyValue @shareable @tag(name: \\"from-reviews\\") {
+        key: String! @tag(name: \\"from-reviews\\")
         value: String!
       }
 

--- a/subgraph-js/src/directives.ts
+++ b/subgraph-js/src/directives.ts
@@ -4,7 +4,6 @@ import {
   GraphQLNonNull,
   GraphQLString,
   GraphQLNamedType,
-  isInputObjectType,
   DirectiveNode,
   GraphQLField,
   FieldDefinitionNode,
@@ -188,7 +187,6 @@ export function typeIncludesDirective(
   type: GraphQLNamedType,
   directiveName: string,
 ): boolean {
-  if (isInputObjectType(type)) return false;
   const directives = gatherDirectives(type);
   return directives.some((directive) => directive.name.value === directiveName);
 }


### PR DESCRIPTION
This PR introduces tag v0.2, which adds support for `@tag` in more locations (arguments, scalars, enums, enum values, input objects, input object fields).