### PR TITLE
Fix fragment expansion nuking @defer and other minor @defer updates

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix issue where fragment expansion can erase applied directives (most notably `@defer`) [PR #2093](https://github.com/apollographql/federation/pull/2093).
 - Fix abnormally high memory usage when extracting subgraphs for some fed1 supergraphs (and small other memory footprint improvements) [PR #2089](https://github.com/apollographql/federation/pull/2089).
 - Fix issue with fragment reusing code something mistakenly re-expanding fragments [PR #2098](https://github.com/apollographql/federation/pull/2098).
 - Fix issue when type is only reachable through a @provides [PR #2083](https://github.com/apollographql/federation/pull/2083).

--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -817,7 +817,7 @@ test('correctly convert to a graphQL-js schema', () => {
   expect(printGraphQLjsSchema(graphqQLSchema)).toMatchString(sdl);
 });
 
-test('Conversion to graphQL-js schema can optionally include @defer definition', () => {
+test('Conversion to graphQL-js schema can optionally include @defer and/or @streams definition(s)', () => {
   const sdl = `
     type Query {
       x: Int
@@ -825,9 +825,18 @@ test('Conversion to graphQL-js schema can optionally include @defer definition',
   `;
   const schema = parseSchema(sdl);
 
-  const graphqQLSchema = schema.toGraphQLJSSchema({ includeDefer: true });
-  expect(printGraphQLjsSchema(graphqQLSchema)).toMatchString(`
-    directive @defer(label: String, if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+  expect(printGraphQLjsSchema(schema.toGraphQLJSSchema({ includeDefer: true }))).toMatchString(`
+    directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    type Query {
+      x: Int
+    }
+  `);
+
+  expect(printGraphQLjsSchema(schema.toGraphQLJSSchema({ includeDefer: true, includeStream:  true }))).toMatchString(`
+    directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    directive @stream(label: String, initialCount: Int = 0, if: Boolean! = true) on FIELD
 
     type Query {
       x: Int

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -1128,7 +1128,7 @@ const graphQLBuiltInDirectivesSpecifications: readonly DirectiveSpecification[] 
     locations: [DirectiveLocation.SCALAR],
     argumentFct: (schema) => ({ args: [{ name: 'url', type: new NonNullType(schema.stringType()) }], errors: [] })
   }),
-  // Note that @defer and @stream a inconditionally added to `Schema` even if they are technically "optional" built-in. _But_,
+  // Note that @defer and @stream are unconditionally added to `Schema` even if they are technically "optional" built-in. _But_,
   // the `Schema#toGraphQLJSSchema` method has an option to decide if @defer/@stream should be included or not in the resulting
   // schema, which is how the gateway and router can, at runtime, decide to include or not include them based on actual support.
   createDirectiveSpecification({

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1894,7 +1894,7 @@ class FragmentSpreadSelection extends FragmentSelection {
     }
 
     const expandedSubSelections = this.selectionSet.expandFragments(names, updateSelectionSetFragments);
-    return sameType(this._element.parentType, this.namedFragment.typeCondition)
+    return sameType(this._element.parentType, this.namedFragment.typeCondition) && this._element.appliedDirectives.length === 0
       ? expandedSubSelections.selections()
       : new InlineFragmentSelection(this._element, expandedSubSelections);
   }

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -3,6 +3,7 @@
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
 
+- Fix issue where fragment expansion can erase applied directives (most notably `@defer`) [PR #2093](https://github.com/apollographql/federation/pull/2093).
 - Fix issue with fragment reusing code something mistakenly re-expanding fragments [PR #2098](https://github.com/apollographql/federation/pull/2098).
 
 ## 2.1.0-alpha.4

--- a/query-planner-js/src/__tests__/buildPlan.defer.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.defer.test.ts
@@ -2458,70 +2458,73 @@ describe('defer with conditions', () => {
     expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Condition(if: $cond) {
-          Defer {
-            Primary {
-              {
-                t {
-                  x
+          Then {
+            Defer {
+              Primary {
+                {
+                  t {
+                    x
+                  }
+                }:
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    t {
+                      __typename
+                      x
+                      id
+                    }
+                  }
                 }
-              }:
-              Fetch(service: "Subgraph1", id: 0) {
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    y
+                  }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          y
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            }
+          } Else {
+            Sequence {
+              Fetch(service: "Subgraph1") {
                 {
                   t {
                     __typename
+                    id
                     x
-                    id
                   }
                 }
-              }
-            }, [
-              Deferred(depends: [0], path: "t") {
-                {
-                  y
-                }:
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph2") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        y
-                      }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
                     }
-                  },
-                }
-              },
-            ]
-          },
-          Sequence {
-            Fetch(service: "Subgraph1") {
-              {
-                t {
-                  __typename
-                  id
-                  x
-                }
-              }
-            },
-            Flatten(path: "t") {
-              Fetch(service: "Subgraph2") {
-                {
-                  ... on T {
-                    __typename
-                    id
+                  } =>
+                  {
+                    ... on T {
+                      y
+                    }
                   }
-                } =>
-                {
-                  ... on T {
-                    y
-                  }
-                }
+                },
               },
-            },
+            }
           }
         },
       }
@@ -2564,50 +2567,53 @@ describe('defer with conditions', () => {
     expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Condition(if: $cond) {
-          Defer {
-            Primary {
+          Then {
+            Defer {
+              Primary {
+                {
+                  t {
+                    x
+                  }
+                }:
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    t {
+                      __typename
+                      x
+                      id
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    y
+                  }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          y
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            }
+          } Else {
+            Fetch(service: "Subgraph1") {
               {
                 t {
                   x
-                }
-              }:
-              Fetch(service: "Subgraph1", id: 0) {
-                {
-                  t {
-                    __typename
-                    x
-                    id
-                  }
-                }
-              }
-            }, [
-              Deferred(depends: [0], path: "t") {
-                {
                   y
-                }:
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph1") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        y
-                      }
-                    }
-                  },
                 }
-              },
-            ]
-          },
-          Fetch(service: "Subgraph1") {
-            {
-              t {
-                x
-                y
               }
             }
           }
@@ -2681,34 +2687,83 @@ describe('defer with conditions', () => {
     expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Condition(if: $cond1) {
-          Condition(if: $cond2) {
-            Defer {
-              Primary {
-                {
-                  t {
-                    x
-                  }
-                }:
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    t {
-                      __typename
-                      x
-                      id
-                    }
-                  }
-                }
-              }, [
-                Deferred(depends: [0], path: "t", label: "bar") {
-                  Defer {
-                    Primary {
+          Then {
+            Condition(if: $cond2) {
+              Then {
+                Defer {
+                  Primary {
+                    {
+                      t {
+                        x
+                      }
+                    }:
+                    Fetch(service: "Subgraph1", id: 0) {
                       {
-                        u {
-                          a
+                        t {
+                          __typename
+                          x
+                          id
                         }
+                      }
+                    }
+                  }, [
+                    Deferred(depends: [0], path: "t", label: "bar") {
+                      Defer {
+                        Primary {
+                          {
+                            u {
+                              a
+                            }
+                          }:
+                          Flatten(path: "t") {
+                            Fetch(service: "Subgraph1", id: 1) {
+                              {
+                                ... on T {
+                                  __typename
+                                  id
+                                }
+                              } =>
+                              {
+                                ... on T {
+                                  u {
+                                    __typename
+                                    a
+                                    id
+                                  }
+                                }
+                              }
+                            },
+                          }
+                        }, [
+                          Deferred(depends: [1], path: "t.u") {
+                            {
+                              b
+                            }:
+                            Flatten(path: "t.u") {
+                              Fetch(service: "Subgraph3") {
+                                {
+                                  ... on U {
+                                    __typename
+                                    id
+                                  }
+                                } =>
+                                {
+                                  ... on U {
+                                    b
+                                  }
+                                }
+                              },
+                            }
+                          },
+                        ]
+                      }
+                    },
+                    Deferred(depends: [0], path: "t", label: "foo") {
+                      {
+                        y
                       }:
                       Flatten(path: "t") {
-                        Fetch(service: "Subgraph1", id: 1) {
+                        Fetch(service: "Subgraph2") {
                           {
                             ... on T {
                               __typename
@@ -2717,20 +2772,149 @@ describe('defer with conditions', () => {
                           } =>
                           {
                             ... on T {
-                              u {
-                                __typename
-                                a
-                                id
-                              }
+                              y
                             }
                           }
                         },
                       }
-                    }, [
-                      Deferred(depends: [1], path: "t.u") {
+                    },
+                  ]
+                }
+              } Else {
+                Defer {
+                  Primary {
+                    {
+                      t {
+                        x
+                        u {
+                          a
+                        }
+                      }
+                    }:
+                    Fetch(service: "Subgraph1", id: 0) {
+                      {
+                        t {
+                          __typename
+                          x
+                          id
+                          u {
+                            __typename
+                            a
+                            id
+                          }
+                        }
+                      }
+                    }
+                  }, [
+                    Deferred(depends: [0], path: "t", label: "foo") {
+                      {
+                        y
+                      }:
+                      Flatten(path: "t") {
+                        Fetch(service: "Subgraph2") {
+                          {
+                            ... on T {
+                              __typename
+                              id
+                            }
+                          } =>
+                          {
+                            ... on T {
+                              y
+                            }
+                          }
+                        },
+                      }
+                    },
+                    Deferred(depends: [0], path: "t.u") {
+                      {
+                        b
+                      }:
+                      Flatten(path: "t.u") {
+                        Fetch(service: "Subgraph3") {
+                          {
+                            ... on U {
+                              __typename
+                              id
+                            }
+                          } =>
+                          {
+                            ... on U {
+                              b
+                            }
+                          }
+                        },
+                      }
+                    },
+                  ]
+                }
+              }
+            }
+          } Else {
+            Condition(if: $cond2) {
+              Then {
+                Defer {
+                  Primary {
+                    {
+                      t {
+                        x
+                        y
+                      }
+                    }:
+                    Sequence {
+                      Fetch(service: "Subgraph1", id: 0) {
                         {
+                          t {
+                            __typename
+                            id
+                            x
+                          }
+                        }
+                      },
+                      Flatten(path: "t") {
+                        Fetch(service: "Subgraph2") {
+                          {
+                            ... on T {
+                              __typename
+                              id
+                            }
+                          } =>
+                          {
+                            ... on T {
+                              y
+                            }
+                          }
+                        },
+                      },
+                    }
+                  }, [
+                    Deferred(depends: [0], path: "t", label: "bar") {
+                      {
+                        u {
+                          a
                           b
-                        }:
+                        }
+                      }:
+                      Sequence {
+                        Flatten(path: "t") {
+                          Fetch(service: "Subgraph1") {
+                            {
+                              ... on T {
+                                __typename
+                                id
+                              }
+                            } =>
+                            {
+                              ... on T {
+                                u {
+                                  __typename
+                                  id
+                                  a
+                                }
+                              }
+                            }
+                          },
+                        },
                         Flatten(path: "t.u") {
                           Fetch(service: "Subgraph3") {
                             {
@@ -2745,147 +2929,30 @@ describe('defer with conditions', () => {
                               }
                             }
                           },
-                        }
-                      },
-                    ]
-                  }
-                },
-                Deferred(depends: [0], path: "t", label: "foo") {
-                  {
-                    y
-                  }:
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          y
-                        }
+                        },
                       }
                     },
-                  }
-                },
-              ]
-            },
-            Defer {
-              Primary {
-                {
-                  t {
-                    x
-                    u {
-                      a
-                    }
-                  }
-                }:
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    t {
-                      __typename
-                      x
-                      id
-                      u {
-                        __typename
-                        a
-                        id
-                      }
-                    }
-                  }
+                  ]
                 }
-              }, [
-                Deferred(depends: [0], path: "t", label: "foo") {
-                  {
-                    y
-                  }:
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          y
-                        }
-                      }
-                    },
-                  }
-                },
-                Deferred(depends: [0], path: "t.u") {
-                  {
-                    b
-                  }:
-                  Flatten(path: "t.u") {
-                    Fetch(service: "Subgraph3") {
-                      {
-                        ... on U {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on U {
-                          b
-                        }
-                      }
-                    },
-                  }
-                },
-              ]
-            }
-          },
-          Condition(if: $cond2) {
-            Defer {
-              Primary {
-                {
-                  t {
-                    x
-                    y
-                  }
-                }:
+              } Else {
                 Sequence {
-                  Fetch(service: "Subgraph1", id: 0) {
+                  Fetch(service: "Subgraph1") {
                     {
                       t {
                         __typename
                         id
                         x
-                      }
-                    }
-                  },
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
+                        u {
                           __typename
                           id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          y
+                          a
                         }
                       }
-                    },
-                  },
-                }
-              }, [
-                Deferred(depends: [0], path: "t", label: "bar") {
-                  {
-                    u {
-                      a
-                      b
                     }
-                  }:
-                  Sequence {
+                  },
+                  Parallel {
                     Flatten(path: "t") {
-                      Fetch(service: "Subgraph1") {
+                      Fetch(service: "Subgraph2") {
                         {
                           ... on T {
                             __typename
@@ -2894,11 +2961,7 @@ describe('defer with conditions', () => {
                         } =>
                         {
                           ... on T {
-                            u {
-                              __typename
-                              id
-                              a
-                            }
+                            y
                           }
                         }
                       },
@@ -2918,57 +2981,9 @@ describe('defer with conditions', () => {
                         }
                       },
                     },
-                  }
-                },
-              ]
-            },
-            Sequence {
-              Fetch(service: "Subgraph1") {
-                {
-                  t {
-                    __typename
-                    id
-                    x
-                    u {
-                      __typename
-                      id
-                      a
-                    }
-                  }
+                  },
                 }
-              },
-              Parallel {
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph2") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        y
-                      }
-                    }
-                  },
-                },
-                Flatten(path: "t.u") {
-                  Fetch(service: "Subgraph3") {
-                    {
-                      ... on U {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on U {
-                        b
-                      }
-                    }
-                  },
-                },
-              },
+              }
             }
           }
         },
@@ -3163,6 +3178,122 @@ describe('named fragments', () => {
                     ... on T {
                       x
                       y
+                    }
+                  }
+                },
+              }
+            },
+          ]
+        },
+      }
+    `);
+  });
+
+  test('expands into the same field deferred and not deferred', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+        }
+      `
+    }
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          x: Int
+          y: Int
+          z: Int
+        }
+      `
+    }
+
+    const [api, queryPlanner] = composeAndCreatePlannerWithDefer(subgraph1, subgraph2);
+    const operation = operationFromDocument(api, gql`
+      {
+        t {
+          ...Fragment1
+          ...Fragment2 @defer
+        }
+      }
+
+      fragment Fragment1 on T {
+        x
+        y
+      }
+
+      fragment Fragment2 on T {
+        y
+        z
+      }
+    `);
+
+    // Field 'y' is queried twice, both in the deferred and non-deferred section. The spec says that
+    // means the field is requested twice, so ensures that's what we do.
+    const queryPlan = queryPlanner.buildQueryPlan(operation);
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Defer {
+          Primary {
+            {
+              t {
+                x
+                y
+              }
+            }:
+            Sequence {
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      x
+                      y
+                    }
+                  }
+                },
+              },
+            }
+          }, [
+            Deferred(depends: [0], path: "t") {
+              {
+                ... on T {
+                  y
+                  z
+                }
+              }:
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      y
+                      z
                     }
                   }
                 },

--- a/query-planner-js/src/__tests__/buildPlan.defer.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.defer.test.ts
@@ -4,7 +4,7 @@ import { QueryPlanner } from '@apollo/query-planner';
 import { composeAndCreatePlanner, composeAndCreatePlannerWithOptions } from "./buildPlan.test";
 
 function composeAndCreatePlannerWithDefer(...services: ServiceDefinition[]): [Schema, QueryPlanner] {
-  return composeAndCreatePlannerWithOptions(services, { deferStreamSupport: { enableDefer : true }});
+  return composeAndCreatePlannerWithOptions(services, { incrementalDelivery: { enableDefer : true }});
 }
 
 describe('handles simple @defer', () => {

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -1911,7 +1911,7 @@ export function computeQueryPlan({
   let assignedDeferLabels: Set<string> | undefined = undefined;
   let hasDefers: boolean = false;
   let deferConditions: SetMultiMap<string, string> | undefined = undefined;
-  if (config.deferStreamSupport.enableDefer) {
+  if (config.incrementalDelivery.enableDefer) {
     ({ operation, hasDefers, assignedDeferLabels, deferConditions } = operation.withNormalizedDefer());
   } else {
     // If defer is not enabled, we remove all @defer from the query. This feels cleaner do this once here than

--- a/query-planner-js/src/config.ts
+++ b/query-planner-js/src/config.ts
@@ -23,7 +23,7 @@ export type QueryPlannerConfig = {
   // new `passthroughSubgraphs` option that is the list of subgraph to which we can pass-through some @defer
   // (and it would be empty by default). Similarly, once we support @stream, grouping the options here will
   // make sense too.
-  deferStreamSupport?: {
+  incrementalDelivery?: {
     /**
      * Enables @defer support by the query planner.
      *
@@ -41,7 +41,7 @@ export function enforceQueryPlannerConfigDefaults(
   return {
     exposeDocumentNodeInFetchNode: true,
     reuseQueryFragments: true,
-    deferStreamSupport: {
+    incrementalDelivery: {
       enableDefer: false,
     },
     ...config,

--- a/query-planner-js/src/snapshotSerializers/queryPlanSerializer.ts
+++ b/query-planner-js/src/snapshotSerializers/queryPlanSerializer.ts
@@ -96,11 +96,15 @@ function printNode(
       break;
     case 'Condition':
       if (node.ifClause) {
+        const indentationInner = indentationNext + config.indent;
         if (node.elseClause) {
           result +=
             `Condition(if: \$${node.condition}) {` + config.spacingOuter +
-            indentationNext + printNode(node.ifClause, config, indentationNext, depth, refs, printer) + ',' + config.spacingOuter +
-            indentationNext + printNode(node.elseClause, config, indentationNext, depth, refs, printer) + config.spacingOuter +
+            indentationNext + `Then {` + config.spacingOuter +
+            indentationInner + printNode(node.ifClause, config, indentationInner, depth, refs, printer) + config.spacingOuter +
+            indentationNext + `} Else {` + config.spacingOuter +
+            indentationInner + printNode(node.elseClause, config, indentationInner, depth, refs, printer) + config.spacingOuter +
+            indentationNext + `}` + config.spacingOuter +
             indentation + '}'
         } else {
           result +=


### PR DESCRIPTION
The patch from #1911 has a small bug in that it tries to avoid adding useless type conditions (inline fragments) when it expands named fragments, but it forgets to check if there is directives first and so "nuke" any such directives if there is one. Effectively, this means that if there is a `@defer` applied to a fragment spread, it gets lost and ignore.

Unfortunately, the @defer unit tests were all using inline fragments, so added a test to fix that coverage and the one-liner fix for the actual issue.

Took the opportunity to include a few minor tweaks related `@defer` following @glasser comments on #1958 (mostly adding a missing unit test and making sure we match recent spec updates, but no functional changes otherwise).