### PR TITLE
Include apollo-server-types 0.9 in federation-js

### DIFF
--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "file:../subgraph-js",
-    "apollo-server-types": "^3.0.2",
+    "apollo-server-types": "^0.9.0 || ^3.0.2",
     "lodash.xorby": "^4.7.0"
   },
   "peerDependencies": {

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -38,7 +38,7 @@
     "apollo-server-caching": "^0.7.0 || ^3.0.0",
     "apollo-server-core": "^2.23.0 || ^3.0.0",
     "apollo-server-errors": "^2.5.0 || ^3.0.0",
-    "apollo-server-types": "^0.9.0 || ^3.0.0",
+    "apollo-server-types": "^0.9.0 || ^3.0.2",
     "async-retry": "^1.3.3",
     "loglevel": "^1.6.1",
     "make-fetch-happen": "^10.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/subgraph": "file:../subgraph-js",
-        "apollo-server-types": "^3.0.2",
+        "apollo-server-types": "^0.9.0 || ^3.0.2",
         "lodash.xorby": "^4.7.0"
       },
       "engines": {
@@ -105,7 +105,7 @@
         "apollo-server-caching": "^0.7.0 || ^3.0.0",
         "apollo-server-core": "^2.23.0 || ^3.0.0",
         "apollo-server-errors": "^2.5.0 || ^3.0.0",
-        "apollo-server-types": "^0.9.0 || ^3.0.0",
+        "apollo-server-types": "^0.9.0 || ^3.0.2",
         "async-retry": "^1.3.3",
         "loglevel": "^1.6.1",
         "make-fetch-happen": "^10.1.2",
@@ -20716,7 +20716,7 @@
       "version": "file:federation-js",
       "requires": {
         "@apollo/subgraph": "file:../subgraph-js",
-        "apollo-server-types": "^3.0.2",
+        "apollo-server-types": "^0.9.0 || ^3.0.2",
         "lodash.xorby": "^4.7.0"
       }
     },
@@ -20736,7 +20736,7 @@
         "apollo-server-caching": "^0.7.0 || ^3.0.0",
         "apollo-server-core": "^2.23.0 || ^3.0.0",
         "apollo-server-errors": "^2.5.0 || ^3.0.0",
-        "apollo-server-types": "^0.9.0 || ^3.0.0",
+        "apollo-server-types": "^0.9.0 || ^3.0.2",
         "async-retry": "^1.3.3",
         "loglevel": "^1.6.1",
         "make-fetch-happen": "^10.1.2",


### PR DESCRIPTION
Draft PR to see if this is an alternative to this change: https://github.com/apollographql/federation/pull/1964/files