### PR TITLE
Add a note about the behavior of shareable value types declared on subgraphs using fed. 1 and fed. 2

### DIFF
--- a/docs/source/federation-2/moving-to-federation-2.mdx
+++ b/docs/source/federation-2/moving-to-federation-2.mdx
@@ -236,6 +236,8 @@ type Position {
 
 > You can also apply `@shareable` directly to a type definition (such as `Position` above). This is equivalent to applying `@shareable` to _all_ of that type's fields.
 
+> If one of the subgraphs declaring the shareable value type is still using Fed. 1, the missing @shareable directive will not cause a composition failure. That's because it will be converted under the hood as part of the newer composition algorithms in Fed. 2.
+
 For more details, see [Value types](../federated-types/sharing-types/).
 
 ### Update entity definitions


### PR DESCRIPTION
Adding a note about the behavior of the shareable value types regarding the composition result, when these value types are declared on subgraphs using both fed.1 and fed.2.

I had to test it and confirm with the apollo team to guarantee that it would work. Maybe this note will be useful for anyone else reading the doc. 