### PR TITLE
Generates __typename edge on interfaces for fed1 supergraphs

### DIFF
--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -582,7 +582,6 @@ export function isRootPath(path: OpGraphPath<any>): path is OpRootPath {
 }
 
 export function terminateWithNonRequestedTypenameField<V extends Vertex>(path: OpGraphPath<V>): OpGraphPath<V> {
-
   // If the last step of the path was a fragment/type-condition, we want to remove it before we get __typename.
   // The reason is that this avoid cases where this method would make us build plans like:
   // {

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -981,8 +981,14 @@ class GraphBuilderFromSchema extends GraphBuilder {
       // "provides" a particular interface field locally *for all the supergraph interfaces implementations* (in other words, we
       // know we can always ask the field to that subgraph directly on the interface and will never miss anything), then we can
       // add a direct edge to the field for the interface in that subgraph (which avoids unnecessary type exploding in practice).
-      if (this.isFederatedSubgraph && !this.forceTypeExplosion) {
-        this.maybeAddInterfaceFieldsEdges(namedType, vertex);
+      if (this.isFederatedSubgraph) {
+        if (!this.forceTypeExplosion) {
+          this.maybeAddInterfaceFieldsEdges(namedType, vertex);
+        } else {
+          // While we don't want to add edges for all the "user" fields, we should still have add one for `__typename`
+          // as that can always be asked from the interface and may be necessary in a few corner cases.
+          this.addEdgeForField(namedType.typenameField()!, vertex);
+        }
       }
       this.addAbstractTypeEdges(namedType, vertex);
     } else if (isUnionType(namedType)) {


### PR DESCRIPTION
Because fed1 supergraph don't have proper interface information, we
"force type explosion" for interfaces, which effectively means skipping
adding edges for interface fields to the query graph. However, as we
did so, we also end up skipping the edge for `__typename` on the
interface, and that edge is necessary for the query planner to handle
some specific cases where parts of the user query has unsatisfiable
type conditions (intersection of fragment conditions with no runtime
implementations). This patches ensure that `__typename` edge is always
added.

Fixes #1907

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
