### PR TITLE
@apollo/subgraph: remove dependency on apollo-server-types

### DIFF
--- a/federation-integration-testsuite-js/src/fixtures/product.ts
+++ b/federation-integration-testsuite-js/src/fixtures/product.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolverMap } from '../resolverMap';
 import { fed2gql as gql } from '../utils/fed2gql';
+import { maybeCacheControlFromInfo } from '@apollo/cache-control-types';
 
 export const name = 'product';
 export const url = `https://${name}.api.com.invalid`;
@@ -198,7 +199,7 @@ export const resolvers: GraphQLResolverMap<any> = {
     __resolveReference(object, _context, info) {
       // For testing dynamic cache control; use `?.` because we don't always run
       // this fixture in a real ApolloServer.
-      info.cacheControl?.cacheHint?.restrict({ maxAge: 30 });
+      maybeCacheControlFromInfo(info)?.cacheHint.restrict({ maxAge: 30 });
       if (object.isbn) {
         const fetchedObject = products.find(
           product => product.isbn === object.isbn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
       },
       "devDependencies": {
+        "@apollo/cache-control-types": "1.0.1",
         "@apollo/client": "3.6.9",
         "@apollo/utils.fetcher": "1.0.0",
         "@graphql-codegen/cli": "2.11.3",
@@ -197,8 +198,7 @@
     },
     "gateway-js/node_modules/lru-cache": {
       "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -296,6 +296,14 @@
       },
       "peerDependencies": {
         "graphql": "^16.0.0"
+      }
+    },
+    "node_modules/@apollo/cache-control-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.1.tgz",
+      "integrity": "sha512-5mEr3wD4ZVLBwsIkxXl+qaMDItvfHVQDH2I5XKhdjrr2modtsz+PHBa6TQl9uNqqueScfgN1DjAmW5sg0bO/fA==",
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/client": {
@@ -622,9 +630,8 @@
     },
     "node_modules/@ardatan/sync-fetch": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
-      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1"
       },
@@ -1730,9 +1737,8 @@
     },
     "node_modules/@graphql-codegen/cli": {
       "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.11.3.tgz",
-      "integrity": "sha512-C1d88Kx0a0PF1tOR00UIZjHq5aWNNcw5fM2k08rOY9O5b4sU7kEb+YbGKP6EExTtJnYb49fePLKVvrIv1ejDFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-codegen/core": "2.6.0",
         "@graphql-codegen/plugin-helpers": "^2.6.1",
@@ -1778,9 +1784,8 @@
     },
     "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -1790,9 +1795,8 @@
     },
     "node_modules/@graphql-codegen/cli/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/core": {
       "version": "2.6.0",
@@ -1815,9 +1819,8 @@
     },
     "node_modules/@graphql-codegen/plugin-helpers": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.6.1.tgz",
-      "integrity": "sha512-RbkCPu8rZo+d3tWPUzqnZhgGutp15GVcs9UhaOcenKpCDDQxNxqGGTn76LuAAymT9y7BSnXdY20k1CW59z4nTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^8.8.0",
         "change-case-all": "1.0.14",
@@ -1855,9 +1858,8 @@
     },
     "node_modules/@graphql-codegen/typescript": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-lFqvLgw4oAChA9+ifC2K7Ie+mE+XvHcZqwXsm45bpF7jbmqfgjS0gvQNfu2egi6u4hdg+xL+olNxwnyhayrikw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.6.0",
         "@graphql-codegen/schema-ast": "^2.5.0",
@@ -1871,9 +1873,8 @@
     },
     "node_modules/@graphql-codegen/typescript-operations": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.2.tgz",
-      "integrity": "sha512-iFZsdsF4380WrN2UQHfgLjrjyo9VFIsZuCaHe1OoC4fQQ+P3t/GfJ0aj0hc5hNwTNJZ3BzBLHSRgE6wqO4591A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.6.0",
         "@graphql-codegen/typescript": "^2.7.2",
@@ -1887,21 +1888,18 @@
     },
     "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.12.0.tgz",
-      "integrity": "sha512-ULhFgOY05U+dlPsXkPT2wSBaAZMtEuHPL5Q1u8xwBdHWHi/uT4L5zEcBx+If/f6UWrOw7ufjEM0L7XSupe1iCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.6.0",
         "@graphql-tools/optimize": "^1.3.0",
@@ -1925,9 +1923,8 @@
     },
     "node_modules/@graphql-tools/apollo-engine-loader": {
       "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.3.6.tgz",
-      "integrity": "sha512-r7YU1X9Ce/sr+tPzSuZqVqlK7knGDpiRfB9HB2uVmbm+kPrlISQ0LuamFoT1g1nkfDZUNZn2p18ag512P1aVVw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ardatan/sync-fetch": "0.0.1",
         "@graphql-tools/utils": "8.9.0",
@@ -1940,9 +1937,8 @@
     },
     "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -1957,9 +1953,8 @@
     },
     "node_modules/@graphql-tools/batch-execute": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.1.tgz",
