### PR TITLE
Fix handling of core/link when definitions are provided or partially so

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet. New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development. When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Fix handling of core/link when definitions are provided or partially so [PR #1662](https://github.com/apollographql/federation/pull/1662).
 - Optimize composition validation when many entities spans many subgraphs [PR #1653](https://github.com/apollographql/federation/pull/1653).
 - Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -1323,7 +1323,7 @@ describe('composition', () => {
 
       expect(result.errors).toBeDefined();
       expect(errors(result)).toStrictEqual([
-        ['DIRECTIVE_DEFINITION_INVALID', '[subgraphA] Found invalid @tag directive definition. Please ensure the directive definition in your schema\'s definitions matches the following:\n\tdirective @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION'],
+        ['DIRECTIVE_DEFINITION_INVALID', '[subgraphA] Invalid definition for directive "@tag": missing required argument "name"'],
       ]);
     });
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -82,7 +82,7 @@ describe('composition', () => {
 
       directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-      directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+      directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
       scalar join__FieldSet
 
@@ -2033,7 +2033,7 @@ describe('composition', () => {
 
       directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-      directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+      directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
       scalar join__FieldSet
 

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -243,7 +243,8 @@ class Merger {
     // pass a `as` to the methods below if necessary. However, as we currently don't propagate any subgraph directives to
     // the supergraph outside of a few well-known ones, we don't bother yet.
     linkSpec.addToSchema(this.merged);
-    linkSpec.applyFeatureToSchema(this.merged, joinSpec, undefined, 'EXECUTION');
+    const errors = linkSpec.applyFeatureToSchema(this.merged, joinSpec, undefined, 'EXECUTION');
+    assert(errors.length === 0, "We shouldn't have errors adding the join spec to the (still empty) supergraph schema");
 
     for (const mergedInfo of MERGED_FEDERATION_DIRECTIVES) {
       this.validateAndMaybeAddSpec(mergedInfo);
@@ -278,7 +279,8 @@ class Merger {
     // don't bother adding the spec to the supergraph.
     if (nameInSupergraph) {
       this.mergedFederationDirectiveNames.add(nameInSupergraph);
-      linkSpec.applyFeatureToSchema(this.merged, specInSupergraph, nameInSupergraph === specInSupergraph.url.name ? undefined : nameInSupergraph);
+      const errors = linkSpec.applyFeatureToSchema(this.merged, specInSupergraph, nameInSupergraph === specInSupergraph.url.name ? undefined : nameInSupergraph);
+      assert(errors.length === 0, "We shouldn't have errors adding the join spec to the (still empty) supergraph schema");
     }
   }
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 > The changes noted within this `vNEXT` section have not been released yet. New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development. When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- Fix handling of core/link when definitions are provided or partially so [PR #1662](https://github.com/apollographql/federation/pull/1662).
 - Optimize composition validation when many entities spans many subgraphs [PR #1653](https://github.com/apollographql/federation/pull/1653).
 - Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).
 - Adds support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -147,7 +147,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
-      '2111ffa6e04caa88d5422b503f72192bfd644910fb4b56a73e0531ec79d5ea92',
+      '3a799fc2690d4e0e2766002f8c583b4b796d2e6732f12da9bfafab782fc01240',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -541,7 +541,7 @@ describe('@core/@link handling', () => {
       query: Query
     }
 
-    directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
     directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
@@ -743,6 +743,22 @@ describe('@core/@link handling', () => {
         directive @key(fields: federation__FieldSet!, resolvable: Boolean!) repeatable on OBJECT | INTERFACE
 
         scalar federation__FieldSet
+      `,
+      // @link `url` argument is allowed to be `null` now, but it used not too, so making sure we still
+      // accept definition where it's mandatory.
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+        scalar link__Import
+        scalar link__Purpose
       `,
     ];
 

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -1,7 +1,10 @@
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+import { Subgraph } from '..';
 import { errorCauses } from '../definitions';
 import { asFed2SubgraphDocument, buildSubgraph } from "../federation"
+import { defaultPrintOptions, printSchema } from '../print';
+import './matchers';
 
 // Builds the provided subgraph (using name 'S' for the subgraph) and, if the
 // subgraph is invalid/has errors, return those errors as a list of [code, message].
@@ -521,5 +524,323 @@ describe('custom error message for misnamed directives', () => {
       ['INVALID_GRAPHQL', `[S] Unknown directive "@shareable". If you meant the \"@shareable\" federation directive, you should use fully-qualified name "@federation__shareable" or add "@shareable" to the \`import\` argument of the @link to the federation specification.`],
       ['INVALID_GRAPHQL', `[S] Unknown directive "@key". If you meant the "@key" federation directive, you should use "@myKey" as it is imported under that name in the @link to the federation specification of this schema.`],
     ]);
+  });
+});
+
+function buildAndValidate(doc: DocumentNode): Subgraph {
+  const name = 'S';
+  return buildSubgraph(name, `http://${name}`, doc).validate();
+}
+
+describe('@core/@link handling', () => {
+  const expectedFullSchema = `
+    schema
+      @link(url: "https://specs.apollo.dev/link/v1.0")
+      @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+    {
+      query: Query
+    }
+
+    directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+    directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+    directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+    directive @federation__external on OBJECT | FIELD_DEFINITION
+
+    directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+    directive @federation__extends on OBJECT | INTERFACE
+
+    directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+    directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+    type T
+      @key(fields: "k")
+    {
+      k: ID!
+    }
+
+    enum link__Purpose {
+      """
+      \`SECURITY\` features provide metadata necessary to securely resolve fields.
+      """
+      SECURITY
+
+      """
+      \`EXECUTION\` features provide metadata necessary for operation execution.
+      """
+      EXECUTION
+    }
+
+    scalar link__Import
+
+    scalar federation__FieldSet
+
+    scalar _Any
+
+    type _Service {
+      sdl: String
+    }
+
+    union _Entity = T
+
+    type Query {
+      _entities(representations: [_Any!]!): [_Entity]!
+      _service: _Service
+    }
+  `
+  const validateFullSchema = (subgraph: Subgraph) => {
+    // Note: we merge types and extensions to avoid having to care whether the @link are on a schema definition or schema extension
+    // as 1) this will vary (we add them to extensions in our test, but when auto-added, they are added to the schema definition)
+    // and 2) it doesn't matter in practice, it's valid in all cases.
+    expect(printSchema(subgraph.schema, { ...defaultPrintOptions, mergeTypesAndExtensions: true})).toMatchString(expectedFullSchema);
+  }
+
+  it('expands everything if only the federation spec is linked', () => {
+    const doc = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+      type T @key(fields: "k") {
+        k: ID!
+      }
+    `;
+
+    validateFullSchema(buildAndValidate(doc));
+  });
+
+  it('expands definitions if both the federation spec and link spec are linked', () => {
+    const doc = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+      type T @key(fields: "k") {
+        k: ID!
+      }
+    `;
+
+    validateFullSchema(buildAndValidate(doc));
+  });
+
+  it('is valid if a schema is complete from the get-go', () => {
+    validateFullSchema(buildAndValidate(gql(expectedFullSchema)));
+  });
+
+  it('expands missing definitions when some are partially provided', () => {
+    const docs = [
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+        scalar federation__FieldSet
+
+        scalar link__Import
+      `,
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        scalar link__Import
+      `,
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        scalar link__Import
+      `,
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        directive @federation__external on OBJECT | FIELD_DEFINITION
+      `,
+    ];
+
+    // Note that we cannot use `validateFullSchema` as-is for those examples because the order or directive is going
+    // to be different. But that's ok, we mostly care that the validation doesn't throw since validation ultimately
+    // calls the graphQL-js validation, so we can be somewhat sure that if something necessary wasn't expanded
+    // properly, we would have an issue. The main reason we did validate the full schema in prior tests is
+    // so we had at least one full example of a subgraph expansion in the tests.
+    docs.forEach((doc) => buildAndValidate(doc));
+  });
+
+  it('allows known directives with incomplete but compatible definitions', () => {
+    const docs = [
+      // @key has a `resolvable` argument in its full definition, but it is optional.
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        directive @key(fields: federation__FieldSet!) repeatable on OBJECT | INTERFACE
+
+        scalar federation__FieldSet
+      `,
+      // @inacessible can be put in a bunch of locations, but you're welcome to restrict yourself to just fields.
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@inaccessible"])
+
+        type T {
+          k: ID! @inaccessible
+        }
+
+        directive @inaccessible on FIELD_DEFINITION
+      `,
+      // @key is repeatable, but you're welcome to restrict yourself to never repeating it.
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
+
+        scalar federation__FieldSet
+      `,
+      // @key `resolvable` argument is optional, but you're welcome to force users to always provide it.
+      gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        type T @key(fields: "k", resolvable: true) {
+          k: ID!
+        }
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean!) repeatable on OBJECT | INTERFACE
+
+        scalar federation__FieldSet
+      `,
+    ];
+
+    // Like above, we really only care that the examples validate.
+    docs.forEach((doc) => buildAndValidate(doc));
+  });
+
+  it('errors on invalid known directive location', () => {
+    const doc = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+      type T @key(fields: "k") {
+        k: ID!
+      }
+
+      directive @federation__external on OBJECT | FIELD_DEFINITION | SCHEMA
+    `;
+
+    // @external is not allowed on 'schema' and likely never will.
+    expect(buildForErrors(doc, { asFed2: false })).toStrictEqual([[
+        'DIRECTIVE_DEFINITION_INVALID',
+        '[S] Invalid definition for directive "@federation__external": "@federation__external" should have locations OBJECT, FIELD_DEFINITION, but found (non-subset) OBJECT, FIELD_DEFINITION, SCHEMA',
+    ]]);
+  });
+
+  it('errors on invalid non-repeatable directive marked repeateable', () => {
+    const doc = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+      type T @key(fields: "k") {
+        k: ID!
+      }
+
+      directive @federation__external repeatable on OBJECT | FIELD_DEFINITION
+    `;
+
+    // @external is not repeatable (and has no reason to be since it has no arguments).
+    expect(buildForErrors(doc, { asFed2: false })).toStrictEqual([[
+      'DIRECTIVE_DEFINITION_INVALID',
+      '[S] Invalid definition for directive "@federation__external": "@federation__external" should not be repeatable',
+    ]]);
+  });
+
+  it('errors on unknown argument of known directive', () => {
+    const doc = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+      type T @key(fields: "k") {
+        k: ID!
+      }
+
+      directive @federation__external(foo: Int) on OBJECT | FIELD_DEFINITION
+    `;
+
+    expect(buildForErrors(doc, { asFed2: false })).toStrictEqual([[
+      'DIRECTIVE_DEFINITION_INVALID',
+      '[S] Invalid definition for directive "@federation__external": unknown/unsupported argument "foo"',
+    ]]);
+  });
+
+  it('errors on invalid type for a known argument', () => {
+    const doc = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+      type T @key(fields: "k") {
+        k: ID!
+      }
+
+      directive @key(fields: Int!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+    `;
+
+    expect(buildForErrors(doc, { asFed2: false })).toStrictEqual([[
+      'DIRECTIVE_DEFINITION_INVALID',
+      '[S] Invalid definition for directive "@key": argument "fields" should have type "federation__FieldSet!" but found type "Int!"',
+    ]]);
+  });
+
+  it('errors on a required argument defined as optional', () => {
+    const doc = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+      type T @key(fields: "k") {
+        k: ID!
+      }
+
+      directive @key(fields: federation__FieldSet, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+      scalar federation__FieldSet
+    `;
+
+    expect(buildForErrors(doc, { asFed2: false })).toStrictEqual([[
+      'DIRECTIVE_DEFINITION_INVALID',
+      '[S] Invalid definition for directive "@key": argument "fields" should have type "federation__FieldSet!" but found type "federation__FieldSet"',
+    ]]);
   });
 });

--- a/internals-js/src/buildSchema.ts
+++ b/internals-js/src/buildSchema.ts
@@ -89,7 +89,7 @@ export function buildSchemaFromAST(
     buildSchemaDefinitionInner(schemaExtension, schema.schemaDefinition, errors, schema.schemaDefinition.newExtension());
   }
 
-  schema.blueprint.onDirectiveDefinitionAndSchemaParsed(schema);
+  errors.push(...schema.blueprint.onDirectiveDefinitionAndSchemaParsed(schema));
 
   for (const definitionNode of documentNode.definitions) {
     switch (definitionNode.kind) {

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -1,6 +1,6 @@
 import { ASTNode, DirectiveLocation, GraphQLError, StringValueNode } from "graphql";
 import { URL } from "url";
-import { CoreFeature, Directive, DirectiveDefinition, EnumType, ErrGraphQLValidationFailed, ListType, NamedType, NonNullType, ScalarType, Schema, SchemaDefinition } from "./definitions";
+import { CoreFeature, Directive, DirectiveDefinition, EnumType, ErrGraphQLValidationFailed, InputType, ListType, NamedType, NonNullType, ScalarType, Schema, SchemaDefinition } from "./definitions";
 import { sameType } from "./types";
 import { err } from '@apollo/core-schema';
 import { assert } from './utils';
@@ -8,6 +8,7 @@ import { ERRORS } from "./error";
 import { valueToString } from "./values";
 import { coreFeatureDefinitionIfKnown, registerKnownFeature } from "./knownCoreFeatures";
 import { didYouMean, suggestionList } from "./suggestions";
+import { ArgumentSpecification, createDirectiveSpecification, createEnumTypeSpecification, createScalarTypeSpecification, DirectiveSpecification, TypeSpecification } from "./directiveAndTypeSpecification";
 
 export const coreIdentity = 'https://specs.apollo.dev/core';
 export const linkIdentity = 'https://specs.apollo.dev/link';
@@ -64,7 +65,7 @@ export abstract class FeatureDefinition {
     return nameInSchema != undefined && (directive.name === nameInSchema || directive.name.startsWith(`${nameInSchema}__`));
   }
 
-  abstract addElementsToSchema(schema: Schema): void;
+  abstract addElementsToSchema(schema: Schema): GraphQLError[];
 
   abstract allElementNames(): string[];
 
@@ -104,6 +105,14 @@ export abstract class FeatureDefinition {
 
   protected addDirective(schema: Schema, name: string): DirectiveDefinition {
     return schema.addDirectiveDefinition(this.directiveNameInSchema(schema, name)!);
+  }
+
+  protected addDirectiveSpec(schema: Schema, spec: DirectiveSpecification): GraphQLError[] {
+    return spec.checkOrAdd(schema, this.directiveNameInSchema(schema, spec.name));
+  }
+
+  protected addTypeSpec(schema: Schema, spec: TypeSpecification): GraphQLError[] {
+    return spec.checkOrAdd(schema, this.typeNameInSchema(schema, spec.name));
   }
 
   protected addScalarType(schema: Schema, name: string): ScalarType {
@@ -288,43 +297,61 @@ export function isCoreSpecDirectiveApplication(directive: Directive<SchemaDefini
   }
 }
 
+const linkPurposeTypeSpec = createEnumTypeSpecification({
+  name: 'Purpose',
+  values: corePurposes.map((name) => ({ name, description: purposesDescription(name)}))
+});
+
+const linkImportTypeSpec = createScalarTypeSpecification({ name: 'Import' });
+
 export class CoreSpecDefinition extends FeatureDefinition {
+  private readonly directiveDefinitionSpec: DirectiveSpecification;
+
   constructor(version: FeatureVersion, identity: string = linkIdentity, name: string = linkDirectiveDefaultName) {
     super(new FeatureUrl(identity, name, version));
+    this.directiveDefinitionSpec = createDirectiveSpecification({
+      name,
+      locations: [DirectiveLocation.SCHEMA],
+      repeatable: true,
+      argumentFct: (schema, nameInSchema) => this.createDefinitionArgumentSpecifications(schema, nameInSchema),
+    });
   }
 
-  addElementsToSchema(_: Schema): void {
+  private createDefinitionArgumentSpecifications(schema: Schema, nameInSchema?: string): { args: ArgumentSpecification[], errors: GraphQLError[] } {
+    const args: ArgumentSpecification[] = [
+      { name: this.urlArgName(), type: new NonNullType(schema.stringType()) },
+      { name: 'as', type: schema.stringType() },
+    ];
+    if (this.supportPurposes()) {
+      const purposeName = `${nameInSchema ?? this.url.name}__${linkPurposeTypeSpec.name}`;
+      const errors = linkPurposeTypeSpec.checkOrAdd(schema, purposeName);
+      if (errors.length > 0) {
+        return { args, errors }
+      }
+      args.push({ name: 'for', type: schema.type(purposeName) as InputType });
+    }
+    if (this.supportImport()) {
+      const importName = `${nameInSchema ?? this.url.name}__${linkImportTypeSpec.name}`;
+      const errors = linkImportTypeSpec.checkOrAdd(schema, importName);
+      if (errors.length > 0) {
+        return { args, errors }
+      }
+      args.push({ name: 'import', type: new ListType(schema.type(importName)!) });
+    }
+    return { args, errors: [] };
+  }
+
+  addElementsToSchema(_: Schema): GraphQLError[] {
     // Core is special and the @core directive is added in `addToSchema` below
+    return [];
   }
 
   // TODO: we may want to allow some `import` as argument to this method. When we do, we need to watch for imports of
   // `Purpose` and `Import` and add the types under their imported name.
-  addToSchema(schema: Schema, as?: string) {
-    const existing = schema.coreFeatures;
-    if (existing) {
-      if (existing.coreItself.url.identity === this.identity) {
-        // Already exists with the same version, let it be.
-        return;
-      } else {
-        throw buildError(`Cannot add feature ${this} to the schema, it already uses ${existing.coreItself.url}`);
-      }
-    }
-
-    const nameInSchema = as ?? this.url.name;
-    const core = schema.addDirectiveDefinition(nameInSchema).addLocations(DirectiveLocation.SCHEMA);
-    core.repeatable = true;
-    core.addArgument(this.urlArgName(), new NonNullType(schema.stringType()));
-    core.addArgument('as', schema.stringType());
-    if (this.supportPurposes()) {
-      const purposeEnum = schema.addType(new EnumType(`${nameInSchema}__Purpose`));
-      for (const purpose of corePurposes) {
-        purposeEnum.addValue(purpose).description = purposesDescription(purpose);
-      }
-      core.addArgument('for', purposeEnum);
-    }
-    if (this.supportImport()) {
-      const importType = schema.addType(new ScalarType(`${nameInSchema}__Import`));
-      core.addArgument('import', new ListType(importType));
+  addToSchema(schema: Schema, as?: string): GraphQLError[] {
+    const errors = this.addDefinitionsToSchema(schema, as);
+    if (errors.length > 0) {
+      return errors;
     }
 
     // Note: we don't use `applyFeatureToSchema` because it would complain the schema is not a core schema, which it isn't
@@ -333,7 +360,25 @@ export class CoreSpecDefinition extends FeatureDefinition {
     if (as) {
       args.as = as;
     }
-    schema.schemaDefinition.applyDirective(nameInSchema, args);
+    schema.schemaDefinition.applyDirective(as ?? this.url.name, args, true);
+    return [];
+  }
+
+  addDefinitionsToSchema(schema: Schema, as?: string): GraphQLError[] {
+    const existingCore = schema.coreFeatures;
+    if (existingCore) {
+      if (existingCore.coreItself.url.identity === this.identity) {
+        // Already exists with the same version, let it be.
+        return [];
+      } else {
+        return [ERRORS.INVALID_LINK_DIRECTIVE_USAGE.err({
+          message: `Cannot add feature ${this} to the schema, it already uses ${existingCore.coreItself.url}`
+        })];
+      }
+    }
+
+    const nameInSchema = as ?? this.url.name;
+    return this.directiveDefinitionSpec.checkOrAdd(schema, nameInSchema);
   }
 
   /**
@@ -381,7 +426,7 @@ export class CoreSpecDefinition extends FeatureDefinition {
     return feature.url.version;
   }
 
-  applyFeatureToSchema(schema: Schema, feature: FeatureDefinition, as?: string, purpose?: CorePurpose) {
+  applyFeatureToSchema(schema: Schema, feature: FeatureDefinition, as?: string, purpose?: CorePurpose): GraphQLError[] {
     const coreDirective = this.coreDirective(schema);
     const args = {
       [this.urlArgName()]: feature.toString(),
@@ -391,8 +436,9 @@ export class CoreSpecDefinition extends FeatureDefinition {
       args.for = purpose;
     }
     schema.schemaDefinition.applyDirective(coreDirective, args);
-    feature.addElementsToSchema(schema);
+    return feature.addElementsToSchema(schema);
   }
+
   extractFeatureUrl(args: CoreOrLinkDirectiveArgs): FeatureUrl {
     return FeatureUrl.parse(args[this.urlArgName()]!);
   }

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -280,7 +280,7 @@ export function isCoreSpecDirectiveApplication(directive: Directive<SchemaDefini
     return false;
   }
   const urlArg = definition.argument('url') ?? definition.argument('feature');
-  if (!urlArg || !sameType(urlArg.type!, new NonNullType(directive.schema().stringType()))) {
+  if (!urlArg || !isValidUrlArgumentType(urlArg.type!, directive.schema())) {
     return false;
   }
 
@@ -295,6 +295,15 @@ export function isCoreSpecDirectiveApplication(directive: Directive<SchemaDefini
   } catch (err) {
     return false;
   }
+}
+
+function isValidUrlArgumentType(type: InputType, schema: Schema): boolean {
+  // Note that the 'url' arg is defined as nullable (mostly for future proofing reasons) but we allow use to provide a definition
+  // where it's non-nullable (and in practice, @core (which we never generate anymore, but recognize) definition technically uses
+  // with a non-nullable argument, and some fed2 previews did if for @link, so this ensure we handle reading schema generated
+  // by those versions just fine).
+  return sameType(type, schema.stringType())
+    || sameType(type, new NonNullType(schema.stringType()));
 }
 
 const linkPurposeTypeSpec = createEnumTypeSpecification({
@@ -319,7 +328,7 @@ export class CoreSpecDefinition extends FeatureDefinition {
 
   private createDefinitionArgumentSpecifications(schema: Schema, nameInSchema?: string): { args: ArgumentSpecification[], errors: GraphQLError[] } {
     const args: ArgumentSpecification[] = [
-      { name: this.urlArgName(), type: new NonNullType(schema.stringType()) },
+      { name: this.urlArgName(), type: schema.stringType() },
       { name: 'as', type: schema.stringType() },
     ];
     if (this.supportPurposes()) {

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -11,6 +11,7 @@ import {
 import { GraphQLError, DirectiveLocation } from "graphql";
 import { registerKnownFeature } from "./knownCoreFeatures";
 import { ERRORS } from "./error";
+import { createDirectiveSpecification } from "./directiveAndTypeSpecification";
 
 export const inaccessibleIdentity = 'https://specs.apollo.dev/inaccessible';
 
@@ -21,13 +22,18 @@ export const inaccessibleLocations = [
   DirectiveLocation.UNION,
 ];
 
+export const inaccessibleDirectiveSpec = createDirectiveSpecification({
+  name: 'inaccessible',
+  locations: [...inaccessibleLocations],
+});
+
 export class InaccessibleSpecDefinition extends FeatureDefinition {
   constructor(version: FeatureVersion) {
     super(new FeatureUrl(inaccessibleIdentity, 'inaccessible', version));
   }
 
-  addElementsToSchema(schema: Schema) {
-    this.addDirective(schema, 'inaccessible').addLocations(...inaccessibleLocations);
+  addElementsToSchema(schema: Schema): GraphQLError[] {
+    return this.addDirectiveSpec(schema, inaccessibleDirectiveSpec);
   }
 
   inaccessibleDirective(schema: Schema): DirectiveDefinition<Record<string, never>> {

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -1,4 +1,4 @@
-import { DirectiveLocation } from 'graphql';
+import { DirectiveLocation, GraphQLError } from 'graphql';
 import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
 import {
   DirectiveDefinition,
@@ -39,7 +39,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
     return this.version.equals(new FeatureVersion(0, 1));
   }
 
-  addElementsToSchema(schema: Schema) {
+  addElementsToSchema(schema: Schema): GraphQLError[] {
     const joinGraph = this.addDirective(schema, 'graph').addLocations(DirectiveLocation.ENUM_VALUE);
     joinGraph.addArgument('name', new NonNullType(schema.stringType()));
     joinGraph.addArgument('url', new NonNullType(schema.stringType()));
@@ -89,6 +89,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
       const joinOwner = this.addDirective(schema, 'owner').addLocations(DirectiveLocation.OBJECT);
       joinOwner.addArgument('graph', new NonNullType(graphEnum));
     }
+    return [];
   }
 
   allElementNames(): string[] {


### PR DESCRIPTION
This fixes the issue described on #1657 but also fix some related handling of errors (that were not properly surfaced previously). I made a separate PR because the issue was not so much with composition than with subgraph validations, so I preferred moving tests in the existing test file dedicated to those subgraph validations. But also, the repro from #1657 uses some definitions that are not exactly the ones that have been used so far and so it doesn't  pass for those reasons.