### PR TITLE
Improvements for fed1 schema support

### DIFF
--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -2762,7 +2762,7 @@ export class DirectiveDefinition<TApplicationArgs extends {[key: string]: any} =
     assert(false, `Directive definition ${this} can't reference other types (it's arguments can); shouldn't be asked to remove reference to ${type}`);
   }
 
-    /**
+  /**
    * Removes this directive definition from its parent schema.
    *
    * After calling this method, this directive definition will be "detached": it will have no parent, schema, or


### PR DESCRIPTION
This PR adds 2 small leniency for fed1 schema (when read by fed2):
1. it allows `@tag` on an external field if the same tag is on a non-external definition of that field.
2. it allows definitions for federation directives that are not quite what they should but, but are close enough.

The reason in both case is that federation 1 allowed those things, and while we don't  accept those in federation 2 schema intentionally, we want the most users possible to be able to use fed2 on fed1 schema and to delay changes to schema for when use migrate to actual fed2 schema as often as reasonable. This provide a slightly better experience since fed1 schema is, after all, a backward compatibility feature.