### PR TITLE
Fix method removing empty branches from selection sets

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix some defer query plans having invalid result sets (with empty branches) [PR #2125](https://github.com/apollographql/federation/pull/2125). 
 - Fix defer information lost when cloning fetch group (resulting in non-deferred parts) [PR #2129](https://github.com/apollographql/federation/pull/2129).
 - Fix directives on fragment spread being lost [PR #2126](https://github.com/apollographql/federation/pull/2126).
 

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -781,7 +781,7 @@ export class ApolloGateway implements GatewayInterface {
                   const operation = operationFromDocument(
                     this.apiSchema!,
                     document,
-                    request.operationName,
+                    { operationName: request.operationName },
                   );
                   // TODO(#631): Can we be sure the query planner has been initialized here?
                   return this.queryPlanner!.buildQueryPlan(operation);

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -4,9 +4,9 @@ import {
   SchemaRootKind,
 } from '../../dist/definitions';
 import { buildSchema } from '../../dist/buildSchema';
-import { Field, FieldSelection, parseOperation, SelectionSet } from '../../dist/operations';
+import { Field, FieldSelection, Operation, operationFromDocument, parseOperation, SelectionSet } from '../../dist/operations';
 import './matchers';
-import { GraphQLError } from 'graphql';
+import { DocumentNode, FieldNode, GraphQLError, Kind, OperationDefinitionNode, OperationTypeNode, SelectionNode, SelectionSetNode } from 'graphql';
 
 function parseSchema(schema: string): Schema {
   try {
@@ -14,6 +14,21 @@ function parseSchema(schema: string): Schema {
   } catch (e) {
     throw new Error('Error parsing the schema:\n' + e.toString());
   }
+}
+
+function astField(name: string, selectionSet?: SelectionSetNode): FieldNode {
+  return {
+    kind: Kind.FIELD,
+    name: { kind: Kind.NAME, value: name },
+    selectionSet,
+  };
+}
+
+function astSSet(...selections: SelectionNode[]): SelectionSetNode {
+  return {
+    kind: Kind.SELECTION_SET,
+    selections,
+  };
 }
 
 describe('fragments optimization', () => {
@@ -375,5 +390,111 @@ describe('validations', () => {
         }
       `)
     }).toThrowError(new GraphQLError(`The @defer and @stream directives cannot be used on ${rootKind} root type "${defaultRootName(rootKind as SchemaRootKind)}"`));
+  });
+});
+
+describe('empty branches removal', () => {
+  const schema = parseSchema(`
+    type Query {
+      t: T
+      u: Int
+    }
+
+    type T {
+      a: Int
+      b: Int
+      c: C
+    }
+
+    type C {
+      x: String
+      y: String
+    }
+  `);
+
+  const withoutEmptyBranches = (op: string | SelectionSetNode) => {
+    let operation: Operation;
+    if (typeof op === 'string') {
+      operation = parseOperation(schema, op);
+    } else {
+      // Note that testing the removal of empty branches requires to take inputs that are not valid operations in the first place,
+      // so we can't build those from `parseOperation` (this call the graphQL-js `parse` under the hood, and there is no way to
+      // disable validation for that method). So instead, we manually build the AST (using some helper methods defined above) and
+      // build the operation from there, disabling validation.
+      const opDef: OperationDefinitionNode = {
+        kind: Kind.OPERATION_DEFINITION,
+        operation: OperationTypeNode.QUERY,
+        selectionSet: op,
+      }
+      const document: DocumentNode = {
+        kind: Kind.DOCUMENT,
+        definitions: [opDef],
+      }
+      operation = operationFromDocument(schema, document, { validate: false });
+    }
+    return operation.selectionSet.withoutEmptyBranches()?.toString()
+  };
+
+
+  it.each([
+    '{ t { a } }',
+    '{ t { a b } }',
+    '{ t { a c { x y } } }',
+  ])('is identity if there is no empty branch', (op) => {
+    expect(withoutEmptyBranches(op)).toBe(op);
+  });
+
+  it('removes simple empty branches', () => {
+    expect(withoutEmptyBranches(
+      astSSet(
+        astField('t', astSSet(
+          astField('a'),
+          astField('c', astSSet()),
+        ))
+      )
+    )).toBe('{ t { a } }');
+
+    expect(withoutEmptyBranches(
+      astSSet(
+        astField('t', astSSet(
+          astField('c', astSSet()),
+          astField('a'),
+        ))
+      )
+    )).toBe('{ t { a } }');
+
+    expect(withoutEmptyBranches(
+      astSSet(
+        astField('t', astSSet())
+      )
+    )).toBeUndefined();
+  });
+
+  it('removes cascading empty branches', () => {
+    expect(withoutEmptyBranches(
+      astSSet(
+        astField('t', astSSet(
+          astField('c', astSSet()),
+        ))
+      )
+    )).toBeUndefined();
+
+    expect(withoutEmptyBranches(
+      astSSet(
+        astField('u'),
+        astField('t', astSSet(
+          astField('c', astSSet()),
+        ))
+      )
+    )).toBe('{ u }');
+
+    expect(withoutEmptyBranches(
+      astSSet(
+        astField('t', astSSet(
+          astField('c', astSSet()),
+        )),
+        astField('u'),
+      )
+    )).toBe('{ u }');
   });
 });

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix some defer query plans having invalid result sets (with empty branches) [PR #2125](https://github.com/apollographql/federation/pull/2125). 
 - Fix defer information lost when cloning fetch group (resulting in non-deferred parts) [PR #2129](https://github.com/apollographql/federation/pull/2129).
 - Fix directives on fragment spread being lost [PR #2126](https://github.com/apollographql/federation/pull/2126).
 

--- a/query-planner-js/src/__tests__/buildPlan.defer.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.defer.test.ts
@@ -2981,7 +2981,7 @@ describe('defer with conditions', () => {
 });
 
 test('defer when some interface has different definitions in different subgraphs', () => {
-  // This test exists to ensure an early bug is fixed: that but was in the code building
+  // This test exists to ensure an early bug is fixed: that bug was in the code building
   // the `subselection` of `DeferNode` in the plan, and was such that those subselections
   // were created with links to subgraph types instead the supergraph ones. As a result,
   // we were sometimes trying to add a field (`b` in the example here) to version of a


### PR DESCRIPTION
As the code for `@defer` build the selection set used for "primary parts",
it may start adding "branches" (selections) that end up being empty
because everything within that branch is actually deferred (and thus
not part of this primary part). So once we've finished building
everything, we call a `withoutEmptyBranches` method on the selection set
that can have such (invalid for graphQL) empty branches to remove
them.

Unfortunately, the logic for that method was broken: it was removing
empty branches in simple cases, but the recursion was done the wrong
way so that if removing an empty "leaf" left its parent empty, this
wasn't removed properly. In other words, given
  `{ a b { c {} } }`
the method was returning:
  `{ a b { } }`
instead of the proper:
  `{ a }`

This commit fixes the logic of that method to behave correctly.

Fixes #2123