### PR TITLE
gateway: remove use of internal Apollo Server function from LocalGraphQLDataSource

### DIFF
--- a/gateway-js/src/datasources/LocalGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/LocalGraphQLDataSource.ts
@@ -6,7 +6,6 @@ import {
   DocumentNode,
   parse,
 } from 'graphql';
-import { enablePluginsForSchemaResolvers } from 'apollo-server-core/dist/utils/schemaInstrumentation';
 import { GraphQLDataSource, GraphQLDataSourceProcessOptions } from './types';
 
 export class LocalGraphQLDataSource<
@@ -14,7 +13,6 @@ export class LocalGraphQLDataSource<
 > implements GraphQLDataSource<TContext>
 {
   constructor(public readonly schema: GraphQLSchema) {
-    enablePluginsForSchemaResolvers(schema);
   }
 
   async process({


### PR DESCRIPTION
I'm not exactly sure what the purpose of LocalGraphQLDataSource is,
other than that it's a convenient thing to use in this repository's test
suite. It is exported from `@apollo/gateway` but does not appear to be
documented.

It currently uses a function stolen from the heart of Apollo Server. We
are working on eliminating the dependency of Gateway on Apollo Server
(https://github.com/apollographql/apollo-server/issues/6719,
https://github.com/apollographql/apollo-server/issues/6057) so this
dependency on something that's not even part of the supported API seems
worth looking into.

`enablePluginsForSchemaResolvers` does two entirely unrelated things.
One is the thing that its name says: it tweaks the schema so that it's
possible to instrument execution on a per-field basis; this is used to
implement Apollo Server's `willResolveField` plugin hook.

The other thing it does is entirely undocumented: it enables an obscure
and undocumented `__resolveObject` feature which we are already planning
to remove in Apollo Server 4.

As mentioned, this class seems to really just be a test helper for this
repository, and in fact, the tests did use `__resolveObject` until a few
months ago in #1658. So one might guess that the point of this line is
just to enable `__resolveObject` in tests and that it can be entirely
removed.

And in fact, ff45cb7c7245ec4 shows that there used to be a comment here
saying exactly that!

So this commit removes the use of an undocumented internal function to
enable an even less documented feature inside an undocumented class.
The tests pass, so that seems good.

Perhaps one could object to this as not fully backwards compatible,
because perhaps there are users out there who are using
LocalGraphQLDataSource directly and... expect willResolveField plugins
to work? But that's not really something you can make work without the
rest of Apollo Server anyway. I guess maybe they could actually be
expecting `__resolveObject` to work? But at that point we're talking
about theoretical people trying to combine two undocumented features
(`LocalGraphQLDataSource` and `__resolveObject`). If we discover that
those people exist, we can encourage them to just add this line back
into their own code themselves. Surely, people who enjoy the thrill of
using two undocumented features will be even happier using three
undocumented features!