-      "integrity": "sha512-hRVDduX0UDEneVyEWtc2nu5H2PxpfSfM/riUlgZvo/a/nG475uyehxR5cFGvTEPEQUKY3vGIlqvtRigzqTfCew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "8.9.0",
         "dataloader": "2.1.0",
@@ -1972,9 +1967,8 @@
     },
     "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -1984,15 +1978,13 @@
     },
     "node_modules/@graphql-tools/batch-execute/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-tools/code-file-loader": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.1.tgz",
-      "integrity": "sha512-nyr0zln7fi4E8lK98THdb8k3gPsSCiyXRFTTNhPRUCPeOD2RCpUZCClM5AB0xv8HjILAipdaxjhb2elPvnY5dw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/graphql-tag-pluck": "7.3.1",
         "@graphql-tools/utils": "8.9.0",
@@ -2006,9 +1998,8 @@
     },
     "node_modules/@graphql-tools/code-file-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2023,9 +2014,8 @@
     },
     "node_modules/@graphql-tools/delegate": {
       "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.8.1.tgz",
-      "integrity": "sha512-NDcg3GEQmdEHlnF7QS8b4lM1PSF+DKeFcIlLEfZFBvVq84791UtJcDj8734sIHLukmyuAxXMfA1qLd2l4lZqzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/batch-execute": "8.5.1",
         "@graphql-tools/schema": "8.5.1",
@@ -2040,9 +2030,8 @@
     },
     "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2052,15 +2041,13 @@
     },
     "node_modules/@graphql-tools/delegate/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-tools/git-loader": {
       "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.2.1.tgz",
-      "integrity": "sha512-grfLO3CqKO8hlymqBQeNsjGCzjMXH+n+epM6vH2OW1tUM9UmPrH+En0BynJCap9VYVZ0KcbYz03o5ZJNYkbaCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/graphql-tag-pluck": "7.3.1",
         "@graphql-tools/utils": "8.9.0",
@@ -2075,9 +2062,8 @@
     },
     "node_modules/@graphql-tools/git-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2092,9 +2078,8 @@
     },
     "node_modules/@graphql-tools/github-loader": {
       "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.3.6.tgz",
-      "integrity": "sha512-TovDdZ0dxShIfnP3/02+aVfPzhYHedtCVU4GB7rajExdOlNEUAfMAjpDKgTReENzD0ZaehqBnGj2BpR+/b4C1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ardatan/sync-fetch": "0.0.1",
         "@graphql-tools/graphql-tag-pluck": "7.3.1",
@@ -2108,9 +2093,8 @@
     },
     "node_modules/@graphql-tools/github-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2125,9 +2109,8 @@
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
       "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.0.tgz",
-      "integrity": "sha512-X3wcC+ZljbXTwdTTSp3oUHJd66mFLDKI750uhB0HidBxE6+wyw7fhmJVJiYROXPswaGliuabpo0JEyLj7hhWKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/import": "6.7.1",
         "@graphql-tools/utils": "8.9.0",
@@ -2141,9 +2124,8 @@
     },
     "node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2158,9 +2140,8 @@
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.1.tgz",
-      "integrity": "sha512-+Aayl4y42ASrxDvu613lp3NiK1JRggy/m9wlo93dJp/9L5vKPYlrtFvuQ1tpPEEuSBboYNa/erOsELrRwzzakA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.16.8",
         "@babel/traverse": "^7.16.8",
@@ -2174,9 +2155,8 @@
     },
     "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2186,15 +2166,13 @@
     },
     "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-tools/import": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.1.tgz",
-      "integrity": "sha512-StLosFVhdw+eZkL+v9dBabszxCAZtEYW4Oy1+750fDkH39GrmzOB8mWiYna7rm9+GMisC9atJtXuAfMF02Aoag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "8.9.0",
         "resolve-from": "5.0.0",
@@ -2206,9 +2184,8 @@
     },
     "node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2218,15 +2195,13 @@
     },
     "node_modules/@graphql-tools/import/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-tools/json-file-loader": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.1.tgz",
-      "integrity": "sha512-+QaeRyJcvUXUNEoIaecYrABunqk8/opFbpdHPAijJyVHvlsYfqXR12/501g+/QZzGHKYnyi+Q3lsZbBboj5LBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "8.9.0",
         "globby": "^11.0.3",
