### PR TITLE
Fix bug in mergeDescriptions

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -229,7 +229,7 @@ describe('composition', () => {
           query: Query
         }
 
-        "Type T"
+        ""
         type T {
           a: String @shareable
         }

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -221,6 +221,44 @@ describe('composition', () => {
     `);
   })
 
+  it('no hint raised when merging empty description', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        schema {
+          query: Query
+        }
+
+        "Type T"
+        type T {
+          a: String @shareable
+        }
+
+        type Query {
+          "Returns tea"
+          t(
+            "An argument that is very important"
+            x: String!
+          ): T
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      typeDefs: gql`
+        "Type T"
+        type T {
+          a: String @shareable
+        }
+      `
+    }
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    assertCompositionSuccess(result);
+    expect(result.hints).toEqual([]);
+  });
+
   it('include types from different subgraphs', () => {
     const subgraphA = {
       typeDefs: gql`


### PR DESCRIPTION
Fix bug in mergeDescriptions, and remove type assertion from `otherElementsPrinter`. 

Issue was when merging empty and non-empty descriptions, we'd pass undefined.