### PR TITLE
Fix potential inefficient planning due to __typename

### DIFF
--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -62,6 +62,8 @@ function haveSameDirectives<TElement extends OperationElement>(op1: TElement, op
 }
 
 abstract class AbstractOperationElement<T extends AbstractOperationElement<T>> extends DirectiveTargetElement<T> {
+  private attachements?: Map<string, string>;
+
   constructor(
     schema: Schema,
     private readonly variablesInElement: Variables
@@ -74,6 +76,25 @@ abstract class AbstractOperationElement<T extends AbstractOperationElement<T>> e
   }
 
   abstract updateForAddingTo(selection: SelectionSet): T;
+
+  addAttachement(key: string, value: string) {
+    if (!this.attachements) {
+      this.attachements = new Map();
+    }
+    this.attachements.set(key, value);
+  }
+
+  getAttachement(key: string): string | undefined {
+    return this.attachements?.get(key);
+  }
+
+  protected copyAttachementsTo(elt: AbstractOperationElement<any>) {
+    if (this.attachements) {
+      for (const [k, v] of this.attachements.entries()) {
+        elt.addAttachement(k, v);
+      }
+    }
+  }
 }
 
 export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> extends AbstractOperationElement<Field<TArgs>> {
@@ -86,7 +107,6 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     readonly alias?: string
   ) {
     super(definition.schema(), variablesInArguments(args));
-    this.validate();
   }
 
   get name(): string {
@@ -106,6 +126,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     for (const directive of this.appliedDirectives) {
       newField.applyDirective(directive.definition!, directive.arguments());
     }
+    this.copyAttachementsTo(newField);
     return newField;
   }
 
@@ -152,7 +173,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     return true;
   }
 
-  private validate() {
+  validate() {
     validate(this.name === this.definition.name, () => `Field name "${this.name}" cannot select field "${this.definition.coordinate}: name mismatch"`);
 
     // We need to make sure the field has valid values for every non-optional argument.
@@ -276,6 +297,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     for (const directive of this.appliedDirectives) {
       newFragment.applyDirective(directive.definition!, directive.arguments());
     }
+    this.copyAttachementsTo(newFragment);
     return newFragment;
   }
 
@@ -326,6 +348,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     }
 
     const updated = new FragmentElement(this.sourceType, this.typeCondition);
+    this.copyAttachementsTo(updated);
     updatedDirectives.forEach((d) => updated.applyDirective(d.definition!, d.arguments()));
     return updated;
   }
@@ -386,6 +409,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     }
 
     const updated = new FragmentElement(this.sourceType, this.typeCondition);
+    this.copyAttachementsTo(updated);
     const deferDirective = this.schema().deferDirective();
     // Re-apply all the non-defer directives
     this.appliedDirectives.filter((d) => d.name !== deferDirective.name).forEach((d) => updated.applyDirective(d.definition!, d.arguments()));
