### PR TITLE
Allows `@shareable` to be repeatable (to allow it on both definition and extensions)

### DIFF
--- a/composition-js/src/__tests__/compose.composeDirective.test.ts
+++ b/composition-js/src/__tests__/compose.composeDirective.test.ts
@@ -1,4 +1,4 @@
-import { assert, FEDERATION2_LINK_WTH_FULL_IMPORTS, printSchema, Schema } from '@apollo/federation-internals';
+import { assert, FEDERATION2_LINK_WITH_FULL_IMPORTS, printSchema, Schema } from '@apollo/federation-internals';
 import { DirectiveLocation } from 'graphql';
 import gql from 'graphql-tag';
 import { composeServices, CompositionResult } from '../compose';
@@ -9,7 +9,7 @@ const generateSubgraph = ({
   linkText = '',
   composeText = '',
   directiveText = '',
-  federationText = FEDERATION2_LINK_WTH_FULL_IMPORTS,
+  federationText = FEDERATION2_LINK_WITH_FULL_IMPORTS,
   usage = '',
 }: {
   name: string,

--- a/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
+++ b/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
@@ -1,4 +1,4 @@
-import { buildSchema, extractSubgraphsFromSupergraph, FEDERATION2_LINK_WTH_FULL_IMPORTS, ObjectType, printSchema, Schema, SubgraphASTNode, Subgraphs } from '@apollo/federation-internals';
+import { buildSchema, extractSubgraphsFromSupergraph, FEDERATION2_LINK_WITH_FULL_IMPORTS, ObjectType, printSchema, Schema, SubgraphASTNode, Subgraphs } from '@apollo/federation-internals';
 import { CompositionResult, composeServices, CompositionSuccess } from '../compose';
 import gql from 'graphql-tag';
 import './matchers';
@@ -66,7 +66,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
       {
         query: Query
       }
@@ -88,7 +88,7 @@ describe('basic type extensions', () => {
     // an extension.
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
       {
         query: Query
       }
@@ -148,7 +148,7 @@ describe('basic type extensions', () => {
     // Same remark than in prevoius test
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
       {
         query: Query
       }
@@ -163,7 +163,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
       {
         query: Query
       }
@@ -235,7 +235,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
       {
         query: Query
       }
@@ -250,7 +250,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
       {
         query: Query
       }
@@ -267,7 +267,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphC')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
       {
         query: Query
       }

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -49,6 +49,7 @@ The following errors might be raised during composition:
 | `INVALID_GRAPHQL` | A schema is invalid GraphQL: it violates one of the rule of the specification. | 2.0.0 |  |
 | `INVALID_LINK_DIRECTIVE_USAGE` | An application of the @link directive is invalid/does not respect the specification. | 2.0.0 |  |
 | `INVALID_LINK_IDENTIFIER` | A url/version for a @link feature is invalid/does not respect the specification. | 2.1.0 |  |
+| `INVALID_SHAREABLE_USAGE` | The `@shareable` federation directive is used in an invalid way. | 2.1.2 |  |
 | `INVALID_SUBGRAPH_NAME` | A subgraph name is invalid (subgraph names cannot be a single underscore ("_")). | 2.0.0 |  |
 | `KEY_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@key` directive includes some directive applications. This is not supported | 2.1.0 |  |
 | `KEY_FIELDS_HAS_ARGS` | The `fields` argument of a `@key` directive includes a field defined with arguments (which is not currently supported). | 2.0.0 |  |

--- a/docs/source/federated-types/sharing-types.mdx
+++ b/docs/source/federated-types/sharing-types.mdx
@@ -95,6 +95,36 @@ Both subgraphs A _and_ B can now resolve the `x` and `y` fields for the `Positio
 * If a type or field is marked `@shareable` in _any_ subgraph, it must be marked either `@shareable` or [`@external`](./federated-directives/#external) in _every_ subgraph that defines it. Otherwise, composition fails.
 * If multiple subgraphs can resolve a field, **make sure each subgraph's resolver for that field behaves identically.** Otherwise, queries might return inconsistent results depending on which subgraph resolves the field.
 
+#### 📝 A note regaring `@shareable` on types
+
+When `@shareable` is put on an object type declaration, it only applies to the fields within that exact declaration. This become relevant if a subgraph defines a type though an [object definition](https://spec.graphql.org/June2018/#ObjectTypeDefinition) and one or more [object extensions](https://spec.graphql.org/June2018/#sec-Object-Extensions). For instance, if a subgraph declares:
+```graphql title="Subgraph A"
+type Position @shareable {
+  x: Int!
+  y: Int!
+}
+
+extend type Position {
+  z: Int!
+}
+```
+then field `z` will _not_ be shareable. To make `z` shareable, you can either mark it with `@shareable` directly or mark the extension itself shareable:
+```graphql title="Subgraph A"
+# This example only works with v2.2+ of the federation specification. In earlier versions, `@shareable` was
+# not marked `repeatable` and so this example would be rejected by graphQL.
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.2", import: ["@shareable"])
+
+type Position @shareable {
+  x: Int!
+  y: Int!
+}
+
+extend type Position @shareable {
+  z: Int!
+}
+```
+
 ## Differing shared fields
 
 Shared fields can differ between subgraphs in specific ways:

--- a/docs/source/subgraph-spec.mdx
+++ b/docs/source/subgraph-spec.mdx
@@ -57,7 +57,7 @@ directive @requires(fields: FieldSet!) on FIELD_DEFINITION
 directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-directive @shareable on OBJECT | FIELD_DEFINITION
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/gateway-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## 2.2.0
+
+- Allows `@shareable` to be repeatable so it can be allowed on both a type definition and its extensions [PR #2175](https://github.com/apollographql/federation/pull/2175).
+  - Note that this require the use of the new 2.2 version of the federation spec introduced in this change.
+
 ## vNext
 
 - Ensures supergraph `@defer`/`@stream` definitions of supergraph are not included in the API schema [PR #2212](https://github.com/apollographql/federation/pull/2212).

--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -1,4 +1,4 @@
-import { FEDERATION2_LINK_WTH_FULL_IMPORTS } from '..';
+import { FEDERATION2_LINK_WITH_FULL_IMPORTS } from '..';
 import { ObjectType } from '../definitions';
 import { buildSubgraph, Subgraphs } from '../federation';
 import { UpgradeChangeID, UpgradeResult, upgradeSubgraphsIfNecessary } from '../schemaUpgrader';
@@ -92,7 +92,7 @@ test('upgrade complex schema', () => {
 
   expect(res.subgraphs?.get('s1')?.toString()).toMatchString(`
     schema
-      ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+      ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
     {
       query: Query
     }
@@ -148,7 +148,7 @@ test('update federation directive non-string arguments', () => {
 
   expect(res.subgraphs?.get('s')?.toString()).toMatchString(`
     schema
-      ${FEDERATION2_LINK_WTH_FULL_IMPORTS}
+      ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
     {
       query: Query
     }

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -405,6 +405,12 @@ const INVALID_FIELD_SHARING = makeCodeDefinition(
   'A field that is non-shareable in at least one subgraph is resolved by multiple subgraphs.'
 );
 
+const INVALID_SHAREABLE_USAGE = makeCodeDefinition(
+  'INVALID_SHAREABLE_USAGE',
+  'The `@shareable` federation directive is used in an invalid way.',
+  { addedIn: '2.1.2' },
+);
+
 const INVALID_LINK_DIRECTIVE_USAGE = makeCodeDefinition(
   'INVALID_LINK_DIRECTIVE_USAGE',
   'An application of the @link directive is invalid/does not respect the specification.'
@@ -581,6 +587,7 @@ export const ERRORS = {
   EXTERNAL_MISSING_ON_BASE,
   INTERFACE_FIELD_IMPLEM_TYPE_MISMATCH,
   INVALID_FIELD_SHARING,
+  INVALID_SHAREABLE_USAGE,
   INVALID_LINK_DIRECTIVE_USAGE,
   INVALID_LINK_IDENTIFIER,
   LINK_IMPORT_NAME_MISMATCH,

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -7,6 +7,7 @@ import {
   Directive,
   DirectiveDefinition,
   ErrGraphQLValidationFailed,
+  Extension,
   FieldDefinition,
   InputFieldDefinition,
   InterfaceType,
@@ -27,7 +28,7 @@ import {
   sourceASTs,
   UnionType,
 } from "./definitions";
-import { assert, joinStrings, MultiMap, printHumanReadableList, OrderedMap } from "./utils";
+import { assert, joinStrings, MultiMap, printHumanReadableList, OrderedMap, mapValues } from "./utils";
 import { SDLValidationRule } from "graphql/validation/ValidationContext";
 import { specifiedSDLRules } from "graphql/validation/specifiedRules";
 import {
@@ -46,7 +47,6 @@ import { KnownTypeNamesInFederationRule } from "./validation/KnownTypeNamesInFed
 import { buildSchema, buildSchemaFromAST } from "./buildSchema";
 import { parseSelectionSet, selectionOfElement, SelectionSet } from './operations';
 import { TAG_VERSIONS } from "./tagSpec";
-import { INACCESSIBLE_VERSIONS } from "./inaccessibleSpec";
 import {
   errorCodeDef,
   ErrorCodeDefinition,
@@ -69,18 +69,10 @@ import {
 import {
   FEDERATION_VERSIONS,
   federationIdentity,
-  fieldSetTypeSpec,
-  keyDirectiveSpec,
-  requiresDirectiveSpec,
-  providesDirectiveSpec,
-  externalDirectiveSpec,
-  extendsDirectiveSpec,
-  shareableDirectiveSpec,
-  overrideDirectiveSpec,
-  composeDirectiveSpec,
-  FEDERATION2_SPEC_DIRECTIVES,
-  ALL_FEDERATION_DIRECTIVES_DEFAULT_NAMES,
-  FEDERATION2_ONLY_SPEC_DIRECTIVES,
+  FederationDirectiveName,
+  FederationTypeName,
+  FEDERATION1_TYPES,
+  FEDERATION1_DIRECTIVES,
 } from "./federationSpec";
 import { defaultPrintOptions, PrintOptions as PrintOptions, printSchema } from "./print";
 import { createObjectTypeSpecification, createScalarTypeSpecification, createUnionTypeSpecification } from "./directiveAndTypeSpecification";
@@ -88,7 +80,6 @@ import { didYouMean, suggestionList } from "./suggestions";
 
 const linkSpec = LINK_VERSIONS.latest();
 const tagSpec = TAG_VERSIONS.latest();
-const inaccessibleSpec = INACCESSIBLE_VERSIONS.latest();
 const federationSpec = FEDERATION_VERSIONS.latest();
 
 // We don't let user use this as a subgraph name. That allows us to use it in `query graphs` to name the source of roots
@@ -115,6 +106,7 @@ const FEDERATION_SPECIFIC_VALIDATION_RULES = [
 
 const FEDERATION_VALIDATION_RULES = specifiedSDLRules.filter(rule => !FEDERATION_OMITTED_VALIDATION_RULES.includes(rule)).concat(FEDERATION_SPECIFIC_VALIDATION_RULES);
 
+const ALL_DEFAULT_FEDERATION_DIRECTIVE_NAMES = Object.values(FederationDirectiveName) as string[];
 
 function validateFieldSetSelections({
   directiveName,
@@ -157,12 +149,12 @@ function validateFieldSetSelections({
         if (metadata.isFieldFakeExternal(field)) {
           onError(errorCode.err(
             `field "${field.coordinate}" should not be part of a @${directiveName} since it is already "effectively" provided by this subgraph `
-              + `(while it is marked @${externalDirectiveSpec.name}, it is a @${keyDirectiveSpec.name} field of an extension type, which are not internally considered external for historical/backward compatibility reasons)`,
+              + `(while it is marked @${FederationDirectiveName.EXTERNAL}, it is a @${FederationDirectiveName.KEY} field of an extension type, which are not internally considered external for historical/backward compatibility reasons)`,
             { nodes: field.sourceAST }
           ));
         } else {
           onError(errorCode.err(
-            `field "${field.coordinate}" should not be part of a @${directiveName} since it is already provided by this subgraph (it is not marked @${externalDirectiveSpec.name})`,
+            `field "${field.coordinate}" should not be part of a @${directiveName} since it is already provided by this subgraph (it is not marked @${FederationDirectiveName.EXTERNAL})`,
             { nodes: field.sourceAST }
           ));
         }
@@ -488,6 +480,48 @@ function validateInterfaceRuntimeImplementationFieldsTypes(
   }
 }
 
+function validateShareableNotRepeatedOnSameDeclaration(
+  element: ObjectType | FieldDefinition<ObjectType>,
+  metadata: FederationMetadata,
+  errorCollector: GraphQLError[],
+) {
+  const shareableApplications: Directive<any, {}>[] = element.appliedDirectivesOf(metadata.shareableDirective());
+  if (shareableApplications.length <= 1) {
+    return;
+  }
+
+  type ByExtensions = {
+    without: Directive<any, {}>[],
+    with: MultiMap<Extension<any>, Directive<any, {}>>,
+  };
+  const byExtensions = shareableApplications.reduce<ByExtensions>(
+    (acc, v) => {
+      const ext = v.ofExtension();
+      if (ext) {
+        acc.with.add(ext, v);
+      } else {
+        acc.without.push(v);
+      }
+      return acc;
+    },
+    { without: [], with: new MultiMap() }
+  );
+  const groups = [ byExtensions.without ].concat(mapValues(byExtensions.with));
+  for (const group of groups) {
+    if (group.length > 1) {
+      const eltStr = element.kind === 'ObjectType'
+        ? `the same type declaration of "${element.coordinate}"`
+        : `field "${element.coordinate}"`;
+      errorCollector.push(ERRORS.INVALID_SHAREABLE_USAGE.err(
+        `Invalid duplicate application of @shareable on ${eltStr}: `
+        + '@shareable is only repeatable on types so it can be used simultaneously on a type definition and its extensions, but it should not be duplicated on the same definition/extension declaration',
+        { nodes: sourceASTs(...group) },
+      ));
+    }
+  }
+}
+
+
 const printFieldCoordinate = (f: FieldDefinition<CompositeType>): string => `"${f.coordinate}"`;
 
 function formatFieldsToReturnType([type, implems]: [string, FieldDefinition<ObjectType>[]]) {
@@ -608,7 +642,7 @@ export class FederationMetadata {
   }
 
   private getFederationDirective<TApplicationArgs extends {[key: string]: any}>(
-    name: string
+    name: FederationDirectiveName
   ): DirectiveDefinition<TApplicationArgs> {
     const directive = this.schema.directive(this.federationDirectiveNameInSchema(name));
     assert(directive, `The provided schema does not have federation directive @${name}`);
@@ -616,45 +650,43 @@ export class FederationMetadata {
   }
 
   keyDirective(): DirectiveDefinition<{fields: any, resolvable?: boolean}> {
-    return this.getFederationDirective(keyDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.KEY);
   }
 
   overrideDirective(): DirectiveDefinition<{from: string}> {
-    return this.getFederationDirective(overrideDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.OVERRIDE);
   }
 
   extendsDirective(): DirectiveDefinition<Record<string, never>> {
-    return this.getFederationDirective(extendsDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.EXTENDS);
   }
 
   externalDirective(): DirectiveDefinition<{reason: string}> {
-    return this.getFederationDirective(externalDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.EXTERNAL);
   }
 
   requiresDirective(): DirectiveDefinition<{fields: any}> {
-    return this.getFederationDirective(requiresDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.REQUIRES);
   }
 
   providesDirective(): DirectiveDefinition<{fields: any}> {
-    return this.getFederationDirective(providesDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.PROVIDES);
   }
 
   shareableDirective(): DirectiveDefinition<{}> {
-    return this.getFederationDirective(shareableDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.SHAREABLE);
   }
 
   tagDirective(): DirectiveDefinition<{name: string}> {
-    return this.getFederationDirective(tagSpec.tagDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.TAG);
   }
 
   composeDirective(): DirectiveDefinition<{name: string}> {
-    return this.getFederationDirective(composeDirectiveSpec.name);
+    return this.getFederationDirective(FederationDirectiveName.COMPOSE_DIRECTIVE);
   }
 
   inaccessibleDirective(): DirectiveDefinition<{}> {
-    return this.getFederationDirective(
-      inaccessibleSpec.inaccessibleDirectiveSpec.name
-    );
+    return this.getFederationDirective(FederationDirectiveName.INACCESSIBLE);
   }
 
   allFederationDirectives(): DirectiveDefinition[] {
@@ -685,7 +717,7 @@ export class FederationMetadata {
   }
 
   fieldSetType(): ScalarType {
-    return this.schema.type(this.federationTypeNameInSchema(fieldSetTypeSpec.name)) as ScalarType;
+    return this.schema.type(this.federationTypeNameInSchema(FederationTypeName.FIELD_SET)) as ScalarType;
   }
 
   allFederationTypes(): NamedType[] {
@@ -873,6 +905,28 @@ export class FederationBlueprint extends SchemaBlueprint {
       validateInterfaceRuntimeImplementationFieldsTypes(itf, metadata, errorCollector);
     }
 
+    // While @shareable is "repeatable", this is only so one can use it on both a main
+    // type definition _and_ possible other type extensions. But putting 2 @shareable
+    // on the same type definition or field is both useless, and suggest some miscomprehension,
+    // so we reject it with an (hopefully helpful) error message.
+    for (const objectType of schema.objectTypes()) {
+      validateShareableNotRepeatedOnSameDeclaration(objectType, metadata, errorCollector);
+      for (const field of objectType.fields()) {
+        validateShareableNotRepeatedOnSameDeclaration(field, metadata, errorCollector);
+      }
+    }
+    // Additionally, reject using @shareable on an interface field, as that does not actually
+    // make sense.
+    for (const shareableApplication of metadata.shareableDirective().applications()) {
+      const element = shareableApplication.parent;
+      if (element instanceof FieldDefinition && !isObjectType(element.parent)) {
+        errorCollector.push(ERRORS.INVALID_SHAREABLE_USAGE.err(
+          `Invalid use of @shareable on field "${element.coordinate}": only object type fields can be marked with @shareable`,
+          { nodes: sourceASTs(shareableApplication, element.parent) },
+        ));
+      }
+    }
+
     return errorCollector;
   }
 
@@ -883,7 +937,7 @@ export class FederationBlueprint extends SchemaBlueprint {
   onUnknownDirectiveValidationError(schema: Schema, unknownDirectiveName: string, error: GraphQLError): GraphQLError {
     const metadata = federationMetadata(schema);
     assert(metadata, `This method should only have been called on a subgraph schema`)
-    if (ALL_FEDERATION_DIRECTIVES_DEFAULT_NAMES.includes(unknownDirectiveName)) {
+    if (ALL_DEFAULT_FEDERATION_DIRECTIVE_NAMES.includes(unknownDirectiveName)) {
       // The directive name is "unknown" but it is a default federation directive name. So it means one of a few things
       // happened:
       //  1. it's a fed1 schema but the directive is a fed2 only one (only possible case for fed1 schema).
@@ -914,7 +968,7 @@ export class FederationBlueprint extends SchemaBlueprint {
       }
     } else if (!metadata.isFed2Schema()) {
       // We could get here in the case where a fed1 schema has tried to use a fed2 directive but mispelled it.
-      const suggestions = suggestionList(unknownDirectiveName, FEDERATION2_ONLY_SPEC_DIRECTIVES.map((spec) => spec.name));
+      const suggestions = suggestionList(unknownDirectiveName, ALL_DEFAULT_FEDERATION_DIRECTIVE_NAMES);
       if (suggestions.length > 0) {
         return withModifiedErrorMessage(
           error,
@@ -971,7 +1025,7 @@ export function setSchemaAsFed2Subgraph(schema: Schema) {
     core.coreItself.nameInSchema,
     {
       url: federationSpec.url.toString(),
-      import: FEDERATION2_SPEC_DIRECTIVES.map((spec) => `@${spec.name}`),
+      import: federationSpec.directiveSpecs().map((spec) => `@${spec.name}`),
     }
   );
   const errors = completeSubgraphSchema(schema);
@@ -982,7 +1036,7 @@ export function setSchemaAsFed2Subgraph(schema: Schema) {
 
 // This is the full @link declaration as added by `asFed2SubgraphDocument`. It's here primarily for uses by tests that print and match
 // subgraph schema to avoid having to update 20+ tests every time we use a new directive or the order of import changes ...
-export const FEDERATION2_LINK_WTH_FULL_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective"])';
+export const FEDERATION2_LINK_WITH_FULL_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.2", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective"])';
 
 export function asFed2SubgraphDocument(document: DocumentNode): DocumentNode {
   const fed2LinkExtension: SchemaExtensionNode = {
@@ -998,7 +1052,7 @@ export function asFed2SubgraphDocument(document: DocumentNode): DocumentNode {
       {
         kind: Kind.ARGUMENT,
         name: { kind: Kind.NAME, value: 'import' },
-        value: { kind: Kind.LIST, values: FEDERATION2_SPEC_DIRECTIVES.map((spec) => ({ kind: Kind.STRING, value: `@${spec.name}` })) }
+        value: { kind: Kind.LIST, values: federationSpec.directiveSpecs().map((spec) => ({ kind: Kind.STRING, value: `@${spec.name}` })) }
       }]
     }]
   };
@@ -1111,8 +1165,8 @@ function completeFed1SubgraphSchema(schema: Schema): GraphQLError[] {
   // Note that, in a perfect world, we'd do this within the `SchemaUpgrader`. But the way the code
   // is organised, this method is called before we reach the `SchemaUpgrader`, and it doesn't seem
   // worth refactoring things drastically for that minor convenience.
-  for (const spec of [keyDirectiveSpec, providesDirectiveSpec, requiresDirectiveSpec]) {
-    const directive = schema.directive(spec.name);
+  for (const name of [FederationDirectiveName.KEY, FederationDirectiveName.PROVIDES, FederationDirectiveName.REQUIRES]) {
+    const directive = schema.directive(name);
     if (!directive) {
       continue;
     }
@@ -1153,15 +1207,9 @@ function completeFed1SubgraphSchema(schema: Schema): GraphQLError[] {
     }
   }
 
-  return [
-    fieldSetTypeSpec.checkOrAdd(schema, '_' + fieldSetTypeSpec.name),
-    keyDirectiveSpec.checkOrAdd(schema),
-    requiresDirectiveSpec.checkOrAdd(schema),
-    providesDirectiveSpec.checkOrAdd(schema),
-    extendsDirectiveSpec.checkOrAdd(schema),
-    externalDirectiveSpec.checkOrAdd(schema),
-    tagSpec.tagDirectiveSpec.checkOrAdd(schema),
-  ].flat();
+  return FEDERATION1_TYPES.map((spec) => spec.checkOrAdd(schema, '_' + spec.name))
+    .concat(FEDERATION1_DIRECTIVES.map((spec) => spec.checkOrAdd(schema)))
+    .flat();
 }
 
 function completeFed2SubgraphSchema(schema: Schema) {
@@ -1224,7 +1272,7 @@ export function parseFieldSetArgument({
           if (msg.endsWith('.')) {
             msg = msg.slice(0, msg.length - 1);
           }
-          if (directive.name === keyDirectiveSpec.name) {
+          if (directive.name === FederationDirectiveName.KEY) {
             msg = msg + ' (the field should either be added to this subgraph or, if it should not be resolved by this subgraph, you need to add it to this subgraph with @external).';
           } else {
             msg = msg + ' (if the field is defined in another subgraph, you need to add it to this subgraph with @external).';

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -106,7 +106,7 @@ const FEDERATION_SPECIFIC_VALIDATION_RULES = [
 
 const FEDERATION_VALIDATION_RULES = specifiedSDLRules.filter(rule => !FEDERATION_OMITTED_VALIDATION_RULES.includes(rule)).concat(FEDERATION_SPECIFIC_VALIDATION_RULES);
 
-const ALL_DEFAULT_FEDERATION_DIRECTIVE_NAMES = Object.values(FederationDirectiveName) as string[];
+const ALL_DEFAULT_FEDERATION_DIRECTIVE_NAMES: string[] = Object.values(FederationDirectiveName);
 
 function validateFieldSetSelections({
   directiveName,
@@ -485,7 +485,7 @@ function validateShareableNotRepeatedOnSameDeclaration(
   metadata: FederationMetadata,
   errorCollector: GraphQLError[],
 ) {
-  const shareableApplications: Directive<any, {}>[] = element.appliedDirectivesOf(metadata.shareableDirective());
+  const shareableApplications: Directive[] = element.appliedDirectivesOf(metadata.shareableDirective());
   if (shareableApplications.length <= 1) {
     return;
   }

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -9,9 +9,10 @@ import {
   createDirectiveSpecification,
   createScalarTypeSpecification,
   DirectiveSpecification,
+  TypeSpecification,
 } from "./directiveAndTypeSpecification";
 import { DirectiveLocation, GraphQLError } from "graphql";
-import { assert } from "./utils";
+import { assert, MapWithCachedArrays } from "./utils";
 import { TAG_VERSIONS } from "./tagSpec";
 import { federationMetadata } from "./federation";
 import { registerKnownFeature } from "./knownCoreFeatures";
@@ -19,10 +20,27 @@ import { INACCESSIBLE_VERSIONS } from "./inaccessibleSpec";
 
 export const federationIdentity = 'https://specs.apollo.dev/federation';
 
-export const fieldSetTypeSpec = createScalarTypeSpecification({ name: 'FieldSet' });
+export enum FederationTypeName {
+  FIELD_SET = 'FieldSet',
+}
 
-export const keyDirectiveSpec = createDirectiveSpecification({
-  name:'key',
+export enum FederationDirectiveName {
+  KEY = 'key',
+  EXTERNAL = 'external',
+  REQUIRES = 'requires',
+  PROVIDES = 'provides',
+  EXTENDS = 'extends',
+  SHAREABLE = 'shareable',
+  OVERRIDE = 'override',
+  TAG = 'tag',
+  INACCESSIBLE = 'inaccessible',
+  COMPOSE_DIRECTIVE = 'composeDirective',
+}
+
+const fieldSetTypeSpec = createScalarTypeSpecification({ name: FederationTypeName.FIELD_SET });
+
+const keyDirectiveSpec = createDirectiveSpecification({
+  name: FederationDirectiveName.KEY,
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE],
   repeatable: true,
   argumentFct: (schema) => ({
@@ -34,13 +52,13 @@ export const keyDirectiveSpec = createDirectiveSpecification({
   }),
 });
 
-export const extendsDirectiveSpec = createDirectiveSpecification({
-  name:'extends',
+const extendsDirectiveSpec = createDirectiveSpecification({
+  name: FederationDirectiveName.EXTENDS,
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE],
 });
 
-export const externalDirectiveSpec = createDirectiveSpecification({
-  name:'external',
+const externalDirectiveSpec = createDirectiveSpecification({
+  name: FederationDirectiveName.EXTERNAL,
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
   argumentFct: (schema) => ({
     args: [{ name: 'reason', type: schema.stringType() }],
@@ -48,8 +66,8 @@ export const externalDirectiveSpec = createDirectiveSpecification({
   }),
 });
 
-export const requiresDirectiveSpec = createDirectiveSpecification({
-  name:'requires',
+const requiresDirectiveSpec = createDirectiveSpecification({
+  name: FederationDirectiveName.REQUIRES,
   locations: [DirectiveLocation.FIELD_DEFINITION],
   argumentFct: (schema) => ({
     args: [fieldsArgument(schema)],
@@ -57,8 +75,8 @@ export const requiresDirectiveSpec = createDirectiveSpecification({
   }),
 });
 
-export const providesDirectiveSpec = createDirectiveSpecification({
-  name:'provides',
+const providesDirectiveSpec = createDirectiveSpecification({
+  name: FederationDirectiveName.PROVIDES,
   locations: [DirectiveLocation.FIELD_DEFINITION],
   argumentFct: (schema) => ({
     args: [fieldsArgument(schema)],
@@ -66,29 +84,21 @@ export const providesDirectiveSpec = createDirectiveSpecification({
   }),
 });
 
-export const shareableDirectiveSpec = createDirectiveSpecification({
-  name: 'shareable',
-  locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
-});
+const legacyFederationTypes = [
+  fieldSetTypeSpec,
+];
 
-export const overrideDirectiveSpec = createDirectiveSpecification({
-  name: 'override',
-  locations: [DirectiveLocation.FIELD_DEFINITION],
-  argumentFct: (schema) => ({
-    args: [{ name: 'from', type: new NonNullType(schema.stringType()) }],
-    errors: [],
-  }),
-});
+const legacyFederationDirectives = [
+  keyDirectiveSpec,
+  requiresDirectiveSpec,
+  providesDirectiveSpec,
+  externalDirectiveSpec,
+  TAG_VERSIONS.latest().tagDirectiveSpec,
+  extendsDirectiveSpec,
+];
 
-export const composeDirectiveSpec = createDirectiveSpecification({
-  name: 'composeDirective',
-  locations: [DirectiveLocation.SCHEMA],
-  repeatable: true,
-  argumentFct: (schema) => ({
-    args: [{ name: 'name', type: schema.stringType() }],
-    errors: [],
-  }),
-})
+export const FEDERATION1_TYPES = legacyFederationTypes;
+export const FEDERATION1_DIRECTIVES = legacyFederationDirectives;
 
 function fieldsArgument(schema: Schema): ArgumentSpecification {
   return { name: 'fields', type: fieldSetType(schema) };
@@ -100,50 +110,65 @@ function fieldSetType(schema: Schema): InputType {
   return new NonNullType(metadata.fieldSetType());
 }
 
-export const FEDERATION2_ONLY_SPEC_DIRECTIVES = [
-  shareableDirectiveSpec,
-  INACCESSIBLE_VERSIONS.latest().inaccessibleDirectiveSpec,
-  overrideDirectiveSpec,
-];
-
-export const FEDERATION2_1_ONLY_SPEC_DIRECTIVES = [
-  composeDirectiveSpec,
-];
-
-const PRE_FEDERATION2_SPEC_DIRECTIVES = [
-  keyDirectiveSpec,
-  requiresDirectiveSpec,
-  providesDirectiveSpec,
-  externalDirectiveSpec,
-  TAG_VERSIONS.latest().tagDirectiveSpec,
-  extendsDirectiveSpec, // TODO: should we stop supporting that?
-];
-
-// Note that this is only used for federation 2+ (federation 1 adds the same directive, but not through a core spec).
-export const FEDERATION2_SPEC_DIRECTIVES = [
-  ...PRE_FEDERATION2_SPEC_DIRECTIVES,
-  ...FEDERATION2_ONLY_SPEC_DIRECTIVES,
-  ...FEDERATION2_1_ONLY_SPEC_DIRECTIVES,
-];
-
-// Note that this is meant to contain _all_ federation directive names ever supported, regardless of which version.
-// But currently, fed2 directives are a superset of fed1's so ... (but this may change if we stop supporting `@extends`
-// in fed2).
-export const ALL_FEDERATION_DIRECTIVES_DEFAULT_NAMES = FEDERATION2_SPEC_DIRECTIVES.map((spec) => spec.name);
-
-export const FEDERATION_SPEC_TYPES = [
-  fieldSetTypeSpec,
-]
-
 export class FederationSpecDefinition extends FeatureDefinition {
+  private readonly _directiveSpecs = new MapWithCachedArrays<string, DirectiveSpecification>();
+  private readonly _typeSpecs = new MapWithCachedArrays<string, TypeSpecification>();
+
   constructor(version: FeatureVersion) {
     super(new FeatureUrl(federationIdentity, 'federation', version));
+
+    for (const type of legacyFederationTypes) {
+      this.registerType(type);
+    }
+
+    for (const directive of legacyFederationDirectives) {
+      this.registerDirective(directive);
+    }
+
+    this.registerDirective(createDirectiveSpecification({
+      name: FederationDirectiveName.SHAREABLE,
+      locations: [DirectiveLocation.OBJECT, DirectiveLocation.FIELD_DEFINITION],
+      repeatable: version >= (new FeatureVersion(2, 2)),
+    }));
+
+    this.registerDirective(INACCESSIBLE_VERSIONS.latest().inaccessibleDirectiveSpec);
+
+    this.registerDirective(createDirectiveSpecification({
+      name: FederationDirectiveName.OVERRIDE,
+      locations: [DirectiveLocation.FIELD_DEFINITION],
+      argumentFct: (schema) => ({
+        args: [{ name: 'from', type: new NonNullType(schema.stringType()) }],
+        errors: [],
+      }),
+    }));
+
+    if (version >= (new FeatureVersion(2, 1))) {
+      this.registerDirective(createDirectiveSpecification({
+        name: FederationDirectiveName.COMPOSE_DIRECTIVE,
+        locations: [DirectiveLocation.SCHEMA],
+        repeatable: true,
+        argumentFct: (schema) => ({
+          args: [{ name: 'name', type: schema.stringType() }],
+          errors: [],
+        }),
+      }));
+    }
   }
 
-  private allFedDirectives(): DirectiveSpecification[] {
-    return PRE_FEDERATION2_SPEC_DIRECTIVES
-      .concat(FEDERATION2_ONLY_SPEC_DIRECTIVES)
-      .concat(this.url.version >= (new FeatureVersion(2, 1)) ? FEDERATION2_1_ONLY_SPEC_DIRECTIVES : []);
+  private registerDirective(spec: DirectiveSpecification) {
+    this._directiveSpecs.set(spec.name, spec);
+  }
+
+  private registerType(spec: TypeSpecification) {
+    this._typeSpecs.set(spec.name, spec);
+  }
+
+  directiveSpecs(): readonly DirectiveSpecification[] {
+    return this._directiveSpecs.values();
+  }
+
+  typeSpecs(): readonly TypeSpecification[] {
+    return this._typeSpecs.values();
   }
 
   addElementsToSchema(schema: Schema): GraphQLError[] {
@@ -151,23 +176,25 @@ export class FederationSpecDefinition extends FeatureDefinition {
     assert(feature, 'The federation specification should have been added to the schema before this is called');
 
     let errors: GraphQLError[] = [];
-    errors = errors.concat(this.addTypeSpec(schema, fieldSetTypeSpec));
+    for (const type of this.typeSpecs()) {
+      errors = errors.concat(this.addTypeSpec(schema, type));
+    }
 
-    for (const directive of this.allFedDirectives()) {
+    for (const directive of this.directiveSpecs()) {
       errors = errors.concat(this.addDirectiveSpec(schema, directive));
     }
     return errors;
   }
 
   allElementNames(): string[] {
-    return this.allFedDirectives().map((spec) => `@${spec.name}`).concat([
-      fieldSetTypeSpec.name,
-    ])
+    return this.directiveSpecs().map((spec) => `@${spec.name}`)
+      .concat(this.typeSpecs().map((spec) => spec.name));
   }
 }
 
 export const FEDERATION_VERSIONS = new FeatureDefinitions<FederationSpecDefinition>(federationIdentity)
   .add(new FederationSpecDefinition(new FeatureVersion(2, 0)))
-  .add(new FederationSpecDefinition(new FeatureVersion(2, 1)));
+  .add(new FederationSpecDefinition(new FeatureVersion(2, 1)))
+  .add(new FederationSpecDefinition(new FeatureVersion(2, 2)));
 
 registerKnownFeature(FEDERATION_VERSIONS);

--- a/internals-js/src/schemaUpgrader.ts
+++ b/internals-js/src/schemaUpgrader.ts
@@ -32,8 +32,8 @@ import {
   Subgraphs,
 } from "./federation";
 import { assert, firstOf, MultiMap } from "./utils";
-import { FEDERATION_SPEC_TYPES } from "./federationSpec";
 import { valueEquals } from "./values";
+import { FEDERATION1_TYPES } from "./federationSpec";
 
 export type UpgradeResult = UpgradeSuccess | UpgradeFailure;
 
@@ -330,7 +330,7 @@ class SchemaUpgrader {
     // `federation__Any`, ... in the new upgraded schema.
     // But note that even "importing" those types would not completely work because fed2 essentially drops the `_` at the beginning of those
     // type names (relying on the core schema prefixing instead) and so some special translation needs to happen.
-    for (const typeSpec of FEDERATION_SPEC_TYPES) {
+    for (const typeSpec of FEDERATION1_TYPES) {
       const typeNameInOriginal = this.originalSubgraph.metadata().federationTypeNameInSchema(typeSpec.name);
       const type = this.schema.type(typeNameInOriginal);
       if (type) {

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
+## 2.2.0
+
+- Adds support for the 2.2 version of the federation spec (that is, `@link(url: "https://specs.apollo.dev/federation/v2.2")`), which:
+  - allows `@shareable` to be repeatable so it can be allowed on both a type definition and its extensions [PR #2175](https://github.com/apollographql/federation/pull/2175).
+
 ## 2.1.0
 
 - Update peer dependency `graphql` to `^16.5.0` to use `GraphQLErrorOptions` [PR #2060](https://github.com/apollographql/federation/pull/2060)

--- a/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
@@ -133,11 +133,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
 
 """
 A user. This user is very complicated and requires so so so so so so so so so so so so so so so so so so so so so so so so so so so so so so so so much description text
@@ -391,11 +391,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
 
 type Review {
   id: ID
@@ -460,11 +460,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
 
 type Review {
   id: ID
@@ -521,11 +521,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
 
 type Product
   @key(fields: "upc")
@@ -573,11 +573,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
 
 type Product
   @key(fields: "upc")
@@ -637,11 +637,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
 
 type Review
   @key(fields: "id")
@@ -706,11 +706,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
 
 extend type User
   @key(fields: "email")
@@ -791,11 +791,11 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
-directive @extends on OBJECT | INTERFACE
-
 directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION`,
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE`,
         typesDefinitions: `
 
 scalar _FieldSet
@@ -830,7 +830,7 @@ directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFAC
 
 directive @federation__extends on OBJECT | INTERFACE
 
-directive @federation__shareable on OBJECT | FIELD_DEFINITION
+directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
 
 directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -3,6 +3,7 @@ import { buildSubgraphSchema } from '../buildSubgraphSchema';
 import { printSubgraphSchema } from '../printSubgraphSchema';
 import gql from 'graphql-tag';
 import './matchers';
+import { FEDERATION2_LINK_WITH_FULL_IMPORTS } from '@apollo/federation-internals';
 
 describe('printSubgraphSchema', () => {
   it('prints a subgraph correctly', () => {
@@ -14,7 +15,7 @@ describe('printSubgraphSchema', () => {
       }
 
       extend schema
-        @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective"])
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
 
       directive @stream on FIELD
 
@@ -109,7 +110,7 @@ describe('printSubgraphSchema', () => {
     const schema = buildSubgraphSchema(fixtures[5].typeDefs);
     expect(printSubgraphSchema(schema)).toMatchString(`
       extend schema
-        @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective"])
+        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
 
       directive @stream on FIELD
 


### PR DESCRIPTION
The rational this is explained on #2135 and in particular allows the example in [this comment](https://github.com/apollographql/federation/issues/2135#issuecomment-1248317927) to work.

For backward compatibility concerns, the patch introduces a new version (`federation/v2.2`) of the federation spec and only make `@shareable` repeatable in that version. This means that nothing changes for existing subgraphs on update and you have to "manually" change the subgraph to use the new version to be able to use this. More importantly, this means that subgraph libraries that continue to generate the previous version won't break in any way. They just may want to start generating the new version at some point in the future so their users can make use of the additional flexibility afforded by this change.

On the upgrade side of things, probably stating the obvious, but if a subgraph does upgrade to use the new 2.2 version, then it needs to make sure to use a version of composition that knows it.

Regarding the code itself, marking `@shareable` repeatable is trivial, but more interesting changes are:
1. the added validation discussed on #2135.
2. some refactoring around the code for the federation spec. Essentially, the exact definitions of the federation directives really depends on the spec version, even more so with this change, but that wasn't well abstracted by the code so far, so this patch tries to improve this a bit.