### PR TITLE
add application/graphql+json mimeType support to gateway

### DIFF
--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -279,7 +279,7 @@ export class RemoteGraphQLDataSource<
     _context?: TContext,
   ): Promise<object | string> {
     const contentType = fetchResponse.headers.get('Content-Type');
-    if (contentType && contentType.startsWith('application/json')) {
+    if (contentType && (contentType.startsWith('application/json') || contentType.startsWith("application/graphql+json"))) {
       return fetchResponse.json();
     } else {
       return fetchResponse.text();

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -279,7 +279,7 @@ export class RemoteGraphQLDataSource<
     _context?: TContext,
   ): Promise<object | string> {
     const contentType = fetchResponse.headers.get('Content-Type');
-    if (contentType && (contentType.startsWith('application/json') || contentType.startsWith("application/graphql+json"))) {
+    if (contentType && (contentType.startsWith('application/json') || contentType.includes('json'))) {
       return fetchResponse.json();
     } else {
       return fetchResponse.text();


### PR DESCRIPTION
Add support for application/graphql+json to gateway.

I know this is not universally accepted yet, and there are related fixes in progress

https://github.com/graphql/graphql-over-http/issues/31
https://github.com/apollographql/apollo-server/pull/6295

This issue comes up when using apollo gateway with popular Java microservices frameworks that set application/graphql+json e.g. https://github.com/smallrye/smallrye-graphql is one such framework