### PR TITLE
bugfix: Use `SECURITY` core purpose for merged inaccessible spec

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -5,6 +5,7 @@ import {
   buildSubgraph,
   extractSubgraphsFromSupergraph,
   FEDERATION2_LINK_WTH_FULL_IMPORTS,
+  inaccessibleIdentity,
   InputObjectType,
   isObjectType,
   ObjectType,
@@ -2638,6 +2639,23 @@ describe('composition', () => {
       );
       expect(print(nodes[1])).toMatchString('q2: A');
     })
+
+    it('uses the SECURITY core purpose for inaccessible in the supergraph', () => {
+      const subgraphA = {
+        typeDefs: gql`
+          type Query {
+            someField: String!
+            privateField: String! @inaccessible
+          }
+        `,
+        name: 'subgraphA',
+      };
+
+      const result = composeAsFed2Subgraphs([subgraphA]);
+      assertCompositionSuccess(result);
+      const supergraph = result.schema;
+      expect(supergraph.coreFeatures?.getByIdentity(inaccessibleIdentity)?.purpose).toBe('SECURITY');
+    });
   });
 
   describe('Enum types', () => {

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -279,7 +279,7 @@ class Merger {
     // pass a `as` to the methods below if necessary. However, as we currently don't propagate any subgraph directives to
     // the supergraph outside of a few well-known ones, we don't bother yet.
     linkSpec.addToSchema(this.merged);
-    const errors = linkSpec.applyFeatureToSchema(this.merged, joinSpec, undefined, 'EXECUTION');
+    const errors = linkSpec.applyFeatureToSchema(this.merged, joinSpec, undefined, joinSpec.defaultCorePurpose);
     assert(errors.length === 0, "We shouldn't have errors adding the join spec to the (still empty) supergraph schema");
 
     for (const mergedInfo of MERGED_FEDERATION_DIRECTIVES) {
@@ -314,7 +314,7 @@ class Merger {
     // If we get here with `nameInSupergraph` unset, it means there is no usage for the directive at all and we
     // don't bother adding the spec to the supergraph.
     if (nameInSupergraph) {
-      const errors = linkSpec.applyFeatureToSchema(this.merged, specInSupergraph, nameInSupergraph === specInSupergraph.url.name ? undefined : nameInSupergraph);
+      const errors = linkSpec.applyFeatureToSchema(this.merged, specInSupergraph, nameInSupergraph === specInSupergraph.url.name ? undefined : nameInSupergraph, specInSupergraph.defaultCorePurpose);
       assert(errors.length === 0, "We shouldn't have errors adding the join spec to the (still empty) supergraph schema");
       this.mergedFederationDirectiveNames.add(nameInSupergraph);
       this.mergedFederationDirectiveInSupergraph.set(specInSupergraph.url.name, this.merged.directive(nameInSupergraph)!);

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -131,6 +131,10 @@ export abstract class FeatureDefinition {
     return features.getByIdentity(this.identity);
   }
 
+  get defaultCorePurpose(): CorePurpose | undefined {
+    return undefined;
+  }
+
   toString(): string {
     return `${this.identity}/${this.version}`
   }

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -1,4 +1,4 @@
-import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
+import { CorePurpose, FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
 import {
   ArgumentDefinition,
   CoreFeatures,
@@ -91,6 +91,10 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
 
   allElementNames(): string[] {
     return ['@inaccessible'];
+  }
+
+  get defaultCorePurpose(): CorePurpose | undefined {
+    return 'SECURITY';
   }
 }
 

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -1,5 +1,5 @@
 import { DirectiveLocation, GraphQLError } from 'graphql';
-import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
+import { CorePurpose, FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
 import {
   DirectiveDefinition,
   EnumType,
@@ -175,6 +175,10 @@ export class JoinSpecDefinition extends FeatureDefinition {
 
   ownerDirective(schema: Schema): DirectiveDefinition<{graph: string}> | undefined {
     return this.directive(schema, 'owner');
+  }
+
+  get defaultCorePurpose(): CorePurpose | undefined {
+    return 'EXECUTION';
   }
 }
 


### PR DESCRIPTION
In #1638 , as part of the ability to use `@inaccessible` in subgraphs, composition will add the inaccessible spec to the supergraph when it's used in a subgraph.

However, we currently don't specify a core purpose. We would like to use `for: SECURITY` in the core/link directive application for inaccessible. This PR makes this change via introducing `defaultCorePurpose` on `FeatureDefinition`.