### PR TITLE
Never merge fragments that have `@defer`

### DIFF
--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -3197,20 +3197,40 @@ export class Directive<
   }
 }
 
-export function sameDirectiveApplication(application1: Directive<any, any>, application2: Directive<any, any>): boolean {
-  return application1.name === application2.name && argumentsEquals(application1.arguments(), application2.arguments());
+/**
+ * Checks if 2 directive applications should be considered equal.
+ *
+ * By default, 2 directive applications are considered equal if they are for the same directive and are passed the same values to
+ * the same arguments. However, some special directive can be excluded so that no 2 applications are ever consider equal. By default,
+ * this is the case of @defer, as never want to merge @defer applications so that each create its own "deferred block".
+ */
+export function sameDirectiveApplication(
+  application1: Directive<any, any>,
+  application2: Directive<any, any>,
+  directivesNeverEqualToThemselves: string[] = [ 'defer' ],
+): boolean {
+  // Note: we check name equality first because this method is most often called with directive that are simply not the same
+  // name and this ensure we exit cheaply more often than not.
+  return application1.name === application2.name 
+    && !directivesNeverEqualToThemselves.includes(application1.name)
+    && !directivesNeverEqualToThemselves.includes(application2.name)
+    && argumentsEquals(application1.arguments(), application2.arguments());
 }
 
 /**
  * Checks whether the 2 provided "set" of directive applications are the same (same applications, regardless or order).
  */
-export function sameDirectiveApplications(applications1: readonly Directive<any, any>[], applications2: readonly Directive<any, any>[]): boolean {
+export function sameDirectiveApplications(
+  applications1: readonly Directive<any, any>[],
+  applications2: readonly Directive<any, any>[],
+  directivesNeverEqualToThemselves: string[] = [ 'defer' ],
+): boolean {
   if (applications1.length !== applications2.length) {
     return false;
   }
 
   for (const directive1 of applications1) {
-    if (!applications2.some(directive2 => sameDirectiveApplication(directive1, directive2))) {
+    if (!applications2.some(directive2 => sameDirectiveApplication(directive1, directive2, directivesNeverEqualToThemselves))) {
       return false;
     }
   }


### PR DESCRIPTION
For efficiency sake, the code merges inline fragments that are "the same" in queries. So something like:
```graphql
{
  t {
    ... on X {
      a
    }
    ... on X {
      a
      b
    }
  }
}
```
is simplified into:
```graphql
{
  t {
    ... on X {
      a
      b
    }
  }
}
```
Which is actually somewhat important because 1) while such query (the first one) is rarely written directly, it can easily happen when you start expanding named fragments, and 2) not doing this could create serious inefficiencies in more complex examples as it could create unecessary fetches.

Anyway, when directives gets involved on fragments, the code still merge fragments but only if the directive applications are the same, which means same name and arguments. So:
```graphql
query foo($if: Boolean) {
  t {
    ... on X @include(if: $if) {
      a
    }
    ... on X @include(if: $if) {
      a
      b
    }
  }
}
```
is simplified into:
```graphql
query foo($if: Boolean) {
  t {
    ... on X @include(if: $if) {
      a
      b
    }
  }
}
```
but:
```graphql
query foo($if1: Boolean, $if2: Boolean) {
  t {
    ... on X @include(if: $if1) {
      a
    }
    ... on X @include(if: $if2) {
      a
      b
    }
  }
}
```
is left as-is.

But those rules meant that:
```graphql
{
  t {
    ... on X @defer {
      a
    }
    ... on X @defer {
      a
      b
    }
  }
}
```
_was_ simplified by merging the 2 branches.

Except that this is kind of wrong for `@defer` as each individual is expected to be it's own deferred chunk.

This patch special cases `@defer` so we don't such merging for it.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
