### PR TITLE
Fix issue where @defer condition gets ignored

### DIFF
--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -831,10 +831,11 @@ class DeferNormalizer {
         const deferArgs = selection.element().deferDirectiveArgs();
         if (deferArgs) {
           hasDefers = true;
+          if (!deferArgs.label || deferArgs.if !== undefined) {
+            hasNonLabelledOrConditionalDefers = true;
+          }
           if (deferArgs.label) {
             this.usedLabels.add(deferArgs.label);
-          } else {
-            hasNonLabelledOrConditionalDefers = true;
           }
         }
       }

--- a/query-planner-js/src/__tests__/buildPlan.defer.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.defer.test.ts
@@ -2417,7 +2417,13 @@ test('@defer everything within entity', () => {
 });
 
 describe('defer with conditions', () => {
-  test('simple @defer with condition', () => {
+  test.each([{
+    name: 'without explicit label',
+    label: undefined,
+  }, {
+    name: 'with explicit label',
+    label: 'testLabel',
+  }])('simple @defer with condition $name', ({label}) => {
     const subgraph1 = {
       name: 'Subgraph1',
       typeDefs: gql`
@@ -2447,14 +2453,14 @@ describe('defer with conditions', () => {
       query($cond: Boolean) {
         t {
           x
-          ... @defer(if: $cond) {
+          ... @defer(${label ? `label: "${label}", ` : ''}if: $cond) {
             y
           }
         }
       }
     `);
 
-    const plan = queryPlanner.buildQueryPlan(operation);
+    let plan = queryPlanner.buildQueryPlan(operation);
     expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Condition(if: $cond) {
@@ -2476,7 +2482,7 @@ describe('defer with conditions', () => {
                   }
                 }
               }, [
-                Deferred(depends: [0], path: "t") {
+                Deferred(depends: [0], path: "t"${label ? `, label: "${label}"` : ''}) {
                   {
                     y
                   }:


### PR DESCRIPTION
Fixes a blunder that got overlooked: the `DeferNormalizer.init` method
had meant to be updated when condition were added to record if we had
any defer with either "no explicit label" or "some condition", and the name
of the variable keeping that information was updated, but somehow forgot
to actually set the variable for "some condition".

This wasn't caught by the existing tests because none of the condition
unit tests was using an explicit label, so the variable mentioned above
ended up being set for the "wrong" reason.

Anyway, this commit fixes the issue and adds test coverage.

Fixes #2100

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