@@ -2239,9 +2214,8 @@
     },
     "node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2256,9 +2230,8 @@
     },
     "node_modules/@graphql-tools/load": {
       "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.7.1.tgz",
-      "integrity": "sha512-rJ2WUV41wwAkMnBgtcBym3TKVbPgz7z9tBCjOmbNVLy5bB9StVPdo2Uci0D5xYSgLV9XIt+zdyAnYGptioJeWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/schema": "8.5.1",
         "@graphql-tools/utils": "8.9.0",
@@ -2271,9 +2244,8 @@
     },
     "node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2288,8 +2260,7 @@
     },
     "node_modules/@graphql-tools/merge": {
       "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
-      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0"
@@ -2300,8 +2271,7 @@
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2344,9 +2314,8 @@
     },
     "node_modules/@graphql-tools/prisma-loader": {
       "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.7.tgz",
-      "integrity": "sha512-vAu2kVqSdfuiZJFOC3bDelKFeOQLfhOHOw1PT8YC0HiJQpLuEFwiDU6eXxWrPALqZEEWfCKMM8/4hlLJv+gokA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/url-loader": "7.13.2",
         "@graphql-tools/utils": "8.9.0",
@@ -2374,9 +2343,8 @@
     },
     "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2409,8 +2377,7 @@
     },
     "node_modules/@graphql-tools/schema": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
-      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "8.3.1",
         "@graphql-tools/utils": "8.9.0",
@@ -2423,8 +2390,7 @@
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2438,9 +2404,8 @@
     },
     "node_modules/@graphql-tools/url-loader": {
       "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.13.2.tgz",
-      "integrity": "sha512-4jtGecsxziiggQ9UryQB/ioqFwVkF10sKdk5bPg/fVKSkPddN5lvCgEwk20LojlDT9mDr53ME0ArMBKkvjTxBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ardatan/sync-fetch": "0.0.1",
         "@graphql-tools/delegate": "8.8.1",
@@ -2464,9 +2429,8 @@
     },
     "node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2511,9 +2475,8 @@
     },
     "node_modules/@graphql-tools/wrap": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.5.1.tgz",
-      "integrity": "sha512-KpVVfha2wLSpE08YLX0jeo5nXPfDLASlxOqMlvfa/B4X8SOVmuLyN1L5YZ132tPLDF93uflwlHFnUO5ahpRNlA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/delegate": "8.8.1",
         "@graphql-tools/schema": "8.5.1",
@@ -2527,9 +2490,8 @@
     },
     "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2539,9 +2501,8 @@
     },
     "node_modules/@graphql-tools/wrap/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.1.1",
@@ -4345,9 +4306,8 @@
     },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.2.0.tgz",
-      "integrity": "sha512-1ENEJNY7Lwlua/1wvzpYP194WtjQBfFxvde2FlzfBFh/ln6wvChrtxlORhbKEnYswzn6fOC4c7HdC5izLPMTJg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asn1js": "^3.0.5",
         "pvtsutils": "^1.3.2",
@@ -4356,15 +4316,13 @@
     },
     "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@peculiar/json-schema": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -4374,9 +4332,8 @@
     },
     "node_modules/@peculiar/webcrypto": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
-      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.1.6",
         "@peculiar/json-schema": "^1.1.12",
@@ -4390,9 +4347,8 @@
     },
     "node_modules/@peculiar/webcrypto/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -4665,9 +4621,8 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-stable-stringify": {
       "version": "1.0.33",
@@ -4706,9 +4661,8 @@
     },
     "node_modules/@types/make-fetch-happen": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.0.tgz",
-      "integrity": "sha512-wey8GZ/osY25cJEvQFNAXGfEGHTZYKMPGd1v0mrmD1vEYDkgRaq7TW+N9tir9YVlF5s1T60VGNWUx8rZExLP0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "*",
         "@types/retry": "*",
@@ -4846,9 +4800,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-      "integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.32.0",
         "@typescript-eslint/type-utils": "5.32.0",
@@ -4980,9 +4933,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-      "integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.32.0",
         "@typescript-eslint/visitor-keys": "5.32.0"
@@ -4997,9 +4949,8 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-      "integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "5.32.0",
         "debug": "^4.3.4",
@@ -5023,9 +4974,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-      "integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5036,9 +4986,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-      "integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.32.0",
         "@typescript-eslint/visitor-keys": "5.32.0",
@@ -5063,9 +5012,8 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-      "integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@typescript-eslint/scope-manager": "5.32.0",
@@ -5087,9 +5035,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-      "integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.32.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -5104,9 +5051,8 @@
     },
     "node_modules/@whatwg-node/fetch": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.2.6.tgz",
