### PR TITLE
Optimise indirect path computations

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet. New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development. When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Optimize composition validation when many entities spans many subgraphs [PR #1653](https://github.com/apollographql/federation/pull/1653).
 - Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet. New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development. When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Optimize composition validation when many entities spans many subgraphs [PR #1653](https://github.com/apollographql/federation/pull/1653).
 - Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
 - Adds support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).
 

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -388,9 +388,12 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
    */
   nextEdges(): readonly Edge[] {
     const tailEdge = this.edgeToTail;
+    // In theory, we could always return `this.graph.outEdges(this.tail)` here. But in practice, `nonTrivialFollowupEdges` may give us a subset
+    // of those "out edges" that avoids some of the edges that we know we don't need to check because they are guaranteed to be inefficient
+    // after the previous `tailEdge`. Note that is purely an optimization (see https://github.com/apollographql/federation/pull/1653 for more details).
     return tailEdge
       ? this.graph.nonTrivialFollowupEdges(tailEdge)
-      : this.graph.outEdges(this.tail);;
+      : this.graph.outEdges(this.tail);
   }
 
   /**

--- a/query-graphs-js/src/nonTrivialEdgePrecomputing.ts
+++ b/query-graphs-js/src/nonTrivialEdgePrecomputing.ts
@@ -1,0 +1,48 @@
+import { assert } from "@apollo/federation-internals";
+import { Edge, QueryGraph, QueryGraphState, simpleTraversal } from "./querygraph";
+
+export function preComputeNonTrivialFollowupEdges(graph: QueryGraph): (previousEdge: Edge) => readonly Edge[] {
+  const state = new QueryGraphState<undefined, readonly Edge[]>(graph);
+  simpleTraversal(graph, () => {}, (edge) => {
+    const followupEdges = graph.outEdges(edge.tail);
+    state.setEdgeState(edge, computeNonTrivialFollowups(edge, followupEdges));
+    return true;
+  });
+  return (previousEdge) => {
+    const nonTrivialFollowups = state.getEdgeState(previousEdge);
+    assert(nonTrivialFollowups, () => `Non-trivial followup edges of ${previousEdge} should have been computed`);
+    return nonTrivialFollowups;
+  }
+}
+
+function computeNonTrivialFollowups(edge: Edge, allFollowups: readonly Edge[]): readonly Edge[] {
+  switch (edge.transition.kind) {
+    case 'KeyResolution':
+      // After taking a key from subgraph A to B, there is no point of following that up with another key
+      // to subgraph C if that key has _the same_ conditions. This is because, due to the way key edges
+      // are created, if we have a key (with some conditions X) from B to C, then we are guaranteed to
+      // also have a key (with the same conditions X) from A to C, and so it's that later key we
+      // should be using in the first place. In other words, it's never better to do 2 hops rather than 1.
+      return allFollowups.filter((followup) => followup.transition.kind !== 'KeyResolution' || !sameConditions(edge, followup));
+    case 'RootTypeResolution':
+      // A 'RootTypeResolution' means that a query reached the query type (or another root type) in some
+      // subgraph A and we're looking at jumping to another subgraph B. But like for keys, there is
+      // no point in trying to jump directly to yet another subgpraph C from B, since we can always
+      // jump directly from A to C and it's better.
+      return allFollowups.filter((followup) => followup.transition.kind !== 'RootTypeResolution');
+    case 'SubgraphEnteringTransition':
+      // This is somewhat similar to 'RootTypeResolution' except that we're starting the query.
+      // But still, not doing "start of query" -> B -> C, since we can do "start of query" -> C
+      // and that's always better.
+      return allFollowups.filter((followup) => followup.transition.kind !== 'RootTypeResolution');
+    default:
+      return allFollowups;
+  }
+}
+
+function sameConditions(e1: Edge, e2: Edge): boolean {
+  if (!e1.conditions) {
+    return !e2.conditions;
+  }
+  return !!e2.conditions && e1.conditions.equals(e2.conditions);
+}

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -35,6 +35,7 @@ import {
 import { inspect } from 'util';
 import { DownCast, FieldCollection, subgraphEnteringTransition, SubgraphEnteringTransition, Transition, KeyResolution, RootTypeResolution } from './transition';
 import { isStructuralFieldSubtype } from './structuralSubtyping';
+import { preComputeNonTrivialFollowupEdges } from './nonTrivialEdgePrecomputing';
 
 // We use our federation reserved subgraph name to avoid risk of conflict with other subgraph names (wouldn't be a huge
 // deal, but safer that way). Using something short like `_` is also on purpose: it makes it stand out in debug messages
@@ -243,6 +244,29 @@ export class Edge {
  */
 export class QueryGraph {
   /**
+   * Given an edge, returns the possible edges that can follow it "productively", that is without creating
+   * a trivially inefficient path.
+   *
+   * More precisely, `nonTrivialFollowupEdges(e)` is equivalent calling `outEdges(e.tail)` and filtering
+   * the edges that "never make sense" after `e`, which mainly amounts to avoiding chaining key edges
+   * when we know there is guaranteed to be a better option. As an example, suppose we have 3 subgraphs
+   * A, B and C which all defined a `@key(fields: "id")` on some entity type `T`. Then it is never
+   * interesting to take that key edge from B -> C after A -> B because if we're in A and want to get
+   * to C, we can always do A -> C (of course, this is only true because it's the "same" key).
+   *
+   * See `preComputeNonTrivialFollowupEdges` for more details on which exact edges are filtered.
+   *
+   * Lastly, note that the main reason for exposing this method is that its result is pre-computed.
+   * Which in turn is done for performance reasons: having the same key defined in multiple subgraphs
+   * is _the_ most common pattern, and while our later algorithms (composition validation and query
+   * planning) would know to not select those trivially inefficient "detour", they might have to redo
+   * those checks many times and pre-computing once it is significantly faster (and pretty easy).
+   * Fwiw, when originally introduced, this optimization lowered composition validation on a big
+   * composition (100+ subgraphs) from ~4 "minutes" to ~10 seconds.
+   */
+  readonly nonTrivialFollowupEdges: (edge: Edge) => readonly Edge[];
+
+  /**
    * Creates a new query graph.
    *
    * This isn't meant to be be called directly outside of `GraphBuilder.build`.
@@ -272,6 +296,7 @@ export class QueryGraph {
      */
     readonly sources: ReadonlyMap<string, Schema>
   ) {
+    this.nonTrivialFollowupEdges = preComputeNonTrivialFollowupEdges(this);
   }
 
   /** The number of vertices in this query graph. */

--- a/query-graphs-js/src/transition.ts
+++ b/query-graphs-js/src/transition.ts
@@ -13,10 +13,10 @@ import { FieldDefinition, CompositeType, SchemaRootKind } from "@apollo/federati
  *  - a key (`KeyResolution`), only found in "federated" query graphs: the edge goes from an
  *    entity type in a particular subgraph to the same entity type but in another subgraph. Edge
   *   with key transition _must_ have `conditions` corresponding to the key fields.
-  * - a query (`QueryResolution`), only found in "federated" query graphs: the edge goes from
-  *   the query root type of a subgraph to the query subgraph of another subgraph. It encodes
-  *   the fact that if a subgraph field returns the query type, any subgraph can be queried
-  *   from there.
+  * - a root type (`RootTypeResolution`), only found in "federated" query graphs: the edge goes from
+  *   a root type (query, mutation or subscription) of a subgraph to the (same) root type of another
+  *   subgraph. It encodes the fact that if a subgraph field returns a root type, any subgraph
+  *   can be queried from there.
   * - a "subgraph entering" edge: this is a special case only used for the edges out of the root
   *   vertices of "federated" query graphs. It does not correspond to any physical graphQL elements
   *   but can be understood as the fact that the gateway is always free to start querying any of


### PR DESCRIPTION
This commit implements 2 optimizations for the computation of "indirect
paths" (think "following all possible key edges"):
1. it adds some pre-computation of edges-following-an-edge that skips
   filters some trivially unecessary options. Essentially, the
   precomputaton is relatively cheap and avoid repeatedly considering
   (and utlimately eliminating) those unecessary options.
2. query planning already has a mechanism by which "the computation of
   indirect paths folowing a given path" is memoized to save
   recomputation. This wasn't done for composition validation however
   and this commit correct that.

Those optimizations are particularly potent when composing a large number
of subgraphs with many entities spanning lots of subgraphs. On a fairly
large example (100+ subgraphs), this reduce composition time from 4+
"minutes" to less than 8 seconds ("on my machine").

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
