### PR TITLE
chore: adds table of contents changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 This repository contains multiple JavaScript packages, each with multiple changelogs. Federation 1 is managed on the [`version-0.x` branch](https://github.com/apollographql/federation/tree/version-0.x), while Federation 2 is managed on the [`main` branch](https://github.com/apollographql/federation/tree/main). Please consult the table below to find the changelog you are looking for:
 
-|npm package|version|changelog|
+|npm package|v1|v2|
 |--|--|--|
-|[`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md)|
-|[`@apollo/query-planner`](https://www.npmjs.com/package/@apollo/query-planner/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md)|
-|[`@apollo/subgraph`](https://www.npmjs.com/package/@apollo/subgraph/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md)|
-|[`@apollo/federation`](https://www.npmjs.com/package/@apollo/federation/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/federation-js/CHANGELOG.md)|
-|[`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/gateway-js/CHANGELOG.md)|
-|[`@apollo/federation-internals`](https://www.npmjs.com/package/@apollo/federation-internals/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/internals-js/CHANGELOG.md)|
-|[`@apollo/query-graphs`](https://www.npmjs.com/package/@apollo/query-graphs/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/query-graphs-js/CHANGELOG.md)|
-|[`@apollo/query-planner`](https://www.npmjs.com/package/@apollo/query-planner/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/query-planner-js/CHANGELOG.md)|
-|[`@apollo/subgraph`](https://www.npmjs.com/package/@apollo/subgraph/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/subgraph-js/CHANGELOG.md)|
-|[`@apollo/composition`](https://www.npmjs.com/package/@apollo/composition/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/composition-js/CHANGELOG.md)|
+|[`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md)|[changelog](https://github.com/apollographql/federation/blob/main/gateway-js/CHANGELOG.md)|
+|[`@apollo/query-planner`](https://www.npmjs.com/package/@apollo/query-planner)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md)|[changelog](https://github.com/apollographql/federation/blob/main/query-planner-js/CHANGELOG.md)|
+|[`@apollo/subgraph`](https://www.npmjs.com/package/@apollo/subgraph)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md)|[changelog](https://github.com/apollographql/federation/blob/main/subgraph-js/CHANGELOG.md)|
+|[`@apollo/federation`](https://www.npmjs.com/package/@apollo/federation)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/federation-js/CHANGELOG.md)|N/A|
+|[`@apollo/federation-internals`](https://www.npmjs.com/package/@apollo/federation-internals)|N/A|[changelog](https://github.com/apollographql/federation/blob/main/internals-js/CHANGELOG.md)|
+|[`@apollo/query-graphs`](https://www.npmjs.com/package/@apollo/query-graphs)|N/A|[changelog](https://github.com/apollographql/federation/blob/main/query-graphs-js/CHANGELOG.md)|
+|[`@apollo/composition`](https://www.npmjs.com/package/@apollo/composition)|N/A|[changelog](https://github.com/apollographql/federation/blob/main/composition-js/CHANGELOG.md)|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+This repository contains multiple JavaScript packages, each with multiple changelogs. Federation 1 is managed on the [`version-0.x` branch](https://github.com/apollographql/federation/tree/version-0.x), while Federation 2 is managed on the [`main` branch](https://github.com/apollographql/federation/tree/main). Please consult the table below to find the changelog you are looking for:
+
+|npm package|version|changelog|
+|--|--|--|
+|[`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md)|
+|[`@apollo/query-planner`](https://www.npmjs.com/package/@apollo/query-planner/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md)|
+|[`@apollo/subgraph`](https://www.npmjs.com/package/@apollo/subgraph/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md)|
+|[`@apollo/federation`](https://www.npmjs.com/package/@apollo/federation/v/latest-1)|v1|[link](https://github.com/apollographql/federation/blob/version-0.x/federation-js/CHANGELOG.md)|
+|[`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/gateway-js/CHANGELOG.md)|
+|[`@apollo/federation-internals`](https://www.npmjs.com/package/@apollo/federation-internals/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/internals-js/CHANGELOG.md)|
+|[`@apollo/query-graphs`](https://www.npmjs.com/package/@apollo/query-graphs/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/query-graphs-js/CHANGELOG.md)|
+|[`@apollo/query-planner`](https://www.npmjs.com/package/@apollo/query-planner/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/query-planner-js/CHANGELOG.md)|
+|[`@apollo/subgraph`](https://www.npmjs.com/package/@apollo/subgraph/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/subgraph-js/CHANGELOG.md)|
+|[`@apollo/composition`](https://www.npmjs.com/package/@apollo/composition/v/latest-2)|v2|[link](https://github.com/apollographql/federation/blob/main/composition-js/CHANGELOG.md)|


### PR DESCRIPTION
# Changelog

This repository contains multiple JavaScript packages, each with multiple changelogs. Federation 1 is managed on the [`version-0.x` branch](https://github.com/apollographql/federation/tree/version-0.x), while Federation 2 is managed on the [`main` branch](https://github.com/apollographql/federation/tree/main). Please consult the table below to find the changelog you are looking for:

|npm package|v1|v2|
|--|--|--|
|[`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md)|[changelog](https://github.com/apollographql/federation/blob/main/gateway-js/CHANGELOG.md)|
|[`@apollo/query-planner`](https://www.npmjs.com/package/@apollo/query-planner)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md)|[changelog](https://github.com/apollographql/federation/blob/main/query-planner-js/CHANGELOG.md)|
|[`@apollo/subgraph`](https://www.npmjs.com/package/@apollo/subgraph)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md)|[changelog](https://github.com/apollographql/federation/blob/main/subgraph-js/CHANGELOG.md)|
|[`@apollo/federation`](https://www.npmjs.com/package/@apollo/federation)|[changelog](https://github.com/apollographql/federation/blob/version-0.x/federation-js/CHANGELOG.md)|N/A|
|[`@apollo/federation-internals`](https://www.npmjs.com/package/@apollo/federation-internals/v/latest-2)|N/A|[changelog](https://github.com/apollographql/federation/blob/main/internals-js/CHANGELOG.md)|
|[`@apollo/query-graphs`](https://www.npmjs.com/package/@apollo/query-graphs/v/latest-2)|N/A|[changelog](https://github.com/apollographql/federation/blob/main/query-graphs-js/CHANGELOG.md)|
|[`@apollo/composition`](https://www.npmjs.com/package/@apollo/composition/v/latest-2)|N/A|[changelog](https://github.com/apollographql/federation/blob/main/composition-js/CHANGELOG.md)|
