### PR TITLE
Update supergraphSDL to be a string

### DIFF
--- a/docs/source/gateway.mdx
+++ b/docs/source/gateway.mdx
@@ -25,8 +25,7 @@ const { ApolloServer, gql } = require('apollo-server');
 const { ApolloGateway } = require('@apollo/gateway');
 const { readFileSync } = require('fs');
 
-const schemaString = readFileSync('./supergraph.graphql').toString();
-const supergraphSdl = gql` ${schemaString} `;
+const supergraphSdl = readFileSync('./supergraph.graphql').toString();
 
 // Initialize an ApolloGateway instance and pass it
 // the supergraph schema


### PR DESCRIPTION
We expect `supergraphSdl` to be a string in the gateway ([code](https://github.com/apollographql/federation/blob/7331cbdb824af20f70ca500f1826859c92edda49/gateway-js/src/config.ts#L281-L286)). 

If `supergraphSdl` is a type document the gateway throws with 
```
Error: When a manual configuration is not provided, gateway requires an Apollo configuration. 
See https://www.apollographql.com/docs/apollo-server/federation/managed-federation/ for more information.
Manual configuration options include: `serviceList`, `supergraphSdl`, and `experimental_updateServiceDefinitions`
```
