### PR TITLE
Fix default value validation for input fields

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+- Fix issues validating default values [PR #1692)](https://github.com/apollographql/federation/pull/1692).
 - Add a level to hints, uppercase their code and related fixes [PR #1683](https://github.com/apollographql/federation/pull/1683).
 
 ## v2.0.0-preview.10

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -9,7 +9,7 @@ import './matchers';
 // Builds the provided subgraph (using name 'S' for the subgraph) and, if the
 // subgraph is invalid/has errors, return those errors as a list of [code, message].
 // If the subgraph is valid, return undefined.
-function buildForErrors(
+export function buildForErrors(
   subgraphDefs: DocumentNode,
   options?: {
     subgraphName?: string,

--- a/internals-js/src/__tests__/values.test.ts
+++ b/internals-js/src/__tests__/values.test.ts
@@ -3,6 +3,8 @@ import {
 } from '../../dist/definitions';
 import { buildSchema } from '../../dist/buildSchema';
 import { parseOperation } from '../../dist/operations';
+import { buildForErrors } from './subgraphValidation.test';
+import gql from 'graphql-tag';
 
 function parseSchema(schema: string): Schema {
   try {
@@ -65,4 +67,260 @@ test('handles non-list value for list argument (as singleton)', () => {
       ],
     }
   `);
+});
+
+describe('default value validation', () => {
+  it('errors on invalid default value in field argument', () => {
+    const doc = gql`
+      type Query {
+        f(a: Int = "foo"): Int
+      }
+    `;
+
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: "foo") provided for argument Query.f(a:) of type Int.'
+    ]]);
+  });
+
+  it('errors on invalid default value in directive argument', () => {
+    const doc = gql`
+      type Query {
+        f: Int
+      }
+
+      directive @myDirective(a: Int = "foo") on FIELD
+    `;
+
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: "foo") provided for argument @myDirective(a:) of type Int.'
+    ]]);
+  });
+
+  it('errors on invalid default value in input field', () => {
+    const doc = gql`
+      input I {
+        x: Int = "foo"
+      }
+    `;
+
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: "foo") provided for input field I.x of type Int.'
+    ]]);
+  });
+
+  it('errors on invalid default value for existing input field', () => {
+    const doc = gql`
+      type Query {
+        f(i: I = { x: 2, y: "3" }): Int
+      }
+
+      input I {
+        x: Int
+        y: Int
+      }
+    `;
+
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: {x: 2, y: "3"}) provided for argument Query.f(i:) of type I.'
+    ]]);
+  });
+
+  it('errors on default value containing unexpected input fields', () => {
+    const doc = gql`
+      type Query {
+        f(i: I = { x: 1, y: 2, z: 3 }): Int
+      }
+
+      input I {
+        x: Int
+        y: Int
+      }
+    `;
+
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: {x: 1, y: 2, z: 3}) provided for argument Query.f(i:) of type I.'
+    ]]);
+  });
+
+  it('errors on default value being unknown enum value', () => {
+    const doc = gql`
+      type Query {
+        f(e: E = THREE): Int
+      }
+
+      enum E {
+        ONE
+        TWO
+      }
+    `;
+
+    // Note that it is slightly imperfect that the error shows the value as a "string" but is the result
+    // of enum values being encoded by string value internally (and while, when a value type-check correctly,
+    // we can use the type to display enum values properly, this is exactly a case where the value is not
+    // correctly type-checked, so we currently don't have a good way to figure out it's an enum when we display
+    // it in the error message). We could fix this someday if we change to using a specific class/object for
+    // enum values internally (though this might have backward compatbility constraints), but in the meantime,
+    // it's unlikely to trip users too much. 
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: "THREE") provided for argument Query.f(e:) of type E.'
+    ]]);
+  });
+
+  it('errors on default value being unknown enum value (as string)', () => {
+    const doc = gql`
+      type Query {
+        f(e: E = "TWOO"): Int
+      }
+
+      enum E {
+        ONE
+        TWO
+      }
+    `;
+
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: "TWOO") provided for argument Query.f(e:) of type E.'
+    ]]);
+  });
+
+  it('accepts default value enum value as string, if a valid enum value', () => {
+    // Please note that this test show we accept strings for enum even though the GraphQL spec kind
+    // of say we shouldn't. But the graphQL spec also doesn't really do default value validation,
+    // which be believe is just wrong, and as a consequence we've seen customer schema with string-for-enum
+    // in default values, and it doesn't sound very harmfull to allow it (the spec even admits that some
+    // transport may have to deal with enums as string anyway), so we prefer having that allowance in
+    // federation (if this ever become a huge issue for some users, we could imagine to add a "strict"
+    // more that start refusing this).
+    const doc = gql`
+      type Query {
+        f(e: E = "TWO"): Int
+      }
+
+      enum E {
+        ONE
+        TWO
+      }
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
+
+  it('accepts any value for a custom scalar in field agument', () => {
+    const doc = gql`
+      type Query {
+        f(i: Scalar = { x: 2, y: "3" }): Int
+      }
+
+      scalar Scalar
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
+
+  it('accepts any value for a custom scalar in directive agument', () => {
+    const doc = gql`
+      type Query {
+        f: Int
+      }
+
+      directive @myDirective(i: Scalar = { x: 2, y: "3" }) on FIELD
+      scalar Scalar
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
+
+  it('accepts any value for a custom scalar in an input field', () => {
+    const doc = gql`
+      input I {
+        x: Scalar = { z: { a: 4} }
+      }
+
+      scalar Scalar
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
+
+  it('accepts default value coercible to list for a list type', () => {
+    const doc = gql`
+      type Query {
+        f(x: [String] = "foo"): Int
+      }
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
+
+  it('accepts default value coercible to its type but needing multiple/nested coercions', () => {
+    const doc = gql`
+      type Query {
+        f(x: I = { j: {x: 1, z: "Foo"} }): Int
+      }
+
+      input I {
+        j: [J]
+      }
+
+      input J {
+        x: ID
+        y: ID
+        z: ID
+      }
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
+
+  it('accepts default values that, if actually coerced, woudl result in infinite loops', () => {
+    // This example is stolen from this comment: https://github.com/graphql/graphql-spec/pull/793#issuecomment-738736539
+    // It essentially show that while, as the other tests of this file show, we 1) validate default value against
+    // their type and 2) ensures default values coercible to said type don't fail such validation, we also do
+    // _not_ do the actual coercion of those values, which in this example would lead to an infinite loop.
+    const doc = gql`
+      input A {
+        b: B = {}
+      }
+
+      input B {
+        a: A = {}
+      }
+
+      type Query {
+        q(a: A = {}): Int
+      }
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
+
+  it('errors on null default value for non-nullable input', () => {
+    const doc = gql`
+      type Query {
+        f(i: Int! = null): Int
+      }
+    `;
+
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] Invalid default value (got: null) provided for argument Query.f(i:) of type Int!.'
+    ]]);
+  });
+
+  it('Accepts null default value for nullable input', () => {
+    const doc = gql`
+      type Query {
+        f(i: Int = null): Int
+      }
+    `;
+
+    expect(buildForErrors(doc)).toBeUndefined();
+  });
 });

--- a/internals-js/src/validate.ts
+++ b/internals-js/src/validate.ts
@@ -254,6 +254,12 @@ class Validator {
           sourceASTs(field.appliedDirectivesOf('deprecated')[0], field)
         ));
       }
+      if (field.defaultValue !== undefined && !isValidValue(field.defaultValue, field, new VariableDefinitions())) {
+        this.errors.push(new GraphQLError(
+          `Invalid default value (got: ${valueToString(field.defaultValue)}) provided for input field ${field.coordinate} of type ${field.type}.`,
+          sourceASTs(field)
+        ));
+      }
     }
   }
 

--- a/internals-js/src/values.ts
+++ b/internals-js/src/values.ts
@@ -61,7 +61,7 @@ export function valueToString(v: any, expectedType?: InputType): string {
   }
 
   if (expectedType && isNonNullType(expectedType)) {
-    expectedType = expectedType.ofType;
+    return valueToString(v, expectedType.ofType);
   }
 
   if (expectedType && isCustomScalarType(expectedType)) {
@@ -88,7 +88,7 @@ export function valueToString(v: any, expectedType?: InputType): string {
   // the value correctly, at least as long as it's a valid value for the element type, since
   // list input coercions may allow this.
   if (expectedType && isListType(expectedType)) {
-    expectedType = expectedType.ofType;
+    return valueToString(v, expectedType.ofType);
   }
 
   if (typeof v === 'object') {


### PR DESCRIPTION
The validation of default values was called for field and directive arguments, but not for input fields, and this commit adds it.

This commits further adds testing for this default value validation and fix a number of issue in that value validation.