### PR TITLE
Fix applying auto-imported federation directive on other directive de…

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 - Fix `Schema.clone` when directive application happens before definition [PR #1785](https://github.com/apollographql/federation/pull/1785)
 - More helpful error message for errors encountered while reading supergraphs generated pre-federation 2 [PR #1796](https://github.com/apollographql/federation/pull/1796)
 - Fix handling of @require "chains" (a @require whose fields have @require themselves) [PR #1790](https://github.com/apollographql/federation/pull/1790)
+- Fix bug applying an imported federation directive on another directive definition [PR #1797](https://github.com/apollographql/federation/pull/1797).
 
 ## v2.0.2-alpha.0
 

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `Schema.clone` when directive application happens before definition [PR #1785](https://github.com/apollographql/federation/pull/1785)
 - More helpful error message for errors encountered while reading supergraphs generated pre-federation 2 [PR #1796](https://github.com/apollographql/federation/pull/1796)
+- Fix bug applying an imported federation directive on another directive definition [PR #1797](https://github.com/apollographql/federation/pull/1797).
 
 ## v2.0.2-alpha.0
 

--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -614,8 +614,8 @@ describe('clone', () => {
   });
 
   // https://github.com/apollographql/federation/issues/1794
-  it.skip('should allow using a core feature in a directive', () => {
-    const schema = buildSchema(`
+  it('should allow using an imported federation diretive in another directive', () => {
+    const schema = buildSubgraph('foo', "", `
       extend schema
         @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])
 
@@ -624,9 +624,9 @@ describe('clone', () => {
       type Query {
         hi: String! @foo
       }
-    `).clone();
+    `).schema.clone();
     expect(schema.elementByCoordinate("@foo")).toBeDefined();
-    expect(schema.elementByCoordinate("@bar")).toBeDefined();
+    expect(schema.elementByCoordinate("@tag")).toBeDefined();
   });
 
   it('should allow type use in directives', () => {


### PR DESCRIPTION
…finition

For subgraphs, applying an auto-imported federation directive (say
`@tag`) to another directive definition argument was triggering a
non-sensical error. That is because we want trying to handle such
directive application _before_ we had properly auto-imported its
definition.

This patch ensure we delay the building of such directive application
to after the auto-importing mechanism has been performed.

Fixes #1794

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
