### PR TITLE
Fix bug with type extension of empty type definition

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -3014,4 +3014,24 @@ describe('composition', () => {
       expect(printType(result.schema.toAPISchema().type('U')!)).toMatchString('union U = A | B | C');
     });
   });
+
+  it('works with normal graphQL type extension when definition is empty', () => {
+    const subgraphA = {
+      typeDefs: gql`
+        type Query {
+          foo: Foo
+        }
+
+        type Foo
+
+        extend type Foo {
+          bar: String
+        }
+      `,
+      name: 'subgraphA',
+    };
+
+    const result = composeServices([subgraphA]);
+    assertCompositionSuccess(result);
+  });
 });

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## vNext
+
+- Fix bug with type extension of empty type definition [PR #1821](https://github.com/apollographql/federation/pull/1821)
+
 ## 2.0.2-alpha.2
 
 - The `fetch` implementation used by default by `UplinkFetcher` and `RemoteGraphQLDataSource` is now imported from `make-fetch-happen` v10 instead of v8. The fetcher used by `RemoteGraphQLDataSource` no longer limits the number of simultaneous requests per subgraph to 15 by default; instead, there is no limit.  (If you want to restore the previous behavior, install `make-fetch-happen`, import `fetcher` from it, and pass `new RemoteGraphQLDataSource({ fetcher: fetcher.defaults(maxSockets: 15)}))` in your `buildService` option.) [PR #1805](https://github.com/apollographql/federation/pull/1805)

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for `@apollo/federation-internals`
 
+## vNext
+
+- Fix bug with type extension of empty type definition [PR #1821](https://github.com/apollographql/federation/pull/1821)
+
 ## 2.0.2-alpha.2
 
 - Fix bug removing an enum type [PR #1813](https://github.com/apollographql/federation/pull/1813)

--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -10,7 +10,7 @@ import {
   InputObjectType,
 } from '../../dist/definitions';
 import {
-  printSchema as printGraphQLjsSchema
+  printSchema as printGraphQLjsSchema,
 } from 'graphql';
 import { defaultPrintOptions, printSchema } from '../../dist/print';
 import { buildSchema } from '../../dist/buildSchema';
@@ -569,6 +569,122 @@ test('handling of extensions', () => {
 
     union AUnion = AType | AType2 | AType3
   `);
+});
+
+describe('type extension where definition is empty', () => {
+  it('works for object types', () => {
+    const sdl = `
+      type Query {
+        foo: Foo
+      }
+
+      type Foo
+
+      extend type Foo {
+        baz: String
+      }
+    `;
+
+    const schema = buildSchema(sdl);
+    expect(printSchema(schema)).toMatchString(sdl);
+    expect(schema.type('Foo')?.hasNonExtensionElements()).toBeTruthy();
+    expect(schema.type('Foo')?.hasExtensionElements()).toBeTruthy();
+  });
+
+  it('works for union', () => {
+    const sdl = `
+      type Query {
+        foo: Foo
+      }
+
+      union Foo
+
+      extend union Foo = Bar
+
+      type Bar {
+        x: Int
+      }
+    `;
+
+    const schema = buildSchema(sdl);
+    expect(printSchema(schema)).toMatchString(sdl);
+    expect(schema.type('Foo')?.hasNonExtensionElements()).toBeTruthy();
+    expect(schema.type('Foo')?.hasExtensionElements()).toBeTruthy();
+  });
+
+  it('works for enum', () => {
+    const sdl = `
+      type Query {
+        foo: Foo
+      }
+
+      enum Foo
+
+      extend enum Foo {
+        Bar
+      }
+    `;
+
+    const schema = buildSchema(sdl);
+    expect(printSchema(schema)).toMatchString(sdl);
+    expect(schema.type('Foo')?.hasNonExtensionElements()).toBeTruthy();
+    expect(schema.type('Foo')?.hasExtensionElements()).toBeTruthy();
+  });
+
+  it('works for input object types', () => {
+    const sdl = `
+      type Query {
+        foo: Int
+      }
+
+      input Foo
+
+      extend input Foo {
+        bar: Int
+      }
+    `;
+
+    const schema = buildSchema(sdl);
+    expect(printSchema(schema)).toMatchString(sdl);
+    expect(schema.type('Foo')?.hasNonExtensionElements()).toBeTruthy();
+    expect(schema.type('Foo')?.hasExtensionElements()).toBeTruthy();
+  });
+
+  it('works for scalar type', () => {
+    const sdl = `
+      type Query {
+        foo: Int
+      }
+
+      scalar Foo
+
+      extend scalar Foo
+        @specifiedBy(url: "something")
+    `;
+
+    const schema = buildSchema(sdl);
+    expect(printSchema(schema)).toMatchString(sdl);
+    expect(schema.type('Foo')?.hasNonExtensionElements()).toBeTruthy();
+    expect(schema.type('Foo')?.hasExtensionElements()).toBeTruthy();
+  });
+})
+
+test('reject type defined multiple times', () => {
+  const sdl = `
+    type Query {
+      foo: Foo
+    }
+
+    type Foo {
+      bar: String
+    }
+
+    type Foo {
+      baz: String
+    }
+  `;
+
+  expect(() => buildSchema(sdl).validate()).toThrow('There can be only one type named "Foo"');
 });
 
 test('default arguments for directives', () => {

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -878,6 +878,30 @@ describe('@core/@link handling', () => {
     // Just making sure this don't error out.
     buildAndValidate(doc);
   });
+
+  it('allows defining a repeatable directive as non-repeatable but validates usages', () => {
+    const doc = gql`
+      type T @key(fields: "k1") @key(fields: "k2") {
+        k1: ID!
+        k2: ID!
+      }
+
+      directive @key(fields: String!) on OBJECT
+    `;
+
+
+    // Test for fed2 (with @key being @link-ed)
+    expect(buildForErrors(doc)).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] The directive "@key" can only be used once at this location.',
+    ]]);
+
+    // Test for fed1
+    expect(buildForErrors(doc, { asFed2: false })).toStrictEqual([[
+      'INVALID_GRAPHQL',
+      '[S] The directive "@key" can only be used once at this location.',
+    ]]);
+  });
 });
 
 describe('federation 1 schema', () => {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -634,6 +634,7 @@ export abstract class NamedSchemaElement<TOwnType extends NamedSchemaElement<TOw
 abstract class BaseNamedType<TReferencer, TOwnType extends NamedType & NamedSchemaElement<TOwnType, Schema, TReferencer>> extends NamedSchemaElement<TOwnType, Schema, TReferencer> {
   protected readonly _referencers: Set<TReferencer> = new Set();
   protected readonly _extensions: Set<Extension<TOwnType>> = new Set();
+  public preserveEmptyDefinition: boolean = false;
 
   constructor(name: string, readonly isBuiltIn: boolean = false) {
     super(name);
@@ -699,7 +700,9 @@ abstract class BaseNamedType<TReferencer, TOwnType extends NamedType & NamedSche
   }
 
   hasNonExtensionElements(): boolean {
-    return this._appliedDirectives.some(d => d.ofExtension() === undefined) || this.hasNonExtensionInnerElements();
+    return this.preserveEmptyDefinition 
+      || this._appliedDirectives.some(d => d.ofExtension() === undefined)
+      || this.hasNonExtensionInnerElements();
   }
 
   protected abstract hasNonExtensionInnerElements(): boolean;
@@ -3271,6 +3274,7 @@ function copySchemaDefinitionInner(source: SchemaDefinition, dest: SchemaDefinit
 }
 
 function copyNamedTypeInner(source: NamedType, dest: NamedType) {
+  dest.preserveEmptyDefinition = source.preserveEmptyDefinition;
   const extensionsMap = copyExtensions(source, dest);
   // Same as copyAppliedDirectives, but as the directive applies to the type, we need to remember if the application
   // is for the extension or not.

--- a/internals-js/src/print.ts
+++ b/internals-js/src/print.ts
@@ -245,7 +245,7 @@ function printFieldBasedTypeDefinitionOrExtension(kind: string, type: ObjectType
   if (options.fieldFilter) {
     fields = fields.filter(options.fieldFilter);
   }
-  if (!directives.length && !interfaces.length && !fields.length) {
+  if (!directives.length && !interfaces.length && !fields.length && (extension || !type.preserveEmptyDefinition)) {
     return undefined;
   }
   return printDescription(type, options, extension)
@@ -253,14 +253,14 @@ function printFieldBasedTypeDefinitionOrExtension(kind: string, type: ObjectType
     + kind + ' ' + type
     + printImplementedInterfaces(interfaces)
     + printAppliedDirectives(directives, options, true, fields.length > 0)
-    + (directives.length === 0 ? ' ' : '')
+    + (directives.length === 0 && fields.length > 0 ? ' ' : '')
     + printFields(fields, options);
 }
 
 function printUnionDefinitionOrExtension(type: UnionType, options: PrintOptions, extension?: Extension<any> | null): string | undefined {
   const directives = forExtension(type.appliedDirectives, extension);
   const members = forExtension(type.members(), extension);
-  if (!directives.length && !members.length) {
+  if (!directives.length && !members.length && (extension || !type.preserveEmptyDefinition)) {
     return undefined;
   }
   const possibleTypes = members.length ? ' = ' + members.map(m => m.type).join(' | ') : '';
@@ -274,7 +274,7 @@ function printUnionDefinitionOrExtension(type: UnionType, options: PrintOptions,
 function printEnumDefinitionOrExtension(type: EnumType, options: PrintOptions, extension?: Extension<any> | null): string | undefined {
   const directives = forExtension(type.appliedDirectives, extension);
   const values = forExtension(type.values, extension);
-  if (!directives.length && !values.length) {
+  if (!directives.length && !values.length && (extension || !type.preserveEmptyDefinition)) {
     return undefined;
   }
   const vals = values.map((v, i) =>
@@ -286,21 +286,21 @@ function printEnumDefinitionOrExtension(type: EnumType, options: PrintOptions, e
     + printIsExtension(extension)
     + 'enum ' + type
     + printAppliedDirectives(directives, options, true, vals.length > 0)
-    + (directives.length === 0 ? ' ' : '')
+    + (directives.length === 0 && vals.length > 0 ? ' ' : '')
     + printBlock(vals);
 }
 
 function printInputDefinitionOrExtension(type: InputObjectType, options: PrintOptions, extension?: Extension<any> | null): string | undefined {
   const directives = forExtension(type.appliedDirectives, extension);
   const fields = forExtension(type.fields(), extension);
-  if (!directives.length && !fields.length) {
+  if (!directives.length && !fields.length && (extension || !type.preserveEmptyDefinition)) {
     return undefined;
   }
   return printDescription(type, options, extension)
     + printIsExtension(extension)
     + 'input ' + type
     + printAppliedDirectives(directives, options, true, fields.length > 0)
-    + (directives.length === 0 ? ' ' : '')
+    + (directives.length === 0 && fields.length > 0 ? ' ' : '')
     + printFields(fields, options);
 }
 


### PR DESCRIPTION
It is valid graphQL to do:
```graphql
type Foo

extend type Foo {
  bar: Int
}
```
and while that's uncommon, this could be the convenient when mechanically concatenating files.

This wasn't handled correctly however as the code was not preserving the empty type definition and was thus considering the schema as just:
```graphql
extend type Foo {
  bar: Int
}
```
which, when trying to compose this, may lead into an error complaining that the type is extended but has no definition (which is obviously incorrect).