### PR TITLE
Add support for inaccessible v0.2

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -2621,7 +2621,7 @@ describe('composition', () => {
       const result = composeAsFed2Subgraphs([subgraphA, subgraphB]);
       expect(result.errors).toBeDefined();
       expect(errors(result)).toStrictEqual([
-        ['REFERENCED_INACCESSIBLE', 'Field "Query.q2" returns @inaccessible type "A" without being marked @inaccessible itself.']
+        ['REFERENCED_INACCESSIBLE', 'Type "A" is @inaccessible but is referenced by "Query.q2", which is in the API schema.']
       ]);
 
       // Because @inaccessible are thrown by the toAPISchema code and not the merge code directly, let's make sure the include
@@ -2630,13 +2630,13 @@ describe('composition', () => {
       // guarantees us that we do get subgraph nodes and not supergraph nodes because supergraph nodes would have @join__*
       // directives and would _not_ have the `@shareable`/`@inacessible` directives.
       const nodes = result.errors![0].nodes!;
-      expect(print(nodes[0])).toMatchString('q2: A');
-      expect(print(nodes[1])).toMatchString(`
+      expect(print(nodes[0])).toMatchString(`
         type A @shareable @inaccessible {
           x: Int
           y: Int
         }`
       );
+      expect(print(nodes[1])).toMatchString('q2: A');
     })
   });
 

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -64,7 +64,6 @@ import {
   didYouMean,
   suggestionList,
   EnumValue,
-  inaccessibleDirectiveSpec,
   baseType,
   isEnumType,
   filterTypesOfKind,
@@ -80,6 +79,7 @@ const linkSpec = LINK_VERSIONS.latest();
 type FieldOrUndefinedArray = (FieldDefinition<any> | undefined)[];
 
 const joinSpec = JOIN_VERSIONS.latest();
+const inaccessibleSpec = INACCESSIBLE_VERSIONS.latest();
 
 export type MergeResult = MergeSuccess | MergeFailure;
 
@@ -1661,7 +1661,7 @@ class Merger {
     this.mergeDescription(valueSources, value);
     this.mergeAppliedDirectives(valueSources, value);
 
-    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(inaccessibleDirectiveSpec.name);
+    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(inaccessibleSpec.inaccessibleDirectiveSpec.name);
     const isInaccessible = inaccessibleInSupergraph && value.hasAppliedDirective(inaccessibleInSupergraph);
     // The merging strategy depends on the enum type usage:
     //  - if it is _only_ used in position of Input type, we merge it with an "intersection" strategy (like other input types/things).
@@ -1732,7 +1732,7 @@ class Merger {
   }
 
   private mergeInput(sources: (InputObjectType | undefined)[], dest: InputObjectType) {
-    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(inaccessibleDirectiveSpec.name);
+    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(inaccessibleSpec.inaccessibleDirectiveSpec.name);
 
     // Like for other inputs, we add all the fields found in any subgraphs initially as a simple mean to have a complete list of
     // field to iterate over, but we will remove those that are not in all subgraphs.

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -2345,14 +2345,6 @@ class Merger {
             [...elementsNodes, ...parentNodes]
           );
         }
-        case ERRORS.INVALID_DEFAULT_VALUE.code: {
-          const element = err.extensions['element'];
-          // Default values are merged via intersection, so no need to filter
-          // out any subgraph elements here.
-          const elementNodes = sourceASTsForCoordinate(element);
-
-          return withModifiedErrorNodes(err, elementNodes);
-        }
         default:
           return err;
       }

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -18,7 +18,9 @@ The following errors may be raised by composition:
 
 | Code | Description | Since | Comment |
 |---|---|---|---|
+| `DEFAULT_VALUE_USES_INACCESSIBLE` | An element is marked as @inaccessible but is used in the default value of an element visible in the API schema. | 2.0.0 |  |
 | `DIRECTIVE_DEFINITION_INVALID` | A built-in or federation directive has an invalid definition in the schema. | 2.0.0 | Replaces: `TAG_DEFINITION_INVALID` |
+| `DISALLOWED_INACCESSIBLE` | An element is marked as @inaccessible that is not allowed to be @inaccessible. | 2.0.0 |  |
 | `EMPTY_MERGED_ENUM_TYPE` | An enum type has no value common to all the subgraphs that define the type. Merging that type would result in an invalid empty enum type. | 2.0.0 |  |
 | `EMPTY_MERGED_INPUT_TYPE` | An input object type has no field common to all the subgraphs that define the type. Merging that type would result in an invalid empty input object type. | 2.0.0 |  |
 | `ENUM_VALUE_MISMATCH` | An enum type that is used as both an input and output type has a value that is not defined in all the subgraphs that define the enum type. | 2.0.0 |  |
@@ -33,6 +35,7 @@ The following errors may be raised by composition:
 | `FIELD_ARGUMENT_DEFAULT_MISMATCH` | An argument (of a field/directive) has a default value that is incompatible with that of other declarations of that same argument in other subgraphs. | 2.0.0 |  |
 | `FIELD_ARGUMENT_TYPE_MISMATCH` | An argument (of a field/directive) has a type that is incompatible with that of other declarations of that same argument in other subgraphs. | 2.0.0 | Replaces: `VALUE_TYPE_INPUT_VALUE_MISMATCH` |
 | `FIELD_TYPE_MISMATCH` | A field has a type that is incompatible with other declarations of that field in other subgraphs. | 2.0.0 | Replaces: `VALUE_TYPE_FIELD_TYPE_MISMATCH` |
+| `IMPLEMENTED_BY_INACCESSIBLE` | An element is marked as @inaccessible but implements an element visible in the API schema. | 2.0.0 |  |
 | `INPUT_FIELD_DEFAULT_MISMATCH` | An input field has a default value that is incompatible with other declarations of that field in other subgraphs. | 2.0.0 |  |
 | `INTERFACE_FIELD_IMPLEM_TYPE_MISMATCH` | For an interface field, some of its concrete implementations have @external or @requires and there is difference in those implementations return type (which is currently not supported; see https://github.com/apollographql/federation/issues/1257) | 2.0.0 |  |
 | `INTERFACE_FIELD_NO_IMPLEM` | After subgraph merging, an implemenation is missing a field of one of the interface it implements (which can happen for valid subgraphs). | 2.0.0 |  |
@@ -49,6 +52,7 @@ The following errors may be raised by composition:
 | `MERGED_DIRECTIVE_APPLICATION_ON_EXTERNAL` | In a subgraph, a field is both marked @external and has a merged directive applied to it | 2.0.0 |  |
 | `NO_QUERIES` | None of the composed subgraphs expose any query. | 2.0.0 |  |
 | `NON_REPEATABLE_DIRECTIVE_ARGUMENTS_MISMATCH` | A non-repeatable directive is applied to a schema element in different subgraphs but with arguments that are different. | 2.0.0 |  |
+| `ONLY_INACCESSIBLE_CHILDREN` | A type visible in the API schema has only @inaccessible children. | 2.0.0 |  |
 | `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
 | `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
 | `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
@@ -58,8 +62,10 @@ The following errors may be raised by composition:
 | `PROVIDES_INVALID_FIELDS` | The `fields` argument of a `@provides` directive is invalid (it has invalid syntax, includes unknown fields, ...). | 2.0.0 |  |
 | `PROVIDES_ON_NON_OBJECT_FIELD` | A `@provides` directive is used to mark a field whose base type is not an object type. | 2.0.0 |  |
 | `PROVIDES_UNSUPPORTED_ON_INTERFACE` | A `@provides` directive is used on an interface, which is not (yet) supported. | 2.0.0 |  |
-| `REFERENCED_INACCESSIBLE` | An element is marked as @inaccessible but is referenced by a non-inaccessible element. | 2.0.0 |  |
+| `QUERY_ROOT_TYPE_INACCESSIBLE` | An element is marked as @inaccessible but is the query root type, which must be visible in the API schema. | 2.0.0 |  |
+| `REFERENCED_INACCESSIBLE` | An element is marked as @inaccessible but is referenced by an element visible in the API schema. | 2.0.0 |  |
 | `REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH` | An argument of a field or directive definition is mandatory in some subgraphs, but the argument is not defined in all the subgraphs that define the field or directive definition. | 2.0.0 |  |
+| `REQUIRED_INACCESSIBLE` | An element is marked as @inaccessible but is required by an element visible in the API schema. | 2.0.0 |  |
 | `REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH` | A field of an input object type is mandatory in some subgraphs, but the field is not defined in all the subgraphs that define the input object type. | 2.0.0 |  |
 | `REQUIRES_FIELDS_HAS_ARGS` | The `fields` argument of a `@requires` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `REQUIRES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@requires` directive includes a field that is not marked as `@external`. | 0.x |  |

--- a/internals-js/src/__tests__/removeInaccessibleElements.test.ts
+++ b/internals-js/src/__tests__/removeInaccessibleElements.test.ts
@@ -1,25 +1,122 @@
-import { ObjectType } from "../definitions";
+import {
+  errorCauses,
+  InterfaceType,
+  ObjectType,
+  UnionType,
+} from "../definitions";
 import { buildSchema } from "../buildSchema";
-import { apiSchemaValidationErrorCode } from "../coreSpec";
 import { removeInaccessibleElements } from "../inaccessibleSpec";
 import { GraphQLErrorExt } from "@apollo/core-schema/dist/error";
 import { GraphQLError } from "graphql";
 
 describe("removeInaccessibleElements", () => {
-  function errorCauses(e: Error): GraphQLError[] {
+  const INACCESSIBLE_V02_HEADER = `
+    directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
+
+    enum core__Purpose {
+      EXECUTION
+      SECURITY
+    }
+
+    directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+    schema
+      @core(feature: "https://specs.apollo.dev/core/v0.2")
+      @core(feature: "https://specs.apollo.dev/inaccessible/v0.2")
+    {
+      query: Query
+    }
+  `;
+
+  function getCauses(e: unknown): GraphQLError[] {
     expect(e instanceof GraphQLErrorExt).toBeTruthy();
-    const error = e as GraphQLErrorExt<string>;
-    expect(error.code).toStrictEqual(apiSchemaValidationErrorCode);
-    const causes = (error as any).causes;
+    const causes = errorCauses(e as Error);
+    expect(causes).toBeDefined();
     expect(Array.isArray(causes)).toBeTruthy();
-    return causes as GraphQLError[];
+    for (const cause of causes!) {
+      expect(cause instanceof GraphQLError).toBeTruthy();
+    }
+    return causes!;
   }
 
-  it(`removes @inaccessible fields`, () => {
+  function expectErrors(expectedCauseCount: number, f: () => void): string[] {
+    let error: unknown = undefined;
+    try {
+      f();
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeDefined();
+    const causes = getCauses(error);
+    expect(causes).toHaveLength(expectedCauseCount);
+    const messages = causes.map((cause) => cause.message);
+    for (const message of messages) {
+      expect(typeof message === "string").toBeTruthy();
+    }
+    messages.sort();
+    return messages;
+  }
+
+  it(`succeeds for no inaccessible spec`, () => {
     const schema = buildSchema(`
       directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
 
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+      enum core__Purpose {
+        EXECUTION
+        SECURITY
+      }
+
+      schema
+        @core(feature: "https://specs.apollo.dev/core/v0.2")
+      {
+        query: Query
+      }
+
+      type Query {
+        someField: String
+      }
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+  });
+
+  it(`doesn't affect non-core @inaccessible`, () => {
+    const schema = buildSchema(`
+      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
+
+      enum core__Purpose {
+        EXECUTION
+        SECURITY
+      }
+
+      schema
+        @core(feature: "https://specs.apollo.dev/core/v0.2")
+      {
+        query: Query
+      }
+
+      type Query {
+        someField: String @inaccessible
+      }
+
+      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("Query.someField")).toBeDefined();
+  });
+
+  it(`fails for no @inaccessible definition`, () => {
+    const schema = buildSchema(`
+      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
+
+      enum core__Purpose {
+        EXECUTION
+        SECURITY
+      }
 
       schema
         @core(feature: "https://specs.apollo.dev/core/v0.2")
@@ -28,10 +125,1157 @@ describe("removeInaccessibleElements", () => {
         query: Query
       }
 
+      type Query {
+        someField: String
+      }
+    `);
+
+    const errorMessages = expectErrors(1, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Invalid schema: declares https://specs.apollo.dev/inaccessible/v0.1 spec but does not define a @inaccessible directive.",
+      ]
+    `);
+  });
+
+  it(`fails for incompatible @inaccessible definition`, () => {
+    const schema = buildSchema(`
+      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
+
       enum core__Purpose {
         EXECUTION
         SECURITY
       }
+
+      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+      schema
+        @core(feature: "https://specs.apollo.dev/core/v0.2")
+        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
+      {
+        query: Query
+      }
+
+      type Query {
+        someField: String
+      }
+    `);
+
+    const errorMessages = expectErrors(1, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Found invalid @inaccessible directive definition. Please ensure the directive definition in your schema's definitions matches the following:
+      	directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION",
+      ]
+    `);
+  });
+
+  it(`handles renames of @inaccessible`, () => {
+    const schema = buildSchema(`
+      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
+
+      enum core__Purpose {
+        EXECUTION
+        SECURITY
+      }
+
+      directive @foo on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+      schema
+        @core(feature: "https://specs.apollo.dev/core/v0.2")
+        @core(feature: "https://specs.apollo.dev/inaccessible/v0.2", as: "foo")
+      {
+        query: Query
+      }
+
+      type Query {
+        someField: Bar @inaccessible
+        privateField: String @foo
+      }
+
+      scalar Bar
+
+      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("Query.someField")).toBeDefined();
+    expect(schema.elementByCoordinate("Query.privateField")).toBeUndefined();
+  });
+
+  it(`fails for @inaccessible built-ins`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Built-in scalar
+      scalar String @inaccessible
+
+      # Built-in directive
+      directive @deprecated(
+        reason: String = "No longer supported" @inaccessible
+      ) on FIELD_DEFINITION | ENUM_VALUE
+    `);
+
+    const errorMessages = expectErrors(2, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Built-in directive \\"@deprecated\\" cannot use @inaccessible.",
+        "Built-in type \\"String\\" cannot use @inaccessible.",
+      ]
+    `);
+  });
+
+  it(`fails for @inaccessible core feature definitions`, () => {
+    const schema = buildSchema(`
+      directive @core(feature: String! @inaccessible, as: String, for: core__Purpose) repeatable on SCHEMA
+
+      enum core__Purpose {
+        EXECUTION @inaccessible
+        SECURITY
+      }
+
+      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+      schema
+        @core(feature: "https://specs.apollo.dev/core/v0.2")
+        @core(feature: "https://specs.apollo.dev/inaccessible/v0.2")
+        @core(feature: "http://localhost/foo/v1.0")
+      {
+        query: Query
+      }
+
+      type Query {
+        someField: String!
+      }
+
+      # Object type
+      type foo__Object1 @inaccessible {
+        foo__Field: String!
+      }
+
+      # Object field
+      type foo__Object2 implements foo__Interface2 {
+        foo__Field: foo__Enum1! @inaccessible
+      }
+
+      # Object field argument
+      type foo__Object3 {
+        someField(someArg: foo__Enum1 @inaccessible): foo__Enum2!
+      }
+
+      # Interface type
+      interface foo__Interface1 @inaccessible {
+        foo__Field: String!
+      }
+
+      # Interface field
+      interface foo__Interface2 {
+        foo__Field: foo__Enum1! @inaccessible
+      }
+
+      # Interface field argument
+      interface foo__Interface3 {
+        someField(someArg: foo__InputObject1 @inaccessible): foo__Enum2!
+      }
+
+      # Union type
+      union foo__Union @inaccessible = foo__Object1 | foo__Object2 | foo__Object3
+
+      # Input object type
+      input foo__InputObject1 @inaccessible {
+        someField: foo__Enum1
+      }
+
+      # Input object field
+      input foo__InputObject2 {
+        someField: foo__Scalar @inaccessible
+      }
+
+      # Enum type
+      enum foo__Enum1 @inaccessible {
+        someValue
+      }
+
+      # Enum value
+      enum foo__Enum2 {
+        someValue @inaccessible
+      }
+
+      # Scalar type
+      scalar foo__Scalar @inaccessible
+
+      # Directive argument
+      directive @foo(arg: foo__InputObject2 @inaccessible) repeatable on OBJECT
+    `);
+
+    // 15 = 6 type kinds + 3 field kinds + 3 argument kinds + 1 enum value + 2 extras on special core elements
+    const errorMessages = expectErrors(15, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Core feature directive \\"@core\\" cannot use @inaccessible.",
+        "Core feature directive \\"@foo\\" cannot use @inaccessible.",
+        "Core feature type \\"core__Purpose\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Enum1\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Enum2\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__InputObject1\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__InputObject2\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Interface1\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Interface2\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Interface3\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Object1\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Object2\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Object3\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Scalar\\" cannot use @inaccessible.",
+        "Core feature type \\"foo__Union\\" cannot use @inaccessible.",
+      ]
+    `);
+  });
+
+  it(`fails for @inaccessible directive definitions that aren't only executable`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      directive @foo(arg1: String @inaccessible) repeatable on OBJECT
+
+      directive @bar(arg2: String, arg3: String @inaccessible) repeatable on SCHEMA | FIELD
+    `);
+
+    const errorMessages = expectErrors(2, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Directive \\"@bar\\" cannot use @inaccessible because it may be applied to these type-system locations: SCHEMA.",
+        "Directive \\"@foo\\" cannot use @inaccessible because it may be applied to these type-system locations: OBJECT.",
+      ]
+    `);
+  });
+
+  it(`removes @inaccessible object types`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      extend schema {
+        mutation: Mutation
+        subscription: Subscription
+      }
+
+      # Non-inaccessible object type
+      type Query {
+        someField: String
+      }
+
+      # Inaccessible mutation types should be removed
+      type Mutation @inaccessible {
+        someObject: Object
+      }
+
+      # Inaccessible subscription types should be removed
+      type Subscription @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible object type
+      type Object @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible object type referenced by inaccessible object field
+      type Referencer1 implements Referencer3 {
+        someField: String
+        privatefield: Object! @inaccessible
+      }
+
+      # Inaccessible object type referenced by non-inaccessible object field
+      # with inaccessible parent
+      type Referencer2 implements Referencer4 @inaccessible {
+        privateField: [Object!]!
+      }
+
+      # Inaccessible object type referenced by inaccessible interface field
+      interface Referencer3 {
+        someField: String
+        privatefield: Object @inaccessible
+      }
+
+      # Inaccessible object type referenced by non-inaccessible interface field
+      # with inaccessible parent
+      interface Referencer4 @inaccessible {
+        privateField: [Object]
+      }
+
+      # Inaccessible object type referenced by union member with
+      # non-inaccessible siblings and parent
+      union Referencer5 = Query | Object
+
+      # Inaccessible object type referenced by union member with no siblings
+      # but with inaccessible parent
+      union Referencer6 @inaccessible = Object
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("Query")).toBeDefined();
+    expect(schema.elementByCoordinate("Mutation")).toBeUndefined();
+    expect(schema.elementByCoordinate("Subscription")).toBeUndefined();
+    expect(schema.elementByCoordinate("Object")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer1.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer1.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer2")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer3.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer3.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer4")).toBeUndefined();
+    const unionType = schema.elementByCoordinate("Referencer5");
+    expect(unionType instanceof UnionType).toBeTruthy();
+    expect((unionType as UnionType).hasTypeMember("Query")).toBeTruthy();
+    expect((unionType as UnionType).hasTypeMember("Object")).toBeFalsy();
+    expect(schema.elementByCoordinate("Referencer6")).toBeUndefined();
+  });
+
+  it(`fails to remove @inaccessible object types for breaking removals`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      # Query types can't be inaccessible
+      type Query @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible object type
+      type Object @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible object type can't be referenced by object field in the API
+      # schema
+      type Referencer1 implements Referencer2 {
+        someField: Object!
+      }
+
+      # Inaccessible object type can't be referenced by interface field in the
+      # API schema
+      interface Referencer2 {
+        someField: Object
+      }
+
+      # Inaccessible object type can't be referenced by union member with a
+      # non-inaccessible parent and no non-inaccessible siblings
+      union Referencer3 = Object
+    `);
+
+    const errorMessages = expectErrors(4, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Type \\"Object\\" is @inaccessible but is referenced by \\"Referencer1.someField\\", which is in the API schema.",
+        "Type \\"Object\\" is @inaccessible but is referenced by \\"Referencer2.someField\\", which is in the API schema.",
+        "Type \\"Query\\" is @inaccessible but is the root query type, which must be in the API schema.",
+        "Type \\"Referencer3\\" is in the API schema but all of its members are @inaccessible.",
+      ]
+    `);
+  });
+
+  it(`removes @inaccessible interface types`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Non-inaccessible interface type
+      interface VisibleInterface {
+        someField: String
+      }
+
+      # Inaccessible interface type
+      interface Interface @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible interface type referenced by inaccessible object field
+      type Referencer1 implements Referencer3 {
+        someField: String
+        privatefield: Interface! @inaccessible
+      }
+
+      # Inaccessible interface type referenced by non-inaccessible object field
+      # with inaccessible parent
+      type Referencer2 implements Referencer4 @inaccessible {
+        privateField: [Interface!]!
+      }
+
+      # Inaccessible interface type referenced by inaccessible interface field
+      interface Referencer3 {
+        someField: String
+        privatefield: Interface @inaccessible
+      }
+
+      # Inaccessible interface type referenced by non-inaccessible interface
+      # field with inaccessible parent
+      interface Referencer4 @inaccessible {
+        privateField: [Interface]
+      }
+
+      # Inaccessible interface type referenced by object type implements
+      type Referencer5 implements VisibleInterface & Interface {
+        someField: String
+      }
+
+      # Inaccessible interface type referenced by interface type implements
+      interface Referencer6 implements VisibleInterface & Interface {
+        someField: String
+      }
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("VisibleInterface")).toBeDefined();
+    expect(schema.elementByCoordinate("Interface")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer1.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer1.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer2")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer3.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer3.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer4")).toBeUndefined();
+    const objectType = schema.elementByCoordinate("Referencer5");
+    expect(objectType instanceof ObjectType).toBeTruthy();
+    expect(
+      (objectType as ObjectType).implementsInterface("VisibleInterface")
+    ).toBeTruthy();
+    expect(
+      (objectType as ObjectType).implementsInterface("Interface")
+    ).toBeFalsy();
+    const interfaceType = schema.elementByCoordinate("Referencer6");
+    expect(interfaceType instanceof InterfaceType).toBeTruthy();
+    expect(
+      (interfaceType as InterfaceType).implementsInterface("VisibleInterface")
+    ).toBeTruthy();
+    expect(
+      (interfaceType as InterfaceType).implementsInterface("Interface")
+    ).toBeFalsy();
+  });
+
+  it(`fails to remove @inaccessible interface types for breaking removals`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Inaccessible interface type
+      interface Interface @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible interface type can't be referenced by object field in the
+      # API schema
+      type Referencer1 implements Referencer2 {
+        someField: [Interface!]!
+      }
+
+      # Inaccessible interface type can't be referenced by interface field in
+      # the API schema
+      interface Referencer2 {
+        someField: [Interface]
+      }
+    `);
+
+    const errorMessages = expectErrors(2, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Type \\"Interface\\" is @inaccessible but is referenced by \\"Referencer1.someField\\", which is in the API schema.",
+        "Type \\"Interface\\" is @inaccessible but is referenced by \\"Referencer2.someField\\", which is in the API schema.",
+      ]
+    `);
+  });
+
+  it(`removes @inaccessible union types`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Non-inaccessible union type
+      union VisibleUnion = Query
+
+      # Inaccessible union type
+      union Union @inaccessible = Query
+
+      # Inaccessible union type referenced by inaccessible object field
+      type Referencer1 implements Referencer3 {
+        someField: String
+        privatefield: Union! @inaccessible
+      }
+
+      # Inaccessible union type referenced by non-inaccessible object field with
+      # inaccessible parent
+      type Referencer2 implements Referencer4 @inaccessible {
+        privateField: [Union!]!
+      }
+
+      # Inaccessible union type referenced by inaccessible interface field
+      interface Referencer3 {
+        someField: String
+        privatefield: Union @inaccessible
+      }
+
+      # Inaccessible union type referenced by non-inaccessible interface field
+      # with inaccessible parent
+      interface Referencer4 @inaccessible {
+        privateField: [Union]
+      }
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("VisibleUnion")).toBeDefined();
+    expect(schema.elementByCoordinate("Union")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer1.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer1.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer2")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer3.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer3.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer4")).toBeUndefined();
+  });
+
+  it(`fails to remove @inaccessible union types for breaking removals`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Inaccessible union type
+      union Union @inaccessible = Query
+
+      # Inaccessible union type can't be referenced by object field in the API
+      # schema
+      type Referencer1 implements Referencer2 {
+        someField: Union!
+      }
+
+      # Inaccessible union type can't be referenced by interface field in the
+      # API schema
+      interface Referencer2 {
+        someField: Union
+      }
+    `);
+
+    const errorMessages = expectErrors(2, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Type \\"Union\\" is @inaccessible but is referenced by \\"Referencer1.someField\\", which is in the API schema.",
+        "Type \\"Union\\" is @inaccessible but is referenced by \\"Referencer2.someField\\", which is in the API schema.",
+      ]
+    `);
+  });
+
+  it(`removes @inaccessible input object types`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Non-inaccessible input object type
+      input VisibleInputObject {
+        someField: String
+      }
+
+      # Inaccessible input object type
+      input InputObject @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible input object type referenced by inaccessible object field
+      # argument
+      type Referencer1 implements Referencer4 {
+        someField(privateArg: InputObject @inaccessible): String
+      }
+
+      # Inaccessible input object type referenced by non-inaccessible object
+      # field argument with inaccessible parent
+      type Referencer2 implements Referencer5 {
+        someField: String
+        privateField(privateArg: InputObject!): String @inaccessible
+      }
+
+      # Inaccessible input object type referenced by non-inaccessible object
+      # field argument with inaccessible grandparent
+      type Referencer3 implements Referencer6 @inaccessible {
+        privateField(privateArg: InputObject!): String
+      }
+
+      # Inaccessible input object type referenced by inaccessible interface
+      # field argument
+      interface Referencer4 {
+        someField(privateArg: InputObject @inaccessible): String
+      }
+
+      # Inaccessible input object type referenced by non-inaccessible interface
+      # field argument with inaccessible parent
+      interface Referencer5 {
+        someField: String
+        privateField(privateArg: InputObject!): String @inaccessible
+      }
+
+      # Inaccessible input object type referenced by non-inaccessible interface
+      # field argument with inaccessible grandparent
+      interface Referencer6 @inaccessible {
+        privateField(privateArg: InputObject!): String
+      }
+
+      # Inaccessible input object type referenced by inaccessible input object
+      # field
+      input Referencer7 {
+        someField: String
+        privateField: InputObject @inaccessible
+      }
+
+      # Inaccessible input object type referenced by non-inaccessible input
+      # object field with inaccessible parent
+      input Referencer8 @inaccessible {
+        privateField: InputObject!
+      }
+
+      # Inaccessible input object type referenced by inaccessible directive
+      # argument
+      directive @referencer9(privateArg: InputObject @inaccessible) on FIELD
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("VisibleInputObject")).toBeDefined();
+    expect(schema.elementByCoordinate("InputObject")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer1.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer1.someField(privateArg:)")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer2.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer2.privateField")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer3")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer4.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer4.someField(privateArg:)")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer5.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer5.privateField")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer6")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer7.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer7.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer8")).toBeUndefined();
+    expect(schema.elementByCoordinate("@referencer9")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("@referencer9(privateArg:)")
+    ).toBeUndefined();
+  });
+
+  it(`fails to remove @inaccessible input object types for breaking removals`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Inaccessible input object type
+      input InputObject @inaccessible {
+        someField: String
+      }
+
+      # Inaccessible input object type can't be referenced by object field
+      # argument in the API schema
+      type Referencer1 implements Referencer2 {
+        someField(someArg: InputObject): String
+      }
+
+      # Inaccessible input object type can't be referenced by interface field
+      # argument in the API schema
+      interface Referencer2 {
+        someField(someArg: InputObject): String
+      }
+
+      # Inaccessible input object type can't be referenced by input object field
+      # in the API schema
+      input Referencer3 {
+        someField: InputObject
+      }
+
+      # Inaccessible input object type can't be referenced by directive argument
+      # in the API schema
+      directive @referencer4(someArg: InputObject) on QUERY
+    `);
+
+    const errorMessages = expectErrors(4, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Type \\"InputObject\\" is @inaccessible but is referenced by \\"@referencer4(someArg:)\\", which is in the API schema.",
+        "Type \\"InputObject\\" is @inaccessible but is referenced by \\"Referencer1.someField(someArg:)\\", which is in the API schema.",
+        "Type \\"InputObject\\" is @inaccessible but is referenced by \\"Referencer2.someField(someArg:)\\", which is in the API schema.",
+        "Type \\"InputObject\\" is @inaccessible but is referenced by \\"Referencer3.someField\\", which is in the API schema.",
+      ]
+    `);
+  });
+
+  it(`removes @inaccessible enum types`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Non-inaccessible enum type
+      enum VisibleEnum {
+        SOME_VALUE
+      }
+
+      # Inaccessible enum type
+      enum Enum @inaccessible {
+        SOME_VALUE
+      }
+
+      # Inaccessible enum type referenced by inaccessible object field
+      type Referencer1 implements Referencer3 {
+        someField: String
+        privatefield: Enum! @inaccessible
+      }
+
+      # Inaccessible enum type referenced by non-inaccessible object field with
+      # inaccessible parent
+      type Referencer2 implements Referencer4 @inaccessible {
+        privateField: [Enum!]!
+      }
+
+      # Inaccessible enum type referenced by inaccessible interface field
+      interface Referencer3 {
+        someField: String
+        privatefield: Enum @inaccessible
+      }
+
+      # Inaccessible enum type referenced by non-inaccessible interface field
+      # with inaccessible parent
+      interface Referencer4 @inaccessible {
+        privateField: [Enum]
+      }
+
+      # Inaccessible enum type referenced by inaccessible object field argument
+      type Referencer5 implements Referencer8 {
+        someField(privateArg: Enum @inaccessible): String
+      }
+
+      # Inaccessible enum type referenced by non-inaccessible object field
+      # argument with inaccessible parent
+      type Referencer6 implements Referencer9 {
+        someField: String
+        privateField(privateArg: Enum!): String @inaccessible
+      }
+
+      # Inaccessible enum type referenced by non-inaccessible object field
+      # argument with inaccessible grandparent
+      type Referencer7 implements Referencer10 @inaccessible {
+        privateField(privateArg: Enum!): String
+      }
+
+      # Inaccessible enum type referenced by inaccessible interface field
+      # argument
+      interface Referencer8 {
+        someField(privateArg: Enum @inaccessible): String
+      }
+
+      # Inaccessible enum type referenced by non-inaccessible interface field
+      # argument with inaccessible parent
+      interface Referencer9 {
+        someField: String
+        privateField(privateArg: Enum!): String @inaccessible
+      }
+
+      # Inaccessible enum type referenced by non-inaccessible interface field
+      # argument with inaccessible grandparent
+      interface Referencer10 @inaccessible {
+        privateField(privateArg: Enum!): String
+      }
+
+      # Inaccessible enum type referenced by inaccessible input object field
+      input Referencer11 {
+        someField: String
+        privateField: Enum @inaccessible
+      }
+
+      # Inaccessible enum type referenced by non-inaccessible input object field
+      # with inaccessible parent
+      input Referencer12 @inaccessible {
+        privateField: Enum!
+      }
+
+      # Inaccessible enum type referenced by inaccessible directive argument
+      directive @referencer13(privateArg: Enum @inaccessible) on FRAGMENT_DEFINITION
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("VisibleEnum")).toBeDefined();
+    expect(schema.elementByCoordinate("Enum")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer1.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer1.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer2")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer3.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer3.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer4")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer5.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer5.someField(privateArg:)")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer6.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer6.privateField")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer7")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer8.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer8.someField(privateArg:)")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer9.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer9.privateField")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer10")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer11.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer11.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer12")).toBeUndefined();
+    expect(schema.elementByCoordinate("@referencer13")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("@referencer13(privateArg:)")
+    ).toBeUndefined();
+  });
+
+  it(`fails to remove @inaccessible enum types for breaking removals`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Inaccessible enum type
+      enum Enum @inaccessible {
+        SOME_VALUE
+      }
+
+      # Inaccessible enum type can't be referenced by object field in the API
+      # schema
+      type Referencer1 implements Referencer2 {
+        somefield: [Enum!]!
+      }
+
+      # Inaccessible enum type can't be referenced by interface field in the API
+      # schema
+      interface Referencer2 {
+        somefield: [Enum]
+      }
+
+      # Inaccessible enum type can't be referenced by object field argument in
+      # the API schema
+      type Referencer3 implements Referencer4 {
+        someField(someArg: Enum): String
+      }
+
+      # Inaccessible enum type can't be referenced by interface field argument
+      # in the API schema
+      interface Referencer4 {
+        someField(someArg: Enum): String
+      }
+
+      # Inaccessible enum type can't be referenced by input object field in the
+      # API schema
+      input Referencer5 {
+        someField: Enum
+      }
+
+      # Inaccessible enum type can't be referenced by directive argument in the
+      # API schema
+      directive @referencer6(someArg: Enum) on FRAGMENT_SPREAD
+    `);
+
+    const errorMessages = expectErrors(6, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Type \\"Enum\\" is @inaccessible but is referenced by \\"@referencer6(someArg:)\\", which is in the API schema.",
+        "Type \\"Enum\\" is @inaccessible but is referenced by \\"Referencer1.somefield\\", which is in the API schema.",
+        "Type \\"Enum\\" is @inaccessible but is referenced by \\"Referencer2.somefield\\", which is in the API schema.",
+        "Type \\"Enum\\" is @inaccessible but is referenced by \\"Referencer3.someField(someArg:)\\", which is in the API schema.",
+        "Type \\"Enum\\" is @inaccessible but is referenced by \\"Referencer4.someField(someArg:)\\", which is in the API schema.",
+        "Type \\"Enum\\" is @inaccessible but is referenced by \\"Referencer5.someField\\", which is in the API schema.",
+      ]
+    `);
+  });
+
+  it(`removes @inaccessible scalar types`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Non-inaccessible scalar type
+      scalar VisibleScalar
+
+      # Inaccessible scalar type
+      scalar Scalar @inaccessible
+
+      # Inaccessible scalar type referenced by inaccessible object field
+      type Referencer1 implements Referencer3 {
+        someField: String
+        privatefield: Scalar! @inaccessible
+      }
+
+      # Inaccessible scalar type referenced by non-inaccessible object field
+      # with inaccessible parent
+      type Referencer2 implements Referencer4 @inaccessible {
+        privateField: [Scalar!]!
+      }
+
+      # Inaccessible scalar type referenced by inaccessible interface field
+      interface Referencer3 {
+        someField: String
+        privatefield: Scalar @inaccessible
+      }
+
+      # Inaccessible scalar type referenced by non-inaccessible interface field
+      # with inaccessible parent
+      interface Referencer4 @inaccessible {
+        privateField: [Scalar]
+      }
+
+      # Inaccessible scalar type referenced by inaccessible object field
+      # argument
+      type Referencer5 implements Referencer8 {
+        someField(privateArg: Scalar @inaccessible): String
+      }
+
+      # Inaccessible scalar type referenced by non-inaccessible object field
+      # argument with inaccessible parent
+      type Referencer6 implements Referencer9 {
+        someField: String
+        privateField(privateArg: Scalar!): String @inaccessible
+      }
+
+      # Inaccessible scalar type referenced by non-inaccessible object field
+      # argument with inaccessible grandparent
+      type Referencer7 implements Referencer10 @inaccessible {
+        privateField(privateArg: Scalar!): String
+      }
+
+      # Inaccessible scalar type referenced by inaccessible interface field
+      # argument
+      interface Referencer8 {
+        someField(privateArg: Scalar @inaccessible): String
+      }
+
+      # Inaccessible scalar type referenced by non-inaccessible interface field
+      # argument with inaccessible parent
+      interface Referencer9 {
+        someField: String
+        privateField(privateArg: Scalar!): String @inaccessible
+      }
+
+      # Inaccessible scalar type referenced by non-inaccessible interface field
+      # argument with inaccessible grandparent
+      interface Referencer10 @inaccessible {
+        privateField(privateArg: Scalar!): String
+      }
+
+      # Inaccessible scalar type referenced by inaccessible input object field
+      input Referencer11 {
+        someField: String
+        privateField: Scalar @inaccessible
+      }
+
+      # Inaccessible scalar type referenced by non-inaccessible input object
+      # field with inaccessible parent
+      input Referencer12 @inaccessible {
+        privateField: Scalar!
+      }
+
+      # Inaccessible scalar type referenced by inaccessible directive argument
+      directive @referencer13(privateArg: Scalar @inaccessible) on INLINE_FRAGMENT
+    `);
+
+    removeInaccessibleElements(schema);
+    schema.validate();
+    expect(schema.elementByCoordinate("VisibleScalar")).toBeDefined();
+    expect(schema.elementByCoordinate("Scalar")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer1.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer1.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer2")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer3.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer3.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer4")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer5.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer5.someField(privateArg:)")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer6.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer6.privateField")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer7")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer8.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer8.someField(privateArg:)")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer9.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer9.privateField")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer10")).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer11.someField")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("Referencer11.privatefield")
+    ).toBeUndefined();
+    expect(schema.elementByCoordinate("Referencer12")).toBeUndefined();
+    expect(schema.elementByCoordinate("@referencer13")).toBeDefined();
+    expect(
+      schema.elementByCoordinate("@referencer13(privateArg:)")
+    ).toBeUndefined();
+  });
+
+  it(`fails to remove @inaccessible scalar types for breaking removals`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
+
+      type Query {
+        someField: String
+      }
+
+      # Inaccessible scalar type
+      scalar Scalar @inaccessible
+
+      # Inaccessible scalar type can't be referenced by object field in the API
+      # schema
+      type Referencer1 implements Referencer2 {
+        somefield: [[Scalar!]!]!
+      }
+
+      # Inaccessible scalar type can't be referenced by interface field in the
+      # API schema
+      interface Referencer2 {
+        somefield: [[Scalar]]
+      }
+
+      # Inaccessible scalar type can't be referenced by object field argument in
+      # the API schema
+      type Referencer3 implements Referencer4 {
+        someField(someArg: Scalar): String
+      }
+
+      # Inaccessible scalar type can't be referenced by interface field argument
+      # in the API schema
+      interface Referencer4 {
+        someField(someArg: Scalar): String
+      }
+
+      # Inaccessible scalar type can't be referenced by input object field in
+      # the API schema
+      input Referencer5 {
+        someField: Scalar
+      }
+
+      # Inaccessible scalar type can't be referenced by directive argument in
+      # the API schema
+      directive @referencer6(someArg: Scalar) on MUTATION
+    `);
+
+    const errorMessages = expectErrors(6, () => {
+      removeInaccessibleElements(schema);
+    });
+
+    expect(errorMessages).toMatchInlineSnapshot(`
+      Array [
+        "Type \\"Scalar\\" is @inaccessible but is referenced by \\"@referencer6(someArg:)\\", which is in the API schema.",
+        "Type \\"Scalar\\" is @inaccessible but is referenced by \\"Referencer1.somefield\\", which is in the API schema.",
+        "Type \\"Scalar\\" is @inaccessible but is referenced by \\"Referencer2.somefield\\", which is in the API schema.",
+        "Type \\"Scalar\\" is @inaccessible but is referenced by \\"Referencer3.someField(someArg:)\\", which is in the API schema.",
+        "Type \\"Scalar\\" is @inaccessible but is referenced by \\"Referencer4.someField(someArg:)\\", which is in the API schema.",
+        "Type \\"Scalar\\" is @inaccessible but is referenced by \\"Referencer5.someField\\", which is in the API schema.",
+      ]
+    `);
+  });
+
+  it(`removes @inaccessible object fields`, () => {
+    const schema = buildSchema(`
+      ${INACCESSIBLE_V02_HEADER}
 
       type Query {
         someField: String
@@ -40,339 +1284,8 @@ describe("removeInaccessibleElements", () => {
     `);
 
     removeInaccessibleElements(schema);
-
-    const queryType = schema.schemaDefinition.rootType("query")!;
-
-    expect(queryType.field("someField")).toBeDefined();
-    expect(queryType.field("privateField")).toBeUndefined();
-  });
-
-  it(`removes @inaccessible object types`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query {
-        fooField: Foo @inaccessible
-        barField: Bar
-      }
-
-      type Foo @inaccessible {
-        someField: String
-      }
-
-      type Bar {
-        someField: String
-      }
-
-      union Baz = Foo | Bar
-    `);
-
-    removeInaccessibleElements(schema);
-
-    expect(schema.type("Foo")).toBeUndefined();
-  });
-
-  it(`removes @inaccessible interface types`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query {
-        fooField: Foo @inaccessible
-        barField: Bar
-      }
-
-      interface Foo @inaccessible {
-        someField: String
-      }
-
-      type Bar implements Foo {
-        someField: String
-      }
-    `);
-
-    removeInaccessibleElements(schema);
-
-    expect(schema.type("Foo")).toBeUndefined();
-    const barType = schema.type("Bar") as ObjectType | undefined;
-    expect(barType).toBeDefined();
-    expect(barType?.field("someField")).toBeDefined();
-    expect([...barType!.interfaces()]).toHaveLength(0);
-  });
-
-  it(`removes @inaccessible union types`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query {
-        fooField: Foo @inaccessible
-        barField: Bar
-      }
-
-      union Foo @inaccessible = Bar | Baz
-
-      type Bar {
-        someField: String
-      }
-
-      type Baz {
-        anotherField: String
-      }
-    `);
-
-    removeInaccessibleElements(schema);
-
-    expect(schema.type("Foo")).toBeUndefined();
-    expect(schema.type("Bar")).toBeDefined();
-    expect(schema.type("Baz")).toBeDefined();
-  });
-
-  it(`throws when a field returning an @inaccessible type isn't marked @inaccessible itself`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query {
-        fooField: Foo
-        barField: Bar
-      }
-
-      type Foo @inaccessible {
-        someField: String
-      }
-
-      type Bar {
-        someField: String
-      }
-
-      union Baz = Foo | Bar
-    `);
-
-    try {
-      // Assert that an aggregate Error is thrown, then allow the error to be
-      // caught for further validation
-      expect(removeInaccessibleElements(schema)).toThrow(GraphQLErrorExt);
-    } catch (err) {
-      const causes = errorCauses(err);
-      expect(causes).toHaveLength(1);
-      expect(causes[0].message).toMatchInlineSnapshot(
-        `"Type \\"Foo\\" is @inaccessible but is referenced by \\"Query.fooField\\", which is in the API schema."`
-      );
-    }
-  });
-
-  it(`throws when there are multiple problems`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query {
-        fooField: Foo
-      }
-
-      type Foo @inaccessible {
-        someField: String
-      }
-
-      union Bar = Foo
-    `);
-
-    try {
-      // Assert that an aggregate Error is thrown, then allow the error to be
-      // caught for further validation
-      expect(removeInaccessibleElements(schema)).toThrow(GraphQLErrorExt);
-    } catch (err) {
-      const causes = errorCauses(err);
-      expect(causes).toHaveLength(2);
-      expect(causes[0].message).toMatchInlineSnapshot(
-        `"Type \\"Foo\\" is @inaccessible but is referenced by \\"Query.fooField\\", which is in the API schema."`
-      );
-      expect(causes[1].message).toMatchInlineSnapshot(
-        `"Type \\"Bar\\" is in the API schema but all of its members are @inaccessible."`
-      );
-    }
-  });
-
-  it(`removes @inaccessible query root type`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query @inaccessible {
-        fooField: Foo
-      }
-
-      type Foo {
-        someField: String
-      }
-    `);
-
-    try {
-      // Assert that an aggregate Error is thrown, then allow the error to be
-      // caught for further validation
-      expect(removeInaccessibleElements(schema)).toThrow(GraphQLErrorExt);
-    } catch (err) {
-      const causes = errorCauses(err);
-      expect(causes).toHaveLength(1);
-      expect(causes[0].message).toMatchInlineSnapshot(
-        `"Type \\"Query\\" is @inaccessible but is the root query type, which must be in the API schema."`
-      );
-    }
-  });
-
-  it(`removes @inaccessible mutation root type`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-        mutation: Mutation
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query {
-        fooField: Foo
-      }
-
-      type Mutation @inaccessible {
-        fooField: Foo
-      }
-
-      type Foo {
-        someField: String
-      }
-    `);
-
-    removeInaccessibleElements(schema);
-
-    expect(schema.schemaDefinition.rootType("mutation")).toBeUndefined();
-    expect(schema.type("Mutation")).toBeUndefined();
-  });
-
-  it(`removes @inaccessible subscription root type`, () => {
-    const schema = buildSchema(`
-      directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
-
-      directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-
-      schema
-        @core(feature: "https://specs.apollo.dev/core/v0.2")
-        @core(feature: "https://specs.apollo.dev/inaccessible/v0.1")
-      {
-        query: Query
-        subscription: Subscription
-      }
-
-      enum core__Purpose {
-        EXECUTION
-        SECURITY
-      }
-
-      type Query {
-        fooField: Foo
-      }
-
-      type Subscription @inaccessible {
-        fooField: Foo
-      }
-
-      type Foo {
-        someField: String
-      }
-    `);
-
-    removeInaccessibleElements(schema);
-
-    expect(schema.schemaDefinition.rootType("subscription")).toBeUndefined();
-    expect(schema.type("Subscription")).toBeUndefined();
+    schema.validate();
+    expect(schema.elementByCoordinate("Query.someField")).toBeDefined();
+    expect(schema.elementByCoordinate("Query.privateField")).toBeUndefined();
   });
 });

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -557,7 +557,7 @@ describe('@core/@link handling', () => {
 
     directive @federation__shareable on OBJECT | FIELD_DEFINITION
 
-    directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+    directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
     directive @federation__override(from: String!) on FIELD_DEFINITION
 

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -706,7 +706,7 @@ export const LINK_VERSIONS = new FeatureDefinitions<CoreSpecDefinition>(linkIden
 registerKnownFeature(CORE_VERSIONS);
 registerKnownFeature(LINK_VERSIONS);
 
-export function removeFeatureElements(schema: Schema) {
+export function removeAllCoreFeatures(schema: Schema) {
   // Gather a list of core features up front, since we can't fetch them during
   // removal. (Also note that core being a feature itself, this will remove core
   // itself and mark the schema as 'not core').

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -1,6 +1,6 @@
 import { ASTNode, DirectiveLocation, GraphQLError, StringValueNode } from "graphql";
 import { URL } from "url";
-import { CoreFeature, Directive, DirectiveDefinition, EnumType, ErrGraphQLValidationFailed, InputType, ListType, NamedType, NonNullType, ScalarType, Schema, SchemaDefinition, SchemaElement } from "./definitions";
+import { CoreFeature, Directive, DirectiveDefinition, EnumType, ErrGraphQLAPISchemaValidationFailed, ErrGraphQLValidationFailed, InputType, ListType, NamedType, NonNullType, ScalarType, Schema, SchemaDefinition, SchemaElement } from "./definitions";
 import { sameType } from "./types";
 import { err } from '@apollo/core-schema';
 import { assert } from './utils';
@@ -777,11 +777,3 @@ export function removeAllCoreFeatures(schema: Schema) {
     throw ErrGraphQLAPISchemaValidationFailed(errors);
   }
 }
-
-export const apiSchemaValidationErrorCode = 'GraphQLAPISchemaValidationFailed';
-
-export const ErrGraphQLAPISchemaValidationFailed = (causes: GraphQLError[]) =>
-  err(apiSchemaValidationErrorCode, {
-    message: 'The supergraph schema failed to produce a valid API schema',
-    causes
-  });

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -25,7 +25,7 @@ import {
   FeatureUrl,
   findCoreSpecVersion,
   isCoreSpecDirectiveApplication,
-  removeFeatureElements,
+  removeAllCoreFeatures,
 } from "./coreSpec";
 import { assert, mapValues, MapWithCachedArrays, setValues } from "./utils";
 import { withDefaultValues, valueEquals, valueToString, valueToAST, variablesInValue, valueFromAST, valueNodeToConstValueNode } from "./values";
@@ -1147,7 +1147,7 @@ export class Schema {
 
       const apiSchema = this.clone();
       removeInaccessibleElements(apiSchema);
-      removeFeatureElements(apiSchema);
+      removeAllCoreFeatures(apiSchema);
       assert(!apiSchema.isCoreSchema(), "The API schema shouldn't be a core schema")
       apiSchema.validate();
       this.apiSchema = apiSchema;

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -17,6 +17,7 @@ import {
   VariableNode
 } from "graphql";
 import {
+  apiSchemaValidationErrorCode,
   CoreImport,
   CoreOrLinkDirectiveArgs,
   CoreSpecDefinition,
@@ -57,7 +58,7 @@ export const ErrGraphQLValidationFailed = (causes: GraphQLError[], message: stri
  */
 export function errorCauses(e: Error): GraphQLError[] | undefined {
   if (e instanceof GraphQLErrorExt) {
-    if (e.code === validationErrorCode) {
+    if (e.code === validationErrorCode || e.code === apiSchemaValidationErrorCode) {
       return ((e as any).causes) as GraphQLError[];
     }
     return [e];
@@ -1146,13 +1147,7 @@ export class Schema {
 
       const apiSchema = this.clone();
       removeInaccessibleElements(apiSchema);
-      const coreFeatures = apiSchema.coreFeatures;
-      if (coreFeatures) {
-        // Note that core being a feature itself, this will remove core itself and mark apiSchema as 'not core'
-        for (const coreFeature of coreFeatures.allFeatures()) {
-          removeFeatureElements(apiSchema, coreFeature);
-        }
-      }
+      removeFeatureElements(apiSchema);
       assert(!apiSchema.isCoreSchema(), "The API schema shouldn't be a core schema")
       apiSchema.validate();
       this.apiSchema = apiSchema;

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -937,9 +937,12 @@ export class CoreFeature {
   }
 
   isFeatureDefinition(element: NamedType | DirectiveDefinition): boolean {
+    const importName = element.kind === 'DirectiveDefinition'
+      ? '@' + element.name
+      : element.name;
     return element.name.startsWith(this.nameInSchema + '__')
       || (element.kind === 'DirectiveDefinition' && element.name === this.nameInSchema)
-      || !!this.imports.find((i) => element.name === (i.as ?? i.name));
+      || !!this.imports.find((i) => importName === (i.as ?? i.name));
   }
 
   directiveNameInSchema(name: string): string {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -17,7 +17,6 @@ import {
   VariableNode
 } from "graphql";
 import {
-  apiSchemaValidationErrorCode,
   CoreImport,
   CoreOrLinkDirectiveArgs,
   CoreSpecDefinition,
@@ -49,6 +48,14 @@ const DEFAULT_VALIDATION_ERROR_MESSAGE = 'The schema is not a valid GraphQL sche
 export const ErrGraphQLValidationFailed = (causes: GraphQLError[], message: string = DEFAULT_VALIDATION_ERROR_MESSAGE) =>
   err(validationErrorCode, {
     message,
+    causes
+  });
+
+const apiSchemaValidationErrorCode = 'GraphQLAPISchemaValidationFailed';
+
+export const ErrGraphQLAPISchemaValidationFailed = (causes: GraphQLError[]) =>
+  err(apiSchemaValidationErrorCode, {
+    message: 'The supergraph schema failed to produce a valid API schema',
     causes
   });
 

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -379,11 +379,6 @@ const ONLY_INACCESSIBLE_CHILDREN = makeCodeDefinition(
   'A type visible in the API schema has only @inaccessible children.'
 );
 
-const INVALID_DEFAULT_VALUE = makeCodeDefinition(
-  'INVALID_DEFAULT_VALUE',
-  'An element has a default value that fails to coerce to its location\'s type.'
-);
-
 const REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH = makeCodeDefinition(
   'REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH',
   'A field of an input object type is mandatory in some subgraphs, but the field is not defined in all the subgraphs that define the input object type.'
@@ -492,7 +487,6 @@ export const ERRORS = {
   DISALLOWED_INACCESSIBLE,
   IMPLEMENTED_BY_INACCESSIBLE,
   ONLY_INACCESSIBLE_CHILDREN,
-  INVALID_DEFAULT_VALUE,
   REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH,
   REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH,
   EMPTY_MERGED_INPUT_TYPE,

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -346,7 +346,42 @@ const LINK_IMPORT_NAME_MISMATCH = makeCodeDefinition(
 
 const REFERENCED_INACCESSIBLE = makeCodeDefinition(
   'REFERENCED_INACCESSIBLE',
-  'An element is marked as @inaccessible but is referenced by a non-inaccessible element.'
+  'An element is marked as @inaccessible but is referenced by an element visible in the API schema.'
+);
+
+const DEFAULT_VALUE_USES_INACCESSIBLE = makeCodeDefinition(
+  'DEFAULT_VALUE_USES_INACCESSIBLE',
+  'An element is marked as @inaccessible but is used in the default value of an element visible in the API schema.'
+);
+
+const QUERY_ROOT_TYPE_INACCESSIBLE = makeCodeDefinition(
+  'QUERY_ROOT_TYPE_INACCESSIBLE',
+  'An element is marked as @inaccessible but is the query root type, which must be visible in the API schema.'
+);
+
+const REQUIRED_INACCESSIBLE = makeCodeDefinition(
+  'REQUIRED_INACCESSIBLE',
+  'An element is marked as @inaccessible but is required by an element visible in the API schema.'
+);
+
+const IMPLEMENTED_BY_INACCESSIBLE = makeCodeDefinition(
+  'IMPLEMENTED_BY_INACCESSIBLE',
+  'An element is marked as @inaccessible but implements an element visible in the API schema.'
+);
+
+const DISALLOWED_INACCESSIBLE = makeCodeDefinition(
+  'DISALLOWED_INACCESSIBLE',
+  'An element is marked as @inaccessible that is not allowed to be @inaccessible.'
+);
+
+const ONLY_INACCESSIBLE_CHILDREN = makeCodeDefinition(
+  'ONLY_INACCESSIBLE_CHILDREN',
+  'A type visible in the API schema has only @inaccessible children.'
+);
+
+const INVALID_DEFAULT_VALUE = makeCodeDefinition(
+  'INVALID_DEFAULT_VALUE',
+  'An element has a default value that fails to coerce to its location\'s type.'
 );
 
 const REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH = makeCodeDefinition(
@@ -451,6 +486,13 @@ export const ERRORS = {
   INVALID_LINK_DIRECTIVE_USAGE,
   LINK_IMPORT_NAME_MISMATCH,
   REFERENCED_INACCESSIBLE,
+  DEFAULT_VALUE_USES_INACCESSIBLE,
+  QUERY_ROOT_TYPE_INACCESSIBLE,
+  REQUIRED_INACCESSIBLE,
+  DISALLOWED_INACCESSIBLE,
+  IMPLEMENTED_BY_INACCESSIBLE,
+  ONLY_INACCESSIBLE_CHILDREN,
+  INVALID_DEFAULT_VALUE,
   REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH,
   REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH,
   EMPTY_MERGED_INPUT_TYPE,

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -45,6 +45,7 @@ import { KnownTypeNamesInFederationRule } from "./validation/KnownTypeNamesInFed
 import { buildSchema, buildSchemaFromAST } from "./buildSchema";
 import { parseSelectionSet, selectionOfElement, SelectionSet } from './operations';
 import { TAG_VERSIONS } from "./tagSpec";
+import { INACCESSIBLE_VERSIONS } from "./inaccessibleSpec";
 import {
   errorCodeDef,
   ErrorCodeDefinition,
@@ -79,10 +80,10 @@ import {
 import { defaultPrintOptions, PrintOptions as PrintOptions, printSchema } from "./print";
 import { createObjectTypeSpecification, createScalarTypeSpecification, createUnionTypeSpecification } from "./directiveAndTypeSpecification";
 import { didYouMean, suggestionList } from "./suggestions";
-import { inaccessibleDirectiveSpec } from "./inaccessibleSpec";
 
 const linkSpec = LINK_VERSIONS.latest();
 const tagSpec = TAG_VERSIONS.latest();
+const inaccessibleSpec = INACCESSIBLE_VERSIONS.latest();
 const federationSpec = FEDERATION_VERSIONS.latest();
 
 // We don't let user use this as a subgraph name. That allows us to use it in `query graphs` to name the source of roots
@@ -565,7 +566,9 @@ export class FederationMetadata {
   }
 
   inaccessibleDirective(): DirectiveDefinition<{}> {
-    return this.getFederationDirective(inaccessibleDirectiveSpec.name);
+    return this.getFederationDirective(
+      inaccessibleSpec.inaccessibleDirectiveSpec.name
+    );
   }
 
   allFederationDirectives(): DirectiveDefinition[] {

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -14,7 +14,7 @@ import { assert } from "./utils";
 import { TAG_VERSIONS } from "./tagSpec";
 import { federationMetadata } from "./federation";
 import { registerKnownFeature } from "./knownCoreFeatures";
-import { inaccessibleDirectiveSpec } from "./inaccessibleSpec";
+import { INACCESSIBLE_VERSIONS } from "./inaccessibleSpec";
 
 export const federationIdentity = 'https://specs.apollo.dev/federation';
 
@@ -91,7 +91,7 @@ function fieldSetType(schema: Schema): InputType {
 
 export const FEDERATION2_ONLY_SPEC_DIRECTIVES = [
   shareableDirectiveSpec,
-  inaccessibleDirectiveSpec,
+  INACCESSIBLE_VERSIONS.latest().inaccessibleDirectiveSpec,
   overrideDirectiveSpec,
 ];
 

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -293,9 +293,9 @@ function validateInaccessibleElements(
             `Built-in type "${type.coordinate}" cannot use @inaccessible.`,
           nodes: type.sourceAST,
           extensions: {
-            disallowed_element: type.coordinate,
             inaccessible_elements: inaccessibleElements
               .map((element) => element.coordinate),
+            inaccessible_referencers: [type.coordinate],
           }
         }));
       }
@@ -309,9 +309,9 @@ function validateInaccessibleElements(
             `Core feature type "${type.coordinate}" cannot use @inaccessible.`,
           nodes: type.sourceAST,
           extensions: {
-            disallowed_element: type.coordinate,
             inaccessible_elements: inaccessibleElements
               .map((element) => element.coordinate),
+            inaccessible_referencers: [type.coordinate],
           }
         }));
       }
@@ -348,8 +348,8 @@ function validateInaccessibleElements(
                 ` by "${referencer.coordinate}", which is in the API schema.`,
               nodes: type.sourceAST,
               extensions: {
-                inaccessible_element: type.coordinate,
-                inaccessible_element_referencer: referencer.coordinate,
+                inaccessible_elements: [type.coordinate],
+                inaccessible_referencers: [referencer.coordinate],
               }
             }));
           }
@@ -361,7 +361,7 @@ function validateInaccessibleElements(
                 ` query type, which must be in the API schema.`,
               nodes: type.sourceAST,
               extensions: {
-                inaccessible_element: type.coordinate,
+                inaccessible_elements: [type.coordinate],
               }
             }));
           }
@@ -388,9 +388,9 @@ function validateInaccessibleElements(
               ` are @inaccessible.`,
             nodes: type.sourceAST,
             extensions: {
-              inaccessible_elements_parent: type.coordinate,
               inaccessible_elements: type.fields()
                 .map((field) => field.coordinate),
+              inaccessible_referencers: [type.coordinate],
             }
           }));
         }
@@ -406,9 +406,9 @@ function validateInaccessibleElements(
               ` members are @inaccessible.`,
             nodes: type.sourceAST,
             extensions: {
-              inaccessible_elements_parent: type.coordinate,
               inaccessible_elements: type.types()
                 .map((type) => type.coordinate),
+              inaccessible_referencers: [type.coordinate],
             }
           }));
         }
@@ -424,9 +424,9 @@ function validateInaccessibleElements(
              ` values are @inaccessible.`,
             nodes: type.sourceAST,
             extensions: {
-              inaccessible_elements_parent: type.coordinate,
               inaccessible_elements: type.values
                 .map((enumValue) => enumValue.coordinate),
+              inaccessible_referencers: [type.coordinate],
             }
           }));
         }
@@ -466,9 +466,8 @@ function validateInaccessibleElements(
                     ` schema.`,
                   nodes: field.sourceAST,
                   extensions: {
-                    inaccessible_element: field.coordinate,
-                    inaccessible_element_implements:
-                      implementedField.coordinate,
+                    inaccessible_elements: [field.coordinate],
+                    inaccessible_referencers: [implementedField.coordinate],
                   }
                 }));
               }
