### PR TITLE
Fix potential rogue expansion of fragments when deoptimizing

### DIFF
--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/query-planner-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+
+- Fix issue with fragment reusing code something mistakenly re-expanding fragments [PR #2098](https://github.com/apollographql/federation/pull/2098).
+
 ## 2.1.0-alpha.4
 
 - Update peer dependency `graphql` to `^16.5.0` to use `GraphQLErrorOptions` [PR #2060](https://github.com/apollographql/federation/pull/2060)


### PR DESCRIPTION
The code from #1911 ensures that named fragments from the user query are
reused in subgraph query "when appropriate", but there were some code
path where a fragment that was reused (correctly) could end up be
"re-expanded" (due to an existing method not handling spreads properly).

The resulting subgraph query ended up with the fragment definition
existing but never being used, which is invalid in graphQL.

This patch ensures that a reused fragment is not mistakenly re-expanded
by the code (and thus avoids a query with unused fragments).

Fixes #2092