### PR TITLE
Compose user directives

### DIFF
--- a/composition-js/src/__tests__/compose.custom.test.ts
+++ b/composition-js/src/__tests__/compose.custom.test.ts
@@ -1,0 +1,431 @@
+import { composeServices } from '../compose';
+import {
+  Schema,
+} from '@apollo/federation-internals';
+import gql from 'graphql-tag';
+import './matchers';
+
+const expectDirectiveOnElement = (schema: Schema, location: string, directiveName: string, props?: { [key: string]: any }) => {
+  const elem = schema.elementByCoordinate(location);
+  expect(elem).toBeDefined();
+  const directive = elem?.appliedDirectives.find(d => {
+    if (d.name !== directiveName) {
+      return false;
+    }
+    if (props) {
+      for (const prop in props) {
+        if (d.arguments()[prop] !== props[prop]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  });
+  expect(directive).toBeDefined();
+};
+
+const expectNoDirectiveOnElement = (schema: Schema, location: string, directiveName: string) => {
+  const elem = schema.elementByCoordinate(location);
+  expect(elem).toBeDefined();
+  const directive = elem?.appliedDirectives.find(d => d.name === directiveName);
+  expect(directive).toBeUndefined();
+};
+
+describe('composing custom directives', () => {
+  it('executable directive successful merge, not explicitly exposed', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY | FIELD_DEFINITION
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY | FIELD_DEFINITION
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectNoDirectiveOnElement(schema, 'User.name', 'foo');
+      expect(schema.directive('foo')?.name).toBe('foo');
+      expect(schema.directive('foo')?.locations).toEqual(['QUERY']);
+    }
+  });
+
+  it('executable directive successful merge, explicitly exposed', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY | FIELD_DEFINITION
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY | FIELD_DEFINITION
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB], { exposeDirectives: ['@foo']});
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectDirectiveOnElement(schema, 'User.name', 'foo', { name: 'graphA'});
+      expect(schema.directive('foo')?.name).toBe('foo');
+      expect(schema.directive('foo')?.locations).toEqual(['QUERY', 'FIELD_DEFINITION']);
+    }
+  });
+
+  it('executable directive, conflicting definitions non-explicit', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY | FIELD_DEFINITION | OBJECT
+        type User @key(fields: "id") @foo(name: "objectB") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectNoDirectiveOnElement(schema, 'User.name', 'foo');
+      expect(schema.directive('foo')?.name).toBe('foo');
+      expect(schema.directive('foo')?.locations).toEqual(['QUERY']);
+    }
+  });
+
+  it('executable directive, conflicting definitions explicit', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on QUERY | FIELD_DEFINITION | OBJECT
+        type User @key(fields: "id") @foo(name: "objectB") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB], { exposeDirectives: ['@foo']});
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectDirectiveOnElement(schema, 'User.description', 'foo', { name: 'graphB'});
+      expectDirectiveOnElement(schema, 'User', 'foo', { name: 'objectB'});
+      expect(schema.directive('foo')?.name).toBe('foo');
+      expect(schema.directive('foo')?.locations).toEqual(['QUERY', 'FIELD_DEFINITION', 'OBJECT']);
+    }
+  });
+
+  it('type-system directive, not exposed', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) on FIELD_DEFINITION
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on FIELD_DEFINITION
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectNoDirectiveOnElement(schema, 'User.name', 'foo');
+    }
+  });
+
+  it('type-system directive, explicitly exposed', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) on FIELD_DEFINITION
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on FIELD_DEFINITION
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB], { exposeDirectives: ['@foo']});
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectDirectiveOnElement(schema, 'User.name', 'foo', { name: 'graphA'});
+    }
+  });
+
+  it('type-system directive, repeatable sometimes', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) repeatable on FIELD_DEFINITION
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on FIELD_DEFINITION
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB], { exposeDirectives: ['@foo']});
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(1);
+    expect(result.hints?.[0].definition.code).toBe('INCONSISTENT_TYPE_SYSTEM_DIRECTIVE_REPEATABLE');
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectDirectiveOnElement(schema, 'User.name', 'foo', { name: 'graphA'});
+    }
+  });
+
+  it('type-system directive, different locations', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        directive @foo(name: String!) on FIELD_DEFINITION | OBJECT
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") @foo(name: "objectA") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        directive @foo(name: String!) on FIELD_DEFINITION
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB], { exposeDirectives: ['@foo']});
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectDirectiveOnElement(schema, 'User.name', 'foo', { name: 'graphA'});
+      expectDirectiveOnElement(schema, 'User', 'foo', { name: 'objectA'});
+    }
+  });
+
+  it('type-system directive, core feature, not exposed', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+        @link(url: "https://specs.apollo.dev/foo/v1.0", import: ["@foo"])
+
+        directive @foo(name: String!) on FIELD_DEFINITION
+
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+        @link(url: "https://specs.apollo.dev/foo/v1.0", import: ["@foo"])
+
+        directive @foo(name: String!) on FIELD_DEFINITION
+
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectNoDirectiveOnElement(schema, 'User.name', 'foo');
+    }
+  });
+
+  it('type-system directive, core feature, explicitly exposed', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+        @link(url: "https://specs.apollo.dev/foo/v1.0", import: ["@foo"])
+
+        directive @foo(name: String!) on FIELD_DEFINITION
+
+        type Query {
+          a: User
+        }
+
+        type User @key(fields: "id") {
+          id: Int
+          name: String @foo(name: "graphA")
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+        @link(url: "https://specs.apollo.dev/foo/v1.0", import: ["@foo"])
+
+        directive @foo(name: String!) on FIELD_DEFINITION
+
+        type User @key(fields: "id") {
+          id: Int
+          description: String @foo(name: "graphB")
+        }
+      `,
+    };
+    const result = composeServices([subgraphA, subgraphB], { exposeDirectives: ['@foo']});
+    expect(result.errors).toBeUndefined();
+    expect(result.hints?.length).toBe(0);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    if (schema) {
+      expectDirectiveOnElement(schema, 'User.name', 'foo', { name: 'graphA'});
+    }
+  });
+
+  it.todo('expose builtin directive');
+});

--- a/composition-js/src/compose.ts
+++ b/composition-js/src/compose.ts
@@ -14,6 +14,7 @@ import { buildFederatedQueryGraph, buildSupergraphAPIQueryGraph } from "@apollo/
 import { mergeSubgraphs } from "./merging";
 import { validateGraphComposition } from "./validate";
 import { CompositionHint } from "./hints";
+import { type CompositionOptions } from './types';
 
 export type CompositionResult = CompositionFailure | CompositionSuccess;
 
@@ -31,7 +32,7 @@ export interface CompositionSuccess {
   errors?: undefined;
 }
 
-export function compose(subgraphs: Subgraphs): CompositionResult {
+export function compose(subgraphs: Subgraphs, options?: CompositionOptions): CompositionResult {
   const upgradeResult = upgradeSubgraphsIfNecessary(subgraphs);
   if (upgradeResult.errors) {
     return { errors: upgradeResult.errors };
@@ -43,7 +44,7 @@ export function compose(subgraphs: Subgraphs): CompositionResult {
     return { errors: validationErrors };
   }
 
-  const mergeResult = mergeSubgraphs(toMerge);
+  const mergeResult = mergeSubgraphs(toMerge, options);
   if (mergeResult.errors) {
     return { errors: mergeResult.errors };
   }
@@ -74,7 +75,7 @@ export function compose(subgraphs: Subgraphs): CompositionResult {
   };
 }
 
-export function composeServices(services: ServiceDefinition[]): CompositionResult  {
+export function composeServices(services: ServiceDefinition[], options?: CompositionOptions): CompositionResult  {
   const subgraphs = subgraphsFromServiceList(services);
   if (Array.isArray(subgraphs)) {
     // Errors in subgraphs are not truly "composition" errors, but it's probably still the best place
@@ -82,5 +83,5 @@ export function composeServices(services: ServiceDefinition[]): CompositionResul
     // include the subgraph name in their message.
     return { errors: subgraphs };
   }
-  return compose(subgraphs);
+  return compose(subgraphs, options);
 }

--- a/composition-js/src/types.ts
+++ b/composition-js/src/types.ts
@@ -1,0 +1,8 @@
+import {
+  type SubtypingRule,
+} from "@apollo/federation-internals";
+
+export type CompositionOptions = {
+  exposeDirectives?: string[],
+  allowedFieldTypeMergingSubtypingRules?: SubtypingRule[],
+};

--- a/gateway-js/src/supergraphManagers/IntrospectAndCompose/index.ts
+++ b/gateway-js/src/supergraphManagers/IntrospectAndCompose/index.ts
@@ -24,6 +24,7 @@ export interface IntrospectAndComposeOptions {
   pollIntervalInMs?: number;
   logger?: Logger;
   subgraphHealthCheck?: boolean;
+  exposeDirectives?: string[];
 }
 
 type State =
@@ -111,7 +112,7 @@ export class IntrospectAndCompose implements SupergraphManager {
   }
 
   private createSupergraphFromSubgraphList(subgraphs: ServiceDefinition[]) {
-    const compositionResult = composeServices(subgraphs);
+    const compositionResult = composeServices(subgraphs, { exposeDirectives: this.config.exposeDirectives });
 
     if (compositionResult.errors) {
       const { errors } = compositionResult;

--- a/internals-js/src/types.ts
+++ b/internals-js/src/types.ts
@@ -3,7 +3,7 @@
  */
 
 import {
-    AbstractType,
+  AbstractType,
   InterfaceType,
   isInterfaceType,
   isListType,


### PR DESCRIPTION
Adds ability to compose custom directives by passing in an optional `exposeDirectives` parameter to the `composeServices` function. This PR intentionally muddies the waters somewhat between executable and type system directives. The type system portion of the directive (e.g. type system locations) are composed by union, whereas the executable portion will continue to compose as it has done.

Add exposeDirectives option to IntrospectAndCompose
