### PR TITLE
gateway: update to version of gateway interface package that explicitly supports AS2

### DIFF
--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -29,7 +29,7 @@
     "@apollo/core-schema": "~0.3.0",
     "@apollo/federation-internals": "file:../internals-js",
     "@apollo/query-planner": "file:../query-planner-js",
-    "@apollo/server-gateway-interface": "^1.0.1",
+    "@apollo/server-gateway-interface": "^1.0.2",
     "@apollo/utils.createhash": "^1.1.0",
     "@apollo/utils.fetcher": "^1.1.0",
     "@apollo/utils.isnodelike": "^1.1.0",

--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -106,7 +106,9 @@ export class RemoteGraphQLDataSource<
     // there.
     const overallCachePolicy =
       this.honorSubgraphCacheControlHeader &&
-      options.kind === GraphQLDataSourceRequestKind.INCOMING_OPERATION
+      options.kind === GraphQLDataSourceRequestKind.INCOMING_OPERATION &&
+      options.incomingRequestContext.overallCachePolicy &&
+      'restrict' in options.incomingRequestContext.overallCachePolicy
         ? options.incomingRequestContext.overallCachePolicy
         : null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "@apollo/core-schema": "~0.3.0",
         "@apollo/federation-internals": "file:../internals-js",
         "@apollo/query-planner": "file:../query-planner-js",
-        "@apollo/server-gateway-interface": "^1.0.1",
+        "@apollo/server-gateway-interface": "^1.0.2",
         "@apollo/utils.createhash": "^1.1.0",
         "@apollo/utils.fetcher": "^1.1.0",
         "@apollo/utils.isnodelike": "^1.1.0",
@@ -403,9 +403,9 @@
       "link": true
     },
     "node_modules/@apollo/server-gateway-interface": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.1.tgz",
-      "integrity": "sha512-YZ+bwSJJIYrIe22NDhF+DA+T9S1PV/sv3Ywp30Ao1RhtlXX7lBSRbu+meZxE1FNkC3nkbj63sUAUEmWiHO/jhw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.2.tgz",
+      "integrity": "sha512-IDYTUwkS29upUg+nv32XAuJ8uNPQ+EixPSn5rrtYQMZlLLLDE+OrRtlETCHob85/TMp5xlGYyuojVQXfaDCpZA==",
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
         "@apollo/utils.fetcher": "^1.0.0",
@@ -18773,7 +18773,7 @@
         "@apollo/core-schema": "~0.3.0",
         "@apollo/federation-internals": "file:../internals-js",
         "@apollo/query-planner": "file:../query-planner-js",
-        "@apollo/server-gateway-interface": "^1.0.1",
+        "@apollo/server-gateway-interface": "^1.0.2",
         "@apollo/utils.createhash": "^1.1.0",
         "@apollo/utils.fetcher": "^1.1.0",
         "@apollo/utils.isnodelike": "^1.1.0",
@@ -18943,9 +18943,9 @@
       }
     },
     "@apollo/server-gateway-interface": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.1.tgz",
-      "integrity": "sha512-YZ+bwSJJIYrIe22NDhF+DA+T9S1PV/sv3Ywp30Ao1RhtlXX7lBSRbu+meZxE1FNkC3nkbj63sUAUEmWiHO/jhw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.2.tgz",
+      "integrity": "sha512-IDYTUwkS29upUg+nv32XAuJ8uNPQ+EixPSn5rrtYQMZlLLLDE+OrRtlETCHob85/TMp5xlGYyuojVQXfaDCpZA==",
       "requires": {
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
         "@apollo/utils.fetcher": "^1.0.0",


### PR DESCRIPTION
We don't really support AS2 in gateway v2 (because we require
graphql-js@16) but we want to stay up to date on this package (whose
change is more relevant for gateway v0). Also reintroduce probing for
the actual method we use on overallCachePolicy (like the comment says)
so that we actually could support AS2 a bit better if the peer dep was
ignored. (By "support" I mean "not crash", not "actually have the cache
policy feature work".)
