### PR TITLE
Fix validation issue introduced by #1653

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/federation-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+
+- Fix regression in composition validation introduced by #1653 [PR #1673](https://github.com/apollographql/federation/pull/1673) .
+
 ## v2.0.0-preview.9
 
 - Fix handling of core/link when definitions are provided or partially so [PR #1662](https://github.com/apollographql/federation/pull/1662).

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+
+- Fix regression in composition validation introduced by #1653 [PR #1673](https://github.com/apollographql/federation/pull/1673) .
+
 ## v2.0.0-preview.9
 
 - Adds support for the `@override` directive on fields to indicate that a field should be moved from one subgraph to another. [PR #1484](https://github.com/apollographql/federation/pull/1484)

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -1008,7 +1008,6 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
         debug.groupEnd(`Ignored: edge is excluded`);
         continue;
       }
-      excludedEdges = addEdgeExclusion(excludedEdges, edge);
 
       // We can only take a non-collecting transition that preserves the current type (typically,
       // jumping subgraphs through a key), with the exception of the federated graph roots, where
@@ -1067,7 +1066,7 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
         edge,
         conditionResolver,
         context,
-        excludedEdges,
+        addEdgeExclusion(excludedEdges, edge),
         excludedConditions,
       );
       if (conditionResolution.satisfied) {


### PR DESCRIPTION
The "edge following other edges"-precomputation optimization introduced
in #1653 introduced a regression in the composition composition code.

The problem is due to the fact that the optimization was assuming that
the validation/query planning algorithm would always find optimal paths,
but the algorithm was a bit too aggressive at avoid some edges given
that new optimization is in place.

Let's use the example this patch uses as test to illustrate:
```graphql
type Query {
  t: T
}

type T @key(fields: "k1") {
  k1: Int
}
```
```graphql
type T @key(fields: "k2") @key(fields: "k1") {
  k1: Int
  k2: Int
}
```
```graphql
type T @key(fields: "k2") {
  k2: Int
  v: Int
}
```
When the algorithm is on `T` in `A` and looks for `v`, it tries to find
where keys can lead it. In doing so, it:
1. looked first at key `k2` to B and checked if it was usable. And it is,
   provided we first use key `k1` to get `k1` from B. It's inefficient
   but possiblly (it's arguably dumb, but it's an algorithm, it has no
   shame).
2. then looked at key `k1` to B. Now, it actually ignored that edge
   because it already had a path to B (the one from the previous point).
   That's because the validation algorithm doesn't care one bit about
   efficiency, and that is not the issue. The issue is that the
   algorithm was also marking that edge "excluded" for remainder of
   the "current loop".
3. it looked at `k2` to C, which is actually edge we want to use. But
   unfortunately, to use it, we first need to get `k2` from B using `k1`
   and as mentioned in the previous point, we had mistankenly excluded
   that edge, so that edge was considered a dead end when it shouldn't.
4. at that point the algorithm was actually looking back at the path
   it found in point 1, which got it to B, and checked if it could get
   to C from there. That's where the algorithm "used to" make progress
   by, at this point, using the `k2` edge from B to C. But the
   optimization from #1653 made use ignore that edge, on account that
   we never should have to use it.

Note that the optimization of #1653 is not really to blame: the true
problem is that in point 3 above, we're not able to use the `k2` edge
from A to C due to an incorrect exclusion. It just happens that
before #1653, the algorithm was able to get back on its feet by using
an inefficient option it shouldn't have had to use.

Long story short, the patch fixes the exclusion issue.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
