### PR TITLE
Reject directives within `fields` arg of `@key`, `@provides` and `@requires`

### DIFF
--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -49,6 +49,7 @@ The following errors might be raised during composition:
 | `INVALID_LINK_DIRECTIVE_USAGE` | An application of the @link directive is invalid/does not respect the specification. | 2.0.0 |  |
 | `INVALID_LINK_IDENTIFIER` | A url/version for a @link feature is invalid/does not respect the specification. | 2.1.0 |  |
 | `INVALID_SUBGRAPH_NAME` | A subgraph name is invalid (subgraph names cannot be a single underscore ("_")). | 2.0.0 |  |
+| `KEY_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@key` directive includes some directive applications. This is not supported | 2.0.0 |  |
 | `KEY_FIELDS_HAS_ARGS` | The `fields` argument of a `@key` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `KEY_FIELDS_SELECT_INVALID_TYPE` | The `fields` argument of `@key` directive includes a field whose type is a list, interface, or union type. Fields of these types cannot be part of a `@key` | 0.x |  |
 | `KEY_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@key` directive is not a string. | 2.0.0 |  |
@@ -61,6 +62,7 @@ The following errors might be raised during composition:
 | `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
 | `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
 | `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
+| `PROVIDES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@provides` directive includes some directive applications. This is not supported | 2.0.0 |  |
 | `PROVIDES_FIELDS_HAS_ARGS` | The `fields` argument of a `@provides` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `PROVIDES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@provides` directive includes a field that is not marked as `@external`. | 0.x |  |
 | `PROVIDES_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@provides` directive is not a string. | 2.0.0 |  |
@@ -72,6 +74,7 @@ The following errors might be raised during composition:
 | `REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH` | An argument of a field or directive definition is mandatory in some subgraphs, but the argument is not defined in all the subgraphs that define the field or directive definition. | 2.0.0 |  |
 | `REQUIRED_INACCESSIBLE` | An element is marked as @inaccessible but is required by an element visible in the API schema. | 2.0.0 |  |
 | `REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH` | A field of an input object type is mandatory in some subgraphs, but the field is not defined in all the subgraphs that define the input object type. | 2.0.0 |  |
+| `REQUIRES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@requires` directive includes some directive applications. This is not supported | 2.0.0 |  |
 | `REQUIRES_FIELDS_HAS_ARGS` | The `fields` argument of a `@requires` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `REQUIRES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@requires` directive includes a field that is not marked as `@external`. | 0.x |  |
 | `REQUIRES_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@requires` directive is not a string. | 2.0.0 |  |

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -49,7 +49,7 @@ The following errors might be raised during composition:
 | `INVALID_LINK_DIRECTIVE_USAGE` | An application of the @link directive is invalid/does not respect the specification. | 2.0.0 |  |
 | `INVALID_LINK_IDENTIFIER` | A url/version for a @link feature is invalid/does not respect the specification. | 2.1.0 |  |
 | `INVALID_SUBGRAPH_NAME` | A subgraph name is invalid (subgraph names cannot be a single underscore ("_")). | 2.0.0 |  |
-| `KEY_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@key` directive includes some directive applications. This is not supported | 2.0.0 |  |
+| `KEY_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@key` directive includes some directive applications. This is not supported | 2.1.0 |  |
 | `KEY_FIELDS_HAS_ARGS` | The `fields` argument of a `@key` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `KEY_FIELDS_SELECT_INVALID_TYPE` | The `fields` argument of `@key` directive includes a field whose type is a list, interface, or union type. Fields of these types cannot be part of a `@key` | 0.x |  |
 | `KEY_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@key` directive is not a string. | 2.0.0 |  |
@@ -62,7 +62,7 @@ The following errors might be raised during composition:
 | `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
 | `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
 | `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
-| `PROVIDES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@provides` directive includes some directive applications. This is not supported | 2.0.0 |  |
+| `PROVIDES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@provides` directive includes some directive applications. This is not supported | 2.1.0 |  |
 | `PROVIDES_FIELDS_HAS_ARGS` | The `fields` argument of a `@provides` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `PROVIDES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@provides` directive includes a field that is not marked as `@external`. | 0.x |  |
 | `PROVIDES_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@provides` directive is not a string. | 2.0.0 |  |
@@ -74,7 +74,7 @@ The following errors might be raised during composition:
 | `REQUIRED_ARGUMENT_MISSING_IN_SOME_SUBGRAPH` | An argument of a field or directive definition is mandatory in some subgraphs, but the argument is not defined in all the subgraphs that define the field or directive definition. | 2.0.0 |  |
 | `REQUIRED_INACCESSIBLE` | An element is marked as @inaccessible but is required by an element visible in the API schema. | 2.0.0 |  |
 | `REQUIRED_INPUT_FIELD_MISSING_IN_SOME_SUBGRAPH` | A field of an input object type is mandatory in some subgraphs, but the field is not defined in all the subgraphs that define the input object type. | 2.0.0 |  |
