### PR TITLE
Move DEFAULT_UPLINK_ENDPOINTS to static member

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -11,6 +11,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 - Cleanup error related code, adding missing error code to a few errors [PR #1914](https://github.com/apollographql/federation/pull/1914).
 - Fix issue generating plan for a "diamond-shaped" dependency [PR #1900](https://github.com/apollographql/federation/pull/1900).
 - Fix issue computing query plan costs that can lead to extra unnecessary fetches [PR #1937](https://github.com/apollographql/federation/pull/1937).
+- Move `DEFAULT_UPLINK_ENDPOINTS` to static member of `UplinkSupergraphManager` [PR #1977](https://github.com/apollographql/federation/pull/1977).
 
 ## 2.1.0-alpha.0
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -1079,5 +1079,4 @@ export {
   FailureToFetchSupergraphSdlAfterInit,
   FailureToFetchSupergraphSdlDuringInit,
   FailureToFetchSupergraphSdlFunctionParams,
-  DEFAULT_UPLINK_ENDPOINTS,
 } from './supergraphManagers';

--- a/gateway-js/src/supergraphManagers/UplinkSupergraphManager/__tests__/UplinkSupergraphManager.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkSupergraphManager/__tests__/UplinkSupergraphManager.test.ts
@@ -2,8 +2,6 @@ import mockedEnv from 'mocked-env';
 
 import { UplinkSupergraphManager } from '@apollo/gateway';
 
-import { DEFAULT_UPLINK_ENDPOINTS } from '..';
-
 let cleanUp: (() => void) | undefined;
 
 const logger = {
@@ -31,7 +29,7 @@ describe('UplinkSupergraphManager', () => {
     it('uses default uplink URLs', async () => {
       const manager = new UplinkSupergraphManager({ apiKey, graphRef, logger });
 
-      expect(manager.uplinkEndpoints).toEqual(DEFAULT_UPLINK_ENDPOINTS);
+      expect(manager.uplinkEndpoints).toEqual(UplinkSupergraphManager.DEFAULT_UPLINK_ENDPOINTS);
     });
 
     it('can set uplink URLs via config', async () => {


### PR DESCRIPTION
This helps reduce the API surface and keeps data scoped to the manager. I made similar changes when working on https://github.com/apollographql/federation/pull/1950 but decided to make a separate PR for these changes.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