-      "integrity": "sha512-NhHiqeGcKjgqUZvJTZSou9qsFEPBBG1LPm2Npz0cmcPvukhhQfjX+p3quRx6b9AyjNPp1f73VB1z4ApHy9FcNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "abort-controller": "^3.0.0",
@@ -5164,9 +5110,8 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -5632,9 +5577,8 @@
     },
     "node_modules/asn1js": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.2",
         "pvutils": "^1.1.3",
@@ -5646,9 +5590,8 @@
     },
     "node_modules/asn1js/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -6118,8 +6061,6 @@
     },
     "node_modules/busboy": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dev": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
@@ -7142,15 +7083,13 @@
     },
     "node_modules/dataloader": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
-      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/date-format": {
       "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.13.tgz",
-      "integrity": "sha512-bnYCwf8Emc3pTD8pXnre+wfnjGtfi5ncMDKy7+cWZXbmRAsdWkOQHrfC1yz/KiwP5thDp2kCHWYWKBX4HP1hoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -7850,9 +7789,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -8032,9 +7970,8 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -8057,15 +7994,13 @@
     },
     "node_modules/event-target-polyfill": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz",
-      "integrity": "sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8528,9 +8463,8 @@
     },
     "node_modules/flatted": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -8572,15 +8506,13 @@
     },
     "node_modules/form-data-encoder": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/formdata-node": {
       "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.3.tgz",
-      "integrity": "sha512-coTew7WODO2vF+XhpUdmYz4UBvlsiTMSNaFYZlrXIqYbFd4W7bMwnoALNLE6uvNgzTg2j1JDF0ZImEfF06VPAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.1"
@@ -8591,9 +8523,8 @@
     },
     "node_modules/formdata-node/node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
-      "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -12834,9 +12765,8 @@
     },
     "node_modules/log4js": {
       "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.6.1.tgz",
-      "integrity": "sha512-J8VYFH2UQq/xucdNu71io4Fo+purYYudyErgBbswWKO0MC6QVOERRomt5su/z6d3RJSmLyTGmXl3Q/XjKCf+/A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "date-format": "^4.0.13",
         "debug": "^4.3.4",
@@ -13643,9 +13573,8 @@
     },
     "node_modules/nock": {
       "version": "13.2.9",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
-      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -13662,8 +13591,6 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "dev": true,
       "funding": [
         {
@@ -13675,6 +13602,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -15037,24 +14965,21 @@
     },
     "node_modules/pvtsutils": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/pvtsutils/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/pvutils": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -16890,9 +16815,8 @@
     },
     "node_modules/streamroller": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.2.tgz",
-      "integrity": "sha512-wZswqzbgGGsXYIrBYhOE0yP+nQ6XRk7xDcYwuQAGTYXdyAUmvgVFE0YU1g5pvQT0m7GBaQfYcSnlHbapuK0H0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "date-format": "^4.0.13",
         "debug": "^4.3.4",
@@ -16904,9 +16828,8 @@
     },
     "node_modules/streamroller/node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -16918,26 +16841,22 @@
     },
     "node_modules/streamroller/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/streamroller/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -17551,9 +17470,8 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17594,9 +17512,8 @@
     },
     "node_modules/ts-node/node_modules/acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -17774,9 +17691,8 @@
     },
     "node_modules/undici": {
       "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
-      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.18"
       }
@@ -18135,18 +18051,16 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/webcrypto-core": {
       "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
-      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.1.6",
         "@peculiar/json-schema": "^1.1.12",
@@ -18157,9 +18071,8 @@
     },
     "node_modules/webcrypto-core/node_modules/tslib": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -18671,6 +18584,7 @@
       "version": "2.1.0-alpha.2",
       "license": "MIT",
       "dependencies": {
+        "@apollo/cache-control-types": "^1.0.1",
         "@apollo/federation-internals": "file:../internals-js"
       },
       "engines": {
@@ -18682,6 +18596,12 @@
     }
   },
   "dependencies": {
+    "@apollo/cache-control-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.1.tgz",
+      "integrity": "sha512-5mEr3wD4ZVLBwsIkxXl+qaMDItvfHVQDH2I5XKhdjrr2modtsz+PHBa6TQl9uNqqueScfgN1DjAmW5sg0bO/fA==",
+      "requires": {}
+    },
     "@apollo/client": {
       "version": "3.6.9",
       "dev": true,
@@ -18800,9 +18720,7 @@
           }
         },
         "lru-cache": {
-          "version": "7.13.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-          "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ=="
+          "version": "7.13.1"
         },
         "make-fetch-happen": {
           "version": "10.1.2",
@@ -18903,6 +18821,7 @@
     "@apollo/subgraph": {
       "version": "file:subgraph-js",
       "requires": {
+        "@apollo/cache-control-types": "^1.0.1",
         "@apollo/federation-internals": "file:../internals-js"
       }
     },
@@ -19051,8 +18970,6 @@
     },
     "@ardatan/sync-fetch": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
