### PR TITLE
Ensures key fields needed post-@require are fetched

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+- Fix case where some key field necessary to a `@require` fetch were not previously fetched [PR #2075](https://github.com/apollographql/federation/pull/2075).
+
 ## 2.1.0-alpha.4
 
 - Update peer dependency `graphql` to `^16.5.0` to use `GraphQLErrorOptions` [PR #2060](https://github.com/apollographql/federation/pull/2060)

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1052,7 +1052,7 @@ export class SelectionSet extends Freezable<SelectionSet> {
    * This is very similar to `mergeIn` except that it takes a direct array of selection, and the direct aliasing
    * remarks from `mergeInd` applies here too.
    */
-  addAll(selections: Selection[]): SelectionSet {
+  addAll(selections: readonly Selection[]): SelectionSet {
     selections.forEach(s => this.add(s));
     return this;
   }


### PR DESCRIPTION
Sometimes, a `@require` on some entity `E` in some subgraph A requires
that the query plan jumps from A to some other subgraph(s) to get the
requirements, and then that we use a key of `E` to jump back to A to
resume fetching the field having the `@require`. When that happens
the code was correctly finding the key need to do that "post-@require"
resuming, and was using it as "inputs" of the post-@require fetch,
but was assuming that those key fields had already fetched. And while
that's true in a number of situation, this is not guaranteed.

This fix ensures that we force fetching (pre-@require) those key
fields that are needed to resume post-@require.

Fixes #2069

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
