### PR TITLE
Release 2.0.2

### DIFF
--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.0.2-alpha.2",
+  "version": "2.0.2",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "2.0.2-alpha.2",
+  "version": "2.0.2",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.0.2-alpha.2",
+  "version": "2.0.2",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.0.2-alpha.2",
+  "version": "2.0.2",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.0.2-alpha.2",
+      "version": "2.0.2",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -82,7 +82,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "2.0.2-alpha.2",
+      "version": "2.0.2",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "graphql-tag": "^2.12.6",
@@ -91,7 +91,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.0.2-alpha.2",
+      "version": "2.0.2",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -296,7 +296,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.0.2-alpha.2",
+      "version": "2.0.2",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/core-schema": "~0.3.0",
@@ -19181,7 +19181,7 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.0.2-alpha.2",
+      "version": "2.0.2",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -19197,7 +19197,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.0.2-alpha.2",
+      "version": "2.0.2",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -19215,7 +19215,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "2.0.2-alpha.2",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js"

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.0.2-alpha.2",
+  "version": "2.0.2",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.0.2-alpha.2",
+  "version": "2.0.2",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "2.0.2-alpha.2",
+  "version": "2.0.2",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# [2.0.2] - 2022-05-03

## ❗ IMPORTANT NOTES ❗

- The `fetch` implementation used by default by `UplinkFetcher` and `RemoteGraphQLDataSource` is now imported from `make-fetch-happen` v10 instead of v8. We don't believe this should cause any compatibility issues but please file an issue if this created any unintentional problems.
- `v2.0.0` accidentally added a limit of 15 simultaneous requests per subgraph; that has been removed. Please accept this new release as our penance.
- We no longer export a `getDefaultFetcher` function. If you were using this function, you can replace `const fetcher = getDefaultFetcher()` with `import fetcher from 'make-fetch-happen'`.

## 🚀 Features

- Improve fed1 schema support during composition [PR #1735](https://github.com/apollographql/federation/pull/1735)
- Add gateway version to schema extensions [PR #1751](https://github.com/apollographql/federation/pull/1751)
- More helpful error message for errors encountered while reading supergraphs generated pre-federation 2 [PR #1796](https://github.com/apollographql/federation/pull/1796)
- Upgrade to `make-fetch-happen` v10, to allow more concurrency and many other improvements [PR #1805](https://github.com/apollographql/federation/pull/1805)

## 🐛 Fixes

- Improve merging of groups during `@require` handling in query planning [PR #1732](https://github.com/apollographql/federation/pull/1732)
- Move `__resolveReference` resolvers on to `extensions` [PR #1746](https://github.com/apollographql/federation/pull/1746)
- Honor directive imports when directive name is spec name [PR #1720](https://github.com/apollographql/federation/pull/1720)
- Fix `Schema.clone` when directive application happens before definition [PR #1785](https://github.com/apollographql/federation/pull/1785)
- Fix handling of @require "chains" (a @require whose fields have @require themselves) [PR #1790](https://github.com/apollographql/federation/pull/1790)
- Fix bug applying an imported federation directive on another directive definition [PR #1797](https://github.com/apollographql/federation/pull/1797).
- Fix bug where planning a query with `@require` impacts the plans of followup queries [PR #1783](https://github.com/apollographql/federation/pull/1783).
- Add __resolveType to _Entity union [PR #1773](https://github.com/apollographql/federation/pull/1773)
- Fix bug removing an enum type [PR #1813](https://github.com/apollographql/federation/pull/1813)

## 🛠 Maintenance

- Improved renovate bot auto-updates for 0.x packages [PR #1736](https://github.com/apollographql/federation/pull/1736) and [PR #1730](https://github.com/apollographql/federation/pull/1730)
- Add missing `@apollo/federation-internals` dependency to gateway [PR #1721](https://github.com/apollographql/federation/pull/1721)
- Migrate to `@apollo/utils` packages for `createSHA` and `isNodeLike` [PR #1765](https://github.com/apollographql/federation/pull/1765)
- The `fetch` implementation returned by `getDefaultFetcher` no longer performs in-memory caching [PR #1792](https://github.com/apollographql/federation/pull/1792)
- Prevent non-core-feature elements from being marked @inaccessible if referenced by core feature elements [PR #1769](https://github.com/apollographql/federation/pull/1769)

## 📚 Documentation

- Roadmap updates! [PR #1717](https://github.com/apollographql/federation/pull/1717)
- Clarify separation of concerns in the intro docs [PR #1753](https://github.com/apollographql/federation/pull/1753)
- Update intro example for fed2 [PR #1741](https://github.com/apollographql/federation/pull/1741)
- Improve error doc generation, add hints generation, add scrolling style to too-large error tables [PR #1740](https://github.com/apollographql/federation/pull/1740)
- Update `supergraphSDL` to be a string when creating an `ApolloGateway` [PR #1744](https://github.com/apollographql/federation/pull/1744)
- Federation subgraph library compatibility updates [PR #1718](https://github.com/apollographql/federation/pull/1744)
- Moved enterprise guide to root documentation repo [PR #1786](https://github.com/apollographql/federation/pull/1786)
- Various docs tidying and "supergraphification" [PR #1758](https://github.com/apollographql/federation/pull/1758)
- Moving to fed2 article improvements [PR #1802](https://github.com/apollographql/federation/pull/1802)