-      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
       "dev": true,
       "requires": {
         "node-fetch": "^2.6.1"
@@ -19725,8 +19642,6 @@
     },
     "@graphql-codegen/cli": {
       "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.11.3.tgz",
-      "integrity": "sha512-C1d88Kx0a0PF1tOR00UIZjHq5aWNNcw5fM2k08rOY9O5b4sU7kEb+YbGKP6EExTtJnYb49fePLKVvrIv1ejDFg==",
       "dev": true,
       "requires": {
         "@graphql-codegen/core": "2.6.0",
@@ -19764,8 +19679,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -19773,8 +19686,6 @@
         },
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
@@ -19797,8 +19708,6 @@
     },
     "@graphql-codegen/plugin-helpers": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.6.1.tgz",
-      "integrity": "sha512-RbkCPu8rZo+d3tWPUzqnZhgGutp15GVcs9UhaOcenKpCDDQxNxqGGTn76LuAAymT9y7BSnXdY20k1CW59z4nTw==",
       "dev": true,
       "requires": {
         "@graphql-tools/utils": "^8.8.0",
@@ -19832,8 +19741,6 @@
     },
     "@graphql-codegen/typescript": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-lFqvLgw4oAChA9+ifC2K7Ie+mE+XvHcZqwXsm45bpF7jbmqfgjS0gvQNfu2egi6u4hdg+xL+olNxwnyhayrikw==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.6.0",
