### PR TITLE
0.36.1 release

### DIFF
--- a/federation-js/CHANGELOG.md
+++ b/federation-js/CHANGELOG.md
@@ -6,6 +6,10 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- _Nothing yet! Stay tuned._
+
+## v0.36.1
+
 - Composition will detect and error if it finds fed2 subgraphs [PR #1723](https://github.com/apollographql/federation/pull/1723).
 
 ## v0.36.0

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Apollo Federation Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,11 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 ## vNEXT
 
-> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+> The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) 
+
+- _Nothing yet! Stay tuned._
+
+## v0.50.1
 
 - Throw a `GraphQLSchemaValidationError` error for issues with the `@inaccessible` directive when calling `toApiSchema`. The error will contain a list of all validation errors pertaining to `@inaccessible` [PR #1581](https://github.com/apollographql/federation/pull/1581).
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
     },
     "federation-js": {
       "name": "@apollo/federation",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/subgraph": "file:../subgraph-js",
@@ -91,7 +91,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "0.50.0",
+      "version": "0.50.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/core-schema": "^0.2.0",
@@ -19094,7 +19094,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -19110,7 +19110,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "engines": {
         "node": ">=12.13.0 <18.0"

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -6,6 +6,11 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- _Nothing yet! Stay tuned._
+
+
+## v0.10.1
+
 - Throw a `GraphQLSchemaValidationError` error for issues with the `@inaccessible` directive when calling `removeInaccessibleElements`. The error will contain a list of all validation errors pertaining to `@inaccessible` [PR #1581](https://github.com/apollographql/federation/pull/1581).
 
 ## v0.10.0
@@ -96,4 +101,3 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 # v0.1.0
 
 - Initial release of TypeScript query planner code extracted from `@apollo/gateway`. (Previous releases of this package were wrappers around `@apollo/query-planner-wasm`, a different implementation.)
-

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release @apollo/PACKAGE1@X.Y.Z [, @apollo/PACKAGE2@X.Y.Z]

As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌   The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.
