### PR TITLE
Fix applying auto-imported federation directive on other directive de…

### DIFF
--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -614,8 +614,8 @@ describe('clone', () => {
   });
 
   // https://github.com/apollographql/federation/issues/1794
-  it.skip('should allow using a core feature in a directive', () => {
-    const schema = buildSchema(`
+  it('should allow using an imported federation diretive in another directive', () => {
+    const schema = buildSubgraph('foo', "", `
       extend schema
         @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])
 
@@ -624,9 +624,9 @@ describe('clone', () => {
       type Query {
         hi: String! @foo
       }
-    `).clone();
+    `).schema.clone();
     expect(schema.elementByCoordinate("@foo")).toBeDefined();
-    expect(schema.elementByCoordinate("@bar")).toBeDefined();
+    expect(schema.elementByCoordinate("@tag")).toBeDefined();
   });
 
   it('should allow type use in directives', () => {


### PR DESCRIPTION
…finition

For subgraphs, applying an auto-imported federation directive (say
`@tag`) to another directive definition argument was triggering a
non-sensical error. That is because we want trying to handle such
directive application _before_ we had properly auto-imported its
definition.

This patch ensure we delay the building of such directive application
to after the auto-importing mechanism has been performed.

Fixes #1794