@@ -19845,16 +19752,12 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "@graphql-codegen/typescript-operations": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.2.tgz",
-      "integrity": "sha512-iFZsdsF4380WrN2UQHfgLjrjyo9VFIsZuCaHe1OoC4fQQ+P3t/GfJ0aj0hc5hNwTNJZ3BzBLHSRgE6wqO4591A==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.6.0",
@@ -19866,16 +19769,12 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "@graphql-codegen/visitor-plugin-common": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.12.0.tgz",
-      "integrity": "sha512-ULhFgOY05U+dlPsXkPT2wSBaAZMtEuHPL5Q1u8xwBdHWHi/uT4L5zEcBx+If/f6UWrOw7ufjEM0L7XSupe1iCA==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.6.0",
@@ -19898,8 +19797,6 @@
     },
     "@graphql-tools/apollo-engine-loader": {
       "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.3.6.tgz",
-      "integrity": "sha512-r7YU1X9Ce/sr+tPzSuZqVqlK7knGDpiRfB9HB2uVmbm+kPrlISQ0LuamFoT1g1nkfDZUNZn2p18ag512P1aVVw==",
       "dev": true,
       "requires": {
         "@ardatan/sync-fetch": "0.0.1",
@@ -19910,8 +19807,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -19925,8 +19820,6 @@
     },
     "@graphql-tools/batch-execute": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.1.tgz",
-      "integrity": "sha512-hRVDduX0UDEneVyEWtc2nu5H2PxpfSfM/riUlgZvo/a/nG475uyehxR5cFGvTEPEQUKY3vGIlqvtRigzqTfCew==",
       "dev": true,
       "requires": {
         "@graphql-tools/utils": "8.9.0",
@@ -19937,8 +19830,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -19946,16 +19837,12 @@
         },
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "@graphql-tools/code-file-loader": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.1.tgz",
-      "integrity": "sha512-nyr0zln7fi4E8lK98THdb8k3gPsSCiyXRFTTNhPRUCPeOD2RCpUZCClM5AB0xv8HjILAipdaxjhb2elPvnY5dw==",
       "dev": true,
       "requires": {
         "@graphql-tools/graphql-tag-pluck": "7.3.1",
@@ -19967,8 +19854,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -19982,8 +19867,6 @@
     },
     "@graphql-tools/delegate": {
       "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.8.1.tgz",
-      "integrity": "sha512-NDcg3GEQmdEHlnF7QS8b4lM1PSF+DKeFcIlLEfZFBvVq84791UtJcDj8734sIHLukmyuAxXMfA1qLd2l4lZqzA==",
       "dev": true,
       "requires": {
         "@graphql-tools/batch-execute": "8.5.1",
@@ -19996,8 +19879,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20005,16 +19886,12 @@
         },
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "@graphql-tools/git-loader": {
       "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.2.1.tgz",
-      "integrity": "sha512-grfLO3CqKO8hlymqBQeNsjGCzjMXH+n+epM6vH2OW1tUM9UmPrH+En0BynJCap9VYVZ0KcbYz03o5ZJNYkbaCg==",
       "dev": true,
       "requires": {
         "@graphql-tools/graphql-tag-pluck": "7.3.1",
@@ -20027,8 +19904,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20042,8 +19917,6 @@
     },
     "@graphql-tools/github-loader": {
       "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.3.6.tgz",
-      "integrity": "sha512-TovDdZ0dxShIfnP3/02+aVfPzhYHedtCVU4GB7rajExdOlNEUAfMAjpDKgTReENzD0ZaehqBnGj2BpR+/b4C1Q==",
       "dev": true,
       "requires": {
         "@ardatan/sync-fetch": "0.0.1",
@@ -20055,8 +19928,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20070,8 +19941,6 @@
     },
     "@graphql-tools/graphql-file-loader": {
       "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.0.tgz",
-      "integrity": "sha512-X3wcC+ZljbXTwdTTSp3oUHJd66mFLDKI750uhB0HidBxE6+wyw7fhmJVJiYROXPswaGliuabpo0JEyLj7hhWKA==",
       "dev": true,
       "requires": {
         "@graphql-tools/import": "6.7.1",
@@ -20083,8 +19952,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20098,8 +19965,6 @@
     },
     "@graphql-tools/graphql-tag-pluck": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.1.tgz",
-      "integrity": "sha512-+Aayl4y42ASrxDvu613lp3NiK1JRggy/m9wlo93dJp/9L5vKPYlrtFvuQ1tpPEEuSBboYNa/erOsELrRwzzakA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.8",
@@ -20111,8 +19976,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20120,16 +19983,12 @@
         },
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "@graphql-tools/import": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.1.tgz",
-      "integrity": "sha512-StLosFVhdw+eZkL+v9dBabszxCAZtEYW4Oy1+750fDkH39GrmzOB8mWiYna7rm9+GMisC9atJtXuAfMF02Aoag==",
       "dev": true,
       "requires": {
         "@graphql-tools/utils": "8.9.0",
@@ -20139,8 +19998,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20148,16 +20005,12 @@
         },
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "@graphql-tools/json-file-loader": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.1.tgz",
-      "integrity": "sha512-+QaeRyJcvUXUNEoIaecYrABunqk8/opFbpdHPAijJyVHvlsYfqXR12/501g+/QZzGHKYnyi+Q3lsZbBboj5LBg==",
       "dev": true,
       "requires": {
         "@graphql-tools/utils": "8.9.0",
@@ -20168,8 +20021,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20183,8 +20034,6 @@
     },
     "@graphql-tools/load": {
       "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.7.1.tgz",
-      "integrity": "sha512-rJ2WUV41wwAkMnBgtcBym3TKVbPgz7z9tBCjOmbNVLy5bB9StVPdo2Uci0D5xYSgLV9XIt+zdyAnYGptioJeWg==",
       "dev": true,
       "requires": {
         "@graphql-tools/schema": "8.5.1",
@@ -20195,8 +20044,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20210,8 +20057,6 @@
     },
     "@graphql-tools/merge": {
       "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
-      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
       "requires": {
         "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0"
@@ -20219,8 +20064,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "requires": {
             "tslib": "^2.4.0"
           }
@@ -20254,8 +20097,6 @@
     },
     "@graphql-tools/prisma-loader": {
       "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.7.tgz",
-      "integrity": "sha512-vAu2kVqSdfuiZJFOC3bDelKFeOQLfhOHOw1PT8YC0HiJQpLuEFwiDU6eXxWrPALqZEEWfCKMM8/4hlLJv+gokA==",
       "dev": true,
       "requires": {
         "@graphql-tools/url-loader": "7.13.2",
@@ -20281,8 +20122,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20311,8 +20150,6 @@
     },
     "@graphql-tools/schema": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
-      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
       "requires": {
         "@graphql-tools/merge": "8.3.1",
         "@graphql-tools/utils": "8.9.0",
@@ -20322,8 +20159,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "requires": {
             "tslib": "^2.4.0"
           }
@@ -20335,8 +20170,6 @@
     },
     "@graphql-tools/url-loader": {
       "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.13.2.tgz",
-      "integrity": "sha512-4jtGecsxziiggQ9UryQB/ioqFwVkF10sKdk5bPg/fVKSkPddN5lvCgEwk20LojlDT9mDr53ME0ArMBKkvjTxBw==",
       "dev": true,
       "requires": {
         "@ardatan/sync-fetch": "0.0.1",
@@ -20358,8 +20191,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20389,8 +20220,6 @@
     },
     "@graphql-tools/wrap": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.5.1.tgz",
-      "integrity": "sha512-KpVVfha2wLSpE08YLX0jeo5nXPfDLASlxOqMlvfa/B4X8SOVmuLyN1L5YZ132tPLDF93uflwlHFnUO5ahpRNlA==",
       "dev": true,
       "requires": {
         "@graphql-tools/delegate": "8.8.1",
@@ -20402,8 +20231,6 @@
       "dependencies": {
         "@graphql-tools/utils": {
           "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-          "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
           "dev": true,
           "requires": {
             "tslib": "^2.4.0"
@@ -20411,8 +20238,6 @@
         },
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
@@ -21738,8 +21563,6 @@
     },
     "@peculiar/asn1-schema": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.2.0.tgz",
-      "integrity": "sha512-1ENEJNY7Lwlua/1wvzpYP194WtjQBfFxvde2FlzfBFh/ln6wvChrtxlORhbKEnYswzn6fOC4c7HdC5izLPMTJg==",
       "dev": true,
       "requires": {
         "asn1js": "^3.0.5",
@@ -21749,16 +21572,12 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "@peculiar/json-schema": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.0"
@@ -21766,8 +21585,6 @@
     },
     "@peculiar/webcrypto": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
-      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
       "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.1.6",
@@ -21779,8 +21596,6 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
@@ -22009,8 +21824,6 @@
     },
     "@types/json-schema": {
       "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
     "@types/json-stable-stringify": {
@@ -22044,8 +21857,6 @@
     },
     "@types/make-fetch-happen": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.0.tgz",
-      "integrity": "sha512-wey8GZ/osY25cJEvQFNAXGfEGHTZYKMPGd1v0mrmD1vEYDkgRaq7TW+N9tir9YVlF5s1T60VGNWUx8rZExLP0A==",
       "dev": true,
       "requires": {
         "@types/node-fetch": "*",
@@ -22163,8 +21974,6 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-      "integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
       "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.32.0",
@@ -22230,8 +22039,6 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-      "integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.32.0",
@@ -22240,8 +22047,6 @@
     },
     "@typescript-eslint/type-utils": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-      "integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "5.32.0",
@@ -22251,14 +22056,10 @@
     },
     "@typescript-eslint/types": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-      "integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-      "integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.32.0",
@@ -22272,8 +22073,6 @@
     },
     "@typescript-eslint/utils": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-      "integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
@@ -22286,8 +22085,6 @@
     },
     "@typescript-eslint/visitor-keys": {
       "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-      "integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.32.0",
@@ -22296,8 +22093,6 @@
     },
     "@whatwg-node/fetch": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.2.6.tgz",
-      "integrity": "sha512-NhHiqeGcKjgqUZvJTZSou9qsFEPBBG1LPm2Npz0cmcPvukhhQfjX+p3quRx6b9AyjNPp1f73VB1z4ApHy9FcNg==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
@@ -22342,8 +22137,6 @@
     },
     "abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
@@ -22653,8 +22446,6 @@
     },
     "asn1js": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
       "dev": true,
       "requires": {
         "pvtsutils": "^1.3.2",
@@ -22664,8 +22455,6 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
@@ -22976,8 +22765,6 @@
     },
     "busboy": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dev": true,
       "requires": {
         "streamsearch": "^1.1.0"
@@ -23698,14 +23485,10 @@
     },
     "dataloader": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
-      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
       "dev": true
     },
     "date-format": {
       "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.13.tgz",
-      "integrity": "sha512-bnYCwf8Emc3pTD8pXnre+wfnjGtfi5ncMDKy7+cWZXbmRAsdWkOQHrfC1yz/KiwP5thDp2kCHWYWKBX4HP1hoQ==",
       "dev": true
     },
     "dateformat": {
@@ -24217,8 +24000,6 @@
     },
     "eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -24286,8 +24067,6 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -24300,14 +24079,10 @@
     },
     "event-target-polyfill": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz",
-      "integrity": "sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==",
       "dev": true
     },
     "event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
     },
     "eventemitter3": {
@@ -24651,8 +24426,6 @@
     },
     "flatted": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
     "fn.name": {
@@ -24681,14 +24454,10 @@
     },
     "form-data-encoder": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "dev": true
     },
     "formdata-node": {
       "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.3.tgz",
-      "integrity": "sha512-coTew7WODO2vF+XhpUdmYz4UBvlsiTMSNaFYZlrXIqYbFd4W7bMwnoALNLE6uvNgzTg2j1JDF0ZImEfF06VPAA==",
       "dev": true,
       "requires": {
         "node-domexception": "1.0.0",
@@ -24697,8 +24466,6 @@
       "dependencies": {
         "web-streams-polyfill": {
           "version": "4.0.0-beta.1",
-          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
-          "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
           "dev": true
         }
       }
@@ -27594,8 +27361,6 @@
     },
     "log4js": {
       "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.6.1.tgz",
-      "integrity": "sha512-J8VYFH2UQq/xucdNu71io4Fo+purYYudyErgBbswWKO0MC6QVOERRomt5su/z6d3RJSmLyTGmXl3Q/XjKCf+/A==",
       "dev": true,
       "requires": {
         "date-format": "^4.0.13",
@@ -28134,8 +27899,6 @@
     },
     "nock": {
       "version": "13.2.9",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
-      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -28149,8 +27912,6 @@
     },
     "node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "dev": true
     },
     "node-fetch": {
@@ -29060,8 +28821,6 @@
     },
     "pvtsutils": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -29069,16 +28828,12 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
     },
     "pvutils": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
       "dev": true
     },
     "q": {
@@ -30320,8 +30075,6 @@
     },
     "streamroller": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.2.tgz",
