### PR TITLE
Ensure supergraph @defer/@stream definitions of supergraph are not in…

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Ensures supergraph `@defer`/`@stream` definitions of supergraph are not included in the API schema [PR #2212](https://github.com/apollographql/federation/pull/2212).
 - Optimize plan for defer where only keys are fetched [PR #2182](https://github.com/apollographql/federation/pull/2182).
 - Improves error message to help with misspelled source of an `@override` [PR #2181](https://github.com/apollographql/federation/pull/2181).
 - Fix validation of variable on input field not taking default into account [PR #2176](https://github.com/apollographql/federation/pull/2176).

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- Ensures supergraph `@defer`/`@stream` definitions of supergraph are not included in the API schema [PR #2212](https://github.com/apollographql/federation/pull/2212).
 - Fix validation of variable on input field not taking default into account [PR #2176](https://github.com/apollographql/federation/pull/2176).
 
 ## 2.1.0

--- a/internals-js/src/__tests__/definitions.test.ts
+++ b/internals-js/src/__tests__/definitions.test.ts
@@ -793,56 +793,102 @@ describe('clone', () => {
   });
 });
 
-test('correctly convert to a graphQL-js schema', () => {
-  const sdl = `
-    schema {
-      query: MyQuery
-    }
+describe('Conversion to graphQL-js schema', () => {
+  test('works on simple schema', () => {
+    const sdl = `
+      schema {
+        query: MyQuery
+      }
 
-    directive @foo on FIELD
+      directive @foo on FIELD
 
-    type A {
-      f1(x: Int): String
-      f2: String
-    }
+      type A {
+        f1(x: Int): String
+        f2: String
+      }
 
-    type MyQuery {
-      a: A
-      b: Int
-    }
-  `;
-  const schema = parseSchema(sdl);
+      type MyQuery {
+        a: A
+        b: Int
+      }
+    `;
+    const schema = parseSchema(sdl);
 
-  const graphqQLSchema = schema.toGraphQLJSSchema();
-  expect(printGraphQLjsSchema(graphqQLSchema)).toMatchString(sdl);
+    const graphqQLSchema = schema.toGraphQLJSSchema();
+    expect(printGraphQLjsSchema(graphqQLSchema)).toMatchString(sdl);
+  });
+
+  test('can optionally add @defer and/or @streams definition(s)', () => {
+    const sdl = `
+      type Query {
+        x: Int
+      }
+    `;
+    const schema = parseSchema(sdl);
+
+    expect(printGraphQLjsSchema(schema.toGraphQLJSSchema({ includeDefer: true }))).toMatchString(`
+      directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      type Query {
+        x: Int
+      }
+    `);
+
+    expect(printGraphQLjsSchema(schema.toGraphQLJSSchema({ includeDefer: true, includeStream:  true }))).toMatchString(`
+      directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      directive @stream(label: String, initialCount: Int = 0, if: Boolean! = true) on FIELD
+
+      type Query {
+        x: Int
+      }
+    `);
+  });
+
+  test('adding @defer and/or @streams definition(s) works properly for API schema of supergraphs with their own @defer definition', () => {
+    // Note that this test doesn't use a valid supergraph schema, but that doesn't really matter in this test. All that matter
+    // is that taking `toAPISchema()` followed by `toGraphQLJSSchema(config)` works properly when the original schema already has
+    // a `@defer` definition.
+    const sdl = `
+      directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+      directive @stream(label: String, initialCount: Int = 0, if: Boolean! = true) on FIELD
+
+      type Query {
+        x: Int
+      }
+    `;
+
+    // Note that with API schema, we want the @defer/@stream definitions from the original schema to essentially be ignored.
+    // So whether or not the @defer/@stream definition ends up in the output of `toGraphQLJSSchema` (of that API schema) should
+    // solely depend on the config provided to that method.
+    const apiSchema = parseSchema(sdl).toAPISchema();
+
+    expect(printGraphQLjsSchema(apiSchema.toGraphQLJSSchema())).toMatchString(`
+      type Query {
+        x: Int
+      }
+    `);
+
+    expect(printGraphQLjsSchema(apiSchema.toGraphQLJSSchema({ includeDefer: true }))).toMatchString(`
+      directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      type Query {
+        x: Int
+      }
+    `);
+
+    expect(printGraphQLjsSchema(apiSchema.toGraphQLJSSchema({ includeDefer: true, includeStream:  true }))).toMatchString(`
+      directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      directive @stream(label: String, initialCount: Int = 0, if: Boolean! = true) on FIELD
+
+      type Query {
+        x: Int
+      }
+    `);
+  });
 });
 
-test('Conversion to graphQL-js schema can optionally include @defer and/or @streams definition(s)', () => {
-  const sdl = `
-    type Query {
-      x: Int
-    }
-  `;
-  const schema = parseSchema(sdl);
-
-  expect(printGraphQLjsSchema(schema.toGraphQLJSSchema({ includeDefer: true }))).toMatchString(`
-    directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-    type Query {
-      x: Int
-    }
-  `);
-
-  expect(printGraphQLjsSchema(schema.toGraphQLJSSchema({ includeDefer: true, includeStream:  true }))).toMatchString(`
-    directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-    directive @stream(label: String, initialCount: Int = 0, if: Boolean! = true) on FIELD
-
-    type Query {
-      x: Int
-    }
-  `);
-});
 
 test('retrieving elements by coordinate', () => {
   const sdl = `

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -1270,6 +1270,19 @@ export class Schema {
       this.validate();
 
       const apiSchema = this.clone();
+
+      // As we compute the API schema of a supergraph, we want to ignore explicit definitions of `@defer` and `@stream` because
+      // those corresponds to the merging of potential definition from the subgraphs, but whether the supergraph API schema
+      // support defer or not is unrelated to the subgraph capacity. As far as gateway/router support goes, whether the defer/stream
+      // definitions ends up being provided or not will depends on the runtime `config` argument of the `toGraphQLJSSchema` that
+      // is the called on the API schema (the schema resulting of that method).
+      for (const toRemoveIfCustom of ['defer', 'stream']) {
+        const directive = apiSchema.directive(toRemoveIfCustom);
+        if (directive && !directive.isBuiltIn) {
+          directive.removeRecursive();
+        }
+      }
+
       removeInaccessibleElements(apiSchema);
       removeAllCoreFeatures(apiSchema);
       assert(!apiSchema.isCoreSchema(), "The API schema shouldn't be a core schema")

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -1272,10 +1272,10 @@ export class Schema {
       const apiSchema = this.clone();
 
       // As we compute the API schema of a supergraph, we want to ignore explicit definitions of `@defer` and `@stream` because
-      // those corresponds to the merging of potential definition from the subgraphs, but whether the supergraph API schema
-      // support defer or not is unrelated to the subgraph capacity. As far as gateway/router support goes, whether the defer/stream
-      // definitions ends up being provided or not will depends on the runtime `config` argument of the `toGraphQLJSSchema` that
-      // is the called on the API schema (the schema resulting of that method).
+      // those correspond to the merging of potential definitions from the subgraphs, but whether the supergraph API schema
+      // supports defer or not is unrelated to the subgraph capacity. As far as gateway/router support goes, whether the defer/stream
+      // definitions end up being provided or not will depend on the runtime `config` argument of the `toGraphQLJSSchema` that
+      // is the called on the API schema (the schema resulting from that method).
       for (const toRemoveIfCustom of ['defer', 'stream']) {
         const directive = apiSchema.directive(toRemoveIfCustom);
         if (directive && !directive.isBuiltIn) {


### PR DESCRIPTION
…cluded in the API schema

Whether or not @defer and @stream ends up in the API schema used by the router/gateway depends on the runtime `config` provided to the call to `apiScheam.toGraphQLJSSchema(config)`, but whatever definition are in the supergraph should be ignored, because those correspond to what the subgraph were declaring (which is irrelevant to the defer support in the supergraph API schema).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
