### PR TITLE
fix @composeDirective corner case

### DIFF
--- a/composition-js/src/__tests__/compose.composeDirective.test.ts
+++ b/composition-js/src/__tests__/compose.composeDirective.test.ts
@@ -688,13 +688,12 @@ describe('composing custom core directives', () => {
     ]);
   });
 
-  it('directive may not be named as to cause a naming conflict with federation directives', () => {
+  it('directive may not be named as to cause a naming conflict with federation directives. Also no @link of link', () => {
     const subgraphA = {
       name: 'subgraphA',
       typeDefs: gql`
       extend schema
         @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective"])
-        @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/foo/v1.0", import: [{ name: "@foo", as: "@inaccessible" }])
         @composeDirective(name: "@inaccessible")
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -2467,7 +2467,7 @@ describe('composition', () => {
       expect(userType?.field('name')?.appliedDirectivesOf('inaccessible').pop()).toBeDefined();
     });
 
-    describe('rejects @inaccessible and @external together', () => {
+    it('rejects @inaccessible and @external together', () => {
       const subgraphA = {
         typeDefs: gql`
           type Query {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -17,7 +17,8 @@ import {
   VariableNode,
   TypeSystemDefinitionNode,
   SchemaDefinitionNode,
-  TypeDefinitionNode
+  TypeDefinitionNode,
+  DirectiveNode
 } from "graphql";
 import {
   CoreImport,
@@ -495,10 +496,36 @@ export class Extension<TElement extends ExtendableElement> {
   }
 }
 
+type UnappliedDirective = {
+  nameOrDef: DirectiveDefinition<Record<string, any>> | string,
+  args: Record<string, any>,
+  extension?: Extension<any>,
+  directive: DirectiveNode,
+};
+
 // TODO: ideally, we should hide the ctor of this class as we rely in places on the fact the no-one external defines new implementations.
 export abstract class SchemaElement<TOwnType extends SchemaElement<any, TParent>, TParent extends SchemaElement<any, any> | Schema> extends Element<TParent> {
   protected readonly _appliedDirectives: Directive<TOwnType>[] = [];
+  protected readonly _unappliedDirectives: UnappliedDirective[] = [];
+
   description?: string;
+
+  addUnappliedDirective({ nameOrDef, args, extension, directive }: UnappliedDirective) {
+    this._unappliedDirectives.push({
+      nameOrDef,
+      args: args ?? {},
+      extension,
+      directive,
+    });
+  }
+
+  processUnappliedDirectives() {
+    for (const { nameOrDef, args, extension, directive } of this._unappliedDirectives) {
+      const d = this.applyDirective(nameOrDef, args);
+      d.setOfExtension(extension);
+      d.sourceAST = directive;
+    }
+  }
 
   get appliedDirectives(): readonly Directive<TOwnType>[] {
     return this._appliedDirectives;
@@ -915,6 +942,14 @@ export class SchemaBlueprint {
 
   onUnknownDirectiveValidationError(_schema: Schema, _unknownDirectiveName: string, error: GraphQLError): GraphQLError {
     return error;
+  }
+
+  isCompleted() {
+    return true;
+  }
+
+  setCompleted() {
+    // intentionally left blank
   }
 }
 


### PR DESCRIPTION
@composeDirective wasn't working when @link of the link directive was not present.

The reason this is happening is that although we are waiting to process core schemas for think that aren't the `link` schema, we aren't doing the same for other directives. This fixes this with a slightly hacky approach of catching all exceptions that occur, and then replaying them once `completeSubgraphSchema` has been called, letting them still throw if they threw originally.