-      "integrity": "sha512-wZswqzbgGGsXYIrBYhOE0yP+nQ6XRk7xDcYwuQAGTYXdyAUmvgVFE0YU1g5pvQT0m7GBaQfYcSnlHbapuK0H0A==",
       "dev": true,
       "requires": {
         "date-format": "^4.0.13",
@@ -30331,8 +30084,6 @@
       "dependencies": {
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -30342,8 +30093,6 @@
         },
         "jsonfile": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -30351,16 +30100,12 @@
         },
         "universalify": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
       }
     },
     "streamsearch": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "dev": true
     },
     "strict-uri-encode": {
@@ -30744,8 +30489,6 @@
     },
     "ts-node": {
       "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -30765,8 +30508,6 @@
       "dependencies": {
         "acorn-walk": {
           "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
           "dev": true
         }
       }
@@ -30869,8 +30610,6 @@
     },
     "undici": {
       "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
-      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==",
       "dev": true
     },
     "union-value": {
@@ -31122,14 +30861,10 @@
     },
     "web-streams-polyfill": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "dev": true
     },
     "webcrypto-core": {
       "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
-      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
       "dev": true,
       "requires": {
         "@peculiar/asn1-schema": "^2.1.6",
@@ -31141,8 +30876,6 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
   },
   "devDependencies": {
+    "@apollo/cache-control-types": "1.0.1",
     "@apollo/client": "3.6.9",
     "@apollo/utils.fetcher": "1.0.0",
     "@graphql-codegen/cli": "2.11.3",

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -24,7 +24,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@apollo/federation-internals": "file:../internals-js"
+    "@apollo/federation-internals": "file:../internals-js",
+    "@apollo/cache-control-types": "^1.0.1"
   },
   "peerDependencies": {
     "graphql": "^16.0.0"

--- a/subgraph-js/src/types.ts
+++ b/subgraph-js/src/types.ts
@@ -13,7 +13,7 @@ import {
   GraphQLResolveInfo,
 } from 'graphql';
 import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
-import type { CacheHint } from 'apollo-server-types';
+import { maybeCacheControlFromInfo } from '@apollo/cache-control-types';
 
 export type Maybe<T> = null | undefined | T;
 
@@ -80,16 +80,18 @@ export function entitiesResolver({
       );
     }
 
-    // Note that while our TypeScript types (as of apollo-server-types@3.0.2)
-    // tell us that cacheControl and restrict are always defined, we want to
-    // avoid throwing when used with Apollo Server 2 which doesn't have
-    // `restrict`, or if the cache control plugin has been disabled.
-    if (info.cacheControl?.cacheHint?.restrict) {
-      const cacheHint: CacheHint | undefined =
-        info.cacheControl.cacheHintFromType(type);
+    // If you're using `@apollo/subgraph` with Apollo Server v3+ (without
+    // disabling the cache control plugin) and the schema has a `@cacheControl`
+    // directive on the specific type selected by `__typename`, restrict the
+    // request's cache policy based on that directive. (This does not work with
+    // Apollo Server 2 or non-Apollo-Server GraphQL servers;
+    // maybeCacheControlFromInfo will return null in that case.)
+    const cacheControl = maybeCacheControlFromInfo(info);
+    if (cacheControl) {
+      const cacheHint = cacheControl.cacheHintFromType(type);
 
       if (cacheHint) {
-        info.cacheControl.cacheHint.restrict(cacheHint);
+        cacheControl.cacheHint.restrict(cacheHint);
       }
     }
 


### PR DESCRIPTION
apollo-server-types is an Apollo Server 3 package that is going away in
Apollo Server 4, so we don't want `@apollo/subgraph` to depend on it.
This was a build-time-only dependency (it just imported a type and that
type isn't used in the generated .d.ts files) but it would still be
helpful to minimize dependencies so that AS4 users don't also end up
with pieces of AS3 installed.

The new package `@apollo/cache-control-types` also has a function that
implements the "does it look like it's the right cacheControl object?"
itself, and it does not rely on AS3's `declare module` to globally
monkeypatch `cacheControl` onto `GraphQLResolveInfo`'s type definition.

Part of https://github.com/apollographql/apollo-server/issues/6057