@@ -486,8 +485,8 @@ function validateInaccessibleElements(
                       ` is a required argument of its field.`,
                     nodes: argument.sourceAST,
                     extensions: {
-                      inaccessible_element: argument.coordinate,
-                      inaccessible_element_requirer: argument.coordinate,
+                      inaccessible_elements: [argument.coordinate],
+                      inaccessible_referencers: [argument.coordinate],
                     }
                   }));
                 }
@@ -534,9 +533,10 @@ function validateInaccessibleElements(
                         ` in the API schema.`,
                       nodes: argument.sourceAST,
                       extensions: {
-                        inaccessible_element: argument.coordinate,
-                        inaccessible_element_requirer:
+                        inaccessible_elements: [argument.coordinate],
+                        inaccessible_referencers: [
                           implementingArgument.coordinate,
+                        ],
                       }
                     }));
                   }
@@ -562,9 +562,10 @@ function validateInaccessibleElements(
                         ` the API schema.`,
                       nodes: argument.sourceAST,
                       extensions: {
-                        inaccessible_element: argument.coordinate,
-                        inaccessible_element_implements:
+                        inaccessible_elements: [argument.coordinate],
+                        inaccessible_referencers: [
                           implementedArgument.coordinate,
+                        ],
                       }
                     }));
                   }
