### PR TITLE
bugfix: Update `EnumType.removeInnerElements()` to call `remove()` on its children

### DIFF
--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for `@apollo/federation-internals`
 
+## vNEXT
+
+- Fix bug removing an enum type [PR #1813](https://github.com/apollographql/federation/pull/1813)
+
 ## 2.0.2-alpha.1
 
 - Fix `Schema.clone` when directive application happens before definition [PR #1785](https://github.com/apollographql/federation/pull/1785)

--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -221,6 +221,27 @@ test('removal of all directives of a schema', () => {
     union U = A | B`);
 });
 
+test('removal of an enum type should remove enum values', () => {
+  const schema = buildSchema(`
+    type Query {
+      someField: String!
+    }
+
+    enum Enum {
+      SOME_VALUE
+      OTHER_VALUE
+    }
+  `);
+
+  const enumType = schema.type("Enum");
+  expectEnumType(enumType)
+  const enumValues = Array.from(enumType.values);
+  enumType.remove()
+  for (const value of enumValues) {
+    expect(value.isAttached()).toBe(false)
+  }
+});
+
 test('removal of all inaccessible elements of a schema', () => {
   const subgraph = buildSubgraph('foo', '', `
     schema @foo {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -2106,7 +2106,11 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   }
 
   protected removeInnerElements(): void {
-    this._values.splice(0, this._values.length);
+    // Make a copy, since EnumValue.remove() will modify this._values.
+    const values = Array.from(this._values);
+    for (const value of values) {
+      value.remove();
+    }
   }
 
   protected hasNonExtensionInnerElements(): boolean {


### PR DESCRIPTION
Noticed a bug in `EnumType.removeInnerElements()`, where it wouldn't call `remove()` on its children. This PR adds a test and provides a fix.