### PR TITLE
docs: Fix path to federation architecture MDX file

### DIFF
--- a/docs/source/building-supergraphs/router.mdx
+++ b/docs/source/building-supergraphs/router.mdx
@@ -3,7 +3,7 @@ title: The graph router
 description: The entry point to your federated supergraph
 ---
 
-import FederationArchitecture from '../shared/diagrams/federation-architecture.mdx';
+import FederationArchitecture from '../../shared/diagrams/federation-architecture.mdx';
 
 After you set up at least one federation-ready [subgraph](./subgraphs-overview/), you can configure a **graph router** (also known as a gateway) to sit in front of your subgraphs. The router serves as the entry point to your supergraph, and it executes incoming operations across one or more of your subgraphs:
 


### PR DESCRIPTION
This unbreaks the docs site build! https://app.netlify.com/sites/apollo-monodocs/deploys/6338f7b905b7250008ca2b5b