### PR TITLE
Release 2.0.2-alpha.0

### DIFF
--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## v2.0.2-alpha.0
+
+- Improve fed1 schema support during composition [PR #1735](https://github.com/apollographql/federation/pull/1735)
 - Add missing @apollo/federation-internals dependency to gateway [PR #1721](https://github.com/apollographql/federation/pull/1721)
+- Improve merging of groups during `@require` handling in query planning [PR #1732](https://github.com/apollographql/federation/pull/1732)
+- Move `__resolveReference` resolvers on to `extensions` [PR #1746](https://github.com/apollographql/federation/pull/1746)
+- Add gateway version to schema extensions [PR #1751](https://github.com/apollographql/federation/pull/1751)
+- Honor directive imports when directive name is spec name [PR #1720](https://github.com/apollographql/federation/pull/1720)
+- Migrate to `@apollo/utils` packages for `createSHA` and `isNodeLike` [PR #1765](https://github.com/apollographql/federation/pull/1765)
 
 ## v2.0.1
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG for `@apollo/federation-internals`
 
+## v2.0.2-alpha.0
+
+- Improve fed1 schema support during composition [PR #1735](https://github.com/apollographql/federation/pull/1735)
+- Honor directive imports when directive name is spec name [PR #1720](https://github.com/apollographql/federation/pull/1720)
+
 ## v2.0.1
 
 - Use `for: SECURITY` in the core/link directive application in the supergraph for `@inaccessible` [PR #1715](https://github.com/apollographql/federation/pull/1715)

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.0.1",
+      "version": "2.0.2-alpha.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -81,7 +81,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "2.0.1",
+      "version": "2.0.2-alpha.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "graphql-tag": "^2.12.6",
@@ -90,7 +90,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.0.1",
+      "version": "2.0.2-alpha.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -123,7 +123,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.0.1",
+      "version": "2.0.2-alpha.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/core-schema": "~0.3.0",
@@ -18972,7 +18972,7 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.0.1",
+      "version": "2.0.2-alpha.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -18988,7 +18988,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.0.1",
+      "version": "2.0.2-alpha.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -19006,7 +19006,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "2.0.1",
+      "version": "2.0.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js"

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## v2.0.2-alpha.0
+
+- Improve merging of groups during `@require` handling in query planning [PR #1732](https://github.com/apollographql/federation/pull/1732)
+
 ## v2.0.1
 
 - Released in sync with other federation packages but no changes to this package.

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# [2.0.2-alpha.0] - 2022-04-22

## 🚀 Features

- Improve fed1 schema support during composition [PR #1735](https://github.com/apollographql/federation/pull/1735)
- Add gateway version to schema extensions [PR #1751](https://github.com/apollographql/federation/pull/1751)

## 🐛 Fixes

- Improve merging of groups during `@require` handling in query planning [PR #1732](https://github.com/apollographql/federation/pull/1732)
- Move `__resolveReference` resolvers on to `extensions` [PR #1746](https://github.com/apollographql/federation/pull/1746)
- Honor directive imports when directive name is spec name [PR #1720](https://github.com/apollographql/federation/pull/1720)

## 🛠 Maintenance

- Improved renovate bot auto-updates for 0.x packages [PR #1736](https://github.com/apollographql/federation/pull/1736) and [PR #1730](https://github.com/apollographql/federation/pull/1730)
- Add missing `@apollo/federation-internals` dependency to gateway [PR #1721](https://github.com/apollographql/federation/pull/1721)
- Migrate to `@apollo/utils` packages for `createSHA` and `isNodeLike` [PR #1765](https://github.com/apollographql/federation/pull/1765)

## 📚 Documentation

- Roadmap updates! [PR #1717](https://github.com/apollographql/federation/pull/1717)
- Clarify separation of concerns in the intro docs [PR #1753](https://github.com/apollographql/federation/pull/1753)
- Update intro example for fed2 [PR #1741](https://github.com/apollographql/federation/pull/1741)
- Improve error doc generation, add hints generation, add scrolling style to too-large error tables [PR #1740](https://github.com/apollographql/federation/pull/1740)
- Update `supergraphSDL` to be a string when creating an `ApolloGateway` [PR #1744](https://github.com/apollographql/federation/pull/1744)
- Federation subgraph library compatibility updates [PR #1718](https://github.com/apollographql/federation/pull/1744)