### PR TITLE
Remove node12 support and bump circle build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,43 +35,28 @@ jobs:
   # The docker tag represents the Node.js version and the full list is available
   # at https://hub.docker.com/r/circleci/node/.
 
-  NodeJS 12:
-    docker:
-      - image: cimg/node:12.22
-    steps:
-      - common_test_steps
-      # We will save the results of this one particular invocation to use in
-      # the publish step. Not only does this make the publishing step take less
-      # time, this also ensures that a passing version gets deployed even if,
-      # theoretically, rebuilding the same commit on the same version of
-      # Node.js should yield the same results!
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./**
-
   NodeJS 14:
     docker:
-      - image: cimg/node:14.19
+      - image: cimg/node:14.20
     steps:
       - common_test_steps
 
   NodeJS 16:
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:16.18
     steps:
       - common_test_steps
 
   NodeJS 18:
     docker:
-      - image: cimg/node:18.2.0
+      - image: cimg/node:18.11.0
     steps:
       - common_test_steps
 
   GraphQL Types:
     description: "Assert generated GraphQL types are up to date"
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:16.18
     steps:
       - checkout
       - oss/npm_clean_install_with_caching
@@ -81,7 +66,7 @@ jobs:
   Error code Doc:
     description: "Ensure the error code documentation is up to date"
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:16.18
     steps:
       - checkout
       - oss/npm_clean_install_with_caching
@@ -91,7 +76,7 @@ jobs:
   Hints code Doc:
     description: "Ensure the hints code documentation is up to date"
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:16.18
     steps:
       - checkout
       - oss/npm_clean_install_with_caching
@@ -121,9 +106,6 @@ workflows:
   version: 2
   Build:
     jobs:
-      - NodeJS 12:
-          name: "JS: Node 12"
-          <<: *common_non_publish_filters
       - NodeJS 14:
           name: "JS: Node 14"
           <<: *common_non_publish_filters
@@ -146,7 +128,6 @@ workflows:
           name: "JS: Package tarballs"
           <<: *common_non_publish_filters
           requires:
-            - "JS: Node 12"
             - "JS: Node 14"
             - "JS: Node 16"
             - "JS: Node 18"
@@ -156,7 +137,6 @@ workflows:
           name: "JS: Dry-run"
           <<: *common_publish_filters
           requires:
-            - "JS: Node 12"
             - "JS: Node 14"
             - "JS: Node 16"
             - "JS: Node 18"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,15 @@ jobs:
       - image: cimg/node:14.20
     steps:
       - common_test_steps
+      # We will save the results of this one particular invocation to use in
+      # the publish step. Not only does this make the publishing step take less
+      # time, this also ensures that a passing version gets deployed even if,
+      # theoretically, rebuilding the same commit on the same version of
+      # Node.js should yield the same results!
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./**
 
   NodeJS 16:
     docker:

--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 - Improves error message to help with misspelled source of an `@override` [PR #2181](https://github.com/apollographql/federation/pull/2181).
 - Provide support for marking @external on object type [PR #2214](https://github.com/apollographql/federation/pull/2214)
+- Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)
 
 ## 2.1.2
 

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -21,7 +21,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "SEE LICENSE IN ./LICENSE",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14.15.0"
   },
   "publishConfig": {
     "access": "public"

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -13,6 +13,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 - Optimize plan for defer where only keys are fetched [PR #2182](https://github.com/apollographql/federation/pull/2182).
 - Improves error message to help with misspelled source of an `@override` [PR #2181](https://github.com/apollographql/federation/pull/2181).
 - Fix validation of variable on input field not taking default into account [PR #2176](https://github.com/apollographql/federation/pull/2176).
+- Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)
 
 ## 2.1.3
 

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -18,7 +18,7 @@
     "apollo"
   ],
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14.15.0"
   },
   "license": "SEE LICENSE IN ./LICENSE",
   "publishConfig": {

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Ensures supergraph `@defer`/`@stream` definitions of supergraph are not included in the API schema [PR #2212](https://github.com/apollographql/federation/pull/2212).
 - Fix validation of variable on input field not taking default into account [PR #2176](https://github.com/apollographql/federation/pull/2176).
 - Provide support for marking @external on object type [PR #2214](https://github.com/apollographql/federation/pull/2214)
+- Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)
 
 ## 2.1.0
 

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -20,7 +20,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "SEE LICENSE IN ./LICENSE",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14.15.0"
   },
   "dependencies": {
     "chalk": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "winston-transport": "4.5.0"
       },
       "engines": {
-        "node": ">=12.13.0",
+        "node": ">=14.15.0",
         "npm": ">=7 <9"
       }
     },
@@ -75,7 +75,7 @@
         "@apollo/query-graphs": "file:../query-graphs-js"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
@@ -115,7 +115,7 @@
         "node-fetch": "^2.6.7"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
@@ -290,7 +290,7 @@
         "js-levenshtein": "^1.1.6"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
@@ -18683,7 +18683,7 @@
         "ts-graphviz": "^0.16.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
@@ -18701,7 +18701,7 @@
         "pretty-format": "^28.0.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
@@ -18716,7 +18716,7 @@
         "@apollo/federation-internals": "file:../internals-js"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "hints-doc:check": "npm run hints-doc && git diff --exit-code"
   },
   "engines": {
-    "node": ">=12.13.0",
+    "node": ">=14.15.0",
     "npm": ">=7 <9"
   },
   "dependencies": {

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)
+
 ## 2.1.0
 
 - Fix abnormally high memory usage when extracting subgraphs for some fed1 supergraphs (and small other memory footprint improvements) [PR #2089](https://github.com/apollographql/federation/pull/2089).

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -20,7 +20,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "SEE LICENSE IN ./LICENSE",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14.15.0"
   },
   "dependencies": {
     "@apollo/federation-internals": "file:../internals-js",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 ## vNext
 
 - Optimize plan for defer where only keys are fetched [PR #2182](https://github.com/apollographql/federation/pull/2182).
+- Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)
 
 ## 2.1.3
 

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -18,7 +18,7 @@
     "apollo"
   ],
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14.15.0"
   },
   "license": "SEE LICENSE IN ./LICENSE",
   "publishConfig": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -41,7 +41,7 @@
     // versions we support.
     {
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "12.x"
+      "allowedVersions": "14.x"
     },
     // node-fetch v3 only ships as ESM. We currently build to CommonJS and even
     // if we start publishing as ESM we're not going to go ESM-only for a while.

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The Federation v0.x equivalent for this package can be found [here](https://github.com/apollographql/federation/blob/version-0.x/subgraph-js/CHANGELOG.md) on the `version-0.x` branch of this repo.
 
-## 2.2.0
+## vNext
 
 - Adds support for the 2.2 version of the federation spec (that is, `@link(url: "https://specs.apollo.dev/federation/v2.2")`), which:
-  - allows `@shareable` to be repeatable so it can be allowed on both a type definition and its extensions [PR #2175](https://github.com/apollographql/federation/pull/2175).
+- allows `@shareable` to be repeatable so it can be allowed on both a type definition and its extensions [PR #2175](https://github.com/apollographql/federation/pull/2175).
+- Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)
 
 ## 2.1.0
 

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14.15.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Node 12 has officially passed end of life, and we have some renovate bot package upgrades that are failing for this reason. I made the minimum required version 14.15.0, since that's the oldest version that's still in LTS, but let me know if you think I should be more tolerant.