### PR TITLE
Switch Logger usages away from `apollo-server-types` to `@apollo/utils.logger`

### DIFF
--- a/docs/source/api/apollo-gateway.mdx
+++ b/docs/source/api/apollo-gateway.mdx
@@ -187,11 +187,11 @@ The default value is `false`.
 
 ###### `logger`
 
-[`Logger`](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-types/src/index.ts#L166-L172)
+[`Logger`](https://github.com/apollographql/apollo-utils/tree/main/packages/logger)
 </td>
 <td>
 
-An object to use for logging in place of `console`. If provided, this object must implement all methods of [the `Logger` interface](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-types/src/index.ts#L166-L172).
+An object to use for logging in place of `console`. If provided, this object must implement all methods of [the `Logger` interface](https://github.com/apollographql/apollo-utils/tree/main/packages/logger).
 
 If you provide this value, the gateway automatically logs all messages of _all_ severity levels (`debug` through `error`), regardless of whether the `debug` option is set to `true`. It is the responsibility of the logger to determine how to handle logged messages of each level.
 
@@ -727,11 +727,11 @@ If `true`, the gateway performs a health check on each subgraph before performin
 
 ###### `logger`
 
-[`Logger`](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-types/src/index.ts#L166-L172)
+[`Logger`](https://github.com/apollographql/apollo-utils/tree/main/packages/logger)
 </td>
 <td>
 
-An object to use for logging in place of `console`. If provided, this object must implement all methods of [the `Logger` interface](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-types/src/index.ts#L166-L172).
+An object to use for logging in place of `console`. If provided, this object must implement all methods of [the `Logger` interface](https://github.com/apollographql/apollo-utils/tree/main/packages/logger).
 
 `IntrospectAndCompose` doesn't share the same logger as the `ApolloGateway` it's configured with. In most cases, you probably want to pass the same logger to both `ApolloGateway` and `IntrospectAndCompose`.
 </td>

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -28,6 +28,7 @@
     "@apollo/composition": "file:../composition-js",
     "@apollo/core-schema": "^0.2.2",
     "@apollo/query-planner": "file:../query-planner-js",
+    "@apollo/utils.logger": "^1.0.0",
     "@josephg/resolvable": "^1.0.1",
     "@opentelemetry/api": "^1.0.1",
     "@types/node-fetch": "2.6.1",

--- a/gateway-js/src/__tests__/execution-utils.ts
+++ b/gateway-js/src/__tests__/execution-utils.ts
@@ -3,7 +3,8 @@ import {
   GraphQLSchemaModule,
   GraphQLResolverMap,
 } from '../schema-helper';
-import { GraphQLRequest, GraphQLExecutionResult, Logger } from 'apollo-server-types';
+import { GraphQLRequest, GraphQLExecutionResult } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import {
   executeQueryPlan,

--- a/gateway-js/src/__tests__/gateway/executor.test.ts
+++ b/gateway-js/src/__tests__/gateway/executor.test.ts
@@ -2,7 +2,7 @@ import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import gql from 'graphql-tag';
 import { ApolloGateway } from '../../';
 import { fixtures } from 'apollo-federation-integration-testsuite';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 
 let logger: {
   warn: jest.MockedFunction<Logger['warn']>,

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -16,7 +16,7 @@ import {
   fixtures,
   fixturesWithUpdate,
 } from 'apollo-federation-integration-testsuite';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import resolvable from '@josephg/resolvable';
 import { createHash } from '../../utilities/createHash';
 import { getTestingSupergraphSdl } from '../execution-utils';

--- a/gateway-js/src/__tests__/gateway/supergraphSdl.test.ts
+++ b/gateway-js/src/__tests__/gateway/supergraphSdl.test.ts
@@ -7,7 +7,7 @@ import {
 import { fixturesWithUpdate } from 'apollo-federation-integration-testsuite';
 import { createHash } from '../../utilities/createHash';
 import { ApolloServer } from 'apollo-server';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { fetch } from '../../__mocks__/make-fetch-happen-fetcher';
 import { getTestingSupergraphSdl } from '../execution-utils';
 import { mockAllServicesHealthCheckSuccess } from '../integration/nockMocks';

--- a/gateway-js/src/__tests__/integration/configuration.test.ts
+++ b/gateway-js/src/__tests__/integration/configuration.test.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 import http from 'http';
 import mockedEnv from 'mocked-env';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { ApolloGateway } from '../..';
 import {
   mockSdlQuerySuccess,

--- a/gateway-js/src/__tests__/integration/logger.test.ts
+++ b/gateway-js/src/__tests__/integration/logger.test.ts
@@ -1,5 +1,5 @@
 import { ApolloGateway } from '../..';
-import { Logger } from "apollo-server-types";
+import type { Logger } from '@apollo/utils.logger';
 import { PassThrough } from "stream";
 
 import * as winston from "winston";

--- a/gateway-js/src/__tests__/integration/networkRequests.test.ts
+++ b/gateway-js/src/__tests__/integration/networkRequests.test.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 import { GraphQLObjectType, GraphQLSchema } from 'graphql';
 import mockedEnv from 'mocked-env';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { ApolloGateway } from '../..';
 import {
   mockSdlQuerySuccess,

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -1,10 +1,8 @@
 import { GraphQLError, GraphQLSchema } from 'graphql';
 import { HeadersInit } from 'node-fetch';
 import { fetch } from 'apollo-server-env';
-import {
-  GraphQLRequestContextExecutionDidStart,
-  Logger,
-} from 'apollo-server-types';
+import { GraphQLRequestContextExecutionDidStart } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { GraphQLDataSource } from './datasources/types';
 import { QueryPlan } from '@apollo/query-planner';
 import { OperationContext } from './operationContext';

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -2,9 +2,9 @@ import { deprecate } from 'util';
 import { GraphQLService, Unsubscriber } from 'apollo-server-core';
 import {
   GraphQLExecutionResult,
-  Logger,
   GraphQLRequestContextExecutionDidStart,
 } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import {
   isObjectType,

--- a/gateway-js/src/supergraphManagers/IntrospectAndCompose/__tests__/IntrospectAndCompose.test.ts
+++ b/gateway-js/src/supergraphManagers/IntrospectAndCompose/__tests__/IntrospectAndCompose.test.ts
@@ -9,7 +9,7 @@ import { IntrospectAndCompose } from '..';
 import { mockAllServicesSdlQuerySuccess } from '../../../__tests__/integration/nockMocks';
 import { getTestingSupergraphSdl, wait } from '../../../__tests__/execution-utils';
 import resolvable from '@josephg/resolvable';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 
 describe('IntrospectAndCompose', () => {
   beforeEach(nockBeforeEach);

--- a/gateway-js/src/supergraphManagers/IntrospectAndCompose/index.ts
+++ b/gateway-js/src/supergraphManagers/IntrospectAndCompose/index.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { HeadersInit } from 'node-fetch';
 import resolvable from '@josephg/resolvable';
 import {

--- a/gateway-js/src/supergraphManagers/LegacyFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/LegacyFetcher/index.ts
@@ -4,7 +4,7 @@
  * configuration options of the gateway and will be removed in a future release
  * along with those options.
  */
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import resolvable from '@josephg/resolvable';
 import {
   SupergraphManager,

--- a/gateway-js/src/supergraphManagers/LocalCompose/index.ts
+++ b/gateway-js/src/supergraphManagers/LocalCompose/index.ts
@@ -1,5 +1,5 @@
 // TODO(trevor:removeServiceList) the whole file goes away
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import { composeServices } from '@apollo/composition';
 import {
   GetDataSourceFunction,

--- a/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkFetcher/index.ts
@@ -1,5 +1,5 @@
 import { fetch } from 'apollo-server-env';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from '@apollo/utils.logger';
 import resolvable from '@josephg/resolvable';
 import { SupergraphManager, SupergraphSdlHookOptions } from '../../config';
 import { SubgraphHealthCheckFunction, SupergraphSdlUpdateFunction } from '../..';

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "@apollo/composition": "file:../composition-js",
         "@apollo/core-schema": "^0.2.2",
         "@apollo/query-planner": "file:../query-planner-js",
+        "@apollo/utils.logger": "^1.0.0",
         "@josephg/resolvable": "^1.0.1",
         "@opentelemetry/api": "^1.0.1",
         "@types/node-fetch": "2.6.1",
@@ -264,6 +265,11 @@
     "node_modules/@apollo/subgraph": {
       "resolved": "subgraph-js",
       "link": true
+    },
+    "node_modules/@apollo/utils.logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.0.tgz",
+      "integrity": "sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q=="
     },
     "node_modules/@apollographql/apollo-tools": {
       "version": "0.5.3",
@@ -18949,6 +18955,7 @@
         "@apollo/composition": "file:../composition-js",
         "@apollo/core-schema": "^0.2.2",
         "@apollo/query-planner": "file:../query-planner-js",
+        "@apollo/utils.logger": "^1.0.0",
         "@josephg/resolvable": "^1.0.1",
         "@opentelemetry/api": "^1.0.1",
         "@types/node-fetch": "2.6.1",
@@ -19036,6 +19043,11 @@
     "@apollo/subgraph": {
       "version": "file:subgraph-js",
       "requires": {}
+    },
+    "@apollo/utils.logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.0.tgz",
+      "integrity": "sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q=="
     },
     "@apollographql/apollo-tools": {
       "version": "0.5.3",


### PR DESCRIPTION
This is just an interface which I'm migrating out of `apollo-server-types`, so breaking gateway's dependency on that one in favor of the one published by `@apollo/utils.logger`.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