@@ -585,8 +586,8 @@ function validateInaccessibleElements(
                   ` but is a required input field of its type.`,
                 nodes: inputField.sourceAST,
                 extensions: {
-                  inaccessible_element: inputField.coordinate,
-                  inaccessible_element_requirer: inputField.coordinate,
+                  inaccessible_elements: [inputField.coordinate],
+                  inaccessible_referencers: [inputField.coordinate],
                 }
               }));
             }
@@ -610,8 +611,8 @@ function validateInaccessibleElements(
                     ` "${referencer.coordinate}", which is in the API schema.`,
                   nodes: type.sourceAST,
                   extensions: {
-                    inaccessible_element: type.coordinate,
-                    inaccessible_element_referencer: referencer.coordinate,
+                    inaccessible_elements: [type.coordinate],
+                    inaccessible_referencers: [referencer.coordinate],
                   }
                 }));
               }
@@ -640,8 +641,8 @@ function validateInaccessibleElements(
                     ` "${referencer.coordinate}", which is in the API schema.`,
                   nodes: type.sourceAST,
                   extensions: {
-                    inaccessible_element: type.coordinate,
-                    inaccessible_element_referencer: referencer.coordinate,
+                    inaccessible_elements: [type.coordinate],
+                    inaccessible_referencers: [referencer.coordinate],
                   }
                 }));
               }