@@ -1238,8 +1262,10 @@ export class SelectionSet extends Freezable<SelectionSet> {
     // If __typename is selected however, we put it first. It's a detail but as __typename is a bit special it looks better,
     // and it happens to mimic prior behavior on the query plan side so it saves us from changing tests for no good reasons.
     const typenameSelection = this._selections.get(typenameFieldName);
+    const isNonAliasedTypenameSelection =
+      (s: Selection) => s.kind === 'FieldSelection' && !s.field.alias && s.field.name === typenameFieldName;
     if (typenameSelection) {
-      return typenameSelection.concat(this.selections().filter(s => s.kind != 'FieldSelection' || s.field.name !== typenameFieldName));
+      return typenameSelection.concat(this.selections().filter(s => !isNonAliasedTypenameSelection(s)));
     } else {
       return this.selections();
     }
@@ -1261,7 +1287,11 @@ export class SelectionSet extends Freezable<SelectionSet> {
   clone(): SelectionSet {
     const cloned = new SelectionSet(this.parentType);
     for (const selection of this.selections()) {
-      cloned.add(selection.clone());
+      const clonedSelection = selection.clone();
+      // Note: while we could used cloned.add() directly, this does some checks (in `updatedForAddingTo` in particular)
+      // which we can skip when we clone (since we know the inputs have already gone through that).
+      cloned._selections.add(clonedSelection.key(), clonedSelection);
+      ++cloned._selectionCount;
     }
     return cloned;
   }
@@ -1470,6 +1500,7 @@ export class FieldSelection extends Freezable<FieldSelection> {
   }
 
   validate() {
+    this.field.validate();
     // Note that validation is kind of redundant since `this.selectionSet.validate()` will check that it isn't empty. But doing it
     // allow to provide much better error messages.
     validate(
@@ -1518,6 +1549,10 @@ export class FieldSelection extends Freezable<FieldSelection> {
       directives: this.element().appliedDirectivesToDirectiveNodes(),
       selectionSet: this.selectionSet?.toSelectionSetNode()
     };
+  }
+
+  withUpdatedSubSelection(newSubSelection: SelectionSet | undefined): FieldSelection {
+    return new FieldSelection(this.field, newSubSelection);
   }
 
   equals(that: Selection): boolean {
@@ -1601,6 +1636,8 @@ export abstract class FragmentSelection extends Freezable<FragmentSelection> {
   abstract withNormalizedDefer(normalizer: DeferNormalizer): FragmentSelection | SelectionSet;
 
   abstract updateForAddingTo(selectionSet: SelectionSet): FragmentSelection;
+
+  abstract withUpdatedSubSelection(newSubSelection: SelectionSet | undefined): FragmentSelection;
 
   protected us(): FragmentSelection {
     return this;
@@ -1805,6 +1842,10 @@ class InlineFragmentSelection extends FragmentSelection {
       : new InlineFragmentSelection(newFragment, updatedSubSelections);
   }
 
+  withUpdatedSubSelection(newSubSelection: SelectionSet | undefined): InlineFragmentSelection {
+    return new InlineFragmentSelection(this.fragmentElement, newSubSelection);
+  }
+
   toString(expandFragments: boolean = true, indent?: string): string {
     return (indent ?? '') + this.fragmentElement + ' ' + this.selectionSet.toString(expandFragments, true, indent);
   }
@@ -1915,6 +1956,10 @@ class FragmentSpreadSelection extends FragmentSelection {
 
   private spreadDirectives(): Directive<FragmentElement>[] {
     return this._element.appliedDirectives.slice(this.namedFragment.appliedDirectives.length);
+  }
+
+  withUpdatedSubSelection(_: SelectionSet | undefined): InlineFragmentSelection {
+    assert(false, `Unssupported`);
   }
 
   toString(expandFragments: boolean = true, indent?: string): string {

--- a/query-planner-js/src/__tests__/buildPlan.defer.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.defer.test.ts
@@ -3359,8 +3359,8 @@ describe('named fragments', () => {
             Deferred(depends: [0], path: "t") {
               {
                 ... on T {
-                  y
                   __typename
+                  y
                 }
               }:
               Flatten(path: "t") {

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -49,6 +49,7 @@ import {
   setValues,
   MultiMap,
   NamedFragmentDefinition,
+  typenameFieldName,
 } from "@apollo/federation-internals";
 import {
   advanceSimultaneousPathsWithOperation,
@@ -88,6 +89,10 @@ import { QueryPlannerConfig } from "./config";
 import { QueryPlan, ResponsePath, SequenceNode, PlanNode, ParallelNode, FetchNode, trimSelectionNodes } from "./QueryPlan";
 
 const debug = newDebugLogger('plan');
+
+// Somewhat random string used to optimise handling __typename in some cases. See usage for details. The concrete value
+// has no particular significance.
+const SIBLING_TYPENAME_KEY = 'sibling_typename';
 
 // If a query can be resolved by more than this number of plans, we'll try to reduce the possible options we'll look
 // at to get it below this number to void query planning running forever.
@@ -983,21 +988,21 @@ class FetchGroup {
 
     const inputNodes = inputs ? inputs.toSelectionSetNode() : undefined;
 
-    const operation = this.isEntityFetch
+    let operation = this.isEntityFetch
       ? operationForEntitiesFetch(
           this.dependencyGraph.subgraphSchemas.get(this.subgraphName)!,
           this.selection,
           variableDefinitions,
-          fragments,
           operationName,
         )
       : operationForQueryFetch(
           this.rootKind,
           this.selection,
           variableDefinitions,
-          fragments,
           operationName,
         );
+
+    operation = operation.optimize(fragments);
 
     const operationDocument = operationToDocument(operation);
     const fetchNode: FetchNode = {
@@ -1882,6 +1887,126 @@ interface FetchGroupProcessor<TProcessed, TDeferred> {
   reduceRoots(roots: TProcessed[], isParallel: boolean): TProcessed,
 }
 
+
+/**
+ * Modify the provided selection set to optimize the handling of __typename selection for query planning.
+ *
+ * Explicit querying of __typename can create some inefficiency for the query planning process if not
+ * handled specially. More precisely, query planning performance is directly proportional to how many possible
+ * plans a query has, since it compute all those options to compare them. Further, the number of possible
+ * plans double for every field for which there is a choice, so miminizing the number of field for which we
+ * have choices is paramount.
+ *
+ * And for a given type, __typename can always be provided by any subgraph having that type (it works as a
+ * kind of "always @shareable" field), so it often creates theoretical choices. In practice it doesn't
+ * matter which subgraph we use for __typename: we're happy to use whichever subgraph we're using for
+ * the "other" fields queried for the type. But the default query planning algorithm does not know how
+ * to do that.
+ *
+ * Let's note that this isn't an issue in most cases, because the query planning algorithm knows not to
+ * consider "obviously" inefficient paths. Typically, querying the __typename of an entity is generally
+ * ok because when looking at a path, the query planning algorithm always favor getting a field "locally"
+ * if it can (which it always can for __typename) and ignore alternative that would jump subgraphs.
+ *
+ * But this can still be a performance issue when a __typename is queried after a @shareable field: in
+ * that case, the algorithm would consider getting the __typename from each version of the @shareable
+ * field and this would add to the options to consider. But as, again, __typename can always be fetched
+ * from any subgraph, it's more efficient to ignore those options and simply get __typename from whichever
+ * subgraph we get any other of the other field requested (on the type on which we request __typename).
+ *
+ * It is unclear how to do this cleanly with the current planning algorithm however, so this method
+ * implements an alternative: to avoid the query planning spending time of exploring options for
+ * __typename, we "remove" the __typename selections from the operation. But of course, we still
+ * need to ensure that __typename is effectively queried, so as we do that removal, we also "tag"
+ * one of the "sibling" selection (using `addAttachement`) to remember that __typename needs to
+ * be added back eventually. The core query planning algorithm will ignore that tag, and because
+ * __typename has been otherwise removed, we'll save any related work. But as we build the final
+ * query plan, we'll check back for those "tags" (see `getAttachement` in `computeGroupsForTree`),
+ * and when we fine one, we'll add back the request to __typename. As this only happen after the 
+ * query planning algorithm has computed all choices, we achieve our goal of not considering useless 
+ * choices due to __typename. Do note that if __typename is the "only" selection of some selection
+ * set, then we leave it untouched, and let the query planning algorithm treat it as any other
+ * field. We have no other choice in that case, and that's actually what we want.
+ */
+function optimizeSiblingTypenames(selectionSet: SelectionSet): SelectionSet {
+  const selections = selectionSet.selections();
+  let updatedSelections: Selection[] | undefined = undefined;
+  let typenameSelection: Selection | undefined = undefined;
+  // We remember the first non-__typename field selection found. This is the one we'll "tag" if we do find a __typename
+  // occurrence that we want to remove. We only use for _field_ selections because at the stage where this is applied,
+  // we cannot be sure the selection set is "minimized" and so some of the inline fragments may end up being eliminated
+  // (for instance, the fragment condition could be "less precise" than the parent type, in which case query planning
+  // will ignore it) and tagging those could lose the tagging.
+  let firstFieldSelection: FieldSelection | undefined = undefined;
+  for (let i = 0; i < selections.length; i++) {
+    const selection = selections[i];
+    let updated: Selection | undefined;
+    if (!typenameSelection && selection.kind === 'FieldSelection' && selection.field.name === typenameFieldName) {
+      // The reason we check for `!typenameSelection` is that due to aliasing, there can be more than one __typename selection
+      // in theory, and so this will only kick in on the first one. This is fine in practice: it only means that if there _is_ 
+      // 2 selection of __typename, then we won't optimise things as much as we could, but there is no practical reason
+      // whatsoever to have 2 selection of __typename in the first place, so not being optimal is moot.
+      updated = undefined;
+      typenameSelection = selection;
+    } else {
+      const updatedSubSelection = selection.selectionSet ? optimizeSiblingTypenames(selection.selectionSet) : undefined;
+      if (updatedSubSelection === selection.selectionSet) {
+        updated = selection;
+      } else {
+        updated = selection.withUpdatedSubSelection(updatedSubSelection);
+      }
+      if (!firstFieldSelection && updated.kind === 'FieldSelection') {
+        firstFieldSelection = updated;
+      }
+    }
+
+    // As soon as we find a selection that is discarded or modified, we need to create new selection set so we
+    // first copy everything up to this selection.
+    if (updated !== selection && !updatedSelections) {
+      updatedSelections = [];
+      for (let j = 0; j < i; j++) {
+        updatedSelections.push(selections[j]);
+      }
+    }
+    // Record the (potentially updated) selection if we're creating a new selection set, and said selection is not discarded.
+    if (updatedSelections && !!updated) {
+      updatedSelections.push(updated);
+    }
+  }
+
+  if (!updatedSelections || (typenameSelection && !firstFieldSelection)) {
+    // This means that either no selection was modified at all, or there is no other field selection than __typename one.
+    // In both case, we want to return the current selectionSet unmodified.
+    return selectionSet;
+  }
+
+  // If we have some __typename selection that was removed but need to be "remembered" for later, "tag" whichever first
+  // field selection is still part of the operation (what we tag doesn't matter since again, __typename can be queried from
+  // anywhere and that has no performance impact).
+  if (typenameSelection) {
+    assert(firstFieldSelection, 'Should not have got here');
+    // Note that as we tag the element, we also record the alias used if any since that needs to be preserved.
+    firstFieldSelection.element().addAttachement(SIBLING_TYPENAME_KEY, typenameSelection.field.alias ? typenameSelection.field.alias : '');
+  }
+  return new SelectionSet(selectionSet.parentType, selectionSet.fragments).addAll(updatedSelections)
+}
+
+/**
+ * Applies `optimizeSiblingTypenames` to the provided operation selection set.
+ */
+function withSiblingTypenameOptimizedAway(operation: Operation): Operation {
+  const updatedSelectionSet = optimizeSiblingTypenames(operation.selectionSet);
+  if (updatedSelectionSet === operation.selectionSet) {
+    return operation;
+  }
+  return new Operation(
+    operation.rootKind,
+    updatedSelectionSet,
+    operation.variableDefinitions,
+    operation.name
+  );
+}
+
 export function computeQueryPlan({
   config,
   supergraphSchema,
@@ -1915,6 +2040,7 @@ export function computeQueryPlan({
   // later if possible (which is why we saved them above before expansion).
   operation = operation.expandAllFragments();
   operation = withoutIntrospection(operation);
+  operation = withSiblingTypenameOptimizedAway(operation);
 
   let assignedDeferLabels: Set<string> | undefined = undefined;
   let hasDefers: boolean = false;
@@ -2806,6 +2932,21 @@ function computeGroupsForTree(
         } else {
           assert(edge.head.source === edge.tail.source, () => `Collecting edge ${edge} for ${operation} should not change the underlying subgraph`)
 
+          // We have a operation element, field or inline fragment. We first check if it's been "tagged" to remember that __typename
+          // must be queried. See the comment on the `optimizeSiblingTypenames()` method to see why this exists.
+          const typenameAttachment = operation.getAttachement(SIBLING_TYPENAME_KEY);
+          if (typenameAttachment !== undefined) {
+            // We need to add the query __typename for the current type in the current group.
+            // Note that the value of the "attachement" is the alias or '' if there is no alias
+            const alias = typenameAttachment === '' ? undefined : typenameAttachment;
+            const typenameField = new Field(operation.parentType.typenameField()!, {}, new VariableDefinitions(), alias);
+            group.addSelection(path.concat(typenameField));
+            dependencyGraph.deferTracking.updateSubselection({
+              ...deferContext,
+              pathToDeferParent: deferContext.pathToDeferParent.concat(typenameField),
+            });
+          }
+
           const { updatedOperation, updatedDeferContext } = extractDeferFromOperation({
             dependencyGraph,
             operation,
@@ -3219,7 +3360,6 @@ function operationForEntitiesFetch(
   subgraphSchema: Schema,
   selectionSet: SelectionSet,
   allVariableDefinitions: VariableDefinitions,
-  fragments?: NamedFragments,
   operationName?: string
 ): Operation {
   const variableDefinitions = new VariableDefinitions();
@@ -3249,17 +3389,14 @@ function operationForEntitiesFetch(
     ),
   );
 
-  return new Operation('query', entitiesCall, variableDefinitions, operationName).optimize(
-    fragments,
-  );
+  return new Operation('query', entitiesCall, variableDefinitions, operationName);
 }
 
 function operationForQueryFetch(
   rootKind: SchemaRootKind,
   selectionSet: SelectionSet,
   allVariableDefinitions: VariableDefinitions,
-  fragments?: NamedFragments,
   operationName?: string
 ): Operation {
-  return new Operation(rootKind, selectionSet, allVariableDefinitions.filter(selectionSet.usedVariables()), operationName).optimize(fragments);
+  return new Operation(rootKind, selectionSet, allVariableDefinitions.filter(selectionSet.usedVariables()), operationName);
 }


### PR DESCRIPTION
This PR fixes a query planning performance issue discovered with some user data. Namely, planning for some particular queries was taking a very noticeable amount of time (~30 sec on my somewhat fancy laptop for reference).

Upon inspection, it was due to some large amount of plans being built and compared, but the only reason there were many plans considered was due to the consideration of multiple options for the `__typename` field in a number of places. Obviously, since `__typename` can be requested equally from any subgraph (as long as it knows the type), evaluating all those options was particularly wasteful.

The attaching commit avoids that problem by essentially making the query planning "ignore" `__typename` as it computes all the possible choices/plans to consider, and then add it back where it should at the very end when finalising the plan.

On the particular example mentioned above, this reduces the number of plans to consider/evaluate by the query planner to just one, and so query planner is reduced to some ~300ms (again, on my laptop, and it's a fairly large query/plan).

Testing this, I randomly run into a (very) minor bug with aliasing `__typename`, in that if one was to query `__typename` twice _in the same selection_ by using an alias, the aliased version was discarded. This PR also opportunistically fixes this. Tbc, I can't think of a reason why anyone would request such a thing but it's valid graphQL and was definitively not handled properly so...