### PR TITLE
Add type definitions to schema extensions

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## vNext
+
 - Fix case where some key field necessary to a `@require` fetch were not previously fetched [PR #2075](https://github.com/apollographql/federation/pull/2075).
+- Add type definitions to schema extensions [PR #2081](https://github.com/apollographql/federation/pull/2081)
 
 ## 2.1.0-alpha.4
 

--- a/gateway-js/src/schema-helper/__tests__/addExtensions.test.ts
+++ b/gateway-js/src/schema-helper/__tests__/addExtensions.test.ts
@@ -30,4 +30,36 @@ describe('addExtensions', () => {
       }
     });
   });
+
+  it('works with undefined apollo block', async () => {
+    const schema = buildSchema('type Query { hello: String }');
+    expect(schema.extensions).toEqual({});
+    schema.extensions = {
+      apollo: undefined
+    };
+    expect(addExtensions(schema).extensions).toEqual({
+      apollo: {
+        gateway: {
+          version: version
+        }
+      }
+    });
+  });
+
+  it('works with undefined gateway block', async () => {
+    const schema = buildSchema('type Query { hello: String }');
+    expect(schema.extensions).toEqual({});
+    schema.extensions = {
+      apollo: {
+        gateway: undefined
+      }
+    };
+    expect(addExtensions(schema).extensions).toEqual({
+      apollo: {
+        gateway: {
+          version: version
+        }
+      }
+    });
+  });
 });

--- a/gateway-js/src/schema-helper/__tests__/addExtensions.test.ts
+++ b/gateway-js/src/schema-helper/__tests__/addExtensions.test.ts
@@ -14,20 +14,17 @@ describe('addExtensions', () => {
     const schema = buildSchema('type Query { hello: String }');
     expect(schema.extensions).toEqual({});
     schema.extensions = {
-      one: 1,
+      foo: 'bar',
       apollo: {
-        two: 2,
         gateway: {
-          three: 3
+          version: 'hello'
         }
       }
     };
     expect(addExtensions(schema).extensions).toEqual({
-      one: 1,
+      foo: 'bar',
       apollo: {
-        two: 2,
         gateway: {
-          three: 3,
           version: version
         }
       }

--- a/gateway-js/src/schema-helper/__tests__/addExtensions.test.ts
+++ b/gateway-js/src/schema-helper/__tests__/addExtensions.test.ts
@@ -3,9 +3,34 @@ import { addExtensions } from '../addExtensions';
 const { version } = require('../../../package.json');
 
 describe('addExtensions', () => {
+
   it('adds gateway extensions to a schema', async () => {
     const schema = buildSchema('type Query { hello: String }');
     expect(schema.extensions).toEqual({});
     expect(addExtensions(schema).extensions).toEqual({ apollo: { gateway: { version: version } } });
+  });
+
+  it('does not delete existing extensions', async () => {
+    const schema = buildSchema('type Query { hello: String }');
+    expect(schema.extensions).toEqual({});
+    schema.extensions = {
+      one: 1,
+      apollo: {
+        two: 2,
+        gateway: {
+          three: 3
+        }
+      }
+    };
+    expect(addExtensions(schema).extensions).toEqual({
+      one: 1,
+      apollo: {
+        two: 2,
+        gateway: {
+          three: 3,
+          version: version
+        }
+      }
+    });
   });
 });

--- a/gateway-js/src/schema-helper/addExtensions.ts
+++ b/gateway-js/src/schema-helper/addExtensions.ts
@@ -1,17 +1,15 @@
 import { GraphQLSchema } from 'graphql';
-import { GraphQLSchemaExtensions } from 'graphql/type/schema';
 
 const { version } = require('../../package.json');
 
 export function addExtensions(schema: GraphQLSchema): GraphQLSchema {
-  const extensions = schema.extensions as GraphQLSchemaExtensions;
-
+  const apolloExtension = schema.extensions.apollo as any ?? {};
   schema.extensions = {
-    ...extensions,
+    ...schema.extensions,
     apollo: {
-      ...extensions.apollo,
+      ...apolloExtension,
       gateway: {
-        ...extensions.apollo?.gateway,
+        ...apolloExtension?.gateway,
         version,
       }
     },

--- a/gateway-js/src/schema-helper/addExtensions.ts
+++ b/gateway-js/src/schema-helper/addExtensions.ts
@@ -5,7 +5,7 @@ const { version } = require('../../package.json');
 
 export function addExtensions(schema: GraphQLSchema): GraphQLSchema {
   const schemaExtension = schema.extensions as GraphQLSchemaExtensions ?? {};
-  const apolloExtension = schemaExtension.apollo ?? {};
+  const apolloExtension = schemaExtension?.apollo ?? {};
   const gatewayExtension = apolloExtension?.gateway ?? {};
 
   schema.extensions = {

--- a/gateway-js/src/schema-helper/addExtensions.ts
+++ b/gateway-js/src/schema-helper/addExtensions.ts
@@ -1,13 +1,17 @@
 import { GraphQLSchema } from 'graphql';
+import { GraphQLSchemaExtensions } from 'graphql/type/schema';
+
 const { version } = require('../../package.json');
 
 export function addExtensions(schema: GraphQLSchema): GraphQLSchema {
+  const extensions = schema.extensions as GraphQLSchemaExtensions;
+
   schema.extensions = {
-    ...schema.extensions,
+    ...extensions,
     apollo: {
-      ...schema.extensions.apollo,
+      ...extensions.apollo,
       gateway: {
-        ...schema.extensions.apollo?.gateway,
+        ...extensions.apollo?.gateway,
         version,
       }
     },

--- a/gateway-js/src/schema-helper/addExtensions.ts
+++ b/gateway-js/src/schema-helper/addExtensions.ts
@@ -1,15 +1,19 @@
 import { GraphQLSchema } from 'graphql';
+import { GraphQLSchemaExtensions } from 'graphql/type/schema';
 
 const { version } = require('../../package.json');
 
 export function addExtensions(schema: GraphQLSchema): GraphQLSchema {
-  const apolloExtension = schema.extensions.apollo as any ?? {};
+  const schemaExtension = schema.extensions as GraphQLSchemaExtensions ?? {};
+  const apolloExtension = schemaExtension.apollo ?? {};
+  const gatewayExtension = apolloExtension?.gateway ?? {};
+
   schema.extensions = {
     ...schema.extensions,
     apollo: {
       ...apolloExtension,
       gateway: {
-        ...apolloExtension?.gateway,
+        ...gatewayExtension,
         version,
       }
     },


### PR DESCRIPTION
TS Compiler error

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/2446877/185483781-b4c9c2d7-ed62-4eb4-b992-98d9d00cddad.png">

Because the type `schema.extensions` is unknown the TS compiler is failing because it doesn't know for sure if `schema.extensions.apollo` is an object. If it is not, we can not perform a spread on it.