### PR TITLE
Release 2.1.4

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -4,6 +4,9 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+
+## 2.1.4
+
 - Improves error message to help with misspelled source of an `@override` [PR #2181](https://github.com/apollographql/federation/pull/2181).
 
 ## 2.1.2

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+## 2.1.4
+
 - Ensures supergraph `@defer`/`@stream` definitions of supergraph are not included in the API schema [PR #2212](https://github.com/apollographql/federation/pull/2212).
 - Optimize plan for defer where only keys are fetched [PR #2182](https://github.com/apollographql/federation/pull/2182).
 - Improves error message to help with misspelled source of an `@override` [PR #2181](https://github.com/apollographql/federation/pull/2181).

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+
+## 2.1.4
+
 - Ensures supergraph `@defer`/`@stream` definitions of supergraph are not included in the API schema [PR #2212](https://github.com/apollographql/federation/pull/2212).
 - Fix validation of variable on input field not taking default into account [PR #2176](https://github.com/apollographql/federation/pull/2176).
 

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -83,7 +83,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "graphql-tag": "^2.12.6",
@@ -92,7 +92,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -283,7 +283,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -18675,7 +18675,7 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -18691,7 +18691,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -18709,7 +18709,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,9 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+
+## 2.1.4
+
 - Optimize plan for defer where only keys are fetched [PR #2182](https://github.com/apollographql/federation/pull/2182).
 
 ## 2.1.3

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌 The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.
