### PR TITLE
Forward-port update from #2037 (backport of #2039)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
       },
       "devDependencies": {
-        "@apollo/cache-control-types": "1.0.1",
+        "@apollo/cache-control-types": "1.0.2",
         "@apollo/client": "3.6.9",
         "@apollo/utils.fetcher": "1.0.0",
         "@graphql-codegen/cli": "2.11.3",
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@apollo/cache-control-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.1.tgz",
-      "integrity": "sha512-5mEr3wD4ZVLBwsIkxXl+qaMDItvfHVQDH2I5XKhdjrr2modtsz+PHBa6TQl9uNqqueScfgN1DjAmW5sg0bO/fA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.2.tgz",
+      "integrity": "sha512-Por80co1eUm4ATsvjCOoS/tIR8PHxqVjsA6z76I6Vw0rFn4cgyVElQcmQDIZiYsy41k8e5xkrMRECkM2WR8pNw==",
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
@@ -18584,7 +18584,7 @@
       "version": "2.1.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@apollo/cache-control-types": "^1.0.1",
+        "@apollo/cache-control-types": "^1.0.2",
         "@apollo/federation-internals": "file:../internals-js"
       },
       "engines": {
@@ -18597,9 +18597,9 @@
   },
   "dependencies": {
     "@apollo/cache-control-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.1.tgz",
-      "integrity": "sha512-5mEr3wD4ZVLBwsIkxXl+qaMDItvfHVQDH2I5XKhdjrr2modtsz+PHBa6TQl9uNqqueScfgN1DjAmW5sg0bO/fA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.2.tgz",
+      "integrity": "sha512-Por80co1eUm4ATsvjCOoS/tIR8PHxqVjsA6z76I6Vw0rFn4cgyVElQcmQDIZiYsy41k8e5xkrMRECkM2WR8pNw==",
       "requires": {}
     },
     "@apollo/client": {
@@ -18821,7 +18821,7 @@
     "@apollo/subgraph": {
       "version": "file:subgraph-js",
       "requires": {
-        "@apollo/cache-control-types": "^1.0.1",
+        "@apollo/cache-control-types": "^1.0.2",
         "@apollo/federation-internals": "file:../internals-js"
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
   },
   "devDependencies": {
-    "@apollo/cache-control-types": "1.0.1",
+    "@apollo/cache-control-types": "1.0.2",
     "@apollo/client": "3.6.9",
     "@apollo/utils.fetcher": "1.0.0",
     "@graphql-codegen/cli": "2.11.3",

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@apollo/federation-internals": "file:../internals-js",
-    "@apollo/cache-control-types": "^1.0.1"
+    "@apollo/cache-control-types": "^1.0.2"
   },
   "peerDependencies": {
     "graphql": "^16.0.0"


### PR DESCRIPTION
Turns out that if you have AS3 in your TS build (which version-0.x
does), you need to be a bit more careful how you declare some things.
This commit ensures that the extra care required for version-0.x doesn't
break main.
