### PR TITLE
Fix fragment reuse in subgraph fetches

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+ - Fix fragment reuse in subgraph fetches [PR #1911](https://github.com/apollographql/federation/pull/1911).
+
 ## 2.1.0-alpha.1
 
 - Expose document representation of sub-query request within GraphQLDataSourceProcessOptions so that it is available to RemoteGraphQLDataSource.process and RemoteGraphQLDataSource.willSendRequest [PR#1878](https://github.com/apollographql/federation/pull/1878)

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -771,12 +771,16 @@ describe('buildQueryPlan', () => {
                       topProducts {
                         __typename
                         ... on Book {
-                          price
+                          ...Price
                         }
                         ... on Furniture {
-                          price
+                          ...Price
                         }
                       }
+                    }
+                    
+                    fragment Price on Product {
+                      price
                     }
                   },
                 }

--- a/gateway-js/src/__tests__/integration/abstract-types.test.ts
+++ b/gateway-js/src/__tests__/integration/abstract-types.test.ts
@@ -1626,14 +1626,16 @@ it('when exploding types through multiple levels', async () => {
             } =>
             {
               ... on Book {
-                reviews {
-                  body
-                }
+                ...ProductReviews
               }
               ... on Furniture {
-                reviews {
-                  body
-                }
+                ...ProductReviews
+              }
+            }
+            
+            fragment ProductReviews on Product {
+              reviews {
+                body
               }
             }
           },

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -3,7 +3,7 @@ import type { HeadersInit } from 'node-fetch';
 import { GraphQLRequestContextExecutionDidStart } from 'apollo-server-types';
 import type { Logger } from '@apollo/utils.logger';
 import { GraphQLDataSource } from './datasources/types';
-import { QueryPlan } from '@apollo/query-planner';
+import { QueryPlan, QueryPlannerConfig } from '@apollo/query-planner';
 import { OperationContext } from './operationContext';
 import { ServiceMap } from './executeQueryPlan';
 import { ServiceDefinition } from "@apollo/federation-internals";
@@ -129,6 +129,8 @@ interface GatewayConfigBase {
   experimental_autoFragmentization?: boolean;
   fetcher?: Fetcher;
   serviceHealthCheck?: boolean;
+
+  queryPlannerConfig?: QueryPlannerConfig;
 }
 
 // TODO(trevor:removeServiceList)

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -563,7 +563,7 @@ export class ApolloGateway implements GraphQLService {
     this.schema = addExtensions(
       wrapSchemaWithAliasResolver(this.apiSchema.toGraphQLJSSchema()),
     );
-    this.queryPlanner = new QueryPlanner(coreSchema);
+    this.queryPlanner = new QueryPlanner(coreSchema, this.config.queryPlannerConfig);
 
     // Notify onSchemaChange listeners of the updated schema
     if (!legacyDontNotifyOnSchemaChangeListeners) {

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -13,133 +13,215 @@ function parseSchema(schema: string): Schema {
   }
 }
 
-test('fragments optimization of selection sets', () => {
-  const schema = parseSchema(`
-    type Query {
-      t: T1
-    }
+describe('fragments optimization', () => {
+  test('handles fragments using other fragments', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T1
+      }
 
-    interface I {
-      b: Int
-    }
+      interface I {
+        b: Int
+      }
 
-    type T1 {
-      a: Int
-      b: Int
-      u: U
-    }
+      type T1 {
+        a: Int
+        b: Int
+        u: U
+      }
 
-    type T2 {
-      x: String
-      y: String
-      b: Int
-      u: U
-    }
+      type T2 {
+        x: String
+        y: String
+        b: Int
+        u: U
+      }
 
-    union U = T1 | T2
-  `);
+      union U = T1 | T2
+    `);
 
-  const operation = parseOperation(schema, `
-    fragment OnT1 on T1 {
-      a
-      b
-    }
+    const operation = parseOperation(schema, `
+      fragment OnT1 on T1 {
+        a
+        b
+      }
 
-    fragment OnT2 on T2 {
-      x
-      y
-    }
+      fragment OnT2 on T2 {
+        x
+        y
+      }
 
-    fragment OnI on I {
-      b
-    }
+      fragment OnI on I {
+        b
+      }
 
-    fragment OnU on U {
-      ...OnI
-      ...OnT1
-      ...OnT2
-    }
-
-    query {
-      t {
+      fragment OnU on U {
+        ...OnI
         ...OnT1
         ...OnT2
-        ...OnI
-        u {
-          ...OnU
+      }
+
+      query {
+        t {
+          ...OnT1
+          ...OnT2
+          ...OnI
+          u {
+            ...OnU
+          }
         }
       }
-    }
-  `);
+    `);
 
-  const withoutFragments = parseOperation(schema, operation.toString(true, true));
-  expect(withoutFragments.toString()).toMatchString(`
-    {
-      t {
-        ... on T1 {
-          a
-          b
-        }
-        ... on T2 {
-          x
-          y
-        }
-        ... on I {
-          b
-        }
-        u {
-          ... on U {
-            ... on I {
-              b
-            }
-            ... on T1 {
-              a
-              b
-            }
-            ... on T2 {
-              x
-              y
+    const withoutFragments = parseOperation(schema, operation.toString(true, true));
+    expect(withoutFragments.toString()).toMatchString(`
+      {
+        t {
+          ... on T1 {
+            a
+            b
+          }
+          ... on T2 {
+            x
+            y
+          }
+          ... on I {
+            b
+          }
+          u {
+            ... on U {
+              ... on I {
+                b
+              }
+              ... on T1 {
+                a
+                b
+              }
+              ... on T2 {
+                x
+                y
+              }
             }
           }
         }
       }
-    }
-  `);
+    `);
 
-  const optimized = withoutFragments.optimize(operation.selectionSet.fragments!);
-  // Note that we expect onU to *not* be recreated because, by default, optimize only
-  // add add back a fragment if it is used at least twice (otherwise, the fragment just
-  // make the query bigger).
-  expect(optimized.toString()).toMatchString(`
-    fragment OnT1 on T1 {
-      a
-      b
-    }
+    const optimized = withoutFragments.optimize(operation.selectionSet.fragments!);
+    // Note that we expect onU to *not* be recreated because, by default, optimize only
+    // add add back a fragment if it is used at least twice (otherwise, the fragment just
+    // make the query bigger).
+    expect(optimized.toString()).toMatchString(`
+      fragment OnT1 on T1 {
+        a
+        b
+      }
 
-    fragment OnT2 on T2 {
-      x
-      y
-    }
+      fragment OnT2 on T2 {
+        x
+        y
+      }
 
-    fragment OnI on I {
-      b
-    }
+      fragment OnI on I {
+        b
+      }
 
-    {
-      t {
-        ...OnT1
-        ...OnT2
-        ...OnI
-        u {
-          ... on U {
+      {
+        t {
+          ...OnT1
+          ...OnT2
+          ...OnI
+          u {
             ...OnI
             ...OnT1
             ...OnT2
           }
         }
       }
-    }
-  `);
+    `);
+  });
+
+  test('handles fragments with nested selections', () => {
+    const schema = parseSchema(`
+      type Query {
+        t1a: T1
+        t2a: T1
+      }
+
+      type T1 {
+        t2: T2
+      }
+
+      type T2 {
+        x: String
+        y: String
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      fragment OnT1 on T1 {
+        t2 {
+          x
+        }
+      }
+
+      query {
+        t1a {
+          ...OnT1
+          t2 {
+            y
+          }
+        }
+        t2a {
+          ...OnT1
+        }
+      }
+    `);
+
+    const withoutFragments = parseOperation(schema, operation.toString(true, true));
+    expect(withoutFragments.toString()).toMatchString(`
+      {
+        t1a {
+          ... on T1 {
+            t2 {
+              x
+            }
+          }
+          t2 {
+            y
+          }
+        }
+        t2a {
+          ... on T1 {
+            t2 {
+              x
+            }
+          }
+        }
+      }
+    `);
+
+    const optimized = withoutFragments.optimize(operation.selectionSet.fragments!);
+    expect(optimized.toString()).toMatchString(`
+      fragment OnT1 on T1 {
+        t2 {
+          x
+        }
+      }
+
+      {
+        t1a {
+          ...OnT1
+          t2 {
+            y
+          }
+        }
+        t2a {
+          ...OnT1
+        }
+      }
+    `);
+  });
 });
 
 describe('selection set freezing', () => {

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+- Fix fragment reuse in subgraph fetches [PR #1911](https://github.com/apollographql/federation/pull/1911).
+
 ## 2.1.0-alpha.1
 
 - Expose document representation of sub-query request within GraphQLDataSourceProcessOptions so that it is available to RemoteGraphQLDataSource.process and RemoteGraphQLDataSource.willSendRequest [PR #1878](https://github.com/apollographql/federation/pull/1878)

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -43,6 +43,7 @@ import {
   conditionalDirectivesInOperationPath,
   MultiMap,
   ERRORS,
+  NamedFragmentDefinition,
 } from "@apollo/federation-internals";
 import {
   advanceSimultaneousPathsWithOperation,
@@ -1540,8 +1541,20 @@ export function computeQueryPlan(queryPlannerConfig: QueryPlannerConfig, supergr
       { nodes: [parse(operation.toString())] },
     );
   }
-  // We expand all fragments. This might merge a number of common branches and save us
-  // some work, and we're going to expand everything during the algorithm anyway.
+
+  const reuseQueryFragments = queryPlannerConfig.reuseQueryFragments ?? true;
+  let fragments = operation.selectionSet.fragments
+  if (fragments && reuseQueryFragments) {
+    // For all subgraph fetches we query `__typename` on every abstract types (see `FetchGroup.toPlanNode`) so if we want
+    // to have a chance to reuse fragments, we should make sure those fragments also query `__typename` for every abstract type.
+    fragments = addTypenameFieldForAbstractTypesInNamedFragments(fragments)
+  } else {
+    fragments = undefined;
+  }
+
+  // We expand all fragments. This might merge a number of common branches and save us some work, and we're
+  // going to expand everything during the algorithm anyway. We'll re-optimize subgraph fetches with fragments
+  // later if possible (which is why we saved them above before expansion).
   operation = operation.expandAllFragments();
   operation = withoutIntrospection(operation);
 
@@ -1553,7 +1566,7 @@ export function computeQueryPlan(queryPlannerConfig: QueryPlannerConfig, supergr
 
   const root = federatedQueryGraph.root(operation.rootKind);
   assert(root, () => `Shouldn't have a ${operation.rootKind} operation if the subgraphs don't have a ${operation.rootKind} root`);
-  const processor = fetchGroupToPlanProcessor(queryPlannerConfig, operation.variableDefinitions, operation.selectionSet.fragments, operation.name);
+  const processor = fetchGroupToPlanProcessor(queryPlannerConfig, operation.variableDefinitions, fragments, operation.name);
   if (operation.rootKind === 'mutation') {
     const dependencyGraphs = computeRootSerialDependencyGraph(supergraphSchema, operation, federatedQueryGraph, root);
     const rootNode = processor.finalize(dependencyGraphs.flatMap(g => g.process(processor)), false);
@@ -1757,6 +1770,100 @@ function addToResponsePath(path: ResponsePath, responseName: string, type: Type)
     type = type.ofType;
   }
   return path;
+}
+
+function addTypenameFieldForAbstractTypesInNamedFragments(fragments: NamedFragments): NamedFragments {
+  // This method is a bit tricky due to potentially nested fragments. More precisely, suppose that
+  // we have:
+  //   fragment MyFragment on T {
+  //     a {
+  //       b {
+  //         ...InnerB
+  //       }
+  //     }
+  //   }
+  //
+  //   fragment InnerB on B {
+  //     __typename
+  //     x
+  //     y
+  //   }
+  // then if we were to "naively" add `__typename`, the first fragment would end up being:
+  //   fragment MyFragment on T {
+  //     a {
+  //       __typename
+  //       b {
+  //         __typename
+  //         ...InnerX
+  //       }
+  //     }
+  //   }
+  // but that's not ideal because the inner-most `__typename` is already within `InnerX`. And that 
+  // gets in the way to re-adding fragments (the `SelectionSet.optimize` method) because if we start
+  // with:
+  //   {
+  //     a {
+  //       __typename
+  //       b {
+  //         __typename
+  //         x
+  //         y
+  //       }
+  //     }
+  //   }
+  // and add `InnerB` first, we get:
+  //   {
+  //     a {
+  //       __typename
+  //       b {
+  //         ...InnerB
+  //       }
+  //     }
+  //   }
+  // and it becomes tricky to recognize the "updated-with-typename" version of `MyFragment` now (we "seem"
+  // to miss a `__typename`).
+  //
+  // Anyway, to avoid this issue, what we do is that for every fragment, we:
+  //  1. expand any nested fragments in its selection.
+  //  2. add `__typename` where we should in that expanded selection.
+  //  3. re-optimize all fragments (using the "updated-with-typename" versions).
+  // which ends up getting us what we need. However, doing so requires us to deal with fragments in order
+  // of dependencies (first the ones with no nested fragments, then the one with only nested fragments of
+  // that first group, etc...), and that's why this method is a bit longer that one could have expected.
+  type FragmentInfo = {
+    original: NamedFragmentDefinition,
+    expandedSelectionSet: SelectionSet,
+    dependentsOn: string[],
+  };
+  const fragmentsMap = new Map<string, FragmentInfo>();
+
+  for (const fragment of fragments.definitions()) {
+    const expandedSelectionSet = fragment.selectionSet.expandFragments();
+    addTypenameFieldForAbstractTypes(expandedSelectionSet);
+    const otherFragmentsUsages = new Map<string, number>();
+    fragment.collectUsedFragmentNames(otherFragmentsUsages);
+    fragmentsMap.set(fragment.name, {
+      original: fragment,
+      expandedSelectionSet,
+      dependentsOn: Array.from(otherFragmentsUsages.keys()),
+    });
+  }
+
+  const optimizedFragments = new NamedFragments();
+  while (fragmentsMap.size > 0) {
+    for (const [name, info] of fragmentsMap) {
+      // Note that graphQL specifies that named fragments cannot have cycles (https://spec.graphql.org/draft/#sec-Fragment-spreads-must-not-form-cycles)
+      // and so we guaranteed that on every ieration, at least element of the map is removed and thus that the
+      // overall `while` loops terminate.
+      if (info.dependentsOn.every((n) => optimizedFragments.has(n))) {
+        const reoptimizedSelectionSet = info.expandedSelectionSet.optimize(optimizedFragments);
+        optimizedFragments.add(info.original.withUpdatedSelectionSet(reoptimizedSelectionSet));
+        fragmentsMap.delete(name);
+      }
+    }
+  }
+
+  return optimizedFragments;
 }
 
 function addSelectionOrSelectionSet(selectionSet: SelectionSet, toAdd: Selection | SelectionSet) {

--- a/query-planner-js/src/config.ts
+++ b/query-planner-js/src/config.ts
@@ -1,3 +1,18 @@
 export interface QueryPlannerConfig {
-  exposeDocumentNodeInFetchNode?: boolean;
+  exposeDocumentNodeInFetchNode?: boolean,
+
+  /**
+   * Whether the query planner should try to reused the named fragments of the planned query in subgraph fetches.
+   *
+   * This is often a good idea as it can prevent very large subgraph queries in some cases (named fragments can
+   * make some relatively small queries (using said fragments) expand to a very large query if all the spreads
+   * are inline). However, due to architecture of the query planner, this optimization is done as an additional
+   * pass on the subgraph queries of the generated plan and can thus increase the latency of building a plan.
+   * As long as query plans are sufficiently cached, this should not be a problem, which is why this option is
+   * enabled by default, but if the distribution of inbound queries prevents efficient caching of query plans,
+   * this may become an undesirable trade-off and cand be disabled in that case.
+   *
+   * Defaults to true.
+   */
+  reuseQueryFragments?: boolean,
 }

--- a/query-planner-js/src/index.ts
+++ b/query-planner-js/src/index.ts
@@ -9,13 +9,8 @@ import { buildFederatedQueryGraph, QueryGraph } from "@apollo/query-graphs";
 import { computeQueryPlan } from './buildPlan';
 import { QueryPlannerConfig } from './config';
 
-// There isn't much in this class yet, and I didn't want to make too many
-// changes at once, but since we were already storing a pointer to a
-// Rust query planner instance in the gateway, I think it makes sense to retain
-// that structure. I suspect having a class instead of a stand-alone function
-// will come in handy to encapsulate schema-derived data that is used during
-// planning but isn't operation specific. The next step is likely to be to
-// convert `buildQueryPlan` into a method.
+export { QueryPlannerConfig } from './config'; 
+
 export class QueryPlanner {
   private readonly config: QueryPlannerConfig;
   private readonly federatedQueryGraph: QueryGraph;


### PR DESCRIPTION
The query planner has code originally meant to reuse fragments from the
user query in subgraph fetches when it made sense. Unfortunately that
code wasn't triggered at all due to the query planner not properly
capturing those fragments. This ticket fixes this issue, adds more
testing and improves a few related issues.

Fixes #1894