### PR TITLE
docs: update @override docs with multiple usage note

### DIFF
--- a/docs/source/federation-spec.md
+++ b/docs/source/federation-spec.md
@@ -377,7 +377,7 @@ type User @key(fields: "email") @shareable {
 directive @override(from: String!) on FIELD_DEFINITION
 ```
 
-The `@override` directive is used to indicate that the current subgraph is taking responsibility for resolving the marked field _away_ from the subgraph specified in the `from` argument. 
+The `@override` directive is used to indicate that the current subgraph is taking responsibility for resolving the marked field _away_ from the subgraph specified in the `from` argument. The directive is meant to only be used once on a field in the supergraph, so usage over multiple subgraphs will throw a composition error.
 
 The following example will result in all query plans made to resolve `User.name` to be directed to SubgraphB.
 

--- a/docs/source/federation-spec.md
+++ b/docs/source/federation-spec.md
@@ -384,13 +384,13 @@ The `@override` directive is used to indicate that the current subgraph is takin
 The following example will result in all query plans made to resolve `User.name` to be directed to SubgraphB.
 
 ```graphql
-# in SubgraphA
+# In SubgraphA
 type User @key(fields: "id") {
   id: ID!
   name: String
 }
 
-# in SubgraphB
+# In SubgraphB
 type User @key(fields: "id") {
   id: ID!
   name: String @override(from: "SubgraphA")

--- a/docs/source/federation-spec.md
+++ b/docs/source/federation-spec.md
@@ -377,7 +377,9 @@ type User @key(fields: "email") @shareable {
 directive @override(from: String!) on FIELD_DEFINITION
 ```
 
-The `@override` directive is used to indicate that the current subgraph is taking responsibility for resolving the marked field _away_ from the subgraph specified in the `from` argument. The directive is meant to only be used once on a field in the supergraph, so usage over multiple subgraphs will throw a composition error.
+The `@override` directive is used to indicate that the current subgraph is taking responsibility for resolving the marked field _away_ from the subgraph specified in the `from` argument.
+
+> Only one subgraph can `@override` any given field. If multiple subgraphs attempt to `@override` the same field, a composition error occurs.
 
 The following example will result in all query plans made to resolve `User.name` to be directed to SubgraphB.
 


### PR DESCRIPTION
The directive is meant to only be used once on a field in the supergraph, so usage over multiple subgraphs will throw a composition error.

Example of composition errors: https://stackblitz.com/edit/apollo-basic-fed-demo-csza64?file=b.js,a.js