### PR TITLE
Release 2.0.0-preview.10

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ This is a quick and opinionated set of commands for building and releasing a new
 #### Start a release PR
 
 1. `FEDERATION_RELEASE_VERSION=X.Y.Z` (e.g. `2.0.1` or `2.0.0-beta.3` or `2.0.0-preview.99`)
-1. `git fetch origin main:main` to fetch the latest `main` branch
+1. `git fetch origin main` to fetch the latest `main` branch
 1. `git checkout -b "release-$FEDERATION_RELEASE_VERSION" main`
 1. Update `CHANGELOG.md` in each repo ([more info](#changelogs))
 1. `git add ':/*CHANGELOG.md'` to add only changelogs to the commit

--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/federation-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## v2.0.0-preview.10
+
 - Fix merging of Input objects and enum types [PR #1672](https://github.com/apollographql/federation/pull/1672).
-- Fix regression in composition validation introduced by #1653 [PR #1673](https://github.com/apollographql/federation/pull/1673) .
+- Fix regression in composition validation introduced by #1653 [PR #1673](https://github.com/apollographql/federation/pull/1673).
+- Add nodes when displaying hints for `@override` [PR #1684](https://github.com/apollographql/federation/pull/1684)
 
 ## v2.0.0-preview.9
 

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.0.0-preview.9",
+  "version": "2.0.0-preview.10",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "2.0.0-preview.9",
+  "version": "2.0.0-preview.10",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## v2.0.0-preview.10
+
 - Fix merging of Input objects and enum types [PR #1672](https://github.com/apollographql/federation/pull/1672).
 - Relax validation of directive redefinition for scalar [PR #1674](https://github.com/apollographql/federation/pull/1674).
 - Fix regression in composition validation introduced by #1653 [PR #1673](https://github.com/apollographql/federation/pull/1673) .
+- Update logging [PR #1688](https://github.com/apollographql/federation/pull/1688) and test [PR #1685](https://github.com/apollographql/federation/pull/1685/) dependencies.
 
 ## v2.0.0-preview.9
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.0.0-preview.9",
+  "version": "2.0.0-preview.10",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for `@apollo/federation-internals`
 
+## v2.0.0-preview.10
+
+- Released in sync with other federation packages but no changes to this package.
+
 ## v2.0.0-preview.9
 
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.0.0-preview.9",
+  "version": "2.0.0-preview.10",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.0.0-preview.9",
+      "version": "2.0.0-preview.10",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -80,7 +80,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "2.0.0-preview.9",
+      "version": "2.0.0-preview.10",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "graphql-tag": "^2.12.6",
@@ -89,7 +89,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.0.0-preview.9",
+      "version": "2.0.0-preview.10",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -120,7 +120,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.0.0-preview.9",
+      "version": "2.0.0-preview.10",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/core-schema": "^0.2.2",
@@ -18832,7 +18832,7 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.0.0-preview.9",
+      "version": "2.0.0-preview.10",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -18848,7 +18848,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.0.0-preview.9",
+      "version": "2.0.0-preview.10",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -18866,7 +18866,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "2.0.0-preview.9",
+      "version": "2.0.0-preview.10",
       "license": "MIT",
       "engines": {
         "node": ">=12.13.0 <18.0"

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for `@apollo/query-graphs`
 
+## v2.0.0-preview.10
+
+- Released in sync with other federation packages but no changes to this package.
+
 ## v2.0.0-preview.9
 
 - Support for Node 17 [PR #1541](https://github.com/apollographql/federation/pull/1541).

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.0.0-preview.9",
+  "version": "2.0.0-preview.10",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## v2.0.0-preview.10
+
+- Released in sync with other federation packages but no changes to this package.
+
 ## v2.0.0-preview.9
 
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.0.0-preview.9",
+  "version": "2.0.0-preview.10",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## v2.0.0-preview.10
+
+- Released in sync with other federation packages but no changes to this package.
+
 ## v2.0.0-preview.9
 
 - Adds Support for `@tag/v0.2`, which allows the `@tag` directive to be additionally placed on arguments, scalars, enums, enum values, input objects, and input object fields. [PR #1652](https://github.com/apollographql/federation/pull/1652).

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "2.0.0-preview.9",
+  "version": "2.0.0-preview.10",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌 The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.