@@ -669,9 +670,9 @@ function validateInaccessibleElements(
             ` @inaccessible.`,
           nodes: directive.sourceAST,
           extensions: {
-            disallowed_element: directive.coordinate,
             inaccessible_elements: inaccessibleElements
               .map((element) => element.coordinate),
+            inaccessible_referencers: [directive.coordinate],
           }
         }));
       }
@@ -687,9 +688,9 @@ function validateInaccessibleElements(
             ` @inaccessible.`,
           nodes: directive.sourceAST,
           extensions: {
-            disallowed_element: directive.coordinate,
             inaccessible_elements: inaccessibleElements
               .map((element) => element.coordinate),
+            inaccessible_referencers: [directive.coordinate],
           }
         }));
       }
@@ -706,9 +707,9 @@ function validateInaccessibleElements(
             ` ${typeSystemLocations.join(', ')}.`,
           nodes: directive.sourceAST,
           extensions: {
-            disallowed_element: directive.coordinate,
             inaccessible_elements: inaccessibleElements
               .map((element) => element.coordinate),
+            inaccessible_referencers: [directive.coordinate],
           }
         }));
       }
@@ -726,8 +727,8 @@ function validateInaccessibleElements(
                 ` required argument of its directive.`,
               nodes: argument.sourceAST,
               extensions: {
-                inaccessible_element: argument.coordinate,
-                inaccessible_element_requirer: argument.coordinate,
+                inaccessible_elements: [argument.coordinate],
+                inaccessible_referencers: [argument.coordinate],
               }
             }));
           }

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -37,7 +37,7 @@ export const inaccessibleIdentity = 'https://specs.apollo.dev/inaccessible';
 export class InaccessibleSpecDefinition extends FeatureDefinition {
   public readonly inaccessibleLocations: DirectiveLocation[];
   public readonly inaccessibleDirectiveSpec: DirectiveSpecification;
-  private readonly printedTagDefinition: string;
+  private readonly printedInaccessibleDefinition: string;
 
   constructor(version: FeatureVersion) {
     super(new FeatureUrl(inaccessibleIdentity, 'inaccessible', version));
@@ -47,7 +47,7 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
       DirectiveLocation.INTERFACE,
       DirectiveLocation.UNION,
     ];
-    this.printedTagDefinition = 'directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION';
+    this.printedInaccessibleDefinition = 'directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION';
     if (!this.isV01()) {
       this.inaccessibleLocations.push(
         DirectiveLocation.ARGUMENT_DEFINITION,
@@ -57,7 +57,7 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
         DirectiveLocation.INPUT_OBJECT,
         DirectiveLocation.INPUT_FIELD_DEFINITION,
       );
-      this.printedTagDefinition = 'directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION';
+      this.printedInaccessibleDefinition = 'directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION';
     }
     this.inaccessibleDirectiveSpec = createDirectiveSpecification({
       name: 'inaccessible',
@@ -83,7 +83,7 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
     const hasValidLocations = definition.locations.every(loc => this.inaccessibleLocations.includes(loc));
     if (hasUnknownArguments || hasRepeatable || !hasValidLocations) {
       return ERRORS.DIRECTIVE_DEFINITION_INVALID.err({
-        message: `Found invalid @inaccessible directive definition. Please ensure the directive definition in your schema's definitions matches the following:\n\t${this.printedTagDefinition}`,
+        message: `Found invalid @inaccessible directive definition. Please ensure the directive definition in your schema's definitions matches the following:\n\t${this.printedInaccessibleDefinition}`,
       });
     }
     return undefined;

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -1,10 +1,11 @@
-import { ErrGraphQLAPISchemaValidationFailed, FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
+import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
 import {
   ArgumentDefinition,
   CoreFeatures,
   DirectiveDefinition,
   EnumType,
   EnumValue,
+  ErrGraphQLAPISchemaValidationFailed,
   executableDirectiveLocations,
   FieldDefinition,
   InputFieldDefinition,

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -222,7 +222,7 @@ function validateInaccessibleElements(
     assert(false, "Unreachable code, element is of unknown type.");
   }
 
-  function fetchInaccessibleElementsInDescendants(
+  function fetchInaccessibleElementsDeep(
     element: HideableElement
   ): HideableElement[] {
     const inaccessibleElements: HideableElement[] = [];
@@ -237,14 +237,14 @@ function validateInaccessibleElements(
     ) {
       for (const field of element.fields()) {
         inaccessibleElements.push(
-          ...fetchInaccessibleElementsInDescendants(field),
+          ...fetchInaccessibleElementsDeep(field),
         );
       }
       return inaccessibleElements;
     } else if (element instanceof EnumType) {
       for (const enumValue of element.values) {
         inaccessibleElements.push(
-          ...fetchInaccessibleElementsInDescendants(enumValue),
+          ...fetchInaccessibleElementsDeep(enumValue),
         )
       }
       return inaccessibleElements;
@@ -254,7 +254,7 @@ function validateInaccessibleElements(
     ) {
       for (const argument of element.arguments()) {
         inaccessibleElements.push(
-          ...fetchInaccessibleElementsInDescendants(argument),
+          ...fetchInaccessibleElementsDeep(argument),
         )
       }
       return inaccessibleElements;
@@ -287,7 +287,7 @@ function validateInaccessibleElements(
     if (hasBuiltInName(type)) {
       // Built-in types (and their descendants) aren't allowed to be
       // @inaccessible, regardless of shadowing.
-      const inaccessibleElements = fetchInaccessibleElementsInDescendants(type);
+      const inaccessibleElements = fetchInaccessibleElementsDeep(type);
       if (inaccessibleElements.length > 0) {
         errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
           message:
@@ -303,7 +303,7 @@ function validateInaccessibleElements(
     } else if (isFeatureDefinition(type)) {
       // Core feature types (and their descendants) aren't allowed to be
       // @inaccessible.
-      const inaccessibleElements = fetchInaccessibleElementsInDescendants(type);
+      const inaccessibleElements = fetchInaccessibleElementsDeep(type);
       if (inaccessibleElements.length > 0) {
         errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
           message:
@@ -663,7 +663,7 @@ function validateInaccessibleElements(
       // Built-in directives (and their descendants) aren't allowed to be
       // @inaccessible, regardless of shadowing.
       const inaccessibleElements =
-        fetchInaccessibleElementsInDescendants(directive);
+        fetchInaccessibleElementsDeep(directive);
       if (inaccessibleElements.length > 0) {
         errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
           message:
@@ -681,7 +681,7 @@ function validateInaccessibleElements(
       // Core feature directives (and their descendants) aren't allowed to be
       // @inaccessible.
       const inaccessibleElements =
-        fetchInaccessibleElementsInDescendants(directive);
+        fetchInaccessibleElementsDeep(directive);
       if (inaccessibleElements.length > 0) {
         errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
           message:
@@ -699,7 +699,7 @@ function validateInaccessibleElements(
       // Directives that can appear on type-system locations (and their
       // descendants) aren't allowed to be @inaccessible.
       const inaccessibleElements =
-        fetchInaccessibleElementsInDescendants(directive);
+        fetchInaccessibleElementsDeep(directive);
       if (inaccessibleElements.length > 0) {
         errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
           message:

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -1,17 +1,35 @@
-import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
+import { ErrGraphQLAPISchemaValidationFailed, FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
 import {
+  ArgumentDefinition,
+  CoreFeatures,
   DirectiveDefinition,
-  ErrGraphQLValidationFailed,
+  EnumType,
+  EnumValue,
+  executableDirectiveLocations,
   FieldDefinition,
-  isCompositeType,
-  isInterfaceType,
-  isObjectType,
+  InputFieldDefinition,
+  InputObjectType,
+  InputType,
+  InterfaceType,
+  isEnumType,
+  isInputObjectType,
+  isListType,
+  isNonNullType,
+  isScalarType,
+  isVariable,
+  NamedType,
+  ObjectType,
+  ScalarType,
   Schema,
+  SchemaDefinition,
+  SchemaElement,
+  UnionType,
 } from "./definitions";
 import { GraphQLError, DirectiveLocation } from "graphql";
 import { registerKnownFeature } from "./knownCoreFeatures";
 import { ERRORS } from "./error";
 import { createDirectiveSpecification, DirectiveSpecification } from "./directiveAndTypeSpecification";
+import { assert } from "./utils";
 
 export const inaccessibleIdentity = 'https://specs.apollo.dev/inaccessible';
 
@@ -51,8 +69,8 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
     return this.addDirectiveSpec(schema, this.inaccessibleDirectiveSpec);
   }
 
-  inaccessibleDirective(schema: Schema): DirectiveDefinition<Record<string, never>> {
-    return this.directive(schema, 'inaccessible')!;
+  inaccessibleDirective(schema: Schema): DirectiveDefinition<Record<string, never>> | undefined {
+    return this.directive(schema, 'inaccessible');
   }
 
   allElementNames(): string[] {
@@ -67,6 +85,10 @@ export const INACCESSIBLE_VERSIONS = new FeatureDefinitions<InaccessibleSpecDefi
 registerKnownFeature(INACCESSIBLE_VERSIONS);
 
 export function removeInaccessibleElements(schema: Schema) {
+  // Note it doesn't hurt to validate here, since we expect the schema to be
+  // validated already, and if it has been, it's cached/inexpensive.
+  schema.validate();
+
   const coreFeatures = schema.coreFeatures;
   if (!coreFeatures) {
     return;
@@ -76,57 +98,1037 @@ export function removeInaccessibleElements(schema: Schema) {
   if (!inaccessibleFeature) {
     return;
   }
-  const inaccessibleSpec = INACCESSIBLE_VERSIONS.find(inaccessibleFeature.url.version);
+  const inaccessibleSpec = INACCESSIBLE_VERSIONS.find(
+    inaccessibleFeature.url.version
+  );
   if (!inaccessibleSpec) {
-    throw new GraphQLError(
-      `Cannot remove inaccessible elements: the schema uses unsupported inaccessible spec version ${inaccessibleFeature.url.version} (supported versions: ${INACCESSIBLE_VERSIONS.versions().join(', ')})`);
+    throw ErrGraphQLAPISchemaValidationFailed([new GraphQLError(
+      `Cannot remove inaccessible elements: the schema uses unsupported` +
+      ` inaccessible spec version ${inaccessibleFeature.url.version}` +
+      ` (supported versions: ${INACCESSIBLE_VERSIONS.versions().join(', ')})`
+    )]);
   }
 
   const inaccessibleDirective = inaccessibleSpec.inaccessibleDirective(schema);
   if (!inaccessibleDirective) {
-    throw new GraphQLError(
-      `Invalid schema: declares ${inaccessibleSpec.url} spec but does not define a @inaccessible directive`
+    throw ErrGraphQLAPISchemaValidationFailed([new GraphQLError(
+      `Invalid schema: declares ${inaccessibleSpec.url} spec but does not` +
+      ` define a @inaccessible directive.`
+    )]);
+  }
+
+  validateInaccessibleElements(
+    schema,
+    coreFeatures,
+    inaccessibleSpec,
+    inaccessibleDirective,
+  );
+
+  removeInaccessibleElementsAssumingValid(
+    schema,
+    inaccessibleDirective,
+  )
+}
+
+// These are elements that may be hidden, by either @inaccessible or core
+// feature definition hiding.
+type HideableElement =
+  | ObjectType
+  | InterfaceType
+  | UnionType
+  | ScalarType
+  | EnumType
+  | InputObjectType
+  | DirectiveDefinition
+  | FieldDefinition<ObjectType | InterfaceType>
+  | ArgumentDefinition<
+    | DirectiveDefinition
+    | FieldDefinition<ObjectType | InterfaceType>>
+  | InputFieldDefinition
+  | EnumValue
+
+// Validate the applications of @inaccessible in the schema. Some of these may
+// technically be caught by Schema.validate() later, but we'd like to give
+// clearer error messaging when possible.
+function validateInaccessibleElements(
+  schema: Schema,
+  coreFeatures: CoreFeatures,
+  inaccessibleSpec: InaccessibleSpecDefinition,
+  inaccessibleDirective: DirectiveDefinition,
+): void {
+  function isInaccessible(element: SchemaElement<any, any>): boolean {
+    return element.hasAppliedDirective(inaccessibleDirective);
+  }
+
+  const featureList = [...coreFeatures.allFeatures()];
+  function isFeatureDefinition(
+    element: NamedType | DirectiveDefinition
+  ): boolean {
+    return featureList.some((feature) => feature.isFeatureDefinition(element));
+  }
+
+  function isInAPISchema(element: HideableElement): boolean {
+    // If this element is @inaccessible, it's not in the API schema.
+    if (
+      !(element instanceof DirectiveDefinition) &&
+      isInaccessible(element)
+    ) return false;
+
+    if (
+      (element instanceof ObjectType) ||
+      (element instanceof InterfaceType) ||
+      (element instanceof UnionType) ||
+      (element instanceof ScalarType) ||
+      (element instanceof EnumType) ||
+      (element instanceof InputObjectType) ||
+      (element instanceof DirectiveDefinition)
+    ) {
+      // These are top-level elements. If they're not @inaccessible, the only
+      // way they won't be in the API schema is if they're definitions of some
+      // core feature.
+      return !isFeatureDefinition(element);
+    } else if (
+      (element instanceof FieldDefinition) ||
+      (element instanceof ArgumentDefinition) ||
+      (element instanceof InputFieldDefinition) ||
+      (element instanceof EnumValue)
+    ) {
+      // While this element isn't marked @inaccessible, this element won't be in
+      // the API schema if its parent isn't.
+      return isInAPISchema(element.parent);
+    }
+    assert(false, "Unreachable code, element is of unknown type.");
+  }
+
+  function fetchInaccessibleElementsInDescendants(
+    element: HideableElement
+  ): HideableElement[] {
+    const inaccessibleElements: HideableElement[] = [];
+    if (isInaccessible(element)) {
+      inaccessibleElements.push(element);
+    }
+
+    if (
+      (element instanceof ObjectType) ||
+      (element instanceof InterfaceType) ||
+      (element instanceof InputObjectType)
+    ) {
+      for (const field of element.fields()) {
+        inaccessibleElements.push(
+          ...fetchInaccessibleElementsInDescendants(field),
+        );
+      }
+      return inaccessibleElements;
+    } else if (element instanceof EnumType) {
+      for (const enumValue of element.values) {
+        inaccessibleElements.push(
+          ...fetchInaccessibleElementsInDescendants(enumValue),
+        )
+      }
+      return inaccessibleElements;
+    } else if (
+      (element instanceof DirectiveDefinition) ||
+      (element instanceof FieldDefinition)
+    ) {
+      for (const argument of element.arguments()) {
+        inaccessibleElements.push(
+          ...fetchInaccessibleElementsInDescendants(argument),
+        )
+      }
+      return inaccessibleElements;
+    } else if (
+      (element instanceof UnionType) ||
+      (element instanceof ScalarType) ||
+      (element instanceof ArgumentDefinition) ||
+      (element instanceof InputFieldDefinition) ||
+      (element instanceof EnumValue)
+    ) {
+      return inaccessibleElements;
+    }
+    assert(false, "Unreachable code, element is of unknown type.");
+  }
+
+  const errors: GraphQLError[] = [];
+  let defaultValueReferencers: Map<
+    DefaultValueReference,
+    SchemaElementWithDefaultValue[]
+  > | undefined = undefined;
+  if (!inaccessibleSpec.isV01()) {
+    // Note that for inaccessible v0.1, enum values and input fields can't be
+    // @inaccessible, so there's no need to validate default values and compute
+    // references (also, starting to validate default values would be a breaking
+    // change for inaccessible v0.1).
+    defaultValueReferencers = computeDefaultValueReferencers(
+      schema,
+      errors
     );
   }
 
-  const errors = [];
-  for (const type of schema.types()) {
-    // @inaccessible can only be on composite types.
-    if (!isCompositeType(type)) {
-      continue;
-    }
-
-    if (type.hasAppliedDirective(inaccessibleDirective)) {
-      const references = type.remove();
-      for (const reference of references) {
-        // If the type was referenced in a field, we need to make sure that field is also inaccessible or the resulting schema will be invalid (the
-        // field type will be `undefined`).
-        if (reference.kind === 'FieldDefinition') {
-          if (!reference.hasAppliedDirective(inaccessibleDirective)) {
-            // We ship the inaccessible type and it's invalid reference in the extensions so composition can extract those and add proper links
-            // in the subgraphs for those elements.
+  for (const type of schema.allTypes()) {
+    if (hasBuiltInName(type)) {
+      // Built-in types (and their descendants) aren't allowed to be
+      // @inaccessible, regardless of shadowing.
+      const inaccessibleElements = fetchInaccessibleElementsInDescendants(type);
+      if (inaccessibleElements.length > 0) {
+        errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
+          message:
+            `Built-in type "${type.coordinate}" cannot use @inaccessible.`,
+          nodes: type.sourceAST,
+          extensions: {
+            disallowed_element: type.coordinate,
+            inaccessible_elements: inaccessibleElements
+              .map((element) => element.coordinate),
+          }
+        }));
+      }
+    } else if (isFeatureDefinition(type)) {
+      // Core feature types (and their descendants) aren't allowed to be
+      // @inaccessible.
+      const inaccessibleElements = fetchInaccessibleElementsInDescendants(type);
+      if (inaccessibleElements.length > 0) {
+        errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
+          message:
+            `Core feature type "${type.coordinate}" cannot use @inaccessible.`,
+          nodes: type.sourceAST,
+          extensions: {
+            disallowed_element: type.coordinate,
+            inaccessible_elements: inaccessibleElements
+              .map((element) => element.coordinate),
+          }
+        }));
+      }
+    } else if (isInaccessible(type)) {
+      // Types can be referenced by other schema elements in a few ways:
+      // 1. Fields, arguments, and input fields may have the type as their base
+      //    type.
+      // 2. Union types may have the type as a member (for object types).
+      // 3. Object and interface types may implement the type (for interface
+      //    types).
+      // 4. Schemas may have the type as a root operation type (for object
+      //    types).
+      //
+      // When a type is hidden, the referencer must follow certain rules for the
+      // schema to be valid. Respectively, these rules are:
+      // 1. The field/argument/input field must not be in the API schema.
+      // 2. The union type, if empty, must not be in the API schema.
+      // 3. No rules are imposed in this case.
+      // 4. The root operation type must not be the query type.
+      //
+      // We validate the 1st and 4th rules above, and leave the 2nd for when we
+      // look at accessible union types.
+      const referencers = type.referencers();
+      for (const referencer of referencers) {
+        if (
+          referencer instanceof FieldDefinition ||
+          referencer instanceof ArgumentDefinition ||
+          referencer instanceof InputFieldDefinition
+        ) {
+          if (isInAPISchema(referencer)) {
             errors.push(ERRORS.REFERENCED_INACCESSIBLE.err({
-              message: `Field "${reference.coordinate}" returns @inaccessible type "${type}" without being marked @inaccessible itself.`,
-              nodes: reference.sourceAST,
+              message:
+                `Type "${type.coordinate}" is @inaccessible but is referenced` +
+                ` by "${referencer.coordinate}", which is in the API schema.`,
+              nodes: type.sourceAST,
               extensions: {
-                "inaccessible_element": type.coordinate,
-                "inaccessible_reference": reference.coordinate,
+                inaccessible_element: type.coordinate,
+                inaccessible_element_referencer: referencer.coordinate,
+              }
+            }));
+          }
+        } else if (referencer instanceof SchemaDefinition) {
+          if (type === referencer.rootType('query')) {
+            errors.push(ERRORS.QUERY_ROOT_TYPE_INACCESSIBLE.err({
+              message:
+                `Type "${type.coordinate}" is @inaccessible but is the root` +
+                ` query type, which must be in the API schema.`,
+              nodes: type.sourceAST,
+              extensions: {
+                inaccessible_element: type.coordinate,
               }
             }));
           }
         }
-        // Other references can be:
-        //  - the type may have been a root type: in that case the schema will simply not have a root for that kind.
-        //  - the type may have been part of a union: it will have been removed from that union. This can leave the union empty but ...
-        //  - the type may an interface that other types implements: those other will simply not implement the (non-existing) interface.
       }
-    } else if (isObjectType(type) || isInterfaceType(type)) {
-      const toRemove = (type.fields() as FieldDefinition<any>[]).filter(f => f.hasAppliedDirective(inaccessibleDirective));
-      toRemove.forEach(f => f.remove());
+    } else {
+      // At this point, we know the type must be in the API schema. For types
+      // with children (all types except scalar), we check that at least one of
+      // the children is accessible.
+      if (
+        (type instanceof ObjectType) ||
+        (type instanceof InterfaceType) ||
+        (type instanceof InputObjectType)
+      ) {
+        let isEmpty = true;
+        for (const field of type.fields()) {
+          if (!isInaccessible(field)) isEmpty = false;
+        }
+        if (isEmpty) {
+          errors.push(ERRORS.ONLY_INACCESSIBLE_CHILDREN.err({
+            message:
+              `Type "${type.coordinate}" is in the API schema but all of its` +
+              ` ${(type instanceof InputObjectType) ? 'input ' : ''}fields` +
+              ` are @inaccessible.`,
+            nodes: type.sourceAST,
+            extensions: {
+              inaccessible_elements_parent: type.coordinate,
+              inaccessible_elements: type.fields()
+                .map((field) => field.coordinate),
+            }
+          }));
+        }
+      } else if (type instanceof UnionType) {
+        let isEmpty = true;
+        for (const member of type.types()) {
+          if (!isInaccessible(member)) isEmpty = false;
+        }
+        if (isEmpty) {
+          errors.push(ERRORS.ONLY_INACCESSIBLE_CHILDREN.err({
+            message:
+              `Type "${type.coordinate}" is in the API schema but all of its` +
+              ` members are @inaccessible.`,
+            nodes: type.sourceAST,
+            extensions: {
+              inaccessible_elements_parent: type.coordinate,
+              inaccessible_elements: type.types()
+                .map((type) => type.coordinate),
+            }
+          }));
+        }
+      } else if (type instanceof EnumType) {
+        let isEmpty = true;
+        for (const enumValue of type.values) {
+          if (!isInaccessible(enumValue)) isEmpty = false;
+        }
+        if (isEmpty) {
+          errors.push(ERRORS.ONLY_INACCESSIBLE_CHILDREN.err({
+            message:
+              `Type "${type.coordinate}" is in the API schema but all of its` +
+             ` values are @inaccessible.`,
+            nodes: type.sourceAST,
+            extensions: {
+              inaccessible_elements_parent: type.coordinate,
+              inaccessible_elements: type.values
+                .map((enumValue) => enumValue.coordinate),
+            }
+          }));
+        }
+      }
+
+      // Descend into the type's children if needed.
+      if (
+        (type instanceof ObjectType) ||
+        (type instanceof InterfaceType)
+      ) {
+        const implementedInterfaces = type.interfaces();
+        const implementingTypes: (ObjectType | InterfaceType)[] = [];
+        if (type instanceof InterfaceType) {
+          for (const referencer of type.referencers()) {
+            if (
+              (referencer instanceof ObjectType) ||
+              (referencer instanceof InterfaceType)
+            ) {
+              implementingTypes.push(referencer);
+            }
+          }
+        }
+        for (const field of type.fields()) {
+          if (isInaccessible(field)) {
+            // Fields can be "referenced" by the corresponding fields of any
+            // interfaces their parent type implements. When a field is hidden
+            // (but its parent isn't), we check that such implemented fields
+            // aren't in the API schema.
+            for (const implementedInterface of implementedInterfaces) {
+              const implementedField = implementedInterface.field(field.name);
+              if (implementedField && isInAPISchema(implementedField)) {
+                errors.push(ERRORS.IMPLEMENTED_BY_INACCESSIBLE.err({
+                  message:
+                    `Field "${field.coordinate}" is @inaccessible but` +
+                    ` implements the interface field` +
+                    ` "${implementedField.coordinate}", which is in the API` +
+                    ` schema.`,
+                  nodes: field.sourceAST,
+                  extensions: {
+                    inaccessible_element: field.coordinate,
+                    inaccessible_element_implements:
+                      implementedField.coordinate,
+                  }
+                }));
+              }
+            }
+          } else {
+            // Descend into the field's arguments.
+            for (const argument of field.arguments()) {
+              if (isInaccessible(argument)) {
+                // When an argument is hidden (but its ancestors aren't), we
+                // check that it isn't a required argument of its field.
+                if (argument.isRequired()) {
+                  errors.push(ERRORS.REQUIRED_INACCESSIBLE.err({
+                    message:
+                      `Argument "${argument.coordinate}" is @inaccessible but` +
+                      ` is a required argument of its field.`,
+                    nodes: argument.sourceAST,
+                    extensions: {
+                      inaccessible_element: argument.coordinate,
+                      inaccessible_element_requirer: argument.coordinate,
+                    }
+                  }));
+                }
+                // When an argument is hidden (but its ancestors aren't), we
+                // check that it isn't a required argument of any implementing
+                // fields in the API schema. This is because the GraphQL spec
+                // requires that any arguments of an implementing field that
+                // aren't in its implemented field are optional.
+                //
+                // You might be thinking that a required argument in an
+                // implementing field would necessitate that the implemented
+                // field would also require that argument (and thus the check
+                // above would also always error, removing the need for this
+                // one), but the GraphQL spec does not enforce this. E.g. it's
+                // valid GraphQL for the implementing and implemented arguments
+                // to be both non-nullable, but for just the implemented
+                // argument to have a default value. Not providing a value for
+                // the argument when querying the implemented type succeeds
+                // GraphQL operation validation, but results in input coercion
+                // failure for the field at runtime.
+                for (const implementingType of implementingTypes) {
+                  const implementingField = implementingType.field(field.name);
+                  assert(
+                    implementingField,
+                    "Schema should have been valid, but an implementing type" +
+                    " did not implement one of this type's fields."
+                  );
+                  const implementingArgument = implementingField
+                    .argument(argument.name);
+                  assert(
+                    implementingArgument,
+                    "Schema should have been valid, but an implementing type" +
+                    " did not implement one of this type's field's arguments."
+                  );
+                  if (
+                    isInAPISchema(implementingArgument) &&
+                    implementingArgument.isRequired()
+                  ) {
+                    errors.push(ERRORS.REQUIRED_INACCESSIBLE.err({
+                      message:
+                        `Argument "${argument.coordinate}" is @inaccessible` +
+                        ` but is implemented by the required argument` +
+                        ` "${implementingArgument.coordinate}", which is` +
+                        ` in the API schema.`,
+                      nodes: argument.sourceAST,
+                      extensions: {
+                        inaccessible_element: argument.coordinate,
+                        inaccessible_element_requirer:
+                          implementingArgument.coordinate,
+                      }
+                    }));
+                  }
+                }
+
+                // Arguments can be "referenced" by the corresponding arguments
+                // of any interfaces their parent type implements. When an
+                // argument is hidden (but its ancestors aren't), we check that
+                // such implemented arguments aren't in the API schema.
+                for (const implementedInterface of implementedInterfaces) {
+                  const implementedArgument = implementedInterface
+                    .field(field.name)
+                    ?.argument(argument.name);
+                  if (
+                    implementedArgument &&
+                    isInAPISchema(implementedArgument)
+                  ) {
+                    errors.push(ERRORS.IMPLEMENTED_BY_INACCESSIBLE.err({
+                      message:
+                        `Argument "${argument.coordinate}" is @inaccessible` +
+                        ` but implements the interface argument` +
+                        ` "${implementedArgument.coordinate}", which is in` +
+                        ` the API schema.`,
+                      nodes: argument.sourceAST,
+                      extensions: {
+                        inaccessible_element: argument.coordinate,
+                        inaccessible_element_implements:
+                          implementedArgument.coordinate,
+                      }
+                    }));
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else if (type instanceof InputObjectType) {
+        for (const inputField of type.fields()) {
+          if (isInaccessible(inputField)) {
+            // When an input field is hidden (but its parent isn't), we check
+            // that it isn't a required argument of its field.
+            if (inputField.isRequired()) {
+              errors.push(ERRORS.REQUIRED_INACCESSIBLE.err({
+                message:
+                  `Input field "${inputField.coordinate}" is @inaccessible` +
+                  ` but is a required input field of its type.`,
+                nodes: inputField.sourceAST,
+                extensions: {
+                  inaccessible_element: inputField.coordinate,
+                  inaccessible_element_requirer: inputField.coordinate,
+                }
+              }));
+            }
+
+            // Input fields can be referenced by schema default values. When an
+            // input field is hidden (but its parent isn't), we check that the
+            // arguments/input fields with such default values aren't in the API
+            // schema.
+            assert(
+              defaultValueReferencers,
+              "Input fields can't be @inaccessible in v0.1, but default value" +
+              " referencers weren't computed (which is only skipped for v0.1)."
+            );
+            const referencers = defaultValueReferencers.get(inputField) ?? [];
+            for (const referencer of referencers) {
+              if (isInAPISchema(referencer)) {
+                errors.push(ERRORS.DEFAULT_VALUE_USES_INACCESSIBLE.err({
+                  message:
+                    `Input field "${inputField.coordinate}" is @inaccessible` +
+                    ` but is used in the default value of` +
+                    ` "${referencer.coordinate}", which is in the API schema.`,
+                  nodes: type.sourceAST,
+                  extensions: {
+                    inaccessible_element: type.coordinate,
+                    inaccessible_element_referencer: referencer.coordinate,
+                  }
+                }));
+              }
+            }
+          }
+        }
+      } else if (type instanceof EnumType) {
+        for (const enumValue of type.values) {
+          if (isInaccessible(enumValue)) {
+            // Enum values can be referenced by schema default values. When an
+            // enum value is hidden (but its parent isn't), we check that the
+            // arguments/input fields with such default values aren't in the API
+            // schema.
+            assert(
+              defaultValueReferencers,
+              "Enum values can't be @inaccessible in v0.1, but default value" +
+              " referencers weren't computed (which is only skipped for v0.1)."
+            );
+            const referencers = defaultValueReferencers.get(enumValue) ?? [];
+            for (const referencer of referencers) {
+              if (isInAPISchema(referencer)) {
+                errors.push(ERRORS.DEFAULT_VALUE_USES_INACCESSIBLE.err({
+                  message:
+                    `Enum value "${enumValue.coordinate}" is @inaccessible` +
+                    ` but is used in the default value of` +
+                    ` "${referencer.coordinate}", which is in the API schema.`,
+                  nodes: type.sourceAST,
+                  extensions: {
+                    inaccessible_element: type.coordinate,
+                    inaccessible_element_referencer: referencer.coordinate,
+                  }
+                }));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const executableDirectiveLocationSet = new Set(executableDirectiveLocations);
+  for (const directive of schema.allDirectives()) {
+    const typeSystemLocations = directive.locations.filter((loc) =>
+      !executableDirectiveLocationSet.has(loc)
+    );
+    if (hasBuiltInName(directive)) {
+      // Built-in directives (and their descendants) aren't allowed to be
+      // @inaccessible, regardless of shadowing.
+      const inaccessibleElements =
+        fetchInaccessibleElementsInDescendants(directive);
+      if (inaccessibleElements.length > 0) {
+        errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
+          message:
+            `Built-in directive "${directive.coordinate}" cannot use` +
+            ` @inaccessible.`,
+          nodes: directive.sourceAST,
+          extensions: {
+            disallowed_element: directive.coordinate,
+            inaccessible_elements: inaccessibleElements
+              .map((element) => element.coordinate),
+          }
+        }));
+      }
+    } else if (isFeatureDefinition(directive)) {
+      // Core feature directives (and their descendants) aren't allowed to be
+      // @inaccessible.
+      const inaccessibleElements =
+        fetchInaccessibleElementsInDescendants(directive);
+      if (inaccessibleElements.length > 0) {
+        errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
+          message:
+            `Core feature directive "${directive.coordinate}" cannot use` +
+            ` @inaccessible.`,
+          nodes: directive.sourceAST,
+          extensions: {
+            disallowed_element: directive.coordinate,
+            inaccessible_elements: inaccessibleElements
+              .map((element) => element.coordinate),
+          }
+        }));
+      }
+    } else if (typeSystemLocations.length > 0) {
+      // Directives that can appear on type-system locations (and their
+      // descendants) aren't allowed to be @inaccessible.
+      const inaccessibleElements =
+        fetchInaccessibleElementsInDescendants(directive);
+      if (inaccessibleElements.length > 0) {
+        errors.push(ERRORS.DISALLOWED_INACCESSIBLE.err({
+          message:
+            `Directive "${directive.coordinate}" cannot use @inaccessible` +
+            ` because it may be applied to these type-system locations:` +
+            ` ${typeSystemLocations.join(', ')}.`,
+          nodes: directive.sourceAST,
+          extensions: {
+            disallowed_element: directive.coordinate,
+            inaccessible_elements: inaccessibleElements
+              .map((element) => element.coordinate),
+          }
+        }));
+      }
+    } else {
+      // At this point, we know the directive must be in the API schema. Descend
+      // into the directive's arguments.
+      for (const argument of directive.arguments()) {
+        // When an argument is hidden (but its parent isn't), we check that it
+        // isn't a required argument of its directive.
+        if (argument.isRequired()) {
+          if (isInaccessible(argument)) {
+            errors.push(ERRORS.REQUIRED_INACCESSIBLE.err({
+              message:
+                `Argument "${argument.coordinate}" is @inaccessible but is a` +
+                ` required argument of its directive.`,
+              nodes: argument.sourceAST,
+              extensions: {
+                inaccessible_element: argument.coordinate,
+                inaccessible_element_requirer: argument.coordinate,
+              }
+            }));
+          }
+        }
+      }
     }
   }
 
   if (errors.length > 0) {
-    throw ErrGraphQLValidationFailed(errors, `Schema has ${errors.length === 1 ? 'an invalid use' : 'invalid uses'} of the @inaccessible directive.`);
+    throw ErrGraphQLAPISchemaValidationFailed(errors);
+  }
+}
+
+type DefaultValueReference = InputFieldDefinition | EnumValue;
+type SchemaElementWithDefaultValue =
+  | ArgumentDefinition<
+    | DirectiveDefinition
+    | FieldDefinition<ObjectType | InterfaceType>>
+  | InputFieldDefinition;
+
+// Default values in a schema may contain references to selectable elements that
+// are @inaccessible (input fields and enum values). For a given schema, this
+// function returns a map from such selectable elements to the elements with
+// default values referencing them. (The default values of built-ins and their
+// descendants are skipped.)
+//
+// Note that this will involve validating schema default values, which (at the
+// time of writing) is conspicuously not in the GraphQL spec. These are
+// validated similar to operation AST values as in the "Values of Correct Type"
+// validation in the GraphQL spec; please see
+// https://spec.graphql.org/draft/#sec-Values-of-Correct-Type
+// for details. The differences are that variable references aren't allowed, and
+// scalar input coercion is skipped (since coercion success is very dependent on
+// the environment/server characteristics).
+//
+// Any errors encountered during default value validation will be pushed onto
+// the given errors array.
+function computeDefaultValueReferencers(
+  schema: Schema,
+  errors: GraphQLError[],
+): Map<
+  DefaultValueReference,
+  SchemaElementWithDefaultValue[]
+> {
+  const referencers = new Map<
+    DefaultValueReference,
+    SchemaElementWithDefaultValue[]
+  >();
+
+  function addReference(
+    reference: DefaultValueReference,
+    referencer: SchemaElementWithDefaultValue,
+  ) {
+    const referencerList = referencers.get(reference) ?? [];
+    if (referencerList.length === 0) {
+      referencers.set(reference, referencerList);
+    }
+    referencerList.push(referencer);
+  }
+
+  // Note that the fields/arguments/input fields for built-in schema elements
+  // can presumably only have types that are built-in types. Since built-ins and
+  // their children aren't allowed to be @inaccessible, this means we shouldn't
+  // have to worry about references within the default values of arguments and
+  // input fields of built-ins, which is why we skip them below.
+  for (const type of schema.allTypes()) {
+    if (hasBuiltInName(type)) continue;
+
+    // Scan object/interface field arguments.
+    if (
+      (type instanceof ObjectType) ||
+      (type instanceof InterfaceType)
+    ) {
+      for (const field of type.fields()) {
+        for (const argument of field.arguments()) {
+          for (
+            const reference of computeDefaultValueReferences(argument, errors)
+          ) {
+            addReference(reference, argument);
+          }
+        }
+      }
+    }
+
+    // Scan input object fields.
+    if (type instanceof InputObjectType) {
+      for (const inputField of type.fields()) {
+        for (
+          const reference of computeDefaultValueReferences(inputField, errors)
+        ) {
+          addReference(reference, inputField);
+        }
+      }
+    }
+  }
+
+  // Scan directive definition arguments.
+  for (const directive of schema.allDirectives()) {
+    if (hasBuiltInName(directive)) continue;
+    for (const argument of directive.arguments()) {
+      for (
+        const reference of computeDefaultValueReferences(argument, errors)
+      ) {
+        addReference(reference, argument);
+      }
+    }
+  }
+
+  return referencers;
+}
+
+// For the given element, compute a list of input fields and enum values that
+// are referenced in its default value (if any). As mentioned above, this will
+// involve validating the default value to an extent. Any errors encountered
+// during default value validation will be pushed onto the given errors array.
+function computeDefaultValueReferences(
+  element: SchemaElementWithDefaultValue,
+  errors: GraphQLError[],
+): DefaultValueReference[] {
+  const references: DefaultValueReference[] = [];
+  addValueReferences(
+    element.defaultValue,
+    getInputType(element),
+    references,
+    element,
+    errors,
+  )
+  return references;
+}
+
+function getInputType(element: SchemaElementWithDefaultValue): InputType {
+  const type = element.type;
+  assert(
+    type,
+    "Schema should have been valid, but argument/input field did not have type."
+  );
+  return type;
+}
+
+// Modelled similarly to valueFromAST() from graphql-js, while adding in some
+// missing validations from ValuesOfCorrectTypeRule() (specifically for input
+// objects). For understanding how AST nodes are represented as JS values, see
+// buildValue(), which is used to create any default values when building a
+// Schema object.
+//
+// As noted above, the primary differences are that variable references aren't
+// allowed, and that scalar input coercion is skipped, even for built-ins. The
+// skipping is because coercion success depends on the environment/server
+// characteristics (e.g. float input coercion success depends on the available
+// precision as per the spec, which is machine-dependent). It would be bad if
+// the user believed a supergraph schema was valid according to the inaccessible
+// spec, but the server believed it was invalid and refused to load the schema
+// because of differences in input coercion.
+function addValueReferences(
+  value: any,
+  type: InputType,
+  references: DefaultValueReference[],
+  element: SchemaElementWithDefaultValue,
+  errors: GraphQLError[],
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (isVariable(value)) {
+    errors.push(ERRORS.INVALID_DEFAULT_VALUE.err({
+      message:
+        `Default value "${element.defaultValue}" of "${element.coordinate}"` +
+        ` cannot contain the variable reference "${value}".`,
+      nodes: element.sourceAST,
+      extensions: {
+        element: element.coordinate,
+        default_value: element.defaultValue,
+      }
+    }));
+    return;
+  }
+
+  if (isNonNullType(type)) {
+    if (value === null) {
+      errors.push(ERRORS.INVALID_DEFAULT_VALUE.err({
+        message:
+          `Default value "${element.defaultValue}" of "${element.coordinate}"` +
+          ` cannot provide null for non-nullable type "${type}".`,
+        nodes: element.sourceAST,
+        extensions: {
+          element: element.coordinate,
+          default_value: element.defaultValue,
+        }
+      }));
+    } else {
+      addValueReferences(
+        value,
+        type.ofType,
+        references,
+        element,
+        errors,
+      );
+    }
+    return;
+  }
+
+  if (value === null) {
+    return;
+  }
+
+  if (isListType(type)) {
+    const itemType: InputType = type.ofType;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        addValueReferences(
+          item,
+          itemType,
+          references,
+          element,
+          errors,
+        );
+      }
+    } else {
+      // Equivalent of coercing non-null element as a list of one.
+      addValueReferences(
+        value,
+        itemType,
+        references,
+        element,
+        errors,
+      );
+    }
+    return;
+  }
+
+  if (isScalarType(type)) {
+    // We explicitly do not attempt scalar input coercion, as the results are
+    // dependent on environment/server characteristics. (It's also not needed to
+    // compute references.)
+    return;
+  }
+
+  if (isInputObjectType(type)) {
+    if (typeof value !== 'object') {
+      errors.push(ERRORS.INVALID_DEFAULT_VALUE.err({
+        message:
+          `Default value "${element.defaultValue}" of "${element.coordinate}"` +
+          ` cannot provide non-object value "${value}" for input object type` +
+          ` ${type}.`,
+        nodes: element.sourceAST,
+        extensions: {
+          element: element.coordinate,
+          default_value: element.defaultValue,
+        }
+      }));
+    } else {
+      const valueKeys = new Set(Object.keys(value));
+      for (const field of type.fields()) {
+        valueKeys.delete(field.name);
+        const fieldValue = value[field.name];
+        if (fieldValue === undefined) {
+          if (
+            field.defaultValue === undefined &&
+            isNonNullType(getInputType(field))
+          ) {
+            errors.push(ERRORS.INVALID_DEFAULT_VALUE.err({
+              message:
+                `Default value "${element.defaultValue}" of` +
+                ` "${element.coordinate}" is missing required field` +
+                ` "${field.name}" for input object type "${type}".`,
+              nodes: element.sourceAST,
+              extensions: {
+                element: element.coordinate,
+                default_value: element.defaultValue,
+              }
+            }));
+          }
+        } else {
+          references.push(field);
+          addValueReferences(
+            fieldValue,
+            getInputType(field),
+            references,
+            element,
+            errors,
+          );
+        }
+      }
+      for (const fieldName of valueKeys) {
+        errors.push(ERRORS.INVALID_DEFAULT_VALUE.err({
+          message:
+            `Default value "${element.defaultValue}" of` +
+            ` "${element.coordinate}" contains input field "${fieldName}"` +
+            ` that is not defined in the input object type "${type}".`,
+          nodes: element.sourceAST,
+          extensions: {
+            element: element.coordinate,
+            default_value: element.defaultValue,
+          }
+        }));
+      }
+    }
+    return;
+  }
+
+  if (isEnumType(type)) {
+    // Note that Schema represents enum values as JS strings. Unfortunately, it
+    // does not ensure that AST string values aren't provided for enum types,
+    // which isn't allowed as per enum input coercion rules in the GraphQL spec.
+    // This can't be easily done in buildValue(), since it doesn't validate type
+    // information there, so the AST information is lost when the Schema builds
+    // and the representation changes. In the future this may change (although
+    // this is a breaking validation change, and ideally would be enacted in a
+    // major version bump).
+    if (typeof value !== 'string') {
+      errors.push(ERRORS.INVALID_DEFAULT_VALUE.err({
+        message:
+          `Default value "${element.defaultValue}" of "${element.coordinate}"` +
+          ` cannot provide non-enum value "${value}" for enum type "${type}".`,
+        nodes: element.sourceAST,
+        extensions: {
+          element: element.coordinate,
+          default_value: element.defaultValue,
+        }
+      }));
+    } else {
+      const enumValue = type.value(value);
+      if (enumValue === undefined) {
+        errors.push(ERRORS.INVALID_DEFAULT_VALUE.err({
+          message:
+            `Default value "${element.defaultValue}" of` +
+            ` "${element.coordinate}" contains enum value "${value}" that is` +
+            ` not defined in the enum type "${type}".`,
+          nodes: element.sourceAST,
+          extensions: {
+            element: element.coordinate,
+            default_value: element.defaultValue,
+          }
+        }));
+      } else {
+        references.push(enumValue);
+      }
+    }
+    return;
+  }
+
+  assert(false, "Unreachable code, element is of unknown type.")
+}
+
+// Determine whether a given schema element has a built-in's name. Note that
+// this is not the same as the isBuiltIn flag, due to shadowing definitions
+// (which will not have the flag set).
+function hasBuiltInName(element: NamedType | DirectiveDefinition): boolean {
+  const schema = element.schema();
+  if (
+    (element instanceof ObjectType) ||
+    (element instanceof InterfaceType) ||
+    (element instanceof UnionType) ||
+    (element instanceof ScalarType) ||
+    (element instanceof EnumType) ||
+    (element instanceof InputObjectType)
+  ) {
+    return schema.builtInTypes(true).some((type) =>
+      type.name === element.name
+    );
+  } else if (element instanceof DirectiveDefinition) {
+    return schema.builtInDirectives(true).some((directive) =>
+      directive.name === element.name
+    );
+  }
+  assert(false, "Unreachable code, element is of unknown type.")
+}
+
+// Remove schema elements marked with @inaccessible in the schema, assuming the
+// schema has been validated with validateInaccessibleElements().
+//
+// Note the schema that results from this may not necessarily be valid GraphQL
+// until core feature definitions have been removed by removeFeatureElements().
+function removeInaccessibleElementsAssumingValid(
+  schema: Schema,
+  inaccessibleDirective: DirectiveDefinition,
+): void {
+  function isInaccessible(element: SchemaElement<any, any>): boolean {
+    return element.hasAppliedDirective(inaccessibleDirective);
+  }
+
+  for (const type of schema.types()) {
+    if (isInaccessible(type)) {
+      type.remove();
+    } else {
+      if ((type instanceof ObjectType) || (type instanceof InterfaceType)) {
+        for (const field of type.fields()) {
+          if (isInaccessible(field)) {
+            field.remove();
+          } else {
+            for (const argument of field.arguments()) {
+              if (isInaccessible(argument)) {
+                argument.remove();
+              }
+            }
+          }
+        }
+      } else if (type instanceof InputObjectType) {
+        for (const inputField of type.fields()) {
+          if (isInaccessible(inputField)) {
+            inputField.remove();
+          }
+        }
+      } else if (type instanceof EnumType) {
+        for (const enumValue of type.values) {
+          if (isInaccessible(enumValue)) {
+            enumValue.remove();
+          }
+        }
+      }
+    }
+  }
+
+  for (const directive of schema.directives()) {
+    for (const argument of directive.arguments()) {
+      if (isInaccessible(argument)) {
+        argument.remove();
+      }
+    }
   }
 }

--- a/internals-js/src/supergraphs.ts
+++ b/internals-js/src/supergraphs.ts
@@ -14,6 +14,7 @@ const SUPPORTED_FEATURES = new Set([
   'https://specs.apollo.dev/tag/v0.1',
   'https://specs.apollo.dev/tag/v0.2',
   'https://specs.apollo.dev/inaccessible/v0.1',
+  'https://specs.apollo.dev/inaccessible/v0.2',
 ]);
 
 export function ErrUnsupportedFeature(feature: CoreFeature): Error {

--- a/subgraph-js/src/directives.ts
+++ b/subgraph-js/src/directives.ts
@@ -117,6 +117,12 @@ export const InaccessibleDirective = new GraphQLDirective({
     DirectiveLocation.OBJECT,
     DirectiveLocation.INTERFACE,
     DirectiveLocation.UNION,
+    DirectiveLocation.ARGUMENT_DEFINITION,
+    DirectiveLocation.SCALAR,
+    DirectiveLocation.ENUM,
+    DirectiveLocation.ENUM_VALUE,
+    DirectiveLocation.INPUT_OBJECT,
+    DirectiveLocation.INPUT_FIELD_DEFINITION,
   ],
 });
 


### PR DESCRIPTION
This PR introduces inaccessible v0.2, which adds support for `@inaccessible` in more locations (arguments, scalars, enums, enum values, input objects, input object fields).

This PR should be ready for review. The only thing missing at the moment is tests for complex default values, but I've encountered some bugs with `Schema` and friends while writing tests there, so I'm going to wait for those to be resolved before writing those.

To summarize the PR:
- Some various bugs in `remove()` implementations have been fixed.
- Anything that would result in the API schema being invalid GraphQL is validated early and given a hopefully more helpful error message.
  - In addition, we perform some validations that aren't technically required for the API schema to be valid GraphQL:
    - All schema default values are validated to an extent, in accordance with the [`Values of Correct Type`](https://spec.graphql.org/draft/#sec-Values-of-Correct-Type) validation that's used for input values in operation ASTs.
      - The GraphQL spec omits input coercion for default values. This means they're not validated to match their expected type.
      - We perform this validation in order to compute references to inaccessible input fields and enum values.
      - We additionally forbid variable references (which are allowed in operation ASTs, but don't make sense in schemas).
      - By "to an extent", I mean we explicitly skip the following:
        - We do not perform scalar input coercion. We can't easily do this for custom scalars, and some built-ins (e.g. Float) have machine-specific input coercion rules.
        - The GraphQL spec forbids AST string nodes to be provided where an enum type is expected (as part of enum input coercion rules). However, the representation of default values in `Schema` and friends uses a JS string for both AST strings and AST enum values, so you can't distinguish them.
          - I'm still new to this codebase, so there may be some validation elsewhere that addresses this. But if there isn't, we should be careful about fixing this later, as we don't want to break gateway/router after Fed 2 GA.
    - Arguments and input fields cannot be `@inaccessible` if that element is required.
      - This is needed for subgraph queries to succeed GraphQL operation validation.
- `@inaccessible` is banned on some element kinds for v0.2:
  - Specifically, those element kinds are: 
    - Built-in schema elements (and their descendants).
    - Core feature schema elements (and their descendants).
    - The descendants of directive definitions with any type-system locations (the definitions themselves can't have directives)
  - In inaccessible v0.1, by coincidence, `@inaccessible` generally couldn't be applied to these element kinds because the locations weren't supported.
    - The directive definition case is defacto forbidden in v0.1 by virtue of arguments not being supported.
    - We can edit the inaccessible v0.1 spec to say that built-ins are forbidden, since the set of built-ins can't change for old gateways (but could change in the future, so we should edit the spec).
    - For core feature schema elements, existing core specs don't introduce object/interface/union types, but there's an edge case if the user introduced a user-defined core spec (via core v0.2) that had those types. I'm leaning toward editing the inaccessible v0.1 spec to declare it as undefined behavior. That way we can perform the ban for both v0.1 and v0.2 in gateway/router.
 