-| `REQUIRES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@requires` directive includes some directive applications. This is not supported | 2.0.0 |  |
+| `REQUIRES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@requires` directive includes some directive applications. This is not supported | 2.1.0 |  |
 | `REQUIRES_FIELDS_HAS_ARGS` | The `fields` argument of a `@requires` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |
 | `REQUIRES_FIELDS_MISSING_EXTERNAL` | The `fields` argument of a `@requires` directive includes a field that is not marked as `@external`. | 0.x |  |
 | `REQUIRES_INVALID_FIELDS_TYPE` | The value passed to the `fields` argument of a `@requires` directive is not a string. | 2.0.0 |  |

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -11,6 +11,10 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 - Cleanup error related code, adding missing error code to a few errors [PR #1914](https://github.com/apollographql/federation/pull/1914).
 - Fix issue generating plan for a "diamond-shaped" dependency [PR #1900](https://github.com/apollographql/federation/pull/1900).
 - Fix issue computing query plan costs that can lead to extra unnecessary fetches [PR #1937](https://github.com/apollographql/federation/pull/1937).
+- Reject directive applications within `fields` of `@key`, `@provides` and `@requires`[PR #1975](https://github.com/apollographql/federation/pull/1975).
+  - __BREAKING__: previously, directive applications within a `@key`, `@provides` or `@requires` were parsed but
+    not honored in any way. As this change reject such applications (at composition time), it could theoretically
+    require to remove some existing (ignored) directive applications within a `@key`, `@provides` or `@requires`.
 
 ## 2.1.0-alpha.0
 

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -385,6 +385,64 @@ describe('fieldset-based directives', () => {
       ['KEY_FIELDS_SELECT_INVALID_TYPE', '[S] On type "T", for @key(fields: "f"): field "T.f" is a Union type which is not allowed in @key'],
     ]);
   });
+
+  it('rejects directive applications in @key', () => {
+    const subgraph =  gql`
+      type Query {
+        t: T
+      }
+
+      type T @key(fields: "v { x ... @include(if: false) { y }}") {
+        v: V
+      }
+
+      type V {
+        x: Int
+        y: Int
+      }
+    `
+    expect(buildForErrors(subgraph)).toStrictEqual([
+      ['KEY_DIRECTIVE_IN_FIELDS_ARG', '[S] On type "T", for @key(fields: "v { x ... @include(if: false) { y }}"): cannot have directive applications in the @key(fields:) argument but found @include(if: false).'],
+    ]);
+  });
+
+  it('rejects directive applications in @provides', () => {
+    const subgraph =  gql`
+      type Query {
+        t: T @provides(fields: "v { ... on V @skip(if: true) { x y } }")
+      }
+
+      type T @key(fields: "id") {
+        id: ID
+        v: V @external
+      }
+
+      type V {
+        x: Int
+        y: Int
+      }
+    `
+    expect(buildForErrors(subgraph)).toStrictEqual([
+      ['PROVIDES_DIRECTIVE_IN_FIELDS_ARG', '[S] On field "Query.t", for @provides(fields: "v { ... on V @skip(if: true) { x y } }"): cannot have directive applications in the @provides(fields:) argument but found @skip(if: true).'],
+    ]);
+  });
+
+  it('rejects directive applications in @requires', () => {
+    const subgraph =  gql`
+      type Query {
+        t: T
+      }
+
+      type T @key(fields: "id") {
+        id: ID
+        a: Int @requires(fields: "... @skip(if: false) { b }")
+        b: Int
+      }
+    `
+    expect(buildForErrors(subgraph)).toStrictEqual([
+      ['REQUIRES_DIRECTIVE_IN_FIELDS_ARG', '[S] On field "T.a", for @requires(fields: "... @skip(if: false) { b }"): cannot have directive applications in the @requires(fields:) argument but found @skip(if: false).'],
+    ]);
+  });
 });
 
 describe('root types', () => {

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -182,6 +182,15 @@ const KEY_UNSUPPORTED_ON_INTERFACE = DIRECTIVE_UNSUPPORTED_ON_INTERFACE.createCo
 const PROVIDES_UNSUPPORTED_ON_INTERFACE = DIRECTIVE_UNSUPPORTED_ON_INTERFACE.createCode('provides');
 const REQUIRES_UNSUPPORTED_ON_INTERFACE = DIRECTIVE_UNSUPPORTED_ON_INTERFACE.createCode('requires');
 
+const DIRECTIVE_IN_FIELDS_ARG = makeFederationDirectiveErrorCodeCategory(
+  'DIRECTIVE_IN_FIELDS_ARG',
+  (directive) => `The \`fields\` argument of a \`@${directive}\` directive includes some directive applications. This is not supported`,
+);
+
+const KEY_HAS_DIRECTIVE_IN_FIELDS_ARGS = DIRECTIVE_IN_FIELDS_ARG.createCode('key');
+const PROVIDES_HAS_DIRECTIVE_IN_FIELDS_ARGS = DIRECTIVE_IN_FIELDS_ARG.createCode('provides');
+const REQUIRES_HAS_DIRECTIVE_IN_FIELDS_ARGS = DIRECTIVE_IN_FIELDS_ARG.createCode('requires');
+
 const EXTERNAL_UNUSED = makeCodeDefinition(
   'EXTERNAL_UNUSED',
   'An `@external` field is not being used by any instance of `@key`, `@requires`, `@provides` or to satisfy an interface implementation.',
@@ -456,6 +465,7 @@ export const ERROR_CATEGORIES = {
   DIRECTIVE_INVALID_FIELDS,
   FIELDS_HAS_ARGS,
   ROOT_TYPE_USED,
+  DIRECTIVE_IN_FIELDS_ARG,
 }
 
 export const ERRORS = {
@@ -526,6 +536,9 @@ export const ERRORS = {
   UNSUPPORTED_FEATURE,
   INVALID_FEDERATION_SUPERGRAPH,
   DOWNSTREAM_SERVICE_ERROR,
+  KEY_HAS_DIRECTIVE_IN_FIELDS_ARGS,
+  PROVIDES_HAS_DIRECTIVE_IN_FIELDS_ARGS,
+  REQUIRES_HAS_DIRECTIVE_IN_FIELDS_ARGS,
 };
 
 const codeDefByCode = Object.values(ERRORS).reduce((obj: {[code: string]: ErrorCodeDefinition}, codeDef: ErrorCodeDefinition) => { obj[codeDef.code] = codeDef; return obj; }, {});

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -185,6 +185,7 @@ const REQUIRES_UNSUPPORTED_ON_INTERFACE = DIRECTIVE_UNSUPPORTED_ON_INTERFACE.cre
 const DIRECTIVE_IN_FIELDS_ARG = makeFederationDirectiveErrorCodeCategory(
   'DIRECTIVE_IN_FIELDS_ARG',
   (directive) => `The \`fields\` argument of a \`@${directive}\` directive includes some directive applications. This is not supported`,
+  { addedIn: '2.1.0' },
 );
 
 const KEY_HAS_DIRECTIVE_IN_FIELDS_ARGS = DIRECTIVE_IN_FIELDS_ARG.createCode('key');

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -114,7 +114,6 @@ const FEDERATION_SPECIFIC_VALIDATION_RULES = [
 const FEDERATION_VALIDATION_RULES = specifiedSDLRules.filter(rule => !FEDERATION_OMITTED_VALIDATION_RULES.includes(rule)).concat(FEDERATION_SPECIFIC_VALIDATION_RULES);
 
 
-// Returns a list of the coordinate of all the fields in the selection that are marked external.
 function validateFieldSetSelections(
   directiveName: string,
   selectionSet: SelectionSet,
@@ -123,6 +122,13 @@ function validateFieldSetSelections(
   allowOnNonExternalLeafFields: boolean,
 ): void {
   for (const selection of selectionSet.selections()) {
+    const appliedDirectives = selection.element().appliedDirectives;
+    if (appliedDirectives.length > 0) {
+      throw ERROR_CATEGORIES.DIRECTIVE_IN_FIELDS_ARG.get(directiveName).err(
+        `cannot have directive applications in the @${directiveName}(fields:) argument but found ${appliedDirectives.join(', ')}.`,
+      );
+    }
+
     if (selection.kind === 'FieldSelection') {
       const field = selection.element().definition;
       const isExternal = federationMetadata.isFieldExternal(field);


### PR DESCRIPTION
Noticed that we accepting (parsing) directive applications with a `@key`, `@provide` or `@requires`, but were silently ignoring it. In other words:
```graphql
type T @key(fields: "x ... @skip(if: true) { y }") {
  x: Int
  y: Int
}
```
was accepted, but the `@skip` was completely ignored. Of course, it's unclear why would anyone write this, but it still imo qualify as a bug that we silently ignore this since the code essentially do not do what is written. It's certainly an oversight.

More generally, as we don't anything with any such directive applications, and for user/custom directives, there is no way to provide any processing whatsoever, so overall, I think we should just reject any directive applications to avoid any risk of confusion, and this is what the patch does.

I'll further note that:
1. the example above with `@skip` is a bit arbitrary when you need a hard-coded `true` or `false` for the `if`: why would you ever write this? But the context here is actually #1921: someone could want to try to see what a `@defer` does within a `fields` value, and we should be clear it just doesn't work.
2. I'm not trying to say that it will never make sense to allow directives in such values. There absolutely could be future use case for it, but we can just relax this validation when that happens. The point is that we shouldn't accept something we don't actually support.
3. one could make the argument that, insofar as this reject things that were not rejected before, this could be considered as a backward incompatible change. My argument here is that the existing behaviour is imo a bug and so I have no qualm putting this in a minor release (I mean, fixing bugs always modify behaviour after all). But of course, we'll still put a word about it in the changelog.