### PR TITLE
Pass gateway.fetcher to UplinkSupergraphManager

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+- Allow passing a custom `fetcher` [PR 1997#](https://github.com/apollographql/federation/pull/1997).
+  - __UNBREAKING__: Previous 2.1.0 alphas removed the custom fetcher for Apollo Uplink. This re-adds that parameter, and requires the fetcher to have the `AbortSignal` interface https://fetch.spec.whatwg.org/#requestinit.
+
 ## 2.1.0-alpha.1
 
 - Expose document representation of sub-query request within GraphQLDataSourceProcessOptions so that it is available to RemoteGraphQLDataSource.process and RemoteGraphQLDataSource.willSendRequest [PR#1878](https://github.com/apollographql/federation/pull/1878)

--- a/gateway-js/src/__tests__/integration/managed.test.ts
+++ b/gateway-js/src/__tests__/integration/managed.test.ts
@@ -1,4 +1,5 @@
 import mockedEnv from 'mocked-env';
+import fetcher from 'make-fetch-happen';
 
 import { ApolloGateway, UplinkSupergraphManager } from '@apollo/gateway';
 import { ApolloServer } from 'apollo-server';
@@ -107,30 +108,27 @@ describe('minimal gateway', () => {
   });
 
   it('supports a custom fetcher', async () => {
-    // fetcher: (...args) => {
-    //   calls++;
-    //   return fetcher(...args);
-    // },
-
     cleanUp = mockedEnv({
       APOLLO_KEY: apiKey,
       APOLLO_GRAPH_REF: graphRef,
     });
+    mockSupergraphSdlRequestSuccess({ url: /.*?apollographql.com/ });
 
-    const schemaConfigDeliveryEndpoint = 'https://example.com';
-    mockSupergraphSdlRequestSuccess({ url: schemaConfigDeliveryEndpoint });
-
-    gateway = new ApolloGateway({ logger, schemaConfigDeliveryEndpoint });
+    let calls = 0;
+    gateway = new ApolloGateway({
+      logger,
+      fetcher: (...args) => {
+        calls++;
+        return fetcher(...args);
+      },
+    });
     server = new ApolloServer({
       gateway,
       plugins: [ApolloServerPluginUsageReportingDisabled()],
     });
     await server.listen({ port: 0 });
-    expect(gateway.supergraphManager).toBeInstanceOf(UplinkSupergraphManager);
-    const uplinkManager = gateway.supergraphManager as UplinkSupergraphManager;
-    expect(uplinkManager.uplinkEndpoints).toEqual([
-      schemaConfigDeliveryEndpoint,
-    ]);
+
+    expect(calls).toEqual(1);
   });
 });
 

--- a/gateway-js/src/__tests__/integration/managed.test.ts
+++ b/gateway-js/src/__tests__/integration/managed.test.ts
@@ -49,7 +49,10 @@ const logger = {
 
 describe('minimal gateway', () => {
   it('uses managed federation', async () => {
-    cleanUp = mockedEnv({ APOLLO_KEY: apiKey });
+    cleanUp = mockedEnv({
+      APOLLO_KEY: apiKey,
+      APOLLO_GRAPH_REF: graphRef,
+    });
     mockSupergraphSdlRequestSuccess({ url: /.*?apollographql.com/ });
 
     gateway = new ApolloGateway({ logger });
@@ -62,7 +65,10 @@ describe('minimal gateway', () => {
   });
 
   it('fetches from provided `uplinkEndpoints`', async () => {
-    cleanUp = mockedEnv({ APOLLO_KEY: apiKey });
+    cleanUp = mockedEnv({
+      APOLLO_KEY: apiKey,
+      APOLLO_GRAPH_REF: graphRef,
+    });
 
     const uplinkEndpoint = 'https://example.com';
     mockSupergraphSdlRequestSuccess({ url: uplinkEndpoint });
@@ -79,7 +85,10 @@ describe('minimal gateway', () => {
   });
 
   it('fetches from (deprecated) provided `schemaConfigDeliveryEndpoint`', async () => {
-    cleanUp = mockedEnv({ APOLLO_KEY: apiKey });});
+    cleanUp = mockedEnv({
+      APOLLO_KEY: apiKey,
+      APOLLO_GRAPH_REF: graphRef,
+    });
 
     const schemaConfigDeliveryEndpoint = 'https://example.com';
     mockSupergraphSdlRequestSuccess({ url: schemaConfigDeliveryEndpoint });
@@ -103,7 +112,10 @@ describe('minimal gateway', () => {
     //   return fetcher(...args);
     // },
 
-    cleanUp = mockedEnv({ APOLLO_KEY: apiKey });
+    cleanUp = mockedEnv({
+      APOLLO_KEY: apiKey,
+      APOLLO_GRAPH_REF: graphRef,
+    });
 
     const schemaConfigDeliveryEndpoint = 'https://example.com';
     mockSupergraphSdlRequestSuccess({ url: schemaConfigDeliveryEndpoint });
@@ -120,6 +132,7 @@ describe('minimal gateway', () => {
       schemaConfigDeliveryEndpoint,
     ]);
   });
+});
 
 describe('Managed gateway with explicit UplinkSupergraphManager', () => {
   it('waits for supergraph schema to load', async () => {

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -360,6 +360,7 @@ export class ApolloGateway implements GraphQLService {
           uplinkEndpoints:
             this.config.uplinkEndpoints ?? schemaDeliveryEndpoints,
           maxRetries: this.config.uplinkMaxRetries,
+          fetcher: this.config.fetcher,
           logger: this.logger,
           fallbackPollIntervalInMs: this.pollIntervalInMs,
         }),

--- a/gateway-js/src/supergraphManagers/UplinkSupergraphManager/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkSupergraphManager/index.ts
@@ -87,6 +87,7 @@ export class UplinkSupergraphManager implements SupergraphManager {
     fallbackPollIntervalInMs,
     maxRetries,
     initialMaxRetries,
+    fetcher,
     shouldRunSubgraphHealthcheck,
     onFailureToFetchSupergraphSdlDuringInit,
     onFailureToFetchSupergraphSdlAfterInit,
@@ -99,6 +100,7 @@ export class UplinkSupergraphManager implements SupergraphManager {
     fallbackPollIntervalInMs?: number;
     maxRetries?: number;
     initialMaxRetries?: number;
+    fetcher?: AbortableFetcher;
     shouldRunSubgraphHealthcheck?: boolean;
     onFailureToFetchSupergraphSdlDuringInit?: FailureToFetchSupergraphSdlDuringInit;
     onFailureToFetchSupergraphSdlAfterInit?: FailureToFetchSupergraphSdlAfterInit;
@@ -121,6 +123,8 @@ export class UplinkSupergraphManager implements SupergraphManager {
       );
       this.pollIntervalMs = UplinkSupergraphManager.MIN_POLL_INTERVAL_MS;
     }
+
+    this.fetcher = fetcher ?? this.fetcher;
 
     this.shouldRunSubgraphHealthcheck =
       shouldRunSubgraphHealthcheck ?? this.shouldRunSubgraphHealthcheck;


### PR DESCRIPTION
I didn't realize configuring the uplink fetcher was a real, documented feature we support https://www.apollographql.com/docs/federation/api/apollo-gateway/#configuring-the-managed-federation-fetcher, and it's not just some weird happenstance of config madness.

So this adds the `fetcher` param back.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
