### PR TITLE
Release 0.52.0

### DIFF
--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "0.35.6",
+  "version": "0.36.0",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-js/package.json
+++ b/federation-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation",
-  "version": "0.36.2",
+  "version": "0.37.0",
   "description": "Apollo Federation Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG pertains only to Apollo Federation packages in the `0.x` range. T
 ## vNEXT
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually)
 
+- Nothing yet! Stay tuned.
+
+## v0.52.0
+
 - The method `RemoteGraphQLDataSource.errorFromResponse` now returns a `GraphQLError` (as defined by `graphql`) rather than an `ApolloError` (as defined by `apollo-server-errors`). [PR #2028](https://github.com/apollographql/federation/pull/2028)
   - __BREAKING__: If you call `RemoteGraphQLDataSource.errorFromResponse` manually and expect its return value to be a particular subclass of `GraphQLError`, or if you expect the error received by `didEncounterError` to be a particular subclass of `GraphQLError`, then this change may affect you. We recommend checking `error.extensions.code` instead.
 - The `LocalGraphQLDataSource` class no longer supports the undocumented `__resolveObject` Apollo Server feature. [PR #2007](https://github.com/apollographql/federation/pull/2007)

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "0.35.6",
+      "version": "0.36.0",
       "license": "MIT",
       "dependencies": {
         "graphql-tag": "^2.10.4",
@@ -74,7 +74,7 @@
     },
     "federation-js": {
       "name": "@apollo/federation",
-      "version": "0.36.2",
+      "version": "0.37.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/subgraph": "file:../subgraph-js",
@@ -90,7 +90,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/core-schema": "^0.2.0",
@@ -20763,7 +20763,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -20779,7 +20779,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2"

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release @apollo/PACKAGE1@X.Y.Z [, @apollo/PACKAGE2@X.Y.Z]

As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌   The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `version-0.x` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `version-0.x` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `version-0.x`.
