### PR TITLE
Prevent non-core-feature elements from being marked @inaccessible if referenced by core feature elements

### DIFF
--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -211,8 +211,18 @@ function validateInaccessibleElements(
     ) {
       // These are top-level elements. If they're not @inaccessible, the only
       // way they won't be in the API schema is if they're definitions of some
-      // core feature.
-      return !isFeatureDefinition(element);
+      // core feature. However, we do intend on introducing mechanisms for
+      // exposing core feature elements in the API schema in the near feature.
+      // Because such mechanisms aren't completely nailed down yet, we opt to
+      // pretend here that all core feature elements are in the API schema for
+      // simplicity sake.
+      //
+      // This has the effect that if a non-core schema element is referenced by
+      // a core schema element, that non-core schema element can't be marked
+      // @inaccessible, despite that the core schema element may likely not be
+      // in the API schema. This may be relaxed in a later version of the
+      // inaccessible spec.
+      return true;
     } else if (
       (element instanceof FieldDefinition) ||
       (element instanceof ArgumentDefinition) ||


### PR DESCRIPTION
So currently, the following supergraph schema does not error when being converted to an API schema:
```graphql
schema
  @link(url: "https://specs.apollo.dev/link/v1.0")
  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
  @link(url: "http://localhost/foo/v1.0")
{
  query: Query
}

# Omitting core feature element definitions for core, join, and inaccessible for brevity.

input InputObject {
  someField: String
  privateField: String @inaccessible
}

# Has a default value that references the @inaccessible input field InputObject.privateField
directive @foo(someArg: InputObject = { privateField: "" }) on FIELD

type Query @join__type(graph: SUBGRAPH) {
  foo: String
}
```

This is because `removeInaccessibleElements()` is aware that core feature elements aren't exposed in the API schema, and won't error when an `@inaccessible` non-core feature element is referenced by a core feature element.

Currently, no Apollo core spec to my knowledge introduces core feature elements that can reference non-built-in, non-core feature elements. And since composition doesn't allow user-defined core specs at the moment, that means nothing should be relying on this behavior for now.

However:
1. I'm guessing in the near future we're going to allow user-defined core specs into the supergraph schema during composition, and we currently don't seem to have validation forbidding core feature elements from referencing non-built-in, non-core feature elements.
2. We're introducing a mechanism for exposing core feature directives in the API schema in https://github.com/apollographql/federation/pull/1760

So in order to prevent exposed core feature directives from also exposing `@inaccessible` feature elements in the API schema, we need to either:
1. Update `removeInaccessibleElements()` to be aware of which core feature elements are exposed in the API schema.
2. Update `removeInaccessibleElements()` to forbid non-core-feature elements from being marked `@inaccessible` if referenced by core feature elements.

I've arbitrarily chosen Option 2 in this PR because:
1. It was easier to code/I'm crunched for time for Contracts GA 😛 
2. I'm not sure how people feel about this core-referencing-non-core thing to start with, and with no one currently relying on it, this would be the time to forbid it.

I'd also be fine with Option 1 (e.g. if folks want to leave the possibility open for this kind of referencing in user-defined core specs). Regardless of what we choose, the main thing I'd like to prevent is the leaking of `@inaccessible` feature elements in the API schema.

Note that the error messaging for when this edge case occurs isn't great in this PR (it tells the user the referencing element is in the API schema, regardless of whether it actually is). I could return a trilean enum from `isInAPISchema()` (using the third value for "maybe") and update messaging if folks would prefer, or some other means of improving the messaging.