### PR TITLE
bugfix: Honor directive imports when directive name is spec name

### DIFF
--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -949,9 +949,10 @@ export class CoreFeature {
     const elementImport = this.imports.find((i) => i.name.charAt(0) === '@' && i.name.slice(1) === name);
     return elementImport
       ? (elementImport.as?.slice(1) ?? name)
-      : name === this.url.name
-      ? this.nameInSchema
-      : this.nameInSchema + '__' + name;
+      : (name === this.url.name
+        ? this.nameInSchema
+        : this.nameInSchema + '__' + name
+      );
   }
 
   typeNameInSchema(name: string): string {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -946,11 +946,12 @@ export class CoreFeature {
   }
 
   directiveNameInSchema(name: string): string {
-    if (name === this.url.name) {
-      return this.nameInSchema;
-    }
     const elementImport = this.imports.find((i) => i.name.charAt(0) === '@' && i.name.slice(1) === name);
-    return elementImport ? (elementImport.as?.slice(1) ?? name) : this.nameInSchema + '__' + name;
+    return elementImport
+      ? (elementImport.as?.slice(1) ?? name)
+      : name === this.url.name
+      ? this.nameInSchema
+      : this.nameInSchema + '__' + name;
   }
 
   typeNameInSchema(name: string): string {


### PR DESCRIPTION
Currently, this import
```typescript
@link(url: "https://specs.apollo.dev/inaccessible/v0.2", import: [{name: "@inaccessible", as: "@foo"}])
```
is not honored. Specifically, elements marked `@inaccessible` will be removed, and elements marked `@foo` will not be removed.

This PR fixes the bug in `directiveNameInSchema()` that caused it, and adds a test for it.

Thankfully, we currently don't generate `import`s in the supergraph schema. However, for the near future, we should avoid having `import`s in the supergraph schema. If the desire arises to allow `import`s in the supergraph schema from `apollographql/federation` devs, please talk to Team Houston for next steps.