### PR TITLE
feat(gateway-js): export GraphQLDataSourceRequestKind 

### DIFF
--- a/gateway-js/src/datasources/index.ts
+++ b/gateway-js/src/datasources/index.ts
@@ -1,3 +1,3 @@
 export { LocalGraphQLDataSource } from './LocalGraphQLDataSource';
 export { RemoteGraphQLDataSource } from './RemoteGraphQLDataSource';
-export { GraphQLDataSource, GraphQLDataSourceProcessOptions } from './types';
+export { GraphQLDataSource, GraphQLDataSourceProcessOptions, GraphQLDataSourceRequestKind } from './types';


### PR DESCRIPTION
# Why

On this [@deprecation note](https://github.com/apollographql/federation/blob/main/gateway-js/src/datasources/types.ts#L33-L41) it suggests to use `incomingRequestContext` after filtering with the `kind`. However the `GraphQLDataSourceRequestKind` is not being exported on the `index.ts`.

# How
Export the type in the index.ts. This is subsequently exported by the main [index.ts](https://github.com/apollographql/federation/blob/main/gateway-js/src/index.ts#L1031)

