### PR TITLE
Fix issue generating plan for a "diamond-shaped" dependency

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+- Fix issue generating plan for a "diamond-shaped" dependency [PR #1900](https://github.com/apollographql/federation/pull/1900)
+
 ## 2.1.0-alpha.0
 
 - Add callback when fetching a supergraph from Apollo Uplink fails [PR #1812](https://github.com/apollographql/federation/pull/1812).

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG for `@apollo/query-graphs`
 
+- Fix issue generating plan for a "diamond-shaped" dependency [PR #1900](https://github.com/apollographql/federation/pull/1900)
+
 ## 2.1.0-alpha.0
 
 - Expand support for Node.js v18 [PR #1884](https://github.com/apollographql/federation/pull/1884)

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -41,6 +41,7 @@ import {
   Directive,
   directiveApplicationsSubstraction,
   conditionalDirectivesInOperationPath,
+  MultiMap,
 } from "@apollo/federation-internals";
 import {
   advanceSimultaneousPathsWithOperation,
@@ -85,13 +86,32 @@ const debug = newDebugLogger('plan');
 // Note: exported so we can have a test that explicitly requires more than this number.
 export const MAX_COMPUTED_PLANS = 10000;
 
-function mapOptionsToSelections<RV extends Vertex>(
-  selectionSet: SelectionSet,
-  options: SimultaneousPathsWithLazyIndirectPaths<RV>[]
-): [Selection, SimultaneousPathsWithLazyIndirectPaths<RV>[]][]  {
-  // We reverse the selections because we're going to pop from `openPaths` and this ensure we end up handling things in the query order.
-  return selectionSet.selections(true).map(node => [node, options]);
-}
+type CostFunction = FetchGroupProcessor<number, number[], number>;
+
+const fetchCost = 10000;
+const pipeliningCost = 100;
+const sameLevelFetchCost = 100;
+
+const defaultCostFunction: CostFunction = {
+  onFetchGroup: (group: FetchGroup) =>  selectionCost(group.selection),
+  reduceParallel: (values: number[]) => values,
+  // That math goes the following way:
+  // - we add the costs in a sequence (the `acc + ...`)
+  // - within a stage of the sequence, the groups are done in parallel, hence the `Math.max(...)` (but still, we prefer querying less services if
+  //   we can help it, hence the `+ (valueArray.length - 1) * sameLevelFetchCost`).
+  // - but each group in a stage require a fetch, so we add a cost proportional to how many we have
+  // - each group within a stage has its own cost plus a flat cost associated to doing that fetch (`fetchCost + s`).
+  // - lastly, we also want to minimize the number of steps in the pipeline, so later stages are more costly (`idx * pipelineCost`)
+  reduceSequence: (values: (number[] | number)[]) =>
+    values.reduceRight(
+      (acc: number, value, idx) => {
+        const valueArray = Array.isArray(value) ? value : [value];
+        return acc + ((idx + 1) * pipeliningCost) * (fetchCost * valueArray.length) * (Math.max(...valueArray) + (valueArray.length - 1) * sameLevelFetchCost)
+      },
+      0
+    ),
+  finalize: (roots: number[], rootsAreParallel: boolean) => roots.length === 0 ? 0 : (rootsAreParallel ? (Math.max(...roots) + (roots.length - 1) * sameLevelFetchCost) : sum(roots))
+};
 
 class QueryPlanningTaversal<RV extends Vertex> {
   // The stack contains all states that aren't terminal.
@@ -350,11 +370,7 @@ class QueryPlanningTaversal<RV extends Vertex> {
     let totalCombinations = 1;
     for (let i = 0; i < others.length; ++i) {
       const eltSize = others[i].length;
-      assert(eltSize, "Got empty option: this shouldn't have happened");
-      if(!eltSize) {
-        totalCombinations = 0;
-        break;
-      }
+      assert(eltSize > 0, "Got empty option: this shouldn't have happened");
       eltIndexes[i] = 0;
       totalCombinations *= eltSize;
     }
@@ -422,77 +438,1034 @@ class QueryPlanningTaversal<RV extends Vertex> {
   }
 }
 
-function possiblePlans(closedBranches: SimultaneousPaths<any>[][]): number {
-  let totalCombinations = 1;
-  for (let i = 0; i < closedBranches.length; ++i){
-    const eltSize = closedBranches[i].length;
-    if(!eltSize) {
-      totalCombinations = 0;
-      break;
+type UnhandledGroups = [FetchGroup, UnhandledParentRelations][];
+type UnhandledParentRelations = ParentRelation[];
+
+class LazySelectionSet {
+  constructor(
+    private _computed?: SelectionSet,
+    private readonly _toCloneOnWrite?: SelectionSet
+  ) {
+    assert(_computed || _toCloneOnWrite, 'Should have one of the argument');
+  }
+
+  forRead(): SelectionSet {
+    return this._computed ? this._computed : this._toCloneOnWrite!;
+  }
+
+  forWrite(): SelectionSet {
+    if (!this._computed) {
+      this._computed = this._toCloneOnWrite!.clone();
     }
-    totalCombinations *= eltSize;
-  }
-  return totalCombinations;
-}
-
-function sum(arr: number[]): number {
-  return arr.reduce((a, b) => a + b, 0);
-}
-
-type CostFunction = FetchGroupProcessor<number, number[], number>;
-
-const fetchCost = 10000;
-const pipeliningCost = 100;
-const sameLevelFetchCost = 100;
-
-function selectionCost(selection?: SelectionSet, depth: number = 1): number {
-  // The cost is essentially the number of elements in the selection, but we make deeped element cost a tiny bit more, mostly to make things a tad more
-  // deterministic (typically, if we have an interface with a single implementation, then we can have a choice between a query plan that type-explode a
-  // field of the interface and one that doesn't, and both will be almost identical, except that the type-exploded field will be a different depth; by
-  // favoring lesser depth in that case, we favor not type-expoding).
-  return selection ? selection.selections().reduce((prev, curr) => prev + depth + selectionCost(curr.selectionSet, depth + 1), 0) : 0;
-}
-
-const defaultCostFunction: CostFunction = {
-  onFetchGroup: (group: FetchGroup) =>  selectionCost(group.selection),
-  reduceParallel: (values: number[]) => values,
-  // That math goes the following way:
-  // - we add the costs in a sequence (the `acc + ...`)
-  // - within a stage of the sequence, the groups are done in parallel, hence the `Math.max(...)` (but still, we prefer querying less services if
-  //   we can help it, hence the `+ (valueArray.length - 1) * sameLevelFetchCost`).
-  // - but each group in a stage require a fetch, so we add a cost proportional to how many we have
-  // - each group within a stage has its own cost plus a flat cost associated to doing that fetch (`fetchCost + s`).
-  // - lastly, we also want to minimize the number of steps in the pipeline, so later stages are more costly (`idx * pipelineCost`)
-  reduceSequence: (values: (number[] | number)[]) =>
-    values.reduceRight(
-      (acc: number, value, idx) => {
-        const valueArray = Array.isArray(value) ? value : [value];
-        return acc + ((idx + 1) * pipeliningCost) * (fetchCost * valueArray.length) * (Math.max(...valueArray) + (valueArray.length - 1) * sameLevelFetchCost)
-      },
-      0
-    ),
-  finalize: (roots: number[], rootsAreParallel: boolean) => roots.length === 0 ? 0 : (rootsAreParallel ? (Math.max(...roots) + (roots.length - 1) * sameLevelFetchCost) : sum(roots))
-};
-
-function isIntrospectionSelection(selection: Selection): boolean {
-  return selection.kind == 'FieldSelection' && selection.element().definition.isIntrospectionField();
-}
-
-function withoutIntrospection(operation: Operation): Operation {
-  // Note that, because we only apply this to the top-level selections, we skip all introspection, including
-  // __typename. In general, we don't want o ignore __typename during query plans, but at top-level, we
-  // can let the gateway execution deal with it rather than querying some service for that.
-  if (!operation.selectionSet.selections().some(isIntrospectionSelection)) {
-    return operation
+    return this._computed;
   }
 
-  const newSelections = operation.selectionSet.selections().filter(s => !isIntrospectionSelection(s));
-  return new Operation(
-    operation.rootKind,
-    new SelectionSet(operation.selectionSet.parentType).addAll(newSelections),
-    operation.variableDefinitions,
-    operation.name
-  );
+  clone(): LazySelectionSet {
+    if (this._computed) {
+      return new LazySelectionSet(undefined, this._computed);
+    } else {
+      return this;
+    }
+  }
+
+  toString() {
+    return this.forRead().toString();
+  }
+}
+
+/**
+ * Used in `FetchDependencyGraph` to store, for a given group, information about one of its parent.
+ * Namely, this structure stores:
+ *  1. the actual parent group, and
+ *  2. the path of the group for which this is a "parent relation" into said parent (`group`). This information
+ *   is maintained for the case where we want/need to merge groups into each other. One can roughly think of
+ *   this as similar to a `mergeAt`, but that is relative to the start of `group`. It can be `undefined`, which
+ *   either mean we don't know that path or that this simply doesn't make sense (there is case where a child `mergeAt` can
+ *   be shorter than its parent's, in which case the `path`, which is essentially `child-mergeAt - parent-mergeAt`, does
+ *   not make sense (or rather, it's negative, which we cannot represent)). Tl;dr, `undefined` for the `path` means that
+ *   should make no assumption and bail on any merging that uses said path.
+ */
+type ParentRelation = {
+  group: FetchGroup,
+  path?: OperationPath,
+}
+
+/**
+ * Represents a subgraph fetch of a query plan, and is a vertex of a `FetchDependencyGraph` (and as such provides links to
+ * its parent and children in that dependency graph).
+ */
+class FetchGroup {
+  private readonly _parents: ParentRelation[] = [];
+  private readonly _children: FetchGroup[] = [];
+
+  private constructor(
+    readonly dependencyGraph: FetchDependencyGraph,
+    public index: number,
+    readonly subgraphName: string,
+    readonly rootKind: SchemaRootKind,
+    readonly parentType: CompositeType,
+    readonly isEntityFetch: boolean,
+    private readonly _selection: LazySelectionSet,
+    private readonly _inputs?: LazySelectionSet,
+    readonly mergeAt?: ResponsePath,
+  ) {
+  }
+
+  static create(
+    dependencyGraph: FetchDependencyGraph,
+    index: number,
+    subgraphName: string,
+    rootKind: SchemaRootKind,
+    parentType: CompositeType,
+    isEntityFetch: boolean,
+    mergeAt?: ResponsePath,
+  ): FetchGroup {
+    return new FetchGroup(
+      dependencyGraph,
+      index,
+      subgraphName,
+      rootKind,
+      parentType,
+      isEntityFetch,
+      new LazySelectionSet(new SelectionSet(parentType)),
+      isEntityFetch ? new LazySelectionSet(new SelectionSet(parentType)) : undefined,
+      mergeAt
+    );
+  }
+
+  cloneShallow(newDependencyGraph: FetchDependencyGraph): FetchGroup {
+    return new FetchGroup(
+      newDependencyGraph,
+      this.index,
+      this.subgraphName,
+      this.rootKind,
+      this.parentType,
+      this.isEntityFetch,
+      this._selection.clone(),
+      this._inputs?.clone(),
+      this.mergeAt
+    );
+  }
+
+  get isTopLevel(): boolean {
+    return !this.mergeAt;
+  }
+
+  // It's important that the returned selection is never modified. Use the other modification methods of this method instead!
+  get selection(): SelectionSet {
+    return this._selection.forRead();
+  }
+
+  // It's important that the returned selection is never modified. Use the other modification methods of this method instead!
+  get inputs(): SelectionSet | undefined {
+    return this._inputs?.forRead();
+  }
+
+  clonedInputs(): LazySelectionSet | undefined {
+    return this._inputs?.clone();
+  }
+
+  addParents(parents: readonly ParentRelation[]) {
+    for (const parent of parents) {
+      this.addParent(parent);
+    }
+  }
+
+  /**
+   * Adds another group as a parent of this one (meaning that this fetch should happen after the provided one).
+   */
+  addParent(parent: ParentRelation) {
+    assert(!this.isChildOf(parent.group), () => `Group ${parent.group} is already a parent of ${this}`);
+    assert(!parent.group.isParentOf(this), () => `Group ${parent.group} is already a parent of ${this} (but the child relationship is broken)`);
+    assert(!parent.group.isChildOf(this), () => `Group ${parent.group} is a child of ${this}: adding is as parent would create a cycle`);
+
+    this.dependencyGraph.onModification();
+    this._parents.push(parent);
+    parent.group._children.push(this);
+  }
+
+  removeChild(child: FetchGroup) {
+    if (!this.isParentOf(child)) {
+      return;
+    }
+
+    this.dependencyGraph.onModification();
+    findAndRemoveInPlace((g) => g === child, this._children);
+    findAndRemoveInPlace((p) => p.group === this, child._parents);
+  }
+
+  isParentOf(maybeChild: FetchGroup): boolean {
+    return this._children.includes(maybeChild);
+  }
+
+  isChildOf(maybeParent: FetchGroup): boolean {
+    return !!this.parentRelation(maybeParent);
+  }
+
+  /**
+   * Returns whether this group is both a child of `maybeParent` but also if we can show that the
+   * dependency between the group is "artificial" in the sense that this group inputs do not truly
+   * depend on anything `maybeParent` fetches.
+   */
+  isChildOfWithArtificialDependency(maybeParent: FetchGroup): boolean {
+    const relation =  this.parentRelation(maybeParent);
+    // To be a child with an artificial dependency, it needs to be a child first,
+    // and the "path in parent" should be know to be empty (which essentially
+    // means the groups are on the same entity at the same level).
+    if (!relation || relation.path?.length !== 0) {
+      return false;
+    }
+    // If we have no inputs, we don't really care about what `maybeParent` fetches.
+    if (!this.inputs) {
+      return true;
+    }
+
+    // In theory, the most general test we could have here is to check if `this.inputs` "intersects"
+    // `maybeParent.selection. As if it doesn't, we know our inputs don't depend on anything the
+    // parent fetches. However, selection set intersection is a bit tricky to implement (due to fragments,
+    // it would be a bit of code to do not-too-inefficiently, but both fragments and alias makes the
+    // definition of what the intersection we'd need here fairly subtle), and getting it wrong could
+    // make us generate incorrect query plans. Adding to that, the current know cases for this method
+    // being useful happens to be when `this.inputs` and `maybeParent.inputs` are the same. Now, checking
+    // inputs is a bit weaker, in the sense that the input could be different and yet the child group
+    // not depend on anything the parent fetches, but it is "sufficient", in that if the inputs of the
+    // parent includes entirely the child inputs, then we know nothing the child needs can be fetched
+    // by the parent (or rather, if it does, it's useless). Anyway, checking inputs inclusion is easier
+    // to do so we rely on this for now. If we run into examples where this happens to general non-optimal
+    // query plan, we can decide then to optimize further and implement a proper intersections.
+    return !!maybeParent.inputs && maybeParent.inputs.contains(this.inputs);
+  }
+
+  parentRelation(maybeParent: FetchGroup): ParentRelation | undefined {
+    return this._parents.find(({ group }) => maybeParent === group);
+  }
+
+  parents(): readonly ParentRelation[] {
+    return this._parents;
+  }
+
+  parentGroups(): readonly FetchGroup[] {
+    return this.parents().map((p) => p.group);
+  }
+
+  children(): readonly FetchGroup[] {
+    return this._children;
+  }
+
+  addInputs(selection: Selection | SelectionSet) {
+    assert(this._inputs, "Shouldn't try to add inputs to a root fetch group");
+    if (selection instanceof SelectionSet) {
+      this._inputs.forWrite().mergeIn(selection);
+    } else {
+      this._inputs.forWrite().add(selection);
+    }
+  }
+
+  addSelection(path: OperationPath) {
+    this._selection.forWrite().addPath(path);
+  }
+
+  addSelections(selection: SelectionSet) {
+    this._selection.forWrite().mergeIn(selection);
+  }
+
+  canMergeChildIn(child: FetchGroup): boolean {
+    return !!child.parentRelation(this)?.path;
+  }
+
+  /**
+   * Merges a child of `this` group into it.
+   *
+   * Note that it is up to the caller to know that doing such merging is reasonable in the first place, which
+   * generally means knowing that 1) `child.inputs` are included in `this.inputs` and 2) all of `child.selection` 
+   * can safely be queried on the `this.subgraphName` subgraph.
+   *
+   * @param child - a group that must be a `child` of this, and for which the 'path in parent' (for `this`) is 
+   *   known. The `canMergeChildIn` method can be used to ensure that `child` meets those requirement.
+   */
+  mergeChildIn(child: FetchGroup) {
+    const relationToChild = child.parentRelation(this);
+    assert(relationToChild, () => `Cannot merge ${child} into ${this}: the former is not a child of the latter`);
+    const childPathInThis = relationToChild.path;
+    assert(childPathInThis, () => `Cannot merge ${child} into ${this}: the path of the former into the later is unknown`);
+    this.mergeInInternal(child, childPathInThis);
+  }
+
+  canMergeSiblingIn(sibling: FetchGroup): boolean {
+    // We only allow merging sibling on the same subgraph, same "mergeAt" and when our common parent is our only parent:
+    // - there is no reason merging siblings of different subgraphs could ever make sense.
+    // - ensuring the same "mergeAt" makes so we can merge the inputs and selections without having to worry about those
+    //   not being at the same level (hence the empty path in the call to `mergeInInternal` below). In theory, we could
+    //   relax this when we have the "path in parent" for both sibling, and if `siblingToMerge` is "deeper" than `this`,
+    //   we could still merge it in using the appropriate path. We don't use this yet, but if this get in the way of
+    //   some query plan optimisation, we may have to do so.
+    // - only handling a single parent could be expanded on later, but we don't need it yet so we focus on the simpler case.
+    const ownParents = this.parents();
+    const siblingParents = sibling.parents();
+    return this.subgraphName === sibling.subgraphName
+      && sameMergeAt(this.mergeAt, sibling.mergeAt)
+      && ownParents.length === 1
+      && siblingParents.length === 1
+      && ownParents[0].group === siblingParents[0].group;
+  }
+
+  /**
+   * Merges the provided sibling (shares a common parent) of `this` group into it.
+   *
+   * Callers _must_ ensures that such merging is possible by calling `canMergeSiblingIn`.
+   *
+   * @param sibling - a sibling group of `this`. Both `this` and `sibling` must share a parent but it should also be
+   * their _only_ parent. Further `this` and `sibling` must be on the same subgraph and have the same `mergeAt`.
+   */
+  mergeSiblingIn(sibling: FetchGroup) {
+    if (sibling.inputs) {
+      this.addInputs(sibling.inputs);
+    }
+    this.mergeInInternal(sibling, []);
+  }
+
+  canMergeGrandChildIn(grandChild: FetchGroup): boolean {
+    const gcParents = grandChild.parents();
+    if (gcParents.length !== 1) {
+      return false;
+    }
+    return !!gcParents[0].path && !!gcParents[0].group.parentRelation(this)?.path;
+  }
+
+  /**
+   * Merges a grand child of `this` group into it.
+   *
+   * Note that it is up to the caller to know that doing such merging is reasonable in the first place, which
+   * generally means knowing that 1) `grandChild.inputs` are included in `this.inputs` and 2) all of `grandChild.selection`
+   * can safely be queried on the `this.subgraphName` subgraph (the later of which is trivially true if `this` and
+   * `grandChild` are on the same subgraph and same mergeAt).
+   *
+   * @param grandChild - a group that must be a "grand child" (a child of a child) of `this`, and for which the
+   *   'path in parent' is know for _both_ the grand child to tis parent and that parent to `this`. The `canMergeGrandChildIn` 
+  *     method can be used to ensure that `grandChild` meets those requirement.
+   */
+  mergeGrandChildIn(grandChild: FetchGroup) {
+    const gcParents = grandChild.parents();
+    assert(gcParents.length === 1, () => `Cannot merge ${grandChild} as it has multiple parents ([${gcParents}])`);
+    const gcParent = gcParents[0];
+    const gcGrandParent = gcParent.group.parentRelation(this);
+    assert(gcGrandParent, () => `Cannot merge ${grandChild} into ${this}: the former parent (${gcParent.group}) is not a child of the latter`);
+    assert(gcParent.path && gcGrandParent.path, () => `Cannot merge ${grandChild} into ${this}: some paths in parents are unknown`);
+    this.mergeInInternal(grandChild, concatOperationPaths(gcGrandParent.path, gcParent.path));
+  }
+
+  /**
+   * Merges another group into `this` group, without knowing the dependencies between those 2 groups.
+   *
+   * Note that it is up to the caller to know if such merging is desirable. In particular, if both group have completely
+   * different inputs, merging them, which also merges their dependencies, might not be judicious for the optimality of
+   * the query plan.
+   *
+   * @param other - another group to merge into `this`. Both `this` and `other` must be on the same subgraph and have the same
+   *   `mergeAt`.
+   */
+  mergeInWithAllDependencies(other: FetchGroup) {
+    assert(this.subgraphName === other.subgraphName, () => `Can only merge unrelated groups to the same subraphs: cannot merge ${this} and ${other}`);
+    assert(sameMergeAt(this.mergeAt, other.mergeAt), () => `Can only merge unrelated groups at the same "mergeAt": ${this} has mergeAt=${this.mergeAt}, but ${other} has mergeAt=${other.mergeAt}`);
+
+    if (other.inputs) {
+      this.addInputs(other.inputs);
+    }
+    this.mergeInInternal(other, [], true);
+  }
+
+  private mergeInInternal(merged: FetchGroup, path: OperationPath, mergeParentDependencies: boolean = false) {
+    assert(!merged.isTopLevel, "Shouldn't remove top level groups");
+
+    // We merge the selection of `merged` into our own selection, but need to "rebase" it according to `path` first. As we do,
+    // we ignore redundant fragments. Typically, `merged` selection will always start by a type-cast into the entity type because
+    // that's what `_entities()` require, but that cast is probably useless when merging.
+    const mergePathConditionalDirectives = conditionalDirectivesInOperationPath(path);
+    let selectionSet: SelectionSet;
+    if (path.length === 0) {
+      selectionSet = merged.selection;
+    } else {
+      selectionSet = selectionSetOfPath(path, (endOfPathSet) => {
+        assert(endOfPathSet, () => `Merge path ${path} ends on a non-selectable type`);
+        for (const selection of merged.selection.selections()) {
+          const withoutUneededFragments = removeRedundantFragments(selection, endOfPathSet.parentType, mergePathConditionalDirectives);
+          addSelectionOrSelectionSet(endOfPathSet, withoutUneededFragments);
+        }
+      });
+    }
+    this._selection.forWrite().mergeIn(selectionSet);
+
+    this.dependencyGraph.onModification();
+    this.relocateChildrenOnMergedIn(merged, path);
+    if (mergeParentDependencies) {
+      this.relocateParentsOnMergedIn(merged);
+    }
+    this.dependencyGraph.remove(merged);
+  }
+
+  private relocateChildrenOnMergedIn(merged: FetchGroup, pathInThis: OperationPath) {
+    for (const child of merged.children()) {
+      // This could already be a child of `this`. Typically, we can have case where we have:
+      //     1
+      //   /  \
+      // 0     3
+      //   \  /
+      //     2
+      // and we can merge siblings 2 into 1.
+      if (this.isParentOf(child)) {
+        continue;
+      }
+      const pathInMerged = child.parentRelation(merged)?.path;
+      child.addParent({ group: this, path: concatPathsInParents(pathInThis, pathInMerged) });
+    }
+  }
+
+  private relocateParentsOnMergedIn(merged: FetchGroup) {
+    for (const parent of merged.parents()) {
+      if (parent.group.isParentOf(this)) {
+        continue;
+      }
+      this.addParent(parent);
+    }
+  }
+
+  toPlanNode(variableDefinitions: VariableDefinitions, fragments?: NamedFragments, operationName?: string) : PlanNode {
+    addTypenameFieldForAbstractTypes(this.selection);
+
+    this.selection.validate();
+    const inputs = this._inputs?.forRead();
+    if (inputs) {
+      inputs.validate();
+    }
+
+    const inputNodes = inputs ? inputs.toSelectionSetNode() : undefined;
+
+    const operation = this.isEntityFetch
+      ? operationForEntitiesFetch(
+          this.dependencyGraph.subgraphSchemas.get(this.subgraphName)!,
+          this.selection,
+          variableDefinitions,
+          fragments,
+          operationName,
+        )
+      : operationForQueryFetch(
+          this.rootKind,
+          this.selection,
+          variableDefinitions,
+          fragments,
+          operationName,
+        );
+
+    const fetchNode: FetchNode = {
+      kind: 'Fetch',
+      serviceName: this.subgraphName,
+      requires: inputNodes ? trimSelectionNodes(inputNodes.selections) : undefined,
+      variableUsages: this.selection.usedVariables().map(v => v.name),
+      operation: stripIgnoredCharacters(print(operationToDocument(operation))),
+      operationKind:schemaRootKindToOperationKind(operation.rootKind),
+      operationName: operation.name,
+    };
+
+    return this.isTopLevel
+      ? fetchNode
+      : {
+        kind: 'Flatten',
+        path: this.mergeAt!,
+        node: fetchNode,
+      };
+  }
+
+  toString(): string {
+    return this.isTopLevel
+      ? `[${this.index}] ${this.subgraphName}[${this._selection}]`
+      : `[${this.index}] ${this.subgraphName}@(${this.mergeAt})[${this._inputs} => ${this._selection}]`;
+  }
+}
+
+/**
+ * A Directed Acyclic Graph (DAG) of `FetchGroup` and their dependencies.
+ *
+ * In the graph, 2 groups are connected if one of them (the parent) must be performed strictly before the other one (the child).
+ */
+class FetchDependencyGraph {
+  private isReduced: boolean = false;
+  private isOptimized: boolean = false;
+
+  private constructor(
+    readonly subgraphSchemas: ReadonlyMap<string, Schema>,
+    readonly federatedQueryGraph: QueryGraph,
+    private readonly rootGroups: MapWithCachedArrays<string, FetchGroup>,
+    readonly groups: FetchGroup[],
+  ) {
+  }
+
+  static create(federatedQueryGraph: QueryGraph) {
+    return new FetchDependencyGraph(
+      federatedQueryGraph.sources,
+      federatedQueryGraph,
+      new MapWithCachedArrays(),
+      [],
+    );
+  }
+
+  private federationMetadata(subgraphName: string): FederationMetadata {
+    const schema = this.subgraphSchemas.get(subgraphName);
+    assert(schema, () => `Unknown schema ${subgraphName}`)
+    const metadata = federationMetadata(schema);
+    assert(metadata, () => `Schema ${subgraphName} should be a federation subgraph`);
+    return metadata;
+  }
+
+  clone(): FetchDependencyGraph {
+    const cloned = new FetchDependencyGraph(
+      this.subgraphSchemas,
+      this.federatedQueryGraph,
+      new MapWithCachedArrays<string, FetchGroup>(),
+      new Array(this.groups.length),
+    );
+
+    for (const group of this.groups) {
+      cloned.groups[group.index] = group.cloneShallow(cloned);
+    }
+
+    for (const root of this.rootGroups.values()) {
+      cloned.rootGroups.set(root.subgraphName, cloned.groups[root.index]);
+    }
+
+    for (const group of this.groups) {
+      const clonedGroup = cloned.groups[group.index];
+      // Note that `addParent` makes sure to set both the parent link in
+      // `clonedGroup` but also the corresponding child link in `parent`.
+      for (const parent of group.parents()) {
+        clonedGroup.addParent({
+          group: cloned.groups[parent.group.index],
+          path: parent.path
+        });
+      }
+    }
+
+    return cloned;
+  }
+
+  getOrCreateRootFetchGroup({
+    subgraphName,
+    rootKind,
+    parentType,
+  }: {
+    subgraphName: string,
+    rootKind: SchemaRootKind,
+    parentType: CompositeType,
+  }): FetchGroup {
+    let group = this.rootGroups.get(subgraphName);
+    if (!group) {
+      group = this.createRootFetchGroup({ subgraphName, rootKind, parentType });
+      this.rootGroups.set(subgraphName, group);
+    }
+    return group;
+  }
+
+  rootSubgraphs(): readonly string[] {
+    return this.rootGroups.keys();
+  }
+
+  createRootFetchGroup({
+    subgraphName,
+    rootKind,
+    parentType,
+  }: {
+    subgraphName: string,
+    rootKind: SchemaRootKind,
+    parentType: CompositeType,
+  }): FetchGroup {
+    const group = this.newFetchGroup({ subgraphName, parentType, isEntityFetch: false, rootKind });
+    this.rootGroups.set(subgraphName, group);
+    return group;
+  }
+
+  private newFetchGroup({
+    subgraphName,
+    parentType,
+    isEntityFetch,
+    rootKind, // always "query" for entity fetches
+    mergeAt,
+  }: {
+    subgraphName: string,
+    parentType: CompositeType,
+    isEntityFetch: boolean,
+    rootKind: SchemaRootKind,
+    mergeAt?: ResponsePath,
+  }): FetchGroup {
+    this.onModification();
+    const newGroup = FetchGroup.create(
+      this,
+      this.groups.length,
+      subgraphName,
+      rootKind,
+      parentType,
+      isEntityFetch,
+      mergeAt,
+    );
+    this.groups.push(newGroup);
+    return newGroup;
+  }
+
+  getOrCreateKeyFetchGroup({
+    subgraphName,
+    mergeAt,
+    parent,
+    conditionsGroups,
+  }: {
+    subgraphName: string,
+    mergeAt: ResponsePath,
+    parent: ParentRelation,
+    conditionsGroups: FetchGroup[],
+  }): FetchGroup {
+    // Let's look if we can reuse a group we have, that is an existing child of the parent that:
+    // 1. is for the same subgraph
+    // 2. has the same mergeAt
+    // 3. is not part of our conditions or our conditions ancestors (meaning that we annot reuse a group if it fetches something we take as input).
+    for (const existing of parent.group.children()) {
+      if (existing.subgraphName === subgraphName
+        && existing.mergeAt
+        && sameMergeAt(existing.mergeAt, mergeAt)
+        && !this.isInGroupsOrTheirAncestors(existing, conditionsGroups)
+      ) {
+        const existingPathInParent = existing.parentRelation(parent.group)?.path;
+        if (!samePathsInParents(existingPathInParent, parent.path)) {
+          // We're at the same "mergeAt", so the 'path in parent' should mostly be the same, but it's not guaranteed to
+          // be the exact same, in particular due to fragments with conditions (@skip/@include) that may be present in
+          // one case but not the other. This is fine, and we still want to reuse the group in those case, but we should
+          // erase the 'path in parent' in that case so we don't end up merging this group to another one "the wrong way"
+          // later on.
+          this.removePathInParent(parent.group, existing);
+        }
+        return existing;
+      }
+    }
+    const newGroup = this.newKeyFetchGroup({ subgraphName, mergeAt });
+    newGroup.addParent(parent);
+    return newGroup
+  }
+
+  private removePathInParent(parent: FetchGroup, child: FetchGroup) {
+    // Simplest option is to remove the parent edge and re-add it without a path.
+    parent.removeChild(child);
+    child.addParent({ group: parent });
+  }
+
+  newRootTypeFetchGroup({
+    subgraphName,
+    rootKind,
+    parentType,
+    mergeAt,
+  }: {
+    subgraphName: string,
+    rootKind: SchemaRootKind,
+    parentType: ObjectType,
+    mergeAt: ResponsePath,
+  }): FetchGroup {
+    return this.newFetchGroup({ subgraphName, parentType, isEntityFetch: false, rootKind, mergeAt });
+  }
+
+  // Returns true if `toCheck` is either part of `conditions`, or is one of their ancestors (potentially recursively).
+  private isInGroupsOrTheirAncestors(toCheck: FetchGroup, conditions: FetchGroup[]): boolean  {
+    const stack = conditions.concat();
+    while (stack.length > 0) {
+      const group = stack.pop()!;
+      if (toCheck === group) {
+        return true;
+      }
+      stack.push(...group.parentGroups());
+    }
+    return false;
+  }
+
+  newKeyFetchGroup({
+    subgraphName,
+    mergeAt,
+  }: {
+    subgraphName: string,
+    mergeAt: ResponsePath,
+  }): FetchGroup {
+    const parentType = this.federationMetadata(subgraphName).entityType();
+    assert(parentType, () => `Subgraph ${subgraphName} has not entities defined`);
+    return this.newFetchGroup({ subgraphName, parentType, isEntityFetch: true, rootKind: 'query', mergeAt });
+  }
+
+  remove(toRemove: FetchGroup) {
+    this.onModification();
+
+    // We copy the initial children and parents since we're going to modify them and wand to avoid issue with
+    // modifying the list we're iterating one.
+    const children = toRemove.children().concat();
+    const parents = toRemove.parents().concat();
+    // We remove any relationship from the removed group to it's children.
+    for (const child of children) {
+      // At the point where we call this, any potential child of the removed group should have been "dealt with": on
+      // merge, the children should have relocated to whichever group we merged into, and if we remove some useless
+      // group, then its child should have other parents, or we would be breaking our graph (leaving those child groups
+      // unreachable). So this is our sanity check to ensure we haven't forgotten some step.
+      assert(child.parents().length > 1, () => `Cannot remove ${toRemove} as it is the *only* parent of ${child}`);
+      toRemove.removeChild(child);
+    }
+
+    // and then any parent relationship to the removed group.
+    for (const parent of parents) {
+      parent.group.removeChild(toRemove);
+    }
+
+    // We can now remove the entries for the removed group itself since it shouldn't be referenced anymore.
+    this.groups.splice(toRemove.index, 1);
+
+    // But as our group indexes index into arrays, we need to keep all existing group indexes contiguous, and as
+    // we just removed `toRemove.index`, we need to "fixup" every index of groups with a higher index (decrementing
+    // said index).
+    for (let i = toRemove.index; i < this.groups.length; i++) {
+      --this.groups[i].index;
+    }
+  }
+
+  /**
+   * Must be called every time the "shape" of the graph is modified to know that the graph may not be minimal/optimized anymore.
+   *
+   * This is not private due to the fact that the graph is implemented through the inter-connection of this class and the
+   * `FetchGroup` one and so `FetchGroup` needs to call this. But this has no reason to be called from any other place.
+   */
+  onModification() {
+    this.isReduced = false;
+    this.isOptimized = false;
+  }
+
+  // Do a transitive reduction (https://en.wikipedia.org/wiki/Transitive_reduction) of the graph
+  // We keep it simple and do a DFS from each vertex. The complexity is not amazing, but dependency
+  // graphs between fetch groups will almost surely never be huge and query planning performance
+  // is not paramount so this is almost surely "good enough".
+  reduce() {
+    if (this.isReduced) {
+      return;
+    }
+
+    for (const group of this.groups) {
+      this.dfsRemoveRedundantEdges(group);
+    }
+
+    this.isReduced = true;
+  }
+
+  // Reduce the graph (see `reduce`) and then do a some additional traversals to optimize for:
+  //  1) fetches with no selection: this can happen when we have a require if the only field requested
+  //     was the one with the require and that forced some dependencies. Those fetch should have
+  //     no dependents and we can just remove them.
+  //  2) fetches that are made in parallel to the same subgraph and the same path, and merge those.
+  private reduceAndOptimize() {
+    if (this.isOptimized) {
+      return;
+    }
+
+    this.reduce();
+
+    for (const group of this.rootGroups.values()) {
+      this.removeEmptyGroups(group);
+    }
+
+    for (const group of this.rootGroups.values()) {
+      this.mergeChildFetchesForSameSubgraphAndPath(group);
+    }
+
+    this.mergeFetchesToSameSubgraphAndSameInputs();
+
+    this.isOptimized = true;
+  }
+
+  private removeEmptyGroups(group: FetchGroup) {
+    const children = group.children().concat();
+    if (group.selection.isEmpty()) {
+      this.remove(group);
+    }
+    for (const g of children) {
+      this.removeEmptyGroups(g);
+    }
+  }
+
+  private mergeChildFetchesForSameSubgraphAndPath(group: FetchGroup) {
+    const children = group.children();
+    if (children.length > 1) {
+      // We iterate on all pairs of children and merge those siblings that can be merged together. Note
+      // that when we merged, we effectively modify the array we're iterating over, so we use indexes
+      // and re-test against `children.length` every time to ensure we don't miss elements as we do so.
+      for (let i = 0; i < children.length; i++) {
+        const gi = children[i];
+        let j = i + 1;
+        while (j < children.length) {
+          const gj = children[j];
+          if (gi.canMergeSiblingIn(gj)) {
+            // In theory, we can merge gi into gj, or gj into gi, it shouldn't matter. But we
+            // merge gi into gj so our iteration can continue properly.
+            gi.mergeSiblingIn(gj);
+
+            // We're working on a minimal graph (we've done a transitive reduction beforehand) and we need to keep the graph
+            // minimal as post-reduce steps (the `process` method) rely on it. But merging 2 groups _can_ break minimality.
+            // Say we have:
+            //   0 ------
+            //            \
+            //             4
+            //   1 -- 3 --/
+            // and we merge groups 0 and 1 (and let's call 2 the result), then we now have:
+            //      ------
+            //     /       \
+            //   0 <-- 3 -- 4
+            // which is not minimal.
+            //
+            // So to fix it, we just re-run our dfs removal from that merged edge (which is probably a tad overkill in theory,
+            // but for the reasons mentioned on `reduce`, this is most likely a non-issue in practice). 
+            //
+            // Note that this DFS can only affect the descendants of gi (its children and recursively so), so it does not
+            // affect our current iteration.
+            this.dfsRemoveRedundantEdges(gi);
+
+            // The merging removed `gj`, so we shouldn't bump `j`, it's already on the next group.
+          } else {
+            ++j;
+          }
+        }
+      }
+    }
+
+    // Now recurse to the sub-groups.
+    for (const g of children) {
+      this.mergeChildFetchesForSameSubgraphAndPath(g);
+    }
+  }
+
+  private mergeFetchesToSameSubgraphAndSameInputs() {
+    // Sometimes, the query will directly query some fields that are also requirements for some other queried fields, and because there
+    // is complex dependencies involved, we won't be able to easily realize that we're doing the same fetch to a subgraph twice in 2
+    // different places (once for the user query, once for the require). For an example of this happening, see the test called 'handles
+    // diamond-shaped dependencies' in `buildPlan.test.ts` Of course, doing so is always inefficient and so this method ensures we
+    // merge such fetches.
+    // In practice, this method merges any 2 fetches that are to the same subgraph and same mergeAt, and have the exact same inputs.
+
+    // To find which groups are to the same subgraph and mergeAt somewhat efficient, we generate a simple string key from each
+    // group subgraph name and mergeAt. We do "sanitize" subgraph name, but have no worries for `mergeAt` since it contains either
+    // number of field names, and the later is restricted by graphQL so as to not be an issue.
+    const makeKey = (g: FetchGroup): string => `${toValidGraphQLName(g.subgraphName)}-${g.mergeAt?.join('::') ?? ''}`;
+    const bySubgraphs = new MultiMap<string, FetchGroup>();
+    for (const group of this.groups) {
+      // we exclude groups without inputs because that's what we look for. In practice, this mostly just exclude
+      // root groups, which we don't really want to bother with anyway.
+      if (group.inputs) {
+        bySubgraphs.add(makeKey(group), group);
+      }
+    }
+    for (const groups of bySubgraphs.values()) {
+      // In the vast majority of cases `groups` is going be a single element, so optimize that trival case away.
+      if (groups.length <= 1) {
+        continue;
+      }
+
+      // An array where each entry is a "bucket" of groups that can all be merge together.
+      const toMergeBuckets: FetchGroup[][] = [];
+      while (groups.length > 1) {
+        const group = groups.pop()!;
+        const bucket: FetchGroup[] = [ group ];
+        // Bit of a hand-rolled loop here, but we're removing some elements, so this feel clearer overall
+        let i = 0;
+        while (i < groups.length) {
+          const current = groups[i];
+          if (group.inputs!.equals(current.inputs!)) {
+            bucket.push(current);
+            groups.splice(i, 1);
+            // Note that we don't change `i` since we just removed the element at that index and so the new
+            // element at that index is the next one we need to check.
+          } else {
+            ++i;
+          }
+        }
+        // The bucket always has at leat the initial group, but there is only merging to be done if there is at least one more
+        if (bucket.length > 1) {
+          toMergeBuckets.push(bucket);
+        }
+      }
+
+      for (const bucket of toMergeBuckets) {
+        // We pick one fo the group and merge all other into it. Note that which group we choose shouldn't matter since
+        // the merging preserves all the dependencies of each group (both parents and children).
+        const group = bucket.pop()!;
+        for (const other of bucket) {
+          group.mergeInWithAllDependencies(other);
+        }
+      }
+    }
+
+    // We may have merged groups and broke the graph miminality in doing so, so we re-reduce to make sure. Note
+    // that if we did no modification to the graph, calling `reduce` is cheap (the `isReduced` variable will still be `true`).
+    this.reduce();
+  }
+
+  private dfsRemoveRedundantEdges(from: FetchGroup) {
+    for (const startVertex of from.children()) {
+      const stack = startVertex.children().concat();
+      while (stack.length > 0) {
+        const v = stack.pop()!;
+        // Note that we rely on `removeChild` to be a no-op if there is not parent-child relation.
+        from.removeChild(v);
+        stack.push(...v.children());
+      }
+    }
+  }
+
+  private processGroup<TProcessedGroup, TParallelReduction, TFinalResult>(
+    processor: FetchGroupProcessor<TProcessedGroup, TParallelReduction, TFinalResult>,
+    group: FetchGroup,
+    isRootGroup: boolean
+  ): [TProcessedGroup, UnhandledGroups] {
+    const children = group.children();
+    const processed = processor.onFetchGroup(group, isRootGroup);
+    if (children.length == 0) {
+      return [processed, []];
+    }
+
+    const allOutGroupsHaveThisAsIn = children.every(g => g.parents().length === 1);
+    if (allOutGroupsHaveThisAsIn) {
+      const nodes: (TProcessedGroup | TParallelReduction)[] = [processed];
+
+      let nextNodes = children;
+      let remainingNext: UnhandledGroups = [];
+      while (nextNodes.length > 0) {
+        const [node, toHandle, remaining] = this.processParallelGroups(processor, nextNodes, remainingNext);
+        nodes.push(node);
+        const [canHandle, newRemaining] = this.mergeRemainings(remainingNext, remaining);
+        remainingNext = newRemaining;
+        nextNodes = canHandle.concat(toHandle);
+      }
+      return [processor.reduceSequence(nodes), remainingNext];
+    } else {
+      // We return just the group, with all other groups to be handled after, but remembering that
+      // this group edge has been handled.
+      return [processed, children.map(g => [g, g.parents().filter((p) => p.group !== group)])];
+    }
+  }
+
+  private processParallelGroups<TProcessedGroup, TParallelReduction, TFinalResult>(
+    processor: FetchGroupProcessor<TProcessedGroup, TParallelReduction, TFinalResult>,
+    groups: readonly FetchGroup[],
+    remaining: UnhandledGroups
+  ): [TParallelReduction, FetchGroup[], UnhandledGroups] {
+    const parallelNodes: TProcessedGroup[] = [];
+    let remainingNext = remaining;
+    const toHandleNext: FetchGroup[] = [];
+    for (const group of groups) {
+      const [node, remaining] = this.processGroup(processor, group, false);
+      parallelNodes.push(node);
+      const [canHandle, newRemaining] = this.mergeRemainings(remainingNext, remaining);
+      toHandleNext.push(...canHandle);
+      remainingNext = newRemaining;
+    }
+    return [
+      processor.reduceParallel(parallelNodes),
+      toHandleNext,
+      remainingNext
+    ];
+  }
+
+  private mergeRemainings(r1: UnhandledGroups, r2: UnhandledGroups): [FetchGroup[], UnhandledGroups] {
+    const unhandled: UnhandledGroups = [];
+    const toHandle: FetchGroup[] = [];
+    for (const [g, edges] of r1) {
+      const newEdges = this.mergeRemaingsAndRemoveIfFound(g, edges, r2);
+      if (newEdges.length == 0) {
+        toHandle.push(g);
+      } else {
+        unhandled.push([g, newEdges])
+      }
+    }
+    unhandled.push(...r2);
+    return [toHandle, unhandled];
+  }
+
+  private mergeRemaingsAndRemoveIfFound(group: FetchGroup, inEdges: UnhandledParentRelations, otherGroups: UnhandledGroups): UnhandledParentRelations {
+    const idx = otherGroups.findIndex(g => g[0] === group);
+    if (idx < 0) {
+      return inEdges;
+    } else {
+      const otherEdges = otherGroups[idx][1];
+      otherGroups.splice(idx, 1);
+      // The uhandled are the one that are unhandled on both side.
+      return inEdges.filter(e => otherEdges.includes(e))
+    }
+  }
+
+  process<TProcessedGroup, TParallelReduction>(processor: FetchGroupProcessor<TProcessedGroup, TParallelReduction, any>): TProcessedGroup[] {
+    this.reduceAndOptimize();
+
+    const rootNodes: TProcessedGroup[] = this.rootGroups.values().map(rootGroup => {
+      const [node, remaining] = this.processGroup(processor, rootGroup, true);
+      assert(remaining.length == 0, () => `Root group ${rootGroup} should have no remaining groups unhandled, but got ${remaining}`);
+      return node;
+    });
+    return rootNodes;
+  }
+
+  dumpOnConsole(msg?: string) {
+    if (msg) {
+      console.log(msg);
+    }
+    console.log('Groups:');
+    for (const group of this.groups) {
+      console.log(`  ${group}`);
+    }
+    console.log('Children relationships:');
+    for (const group of this.groups) {
+      const children = group.children();
+      if (children.length === 1) {
+        console.log(`  [${group.index}] => [ ${children[0]} ]`);
+      } else if (children.length !== 0) {
+        console.log(`  [${group.index}] => [\n    ${children.join('\n    ')}\n  ]`);
+      }
+    }
+    console.log('Parent relationships:');
+    const printParentRelation = (rel: ParentRelation) => (
+      rel.path ? `${rel.group} (path: [${rel.path.join(', ')}])` : rel.group.toString()
+    );
+    for (const group of this.groups) {
+      const parents = group.parents();
+      if (parents.length === 1) {
+        console.log(`  [${group.index}] => [ ${printParentRelation(parents[0])} ]`);
+      } else if (parents.length !== 0) {
+        console.log(`  [${group.index}] => [\n    ${parents.map(printParentRelation).join('\n    ')}\n  ]`);
+      }
+    }
+    console.log('--------');
+  }
+
+  toString() : string {
+    return this.rootGroups.values().map(g => this.toStringInternal(g, "")).join('\n');
+  }
+
+  toStringInternal(group: FetchGroup, indent: string): string {
+    const children = group.children();
+    return [indent + group.subgraphName + ' <- ' + children.map((child) => child.subgraphName).join(', ')]
+      .concat(children
+        .flatMap(g => g.children().length == 0
+          ? []
+          : this.toStringInternal(g, indent + "  ")))
+      .join('\n');
+  }
+}
+
+/**
+ * Generic interface for "processing" a (reduced) dependency graph of fetch groups (a `FetchDependencyGraph`).
+ *
+ * The processor methods will be called in a way that "respects" the dependency graph. More precisely, a
+ * reduced fetch group dependency graph can be expressed as an alternance of parallel branches and sequences
+ * of groups (the roots needing to be either parallel or sequential depending on whether we represent a `query`
+ * or a `mutation`), and the processor will be called on groups in such a way.
+ */
+interface FetchGroupProcessor<TProcessedGroup, TParallelReduction, TFinalResult> {
+  onFetchGroup(group: FetchGroup, isRootGroup: boolean): TProcessedGroup;
+  reduceParallel(values: TProcessedGroup[]): TParallelReduction;
+  reduceSequence(values: (TProcessedGroup | TParallelReduction)[]): TProcessedGroup;
+  finalize(roots: TProcessedGroup[], isParallel: boolean): TFinalResult
 }
 
 export function computeQueryPlan(supergraphSchema: Schema, federatedQueryGraph: QueryGraph, operation: Operation): QueryPlan {
@@ -527,6 +1500,63 @@ export function computeQueryPlan(supergraphSchema: Schema, federatedQueryGraph: 
     debug.groupEnd('Query plan computed');
     return { kind: 'QueryPlan', node: rootNode };
   }
+}
+
+function isIntrospectionSelection(selection: Selection): boolean {
+  return selection.kind == 'FieldSelection' && selection.element().definition.isIntrospectionField();
+}
+
+function mapOptionsToSelections<RV extends Vertex>(
+  selectionSet: SelectionSet,
+  options: SimultaneousPathsWithLazyIndirectPaths<RV>[]
+): [Selection, SimultaneousPathsWithLazyIndirectPaths<RV>[]][]  {
+  // We reverse the selections because we're going to pop from `openPaths` and this ensure we end up handling things in the query order.
+  return selectionSet.selections(true).map(node => [node, options]);
+}
+
+function possiblePlans(closedBranches: SimultaneousPaths<any>[][]): number {
+  let totalCombinations = 1;
+  for (let i = 0; i < closedBranches.length; ++i){
+    const eltSize = closedBranches[i].length;
+    if (eltSize === 0) {
+      // This would correspond to not being to find *any* path for a particular queried field, which means we have no plan
+      // for the overall query. Now, this shouldn't happen in practice if composition validation has been run successfully
+      // (and is not buggy), since the goal of composition validation is exactly to ensure we can never run into this path.
+      // In any case, we will throw later if that happens, but let's just return the proper result here, which is no plan at all.
+      return 0;
+    }
+    totalCombinations *= eltSize;
+  }
+  return totalCombinations;
+}
+
+function sum(arr: number[]): number {
+  return arr.reduce((a, b) => a + b, 0);
+}
+
+function selectionCost(selection?: SelectionSet, depth: number = 1): number {
+  // The cost is essentially the number of elements in the selection, but we make deeped element cost a tiny bit more, mostly to make things a tad more
+  // deterministic (typically, if we have an interface with a single implementation, then we can have a choice between a query plan that type-explode a
+  // field of the interface and one that doesn't, and both will be almost identical, except that the type-exploded field will be a different depth; by
+  // favoring lesser depth in that case, we favor not type-expoding).
+  return selection ? selection.selections().reduce((prev, curr) => prev + depth + selectionCost(curr.selectionSet, depth + 1), 0) : 0;
+}
+
+function withoutIntrospection(operation: Operation): Operation {
+  // Note that, because we only apply this to the top-level selections, we skip all introspection, including
+  // __typename. In general, we don't want o ignore __typename during query plans, but at top-level, we
+  // can let the gateway execution deal with it rather than querying some service for that.
+  if (!operation.selectionSet.selections().some(isIntrospectionSelection)) {
+    return operation
+  }
+
+  const newSelections = operation.selectionSet.selections().filter(s => !isIntrospectionSelection(s));
+  return new Operation(
+    operation.rootKind,
+    new SelectionSet(operation.selectionSet.parentType).addAll(newSelections),
+    operation.variableDefinitions,
+    operation.name
+  );
 }
 
 function computeRootParallelDependencyGraph(
@@ -663,202 +1693,6 @@ function addToResponsePath(path: ResponsePath, responseName: string, type: Type)
   return path;
 }
 
-class LazySelectionSet {
-  constructor(
-    private _computed?: SelectionSet,
-    private readonly _toCloneOnWrite?: SelectionSet
-  ) {
-    assert(_computed || _toCloneOnWrite, 'Should have one of the argument');
-  }
-
-  forRead(): SelectionSet {
-    return this._computed ? this._computed : this._toCloneOnWrite!;
-  }
-
-  forWrite(): SelectionSet {
-    if (!this._computed) {
-      this._computed = this._toCloneOnWrite!.clone();
-    }
-    return this._computed;
-  }
-
-  clone(): LazySelectionSet {
-    if (this._computed) {
-      return new LazySelectionSet(undefined, this._computed);
-    } else {
-      return this;
-    }
-  }
-
-  toString() {
-    return this.forRead().toString();
-  }
-}
-
-class FetchGroup {
-  private constructor(
-    readonly dependencyGraph: FetchDependencyGraph,
-    public index: number,
-    readonly subgraphName: string,
-    readonly rootKind: SchemaRootKind,
-    readonly parentType: CompositeType,
-    readonly isEntityFetch: boolean,
-    private readonly _selection: LazySelectionSet,
-    private readonly _inputs?: LazySelectionSet,
-    readonly mergeAt?: ResponsePath,
-  ) {
-  }
-
-  static create(
-    dependencyGraph: FetchDependencyGraph,
-    index: number,
-    subgraphName: string,
-    rootKind: SchemaRootKind,
-    parentType: CompositeType,
-    isEntityFetch: boolean,
-    mergeAt?: ResponsePath,
-  ): FetchGroup {
-    return new FetchGroup(
-      dependencyGraph,
-      index,
-      subgraphName,
-      rootKind,
-      parentType,
-      isEntityFetch,
-      new LazySelectionSet(new SelectionSet(parentType)),
-      isEntityFetch ? new LazySelectionSet(new SelectionSet(parentType)) : undefined,
-      mergeAt
-    );
-  }
-
-  clone(newDependencyGraph: FetchDependencyGraph): FetchGroup {
-    return new FetchGroup(
-      newDependencyGraph,
-      this.index,
-      this.subgraphName,
-      this.rootKind,
-      this.parentType,
-      this.isEntityFetch,
-      this._selection.clone(),
-      this._inputs?.clone(),
-      this.mergeAt
-    );
-  }
-
-  get isTopLevel(): boolean {
-    return !this.mergeAt;
-  }
-
-  // It's important that the returned selection is never modified. Use the other modification methods of this method instead!
-  get selection(): SelectionSet {
-    return this._selection.forRead();
-  }
-
-  // It's important that the returned selection is never modified. Use the other modification methods of this method instead!
-  get inputs(): SelectionSet | undefined {
-    return this._inputs?.forRead();
-  }
-
-  clonedInputs(): LazySelectionSet | undefined {
-    return this._inputs?.clone();
-  }
-
-  addDependencyOn(groups: FetchGroup | FetchGroup[], pathInGroups?: OperationPath) {
-    this.dependencyGraph.addDependency(this, groups, pathInGroups);
-  }
-
-  removeDependencyOn(groups: FetchGroup | FetchGroup[]) {
-    this.dependencyGraph.removeDependency(this, groups);
-  }
-
-  addInputs(selection: Selection | SelectionSet) {
-    assert(this._inputs, "Shouldn't try to add inputs to a root fetch group");
-    if (selection instanceof SelectionSet) {
-      this._inputs.forWrite().mergeIn(selection);
-    } else {
-      this._inputs.forWrite().add(selection);
-    }
-  }
-
-  addSelection(path: OperationPath) {
-    this._selection.forWrite().addPath(path);
-  }
-
-  addSelections(selection: SelectionSet) {
-    this._selection.forWrite().mergeIn(selection);
-  }
-
-  mergeIn(toMerge: FetchGroup, mergePath: OperationPath) {
-    assert(!toMerge.isTopLevel, () => `Shouldn't merge top level group ${toMerge} into ${this}`);
-    // Note that because toMerge is not top-level, the first "level" of it's selection is going to be a typeCast into the entity type
-    // used to get to the group (because the entities() operation, which is called, returns the _Entity and _needs_ type-casting).
-    // But when we merge-in, if the point we're merging in is already the entity, then the cast can be skipped.
-    const mergePathConditionalDirectives = conditionalDirectivesInOperationPath(mergePath);
-    const selectionSet = selectionSetOfPath(mergePath, (endOfPathSet) => {
-      assert(endOfPathSet, () => `Merge path ${mergePath} ends on a non-selectable type`);
-      for (const selection of toMerge.selection.selections()) {
-        const withoutUneededFragments = removeRedundantFragments(selection, endOfPathSet.parentType, mergePathConditionalDirectives);
-        addSelectionOrSelectionSet(endOfPathSet, withoutUneededFragments);
-      }
-    });
-
-    this._selection.forWrite().mergeIn(selectionSet);
-    this.dependencyGraph.onMergedIn(this, toMerge);
-  }
-
-  toPlanNode(variableDefinitions: VariableDefinitions, fragments?: NamedFragments, operationName?: string) : PlanNode {
-    addTypenameFieldForAbstractTypes(this.selection);
-
-    this.selection.validate();
-    const inputs = this._inputs?.forRead();
-    if (inputs) {
-      inputs.validate();
-    }
-
-    const inputNodes = inputs ? inputs.toSelectionSetNode() : undefined;
-
-    const operation = this.isEntityFetch
-      ? operationForEntitiesFetch(
-          this.dependencyGraph.subgraphSchemas.get(this.subgraphName)!,
-          this.selection,
-          variableDefinitions,
-          fragments,
-          operationName,
-        )
-      : operationForQueryFetch(
-          this.rootKind,
-          this.selection,
-          variableDefinitions,
-          fragments,
-          operationName,
-        );
-
-    const fetchNode: FetchNode = {
-      kind: 'Fetch',
-      serviceName: this.subgraphName,
-      requires: inputNodes ? trimSelectionNodes(inputNodes.selections) : undefined,
-      variableUsages: this.selection.usedVariables().map(v => v.name),
-      operation: stripIgnoredCharacters(print(operationToDocument(operation))),
-      operationKind:schemaRootKindToOperationKind(operation.rootKind),
-      operationName: operation.name,
-    };
-
-    return this.isTopLevel
-      ? fetchNode
-      : {
-        kind: 'Flatten',
-        path: this.mergeAt!,
-        node: fetchNode,
-      };
-  }
-
-  toString(): string {
-    return this.isTopLevel
-      ? `[${this.index}]${this.subgraphName}[${this._selection}]`
-      : `[${this.index}]${this.subgraphName}@(${this.mergeAt})[${this._inputs} => ${this._selection}]`;
-  }
-}
-
 function addSelectionOrSelectionSet(selectionSet: SelectionSet, toAdd: Selection | SelectionSet) {
   if (toAdd instanceof SelectionSet) {
     selectionSet.mergeIn(toAdd);
@@ -928,9 +1762,9 @@ function removeRedundantFragments(
     return selection;
   } else {
     // We need the fragment, but we can skip some of its directive.
-    const updatedFragement = new FragmentElement(type, fragment.typeCondition);
-    neededDirectives.forEach((d) => updatedFragement.applyDirective(d.definition!, d.arguments()));
-    return selectionSetOfElement(updatedFragement, selection.selectionSet);
+    const updatedFragment = new FragmentElement(type, fragment.typeCondition);
+    neededDirectives.forEach((d) => updatedFragment.applyDirective(d.definition!, d.arguments()));
+    return selectionSetOfElement(updatedFragment, selection.selectionSet);
   }
 }
 
@@ -942,22 +1776,13 @@ function schemaRootKindToOperationKind(operation: SchemaRootKind): OperationType
   }
 }
 
-function removeInPlace<T>(value: T, array: T[]) {
-  const idx = array.indexOf(value);
+function findAndRemoveInPlace<T>(predicate: (v: T) => boolean, array: T[]): number {
+  const idx = array.findIndex((v) => predicate(v));
   if (idx >= 0) {
     array.splice(idx, 1);
   }
+  return idx;
 }
-
-interface FetchGroupProcessor<G, P, F> {
-  onFetchGroup(group: FetchGroup, isRootGroup: boolean): G;
-  reduceParallel(values: G[]): P;
-  reduceSequence(values: (G | P)[]): G;
-  finalize(roots: G[], isParallel: boolean): F
-}
-
-type UnhandledGroups = [FetchGroup, UnhandledInEdges][];
-type UnhandledInEdges = number[];
 
 function sameMergeAt(m1: ResponsePath | undefined, m2: ResponsePath | undefined): boolean {
   if (!m1) {
@@ -969,540 +1794,15 @@ function sameMergeAt(m1: ResponsePath | undefined, m2: ResponsePath | undefined)
   return arrayEquals(m1, m2);
 }
 
-class FetchDependencyGraph {
-  private isReduced: boolean = false;
+function concatPathsInParents(first: OperationPath | undefined, second: OperationPath | undefined): OperationPath | undefined  {
+  return first && second ? concatOperationPaths(first, second) : undefined;
+}
 
-  private constructor(
-    readonly subgraphSchemas: ReadonlyMap<string, Schema>,
-    readonly federatedQueryGraph: QueryGraph,
-    private readonly rootGroups: MapWithCachedArrays<string, FetchGroup>,
-    private readonly groups: FetchGroup[],
-    private readonly adjacencies: number[][],
-    private readonly inEdges: number[][],
-    // For each groups, an optional path in its "unique" parent. If a group has more than one parent, then
-    // this will be undefined. Even if the group has a unique parent, it's not guaranteed to be set.
-    private readonly pathsInParents: (OperationPath | undefined)[]
-  ) {}
-
-  static create(federatedQueryGraph: QueryGraph) {
-    return new FetchDependencyGraph(
-      federatedQueryGraph.sources,
-      federatedQueryGraph,
-      new MapWithCachedArrays(),
-      [],
-      [],
-      [],
-      []
-    );
+function samePathsInParents(first: OperationPath | undefined, second: OperationPath | undefined): boolean  {
+  if (!first) {
+    return !second;
   }
-
-  private federationMetadata(subgraphName: string): FederationMetadata {
-    const schema = this.subgraphSchemas.get(subgraphName);
-    assert(schema, () => `Unknown schema ${subgraphName}`)
-    const metadata = federationMetadata(schema);
-    assert(metadata, () => `Schema ${subgraphName} should be a federation subgraph`);
-    return metadata;
-  }
-
-  clone(): FetchDependencyGraph {
-    const cloned = new FetchDependencyGraph(
-      this.subgraphSchemas,
-      this.federatedQueryGraph,
-      new MapWithCachedArrays<string, FetchGroup>(),
-      new Array(this.groups.length),
-      this.adjacencies.map(a => a.concat()),
-      this.inEdges.map(a => a.concat()),
-      this.pathsInParents.concat()
-    );
-
-    for (let i = 0; i < this.groups.length; i++) {
-      cloned.groups[i] = this.groups[i].clone(cloned);
-    }
-    for (const group of this.rootGroups.values()) {
-      cloned.rootGroups.set(group.subgraphName, cloned.groups[group.index]);
-    }
-    return cloned;
-  }
-
-  getOrCreateRootFetchGroup(subgraphName: string, rootKind: SchemaRootKind, parentType: CompositeType): FetchGroup {
-    let group = this.rootGroups.get(subgraphName);
-    if (!group) {
-      group = this.createRootFetchGroup(subgraphName, rootKind, parentType);
-      this.rootGroups.set(subgraphName, group);
-    }
-    return group;
-  }
-
-  rootSubgraphs(): readonly string[] {
-    return this.rootGroups.keys();
-  }
-
-  createRootFetchGroup(subgraphName: string, rootKind: SchemaRootKind, parentType: CompositeType): FetchGroup {
-    const group = this.newFetchGroup(subgraphName, parentType, false, rootKind);
-    this.rootGroups.set(subgraphName, group);
-    return group;
-  }
-
-  private newFetchGroup(
-    subgraphName: string,
-    parentType: CompositeType,
-    isEntityFetch: boolean,
-    rootKind: SchemaRootKind, // always "query" for entity fetches
-    mergeAt?: ResponsePath,
-    directParent?: FetchGroup,
-    pathInParent?: OperationPath
-  ): FetchGroup {
-    this.onModification();
-    const newGroup = FetchGroup.create(
-      this,
-      this.groups.length,
-      subgraphName,
-      rootKind,
-      parentType,
-      isEntityFetch,
-      mergeAt,
-    );
-    this.groups.push(newGroup);
-    this.adjacencies.push([]);
-    this.inEdges.push([]);
-    if (directParent) {
-      this.addEdge(directParent.index, newGroup.index, pathInParent);
-    }
-    return newGroup;
-  }
-
-  getOrCreateKeyFetchGroup(
-    subgraphName: string,
-    mergeAt: ResponsePath,
-    directParent: FetchGroup,
-    pathInParent: OperationPath,
-    conditionsGroups: FetchGroup[]
-  ): FetchGroup {
-    // Let's look if we can reuse a group we have, that is an existing dependent of the parent for
-    // the same subgraph and same mergeAt and that is not part of our condition dependencies (the latter
-    // meaning that we cannot reuse a group that fetched something we actually as input.
-    for (const existing of this.dependents(directParent)) {
-      if (existing.subgraphName === subgraphName
-        && existing.mergeAt
-        && sameMergeAt(existing.mergeAt, mergeAt)
-        && !this.isDependedOn(existing, conditionsGroups)
-      ) {
-        const existingPathInParent = this.pathInParent(existing);
-        if (pathInParent && existingPathInParent && !sameOperationPaths(existingPathInParent, pathInParent)) {
-          this.pathsInParents[existing.index] = undefined;
-        }
-        return existing;
-      }
-    }
-    const entityType = this.federationMetadata(subgraphName).entityType();
-    assert(entityType, () => `Subgraph ${subgraphName} has not entities defined`);
-    return this.newFetchGroup(subgraphName, entityType, true, 'query', mergeAt, directParent, pathInParent);
-  }
-
-  newRootTypeFetchGroup(
-    subgraphName: string,
-    rootKind: SchemaRootKind,
-    parentType: ObjectType,
-    mergeAt: ResponsePath,
-    directParent: FetchGroup,
-    pathInParent: OperationPath,
-  ): FetchGroup {
-    return this.newFetchGroup(subgraphName, parentType, false, rootKind, mergeAt, directParent, pathInParent);
-  }
-
-  // Returns true if `toCheck` is either part of `conditions`, or is a dependency (potentially recursively)
-  // of one of the gorup of conditions.
-  private isDependedOn(toCheck: FetchGroup, conditions: FetchGroup[]): boolean  {
-    const stack = conditions.concat();
-    while (stack.length > 0) {
-      const group = stack.pop()!;
-      if (toCheck.index === group.index) {
-        return true;
-      }
-      stack.push(...this.dependencies(group));
-    }
-    return false;
-  }
-
-  newKeyFetchGroup(
-    subgraphName: string,
-    mergeAt: ResponsePath,
-  ): FetchGroup {
-    const entityType = this.federationMetadata(subgraphName).entityType();
-    assert(entityType, () => `Subgraph ${subgraphName} has not entities defined`);
-    return this.newFetchGroup(subgraphName, entityType, true, 'query', mergeAt);
-  }
-
-  addDependency(dependentGroup: FetchGroup, dependentOn: FetchGroup | FetchGroup[], pathInDependentOn?: OperationPath) {
-    this.onModification();
-    const groups = Array.isArray(dependentOn) ? dependentOn : [ dependentOn ];
-    for (const group of groups) {
-      this.addEdge(group.index, dependentGroup.index, pathInDependentOn);
-    }
-  }
-
-  removeDependency(dependentGroup: FetchGroup, dependentOn: FetchGroup | FetchGroup[]) {
-    this.onModification();
-    const groups = Array.isArray(dependentOn) ? dependentOn : [ dependentOn ];
-    for (const group of groups) {
-      this.removeEdge(group.index, dependentGroup.index);
-    }
-  }
-
-  pathInParent(group: FetchGroup): OperationPath | undefined {
-    return this.pathsInParents[group.index];
-  }
-
-  private addEdge(from: number, to: number, pathInFrom?: OperationPath) {
-    if (!this.adjacencies[from].includes(to)) {
-      this.adjacencies[from].push(to);
-      this.inEdges[to].push(from);
-      const parentsCount = this.inEdges[to].length;
-      if (pathInFrom && parentsCount === 1) {
-        this.pathsInParents[to] = pathInFrom;
-      } else if (parentsCount > 1) {
-        this.pathsInParents[to] = undefined;
-      }
-    }
-  }
-
-  private removeEdge(from: number, to: number) {
-    if (this.adjacencies[from].includes(to)) {
-      removeInPlace(to, this.adjacencies[from]);
-      removeInPlace(from, this.inEdges[to]);
-      // If this was the only edge, we should erase the path. If it wasn't, we shouldn't have add a path in the
-      // first place, so setting to undefined is harmless.
-      this.pathsInParents[to] = undefined;
-    }
-  }
-
-  onMergedIn(mergedInto: FetchGroup, merged: FetchGroup) {
-    assert(!merged.isTopLevel, "Shouldn't remove top level groups");
-    this.onModification();
-    this.relocateDependentsOnMergedIn(mergedInto, merged.index);
-    this.removeInternal(merged.index);
-  }
-
-  private relocateDependentsOnMergedIn(mergedInto: FetchGroup, mergedIndex: number) {
-    for (const dependentIdx of this.adjacencies[mergedIndex]) {
-      this.addEdge(mergedInto.index, dependentIdx);
-      // While at it, we also remove the in-edge of the dependent to `merged` if it exists.
-      const idxInIns = this.inEdges[dependentIdx].indexOf(mergedIndex);
-      if (idxInIns >= 0) {
-        this.inEdges[dependentIdx].splice(idxInIns, 1);
-      }
-    }
-  }
-
-  remove(group: FetchGroup) {
-    this.onModification();
-    const dependents = this.dependents(group);
-    const dependencies = this.dependencies(group);
-    assert(dependents.length === 0, () => `Cannot remove group ${group} with dependents [${dependents}]`);
-    assert(dependencies.length <= 1, () => `Cannot remove group ${group} with more/less than one dependency: [${dependencies}]`);
-    this.removeInternal(group.index);
-  }
-
-  private removeInternal(mergedIndex: number) {
-    // We remove `merged` from any it depends on
-    for (const dependedIdx of this.inEdges[mergedIndex]) {
-      const idxInAdj = this.adjacencies[dependedIdx].indexOf(mergedIndex);
-      this.adjacencies[dependedIdx].splice(idxInAdj, 1);
-    }
-
-    // We then remove the entries for the merged group.
-    this.groups.splice(mergedIndex, 1);
-    this.adjacencies.splice(mergedIndex, 1);
-    this.inEdges.splice(mergedIndex, 1);
-    this.pathsInParents.splice(mergedIndex, 1);
-
-    // But now, every group index above `merge.index` is one-off.
-    this.groups.forEach(g => {
-      if (g.index > mergedIndex) {
-        --g.index;
-      }
-    });
-    this.adjacencies.forEach(adj => { adj.forEach((v, i) => {
-      if (v > mergedIndex) {
-        adj[i] = v - 1;
-      }
-    })});
-    this.inEdges.forEach(ins => { ins.forEach((v, i) => {
-      if (v > mergedIndex) {
-        ins[i] = v - 1;
-      }
-    })});
-  }
-
-  private onModification() {
-    this.isReduced = false;
-  }
-
-  // Do a transitive reduction (https://en.wikipedia.org/wiki/Transitive_reduction) of the graph
-  // We keep it simple and do a DFS from each vertex. The complexity is not amazing, but dependency
-  // graphs between fetch groups will almost surely never be huge and query planning performance
-  // is not paramount so this is almost surely "good enough".
-  // After the transitive reduction, we also do an additional traversals to check for:
-  //  1) fetches with no selection: this can happen when we have a require if the only field requested
-  //     was the one with the require and that forced some dependencies. Those fetch should have
-  //     no dependents and we can just remove them.
-  //  2) fetches that are made in parallel to the same subgraph and the same path, and merge those.
-  private reduce() {
-    if (this.isReduced) {
-      return;
-    }
-
-    for (const group of this.groups) {
-      this.dfsRemoveRedundantEdges(group);
-    }
-
-    for (const group of this.rootGroups.values()) {
-      this.removeEmptyGroups(group);
-    }
-
-    for (const group of this.rootGroups.values()) {
-      this.mergeDependentFetchesForSameSubgraphAndPath(group);
-    }
-
-    this.isReduced = true;
-  }
-
-  private removeEmptyGroups(group: FetchGroup) {
-    const dependents = this.dependents(group);
-    if (group.selection.isEmpty()) {
-      for (const dependent of dependents) {
-        // When we handle nested requires (@require of a field that has itself some @require), we may create temporary group
-        // for the "inner" require that never get any selection filled-in but are a dependency for the "outer" require. When,
-        // that happens however, the "outer" group should have dependency on other non-empty groups, and in that case it's
-        // safe to remove that one empty group (the group is useless and removing it doesn't break the dependency graph
-        // with remains connected).
-        assert(this.dependencies(dependent).length > 1, () => `Empty group ${group} is the *only* dependency of ${dependent}`);
-        this.removeDependency(dependent, group);
-      }
-      this.remove(group);
-    }
-    for (const g of dependents) {
-      this.removeEmptyGroups(g);
-    }
-  }
-
-  private mergeDependentFetchesForSameSubgraphAndPath(group: FetchGroup) {
-    const dependents = this.dependents(group);
-    if (dependents.length > 1) {
-      for (const g1 of dependents) {
-        for (const g2 of dependents) {
-          if (g1.index !== g2.index
-            && g1.subgraphName === g2.subgraphName
-            && sameMergeAt(g1.mergeAt, g2.mergeAt)
-            && this.dependencies(g1).length === 1
-            && this.dependencies(g2).length === 1
-          ) {
-            // We replace g1 by a new group that is the same except (possibly) for it's parentType ...
-            // (that's why we don't use `newKeyFetchGroup`, it assigns the index while we reuse g1's one here)
-            const merged = FetchGroup.create(this, g1.index, g1.subgraphName, g1.rootKind, g1.selection.parentType, g1.isEntityFetch, g1.mergeAt);
-            // Erase the pathsInParents as it's now potentially invalid (we won't really use it from that point on, but better
-            // safe than sorry).
-            this.pathsInParents[g1.index] = undefined;
-            if (g1.inputs) {
-              merged.addInputs(g1.inputs);
-            }
-            merged.addSelections(g1.selection);
-            this.groups[merged.index] = merged;
-
-            // ... and then merge g2 into that.
-            if (g2.inputs) {
-              merged.addInputs(g2.inputs);
-            }
-            merged.addSelections(g2.selection);
-            this.onMergedIn(merged, g2);
-
-            // We're working on a minimal graph (we've done a transitive reduction beforehand) and we need to keep the graph
-            // minimal as post-reduce steps (the `process` method) rely on it. But merging 2 groups _can_ break minimality.
-            // Say we have:
-            //   0 ------
-            //            \
-            //             4
-            //   1 -- 3 --/
-            // and we merge groups 0 and 1 (and let's call 2 the result), then we now have:
-            //      ------
-            //     /       \
-            //   2 <-- 3 -- 4
-            // which is not minimal.
-            //
-            // So to fix it, we just re-run our dfs removal from that merged edge (which is probably a tad overkill in theory,
-            // but for the reasons mentioned on `reduce`, this is most likely a non-issue in practice). 
-            this.dfsRemoveRedundantEdges(merged);
-
-            // As we've just changed the dependency graph, our current iterations are kind of invalid anymore. So
-            // we simply call ourselves back on the current group, which will retry the newly modified dependencies.
-            this.mergeDependentFetchesForSameSubgraphAndPath(group);
-            return;
-          }
-        }
-      }
-    }
-
-    // Now recurse to the sub-groups.
-    for (const g of dependents) {
-      this.mergeDependentFetchesForSameSubgraphAndPath(g);
-    }
-  }
-
-  dependencies(group: FetchGroup): FetchGroup[] {
-    return this.inEdges[group.index].map(i => this.groups[i]);
-  }
-
-  dependents(group: FetchGroup): FetchGroup[] {
-    return this.adjacencies[group.index].map(i => this.groups[i]);
-  }
-
-  private dfsRemoveRedundantEdges(from: FetchGroup) {
-    for (const startVertex of this.adjacencies[from.index]) {
-      // Note that we re-get the adjacencies of our starting point in each loop because it may change
-      // between loop iterations.
-      const parentAdjacencies = this.adjacencies[from.index];
-      const stack = [ ...this.adjacencies[startVertex] ];
-      while (stack.length > 0) {
-        const v = stack.pop()!;
-        removeInPlace(v, parentAdjacencies);
-        removeInPlace(from.index, this.inEdges[v]);
-        stack.push(...this.adjacencies[v]);
-      }
-    }
-  }
-
-  private outGroups(group: FetchGroup): FetchGroup[] {
-    return this.adjacencies[group.index].map(i => this.groups[i]);
-  }
-
-  private inGroups(group: FetchGroup): FetchGroup[] {
-    return this.inEdges[group.index].map(i => this.groups[i]);
-  }
-
-  private processGroup<G, P, F>(
-    processor: FetchGroupProcessor<G, P, F>,
-    group: FetchGroup,
-    isRootGroup: boolean
-  ): [G, UnhandledGroups] {
-    const outGroups = this.outGroups(group);
-    const processed = processor.onFetchGroup(group, isRootGroup);
-    if (outGroups.length == 0) {
-      return [processed, []];
-    }
-
-    const allOutGroupsHaveThisAsIn = outGroups.every(g => this.inGroups(g).length === 1);
-    if (allOutGroupsHaveThisAsIn) {
-      const nodes: (G | P)[] = [processed];
-
-      let nextNodes = outGroups;
-      let remainingNext: UnhandledGroups = [];
-      while (nextNodes.length > 0) {
-        const [node, toHandle, remaining] = this.processParallelGroups(processor, nextNodes, remainingNext);
-        nodes.push(node);
-        const [canHandle, newRemaining] = this.mergeRemainings(remainingNext, remaining);
-        remainingNext = newRemaining;
-        nextNodes = canHandle.concat(toHandle);
-      }
-      return [processor.reduceSequence(nodes), remainingNext];
-    } else {
-      // We return just the group, with all other groups to be handled after, but remembering that
-      // this group edge has been handled.
-      return [processed, outGroups.map(g => [g, this.inEdges[g.index].filter(e => e !== group.index)])];
-    }
-  }
-
-  private processParallelGroups<G, P, F>(
-    processor: FetchGroupProcessor<G, P, F>,
-    groups: FetchGroup[],
-    remaining: UnhandledGroups
-  ): [P, FetchGroup[], UnhandledGroups] {
-    const parallelNodes: G[] = [];
-    let remainingNext = remaining;
-    const toHandleNext: FetchGroup[] = [];
-    for (const group of groups) {
-      const [node, remaining] = this.processGroup(processor, group, false);
-      parallelNodes.push(node);
-      const [canHandle, newRemaining] = this.mergeRemainings(remainingNext, remaining);
-      toHandleNext.push(...canHandle);
-      remainingNext = newRemaining;
-    }
-    return [
-      processor.reduceParallel(parallelNodes),
-      toHandleNext,
-      remainingNext
-    ];
-  }
-
-  private mergeRemainings(r1: UnhandledGroups, r2: UnhandledGroups): [FetchGroup[], UnhandledGroups] {
-    const unhandled: UnhandledGroups = [];
-    const toHandle: FetchGroup[] = [];
-    for (const [g, edges] of r1) {
-      const newEdges = this.mergeRemaingsAndRemoveIfFound(g, edges, r2);
-      if (newEdges.length == 0) {
-        toHandle.push(g);
-      } else {
-        unhandled.push([g, newEdges])
-      }
-    }
-    unhandled.push(...r2);
-    return [toHandle, unhandled];
-  }
-
-  private mergeRemaingsAndRemoveIfFound(group: FetchGroup, inEdges: UnhandledInEdges, otherGroups: UnhandledGroups): UnhandledInEdges {
-    const idx = otherGroups.findIndex(g => g[0].index === group.index);
-    if (idx < 0) {
-      return inEdges;
-    } else {
-      const otherEdges = otherGroups[idx][1];
-      otherGroups.splice(idx, 1);
-      // The uhandled are the one that are unhandled on both side.
-      return inEdges.filter(e => otherEdges.includes(e))
-    }
-  }
-
-  process<G, P>(processor: FetchGroupProcessor<G, P, any>): G[] {
-    this.reduce();
-
-    const rootNodes: G[] = this.rootGroups.values().map(rootGroup => {
-      const [node, remaining] = this.processGroup(processor, rootGroup, true);
-      assert(remaining.length == 0, () => `Root group ${rootGroup} should have no remaining groups unhandled, but got ${remaining}`);
-      return node;
-    });
-    return rootNodes;
-  }
-
-  dumpOnConsole(msg?: string) {
-    if (msg) {
-      console.log(msg);
-    }
-    console.log('Groups:');
-    for (const group of this.groups) {
-      const pathInParent = this.pathsInParents[group.index];
-      console.log(`  ${group}${pathInParent ? ` (path in parent: ${pathInParent.map(p => p.toString()).join('::')})` : ''}`);
-    }
-    console.log('Adjacencies:');
-    for (const [i, adj] of this.adjacencies.entries()) {
-      console.log(`  ${i} => [${adj.join(', ')}]`);
-    }
-    console.log('In-Edges:');
-    for (const [i, ins] of this.inEdges.entries()) {
-      console.log(`  ${i} => [${ins.join(', ')}]`);
-    }
-  }
-
-  toString() : string {
-    return this.rootGroups.values().map(g => this.toStringInternal(g, "")).join('\n');
-  }
-
-  toStringInternal(group: FetchGroup, indent: string): string {
-    const groupDependents = this.adjacencies[group.index];
-    return [indent + group.subgraphName + ' <- ' + groupDependents.map(i => this.groups[i].subgraphName).join(', ')]
-      .concat(groupDependents
-        .flatMap(g => this.adjacencies[g].length == 0
-          ? []
-          : this.toStringInternal(this.groups[g], indent + "  ")))
-      .join('\n');
-  }
+  return !!second && sameOperationPaths(first, second);
 }
 
 function computeRootFetchGroups(dependencyGraph: FetchDependencyGraph, pathTree: OpRootPathTree, rootKind: SchemaRootKind): FetchDependencyGraph {
@@ -1511,21 +1811,21 @@ function computeRootFetchGroups(dependencyGraph: FetchDependencyGraph, pathTree:
   // Note that we can safely ignore the triggers of that first level as it will all be free transition, and we know we cannot have conditions.
   for (const [edge, _trigger, _conditions, child] of pathTree.childElements()) {
     assert(edge !== null, `The root edge should not be null`);
-    const source = edge.tail.source;
+    const subgraphName = edge.tail.source;
     // The edge tail type is one of the subgraph root type, so it has to be an ObjectType.
     const rootType = edge.tail.type as ObjectType;
-    const group = dependencyGraph.getOrCreateRootFetchGroup(source, rootKind, rootType);
+    const group = dependencyGraph.getOrCreateRootFetchGroup({ subgraphName, rootKind, parentType: rootType });
     computeGroupsForTree(dependencyGraph, child, group);
   }
   return dependencyGraph;
 }
 
 function computeNonRootFetchGroups(dependencyGraph: FetchDependencyGraph, pathTree: OpPathTree, rootKind: SchemaRootKind): FetchDependencyGraph {
-  const source = pathTree.vertex.source;
+  const subgraphName = pathTree.vertex.source;
   // The edge tail type is one of the subgraph root type, so it has to be an ObjectType.
   const rootType = pathTree.vertex.type;
   assert(isCompositeType(rootType), () => `Should not have condition on non-selectable type ${rootType}`);
-  const group = dependencyGraph.getOrCreateRootFetchGroup(source, rootKind, rootType);
+  const group = dependencyGraph.getOrCreateRootFetchGroup({ subgraphName, rootKind, parentType: rootType} );
   computeGroupsForTree(dependencyGraph, pathTree, group);
   return dependencyGraph;
 }
@@ -1569,6 +1869,17 @@ function extractPathInParentForKeyFetch(type: CompositeType, path: OperationPath
     : path;
 }
 
+/**
+ * If `maybePrefix` is a prefix of `basePath`, then return the path corresponding to the end of `basePath` after `maybePrefix` (which may
+ * be empty if those are the same path). Otherwise, if `maybePrefix` is not a proper prefix, return `undefined`.
+ */
+function maybeSubstratPathPrefix(basePath: OperationPath, maybePrefix: OperationPath): OperationPath | undefined {
+  if (maybePrefix.length <= basePath.length && sameOperationPaths(maybePrefix,  basePath.slice(0, maybePrefix.length))) {
+    return basePath.slice(maybePrefix.length);
+  }
+  return undefined;
+}
+
 function computeGroupsForTree(
   dependencyGraph: FetchDependencyGraph,
   pathTree: OpPathTree<any>,
@@ -1603,15 +1914,30 @@ function computeGroupsForTree(
           if (edge.transition.kind === 'KeyResolution') {
             assert(conditions, () => `Key edge ${edge} should have some conditions paths`);
             // First, we need to ensure we fetch the conditions from the current group.
-            const groupsForConditions = computeGroupsForTree(dependencyGraph, conditions, group, mergeAt, path);
+            const conditionsGroups = computeGroupsForTree(dependencyGraph, conditions, group, mergeAt, path);
+            createdGroups.push(...conditionsGroups);
             // Then we can "take the edge", creating a new group. That group depends
             // on the condition ones.
             const type = edge.tail.type as CompositeType; // We shouldn't have a key on a non-composite type
             const pathInParent = extractPathInParentForKeyFetch(type, path);
-            const newGroup = dependencyGraph.getOrCreateKeyFetchGroup(edge.tail.source, mergeAt, group, pathInParent, groupsForConditions);
+            const newGroup = dependencyGraph.getOrCreateKeyFetchGroup({
+              subgraphName: edge.tail.source,
+              mergeAt,
+              parent: { group, path: pathInParent },
+              conditionsGroups,
+            });
             createdGroups.push(newGroup);
-            // The new group depends on the current group but 'newKeyFetchGroup' already handled that.
-            newGroup.addDependencyOn(groupsForConditions);
+            newGroup.addParents(conditionsGroups.map((conditionGroup) => {
+              // If `conditionGroup` parent is `group`, that is the same as `newGroup` current parent, then we can infer the path of `newGroup` into
+              // that condition `group` by looking at the paths of each to their common parent. But otherwise, we cannot have a proper
+              // "path in parent".
+              const conditionGroupParents = conditionGroup.parents();
+              let path: OperationPath | undefined = undefined;
+              if (conditionGroupParents.length === 1 && conditionGroupParents[0].group === group && conditionGroupParents[0].path) {
+                path = maybeSubstratPathPrefix(conditionGroupParents[0].path, pathInParent);
+              }
+              return { group: conditionGroup, path };
+            }));
             const inputSelections = new SelectionSet(type);
             inputSelections.add(new FieldSelection(new Field(type.typenameField()!)));
             inputSelections.mergeIn(edge.conditions!);
@@ -1641,7 +1967,13 @@ function computeGroupsForTree(
             // We take the edge, creating a new group. Note that we always create a new group because this
             // correspond to jumping subgraph after a field returned the query root type, and we want to
             // preserve this ordering somewhat (debatable, possibly).
-            const newGroup = dependencyGraph.newRootTypeFetchGroup(edge.tail.source, rootKind, type, mergeAt, group, path);
+            const newGroup = dependencyGraph.newRootTypeFetchGroup({
+              subgraphName: edge.tail.source,
+              rootKind,
+              parentType: type,
+              mergeAt,
+            });
+            newGroup.addParent({ group, path });
             const newPath = createNewFetchSelectionContext(type, undefined, newContext)[1];
             stack.push({tree: child, group: newGroup, mergeAt, path: newPath, context: newContext });
           }
@@ -1725,6 +2057,19 @@ function handleRequires(
   // @requires should be on an entity type, and we only support object types right now
   const entityType = edge.head.type as ObjectType;
 
+  // In many case, we can optimize requires by merging the requirement to previously existing groups. However,
+  // we only do this when the current group has only a single parent (it's hard to reason about it otherwise).
+  // But the current could have multiple parents due to the graph lacking minimimality, and we don't want that
+  // to needlessly prevent us from this optimization. So we do a graph reduction first (which effectively
+  // just eliminate unecessary edges). To illustrate, we could be in a case like:
+  //     1
+  //   /  \
+  // 0 --- 2
+  // with current group 2. And while the group currently has 2 parents, the `reduce` step will ensure
+  // the edge `0 --- 2` is removed (since the dependency of 2 on 0 is already provide transitively through 1).
+  dependencyGraph.reduce();
+
+  const parents = group.parents();
   // In general, we should do like for an edge, and create a new group _for the current subgraph_
   // that depends on the createdGroups and have the created groups depend on the current one.
   // However, we can be more efficient in general (and this is expected by the user) because
@@ -1734,17 +2079,21 @@ function handleRequires(
   // group we're coming from is our "direct parent", we can merge it to said direct parent (which
   // effectively means that the parent group will collect the provides before taking the edge
   // to our current group).
-  if (!group.isTopLevel && pathHasOnlyFragments(path)) {
+  if (parents.length === 1 && pathHasOnlyFragments(path)) {
+    const parent = parents[0];
+
     // We start by computing the groups for the conditions. We do this using a copy of the current
     // group (with only the inputs) as that allows to modify this copy without modifying `group`.
     const originalInputs = group.clonedInputs()!;
-    const newGroup = dependencyGraph.newKeyFetchGroup(group.subgraphName, group.mergeAt!);
+    const newGroup = dependencyGraph.newKeyFetchGroup({ subgraphName: group.subgraphName, mergeAt: group.mergeAt!});
+    newGroup.addParent(parent);
     newGroup.addInputs(originalInputs.forRead());
     const createdGroups = computeGroupsForTree(dependencyGraph, requiresConditions, newGroup, mergeAt, path);
     if (createdGroups.length == 0) {
       // All conditions were local. Just merge the newly created group back in the current group (we didn't need it)
       // and continue.
-      group.mergeIn(newGroup, path);
+      assert(group.canMergeSiblingIn(newGroup), () => `We should be able to merge ${newGroup} into ${group} by construction`);
+      group.mergeSiblingIn(newGroup);
       return {group, mergeAt, path, createdGroups: []};
     }
 
@@ -1764,84 +2113,85 @@ function handleRequires(
     // strictly contained in its inputs but only due to the selection of some `__typename`, then we
     // still want to ignore that group, because `__typename` are always trivially queriable from any
     // type in any subgraph and so that `__typename` can always be fetched from the parent. Which is
-    // what the `newGroupIsUseless` check ignores `__typename` in the selection.
-    const newGroupIsUnneeded = newGroup.inputs!.contains(withoutTypename(newGroup.selection));
-    const parents = dependencyGraph.dependencies(group);
-    const pathInParent = dependencyGraph.pathInParent(group);
+    // what the `newGroupIsUnneeded` check ignores `__typename` in the selection.
+    const newGroupIsUnneeded = newGroup.inputs!.contains(withoutTypename(newGroup.selection)) && parent.path;
     const unmergedGroups = [];
 
-    // As just explained, we've ignored `__typename` in the selection when checking if the group
-    // is "useless". But if the selection _did_ have `__typename` that weren't in the inputs then
-    // we still need to ensure those additional `__typename` are fetched from the parent, and we're
-    // not sure they are, so we detect this case and merge the selection into the parent (which is
-    // safe, we're merging inputs that come from the parents with just a few additional `__typename`).
-    //
-    // Note that if we have multiple parents, we don't preserve the `pathInParent` for each and so
-    // we cannot merge `newGroup` into parents, so in that case we don't remove `newGroup` at all.
-    // This could possibly be optimised later but it's likely excessively rare (in fact, it's
-    // worth double-checking if it's even possible to have multiple parents at this stage of
-    // handling requires).
-    const shouldMergeNewGroupToParent = newGroupIsUnneeded && !newGroup.inputs!.contains(newGroup.selection);
-    if (newGroupIsUnneeded && (pathInParent || !shouldMergeNewGroupToParent)) {
-      // We can remove `newGroup` and attach `createdGroups` as dependencies of `group`'s parents. That said,
-      // as we do so, we check if one/some of the created groups can be "merged" into the parent
-      // directly (assuming we have only 1 parent, it's the same subgraph/mergeAt and we know the path in this parent).
-      // If it can, that essentially means that the requires could have been fetched directly from the parent,
-      // and that will likely be common.
+    if (newGroupIsUnneeded) {
+      // Up to this point, `newGroup` had no parent, so let's first merge `newGroup` to the parent, thus "rooting"
+      // it's children to it. Note that we just checked that `newGroup` selection was just its inputs, so
+      // we know that merging it to the parent is mostly a no-op from that POV, except maybe for requesting
+      // a few addition `__typename` we didn't before (due to the exclusion of `__typename` in the `newGroupIsUnneeded` check)
+      parent.group.mergeChildIn(newGroup);
+
+      // Now, all created groups are going to be descendant of `parentGroup`. But some of them may actually be
+      // mergeable into it.
       for (const created of createdGroups) {
-        const createdPathInParent = dependencyGraph.pathInParent(created);
-        // Note that pathInParent !== undefined implies that parents is of size 1
-        if (pathInParent
-          && createdPathInParent
-          && created.subgraphName === parents[0].subgraphName
-        ) {
-          parents[0].mergeIn(created, concatOperationPaths(pathInParent, createdPathInParent));
+        // Note that `created` may not be a direct child of `parent.group`, but `canMergeChildIn` just return `false` in
+        // that case, yielding the behaviour we want (not trying to merge it in).
+        if (created.subgraphName === parent.group.subgraphName && parent.group.canMergeChildIn(created)) {
+          parent.group.mergeChildIn(created);
         } else {
-          // We move created from depending on `newGroup` to depend on all of `group`'s parents.
-          created.removeDependencyOn(newGroup);
-          const pathInParents = pathInParent && createdPathInParent
-            ? concatOperationPaths(pathInParent, createdPathInParent)
-            : undefined;
-          created.addDependencyOn(parents, pathInParents);
           unmergedGroups.push(created);
+          // `created` cannot be merged into `parent.group`, which may typically be because they are not to the same
+          // subgraph. However, while `created` currently depend on `parent.group` (directly or indirectly), that
+          // dependency just come from the fact that `parent.group` is the parent of the group whose @require we're
+          // dealing with. And in practice, it could well be that some of the fetches needed for that require don't
+          // really depend on anything that parent fetches and could be done in parallel with it. If we detect that
+          // this is the case for `created`, we can move it "up the chain of dependency".
+          let currentParent: ParentRelation | undefined = parent;
+          while (currentParent
+            && !currentParent.group.isTopLevel
+            && created.isChildOfWithArtificialDependency(currentParent.group)
+          ) {
+            currentParent.group.removeChild(created);
+            const grandParents = currentParent.group.parents();
+            assert(grandParents.length > 0, `${currentParent.group} is not top-level, so it should have parents`);
+            for (const grandParent of grandParents) {
+              created.addParent({
+                group: grandParent.group,
+                path: concatPathsInParents(grandParent.path, currentParent.path),
+              });
+            }
+            // If we have more that 1 "grand parent", let's stop there as it would get more complicated
+            // and that's probably not needed. Otherwise, we can check if `created` may be able to move even
+            // further up.
+            currentParent = grandParents.length === 1 ? grandParents[0] : undefined;
+          }
         }
       }
-
-      if (shouldMergeNewGroupToParent) {
-        // Note that we're guaranteed that pathInParent is defined, but typescript don't seem to be able to figure it out.
-        parents[0].mergeIn(newGroup, pathInParent!);
-      } else {
-        // We know newGroup is useless and nothing should depend on it anymore, we can remove it.
-        dependencyGraph.remove(newGroup);
-      }
     } else {
-      // There is things in `newGroup`, let's merge them in `group` (no reason not to). This will
-      // make the created groups depend on `group`, which we want.
-      group.mergeIn(newGroup, path);
+      // We cannot merge `newGroup` to the parent, either because there it fetches some things necessary to the
+      // @require, or because we had more than one parent and don't know how to handle this (unsure if the later
+      // can actually happen at this point tbh (?)). Bu not reason not to merge `newGroup` back to `group` so
+      // we do that first.
+      assert(group.canMergeSiblingIn(newGroup), () => `We should be able to merge ${newGroup} into ${group} by construction`);
+      group.mergeSiblingIn(newGroup);
 
       // The created group depend on `group` and the dependency cannot be moved to the parent in
       // this case. However, we might still be able to merge some created group directly in the
       // parent. But for this to be true, we should essentially make sure that the dependency
       // on `group` is not a "true" dependency. That is, if the created group inputs are the same
-      // as `group` inputs (and said created group is the same subgraph than then parent of
-      // `group`, then it means we're only depending on value that are already in the parent and
-      // we merge the group).
-      for (const created of createdGroups) {
-        // Note that pathInParent != undefined implies that parents is of size 1
-        if (pathInParent
-          && created.subgraphName === parents[0].subgraphName
-          && sameMergeAt(created.mergeAt, group.mergeAt)
-          && originalInputs.forRead().contains(created.inputs!)
-        ) {
-          parents[0].mergeIn(created, pathInParent);
-        } else {
-          unmergedGroups.push(created);
+      // as `group` inputs (and said created group is the same subgraph than the parent of
+      // `group`, then it means we're only depending on values that are already in the parent and
+      // can merge the group).
+      if (parent.path) {
+        for (const created of createdGroups) {
+          if (created.subgraphName === parent.group.subgraphName
+            && parent.group.canMergeGrandChildIn(created)
+            && sameMergeAt(created.mergeAt, group.mergeAt)
+            && group.inputs!.contains(created.inputs!)
+          ) {
+            parent.group.mergeGrandChildIn(created);
+          } else {
+            unmergedGroups.push(created);
+          }
         }
       }
     }
 
-    // If we've merged all the created groups, the all provides are handled _before_ we get to the
-    // current group, so we can "continue" with the current group (and we remove the useless `newGroup`).
+    // If we've merged all the created groups, then all the "requires" are handled _before_ we get to the
+    // current group, so we can "continue" with the current group.
     if (unmergedGroups.length == 0) {
       // We still need to add the stuffs we require though (but `group` already has a key in its inputs,
       // we don't need one).
@@ -1849,11 +2199,21 @@ function handleRequires(
       return { group, mergeAt, path, createdGroups: [] };
     }
 
-    // If we get here, it means the @require needs the information from `createdGroups` _and_ those
-    // rely on some information from the current `group`. So we need to create a new group that
-    // depends on all the created groups and return that.
-    const postRequireGroup = dependencyGraph.newKeyFetchGroup(group.subgraphName, group.mergeAt!);
-    postRequireGroup.addDependencyOn(unmergedGroups);
+    // If we get here, it means that @require needs the information from `unmergedGroups` (plus whatever has
+    // been merged before) _and_ those rely on some information from the current `group` (if they hadn't, we
+    // would have been able to merge `newGroup` to `group`'s parent). So the group we should return, which
+    // is the group where the "post-@require" fields will be add, needs to a be a new group that depends
+    // on all those `unmergedGroups`.
+    const postRequireGroup = dependencyGraph.newKeyFetchGroup({ subgraphName: group.subgraphName, mergeAt: group.mergeAt!});
+    // Note that `postRequireGroup` cannot generally be merged in any of the `unmergedGroup` and we don't provide a `path`.
+    postRequireGroup.addParents(unmergedGroups.map((group) => ({ group })));
+    // That group also need, in general, to depend on the current `group`. That said, if we detected that the @require
+    // didn't need anything of said `group` (if `newGroupIsUnneeded`), then we can depend on the parent instead.
+    if (newGroupIsUnneeded) {
+      postRequireGroup.addParent(parent);
+    } else {
+      postRequireGroup.addParent({ group, path: []});
+    }
     const [inputs, newPath] = inputsForRequire(dependencyGraph.federatedQueryGraph, entityType, edge, context);
     // The post-require group needs both the inputs from `group` (the key to `group` subgraph essentially, and the additional requires conditions)
     postRequireGroup.addInputs(inputs);
@@ -1864,6 +2224,10 @@ function handleRequires(
       createdGroups: unmergedGroups.concat(postRequireGroup),
     };
   } else {
+    // We're in the somewhat simpler case where a @require happens somewhere in the middle of a subgraph query (so, not
+    // just after having jumped to that subgraph). In that case, there isn't tons of optimisation we can do: we have to
+    // see what satisfying the @require necessitate, and if it needs anything from another subgraph, we have to stop the
+    // current subgraph fetch there, get the requirements from other subgraphs, and then resume the query of that particular subgraph.
     const createdGroups = computeGroupsForTree(dependencyGraph, requiresConditions, group, mergeAt, path);
     // If we didn't created any group, that means the whole condition was fetched from the current group
     // and we're good.
@@ -1873,8 +2237,8 @@ function handleRequires(
     // We need to create a new group, on the same subgraph `group`, where we resume fetching the field for
     // which we handle the @requires _after_ we've delt with the `requiresConditionsGroups`.
     // Note that we know the conditions will include a key for our group so we can resume properly.
-    const newGroup = dependencyGraph.newKeyFetchGroup(group.subgraphName, mergeAt);
-    newGroup.addDependencyOn(createdGroups);
+    const newGroup = dependencyGraph.newKeyFetchGroup({ subgraphName: group.subgraphName, mergeAt });
+    newGroup.addParents(createdGroups.map((group) => ({ group })));
     const [inputs, newPath] = inputsForRequire(dependencyGraph.federatedQueryGraph, entityType, edge, context);
     newGroup.addInputs(inputs);
     return { group: newGroup, mergeAt, path: newPath, createdGroups };


### PR DESCRIPTION
The core of this commit is to fix the handling of merging groups when
we handle requires, which wasn't done probably in particular due to
a sub-optimal tracking of the "path in parents" for groups (without
which we cannot do merging properly). The surrounding code was however
starting to be difficult to read/follow, so this commit is by and large
a refactor the dependency graph code to make things clearer. Amongst
other things, it changes the naming from talking about a group
dependencies/depedents to talking of childs/parents: this is the same
thing, but feels much easier to read/reason about.

A few additional optimisation are needed to ensure the generated plan
is optimal. One of them ensure identical fetches (same group/same
inputs) always get merged together, and that fix doesn't only include
@require. In fact, we had an existing test in `abstract-types.test.ts`
that was generating an inefficient with such duplicate fetch, and
the test had a comment explaining that the plan was inefficient and
needed to be improved. This commit fix that known-inefficient test
as a consequence.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
