### PR TITLE
Exclude v0 packages from the grouped patch/minor update group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -80,6 +80,10 @@
     {
       groupName: "all non-major dependencies",
       matchUpdateTypes: ["patch", "minor"],
+      // Exclude all v0 dependencies from the patch/minor group. Changes to v0 packages
+      // should be treated as major updates, but renovate treats all patches and minors
+      // the same.
+      matchCurrentVersion: "!/^[\^~]?0/",
       groupSlug: "all-npm-minor-patch",
       matchManagers: [ "npm" ],
     },


### PR DESCRIPTION
See: https://github.com/renovatebot/renovate/discussions/15093

Right now our renovate config will group version 0.x updates into the automerged minor/patch group. This isn't really desirable since any update to a v0 package can be a breaking change. This update to the minor/patch group excludes all packages with `0.y.z`, `~0.y.z`, and `^0.y.z` from the group, forcing them into their own PR which won't be automerged (like all other major version bumps).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
