### PR TITLE
gateway: remove dependency on apollo-server-caching

### DIFF
--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -36,12 +36,12 @@
     "@josephg/resolvable": "^1.0.1",
     "@opentelemetry/api": "^1.0.1",
     "apollo-reporting-protobuf": "^0.8.0 || ^3.0.0",
-    "apollo-server-caching": "^0.7.0 || ^3.0.0",
     "apollo-server-core": "^2.23.0 || ^3.0.0",
     "apollo-server-errors": "^2.5.0 || ^3.0.0",
     "apollo-server-types": "^0.9.0 || ^3.0.0",
     "async-retry": "^1.3.3",
     "loglevel": "^1.6.1",
+    "lru-cache": "^7.13.1",
     "make-fetch-happen": "^10.1.2",
     "node-abort-controller": "^3.0.1",
     "node-fetch": "^2.6.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,12 +105,12 @@
         "@josephg/resolvable": "^1.0.1",
         "@opentelemetry/api": "^1.0.1",
         "apollo-reporting-protobuf": "^0.8.0 || ^3.0.0",
-        "apollo-server-caching": "^0.7.0 || ^3.0.0",
         "apollo-server-core": "^2.23.0 || ^3.0.0",
         "apollo-server-errors": "^2.5.0 || ^3.0.0",
         "apollo-server-types": "^0.9.0 || ^3.0.0",
         "async-retry": "^1.3.3",
         "loglevel": "^1.6.1",
+        "lru-cache": "^7.13.1",
         "make-fetch-happen": "^10.1.2",
         "node-abort-controller": "^3.0.1",
         "node-fetch": "^2.6.7"
@@ -197,8 +197,9 @@
       }
     },
     "gateway-js/node_modules/lru-cache": {
-      "version": "7.8.1",
-      "license": "ISC",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
+      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
       "engines": {
         "node": ">=12"
       }
@@ -5383,16 +5384,6 @@
       },
       "peerDependencies": {
         "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-caching": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/apollo-server-core": {
@@ -18745,12 +18736,12 @@
         "@josephg/resolvable": "^1.0.1",
         "@opentelemetry/api": "^1.0.1",
         "apollo-reporting-protobuf": "^0.8.0 || ^3.0.0",
-        "apollo-server-caching": "^0.7.0 || ^3.0.0",
         "apollo-server-core": "^2.23.0 || ^3.0.0",
         "apollo-server-errors": "^2.5.0 || ^3.0.0",
         "apollo-server-types": "^0.9.0 || ^3.0.0",
         "async-retry": "^1.3.3",
         "loglevel": "^1.6.1",
+        "lru-cache": "^7.13.1",
         "make-fetch-happen": "^10.1.2",
         "node-abort-controller": "^3.0.1",
         "node-fetch": "^2.6.7"
@@ -18811,7 +18802,9 @@
           }
         },
         "lru-cache": {
-          "version": "7.8.1"
+          "version": "7.13.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
+          "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ=="
         },
         "make-fetch-happen": {
           "version": "10.1.2",
@@ -22491,12 +22484,6 @@
         "apollo-server-core": "^3.10.0",
         "apollo-server-express": "^3.10.0",
         "express": "^4.17.1"
-      }
-    },
-    "apollo-server-caching": {
-      "version": "3.3.0",
-      "requires": {
-        "lru-cache": "^6.0.0"
       }
     },
     "apollo-server-core": {


### PR DESCRIPTION
The point of apollo-server-caching is to provide an abstraction over
multiple cache backends. Gateway is not using that abstraction; it's
just using one particular implementation, which is a wrapper around an
old version of lru-cache.

As part of https://github.com/apollographql/apollo-server/issues/6057
and https://github.com/apollographql/apollo-server/issues/6719 we want
to remove dependencies on Apollo Server from Apollo Gateway. Technically
we don't really need to remove this dependency (since
apollo-server-caching doesn't depend on anything else in AS) but
apollo-server-caching won't be updated any more (in fact, even in AS3 it
has already been replaced by `@apollo/utils.keyvaluecache`), so let's do
it.

While we're at it, we make a few other improvements:
- Ever since #440, the queryPlanStore field is always set, so we can
  remove some conditionals around it.
- Instead of using the old lru-cache@6 wrapped by the
  apollo-server-caching package, we use the newer lru-cache@7 (which
  improves the algorithm internally and changes the names of methods a
  bit).
- The get and set methods on InMemoryLRUCache were only async because
  they implement the abstract KeyValueCache interface: the
  implementations didn't actually do anything async. So we no longer
  need to await them or include a giant comment about how we're not
  awaiting them.
