### PR TITLE
Bug when all root operation are in schema extension

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+- Fix issue when all root operations were defined in an `extend schema` [PR #1875](https://github.com/apollographql/federation/issues/1875).
+
 ## 2.0.3
 
 - Fix bug with type extension of empty type definition [PR #1821](https://github.com/apollographql/federation/pull/1821)

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG for `@apollo/federation-internals`
 
+- Fix issue when all root operations were defined in an `extend schema` [PR #1875](https://github.com/apollographql/federation/issues/1875).
+
 ## 2.0.3
 
 - Fix bug with type extension of empty type definition [PR #1821](https://github.com/apollographql/federation/pull/1821)

--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -890,3 +890,20 @@ test('retrieving elements by coordinate', () => {
   // Note that because 'Date' is a scalar, it cannot have fields
   expect(() => schema.elementByCoordinate('Date.bar')).toThrow();
 })
+
+test('parse error', () => {
+  const schema = `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])
+    {
+      query: Query
+    }
+
+    type Query {
+      hello: String
+    }
+  `;
+  const subgraph = buildSubgraph('test', '', schema);
+
+  expect(subgraph.toString()).toMatchString(schema);
+});

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -361,8 +361,8 @@ export class CoreSpecDefinition extends FeatureDefinition {
 
   // TODO: we may want to allow some `import` as argument to this method. When we do, we need to watch for imports of
   // `Purpose` and `Import` and add the types under their imported name.
-  addToSchema(schema: Schema, as?: string): GraphQLError[] {
-    const errors = this.addDefinitionsToSchema(schema, as);
+  addToSchema(schema: Schema, alias?: string): GraphQLError[] {
+    const errors = this.addDefinitionsToSchema(schema, alias);
     if (errors.length > 0) {
       return errors;
     }
@@ -370,8 +370,8 @@ export class CoreSpecDefinition extends FeatureDefinition {
     // Note: we don't use `applyFeatureToSchema` because it would complain the schema is not a core schema, which it isn't
     // until the next line.
     const args = { [this.urlArgName()]: this.toString() } as unknown as CoreOrLinkDirectiveArgs;
-    if (as) {
-      args.as = as;
+    if (alias) {
+      args.as = alias;
     }
 
     // This adds `@link(url: "https://specs.apollo.dev/link/v1.0")` to the "schema" definition. And we have
@@ -403,7 +403,7 @@ export class CoreSpecDefinition extends FeatureDefinition {
     // Side-note: this test must be done _before_ we call `applyDirective`, otherwise it would take it into
     // account.
     const hasDefinition = schemaDef.hasNonExtensionElements();
-    const directive = schemaDef.applyDirective(as ?? this.url.name, args, true);
+    const directive = schemaDef.applyDirective(alias ?? this.url.name, args, true);
     if (!hasDefinition && schemaDef.hasExtensionElements()) {
       const extension = firstOf(schemaDef.extensions());
       assert(extension, '`hasExtensionElements` should not have been `true`');

--- a/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
@@ -744,7 +744,6 @@ type Query {
 
     const validateTag = async (
       header: string,
-      additionalHeader: string,
       directiveDefinitions: string,
       typeDefinitions: string,
     ) => {
@@ -762,7 +761,7 @@ type Query {
 
       const { data, errors } = await graphql({ schema, source: query });
       expect(errors).toBeUndefined();
-      expect((data?._service as any).sdl).toEqual(`${additionalHeader}${header}${directiveDefinitions}
+      expect((data?._service as any).sdl).toEqual(`${header}${directiveDefinitions}
 
 type User
   @key(fields: "email")
@@ -786,7 +785,6 @@ union UserButAUnion
       {
         name: 'fed1',
         header: '',
-        additionalHeader: '',
         directiveDefinitions: `directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
 directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
@@ -817,8 +815,7 @@ type Query {
       },
       {
         name: 'fed2',
-        header: 'extend schema\n  @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@tag"])\n\n',
-        additionalHeader: 'schema\n  @link(url: "https://specs.apollo.dev/link/v1.0")\n{\n  query: Query\n}\n\n',
+        header: 'extend schema\n  @link(url: "https://specs.apollo.dev/link/v1.0")\n  @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@tag"])\n\n',
         directiveDefinitions: `directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
@@ -869,8 +866,8 @@ type Query {
   _service: _Service!
 }`,
       }
-    ])('adds it for $name schema', async ({header, additionalHeader, directiveDefinitions, typesDefinitions}) => {
-      await validateTag(header, additionalHeader, directiveDefinitions, typesDefinitions);
+    ])('adds it for $name schema', async ({header, directiveDefinitions, typesDefinitions}) => {
+      await validateTag(header, directiveDefinitions, typesDefinitions);
     });
   });
 


### PR DESCRIPTION
The code that was "expanding" subgraphs was always adding the
`@link` to link-itself to the schema _definition_. However,
if all the root operation of the schema were defined in a schema
_extension_ (which is technically illegal according to the graphQL
spec, but de-facto accepted because graphQL-js has never validated
that schema extension were illegal unless a corresponding definition
was present), then there was no way to print that schema properly
and indeed the code was generating invalid syntax.

This commit makes the code a bit more lenient to that case (where
there is a schema extension defining the query root operation but no
corresponding definition) by putting the `@link`-to-link on the
schema extension.

Fixes #1875

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
