### PR TITLE
docs: fix v2 redirects

### DIFF
--- a/docs/source/_redirects
+++ b/docs/source/_redirects
@@ -1,15 +1,13 @@
-/federation-2/*  /docs/federation/v2/federation-2/:splat
+/federation-2/coming-to-federation-2/ /docs/federation/v2/federation-2/under-consideration/
+/federated-types/restricting-types-fields/ /docs/federation/v2/federated-types/ownership-directives/
+/federated-types/types-fields/ /docs/federation/v2/federated-types/
+/value-types/ /docs/federation/v2/federated-types/sharing-types/
+/federated-types/value-types/  /docs/federation/v2/federated-types/sharing-types/
 
-/v2/federation-2/coming-to-federation-2/ /docs/federation/v2/federation-2/under-consideration/
-/v2/federated-types/restricting-types-fields/ /docs/federation/v2/federated-types/ownership-directives/
-/v2/federated-types/types-fields/ /docs/federation/v2/federated-types/
-/v2/value-types/ /docs/federation/v2/federated-types/sharing-types/
-/v2/federated-types/value-types/  /docs/federation/v2/federated-types/sharing-types/
-
-/v2/quickstart/ /docs/federation/v2/quickstart/setup/
-/v2/quickstart-pt-2/ /docs/federation/v2/quickstart/studio-composition/
-/v2/quickstart-pt-3/ /docs/federation/v2/quickstart/local-composition/
-/v2/quickstart-pt-4/ /docs/federation/v2/quickstart/local-subgraphs/
+/quickstart/ /docs/federation/v2/quickstart/setup/
+/quickstart-pt-2/ /docs/federation/v2/quickstart/studio-composition/
+/quickstart-pt-3/ /docs/federation/v2/quickstart/local-composition/
+/quickstart-pt-4/ /docs/federation/v2/quickstart/local-subgraphs/
 
 /core-concepts/ /docs/federation/implementing-services/
 /implementing-services/ /docs/federation/subgraphs/


### PR DESCRIPTION
This PR removes the `/federation-2/*` redirect and removes the `/v2` path prefix infront of all v2 redirects.