### PR TITLE
Fix error when a skipped enum value had directives applied

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -4,6 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix error when a skipped enum value had directives applied [PR #2232](https://github.com/apollographql/federation/pull/2232).
 
 ## 2.1.4
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -2818,6 +2818,44 @@ describe('composition', () => {
       `);
     });
 
+    it('do not error if a skipped inconsistent value has directive applied', () => {
+      const subgraphA = {
+        name: 'subgraphA',
+        typeDefs: gql`
+          type Query {
+            f(e: E!): Int
+          }
+
+          enum E {
+            V1
+            V2 @deprecated(reason: "use V3 instead")
+            V3
+          }
+        `,
+      };
+
+      const subgraphB = {
+        name: 'subgraphB',
+        typeDefs: gql`
+          enum E {
+            V1
+            V3
+          }
+        `,
+      };
+
+      const result = composeAsFed2Subgraphs([subgraphA, subgraphB]);
+      assertCompositionSuccess(result);
+      // Note that we will also generate an hint for the skipped value but this is already
+      // tested by `hints.test.ts` so we don't duplicate the check here.
+      expect(printType(result.schema.toAPISchema().type('E')!)).toMatchString(`
+        enum E {
+          V1
+          V3
+        }
+      `);
+    });
+
     it('errors if enum used _only_ as input as no consistent values', () => {
       const subgraphA = {
         name: 'subgraphA',

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1971,6 +1971,14 @@ class Merger {
   // to be called after elements are merged
   private mergeAllAppliedDirectives() {
     for (const { names, sources, dest } of this.appliedDirectivesToMerge) {
+      // There is some cases where we had to call the method that records directives to merged
+      // on a `dest` that ended up being removed from the ouptut (typically because we needed
+      // to known if that `dest` was @inaccessible before deciding if it should be kept or
+      // not). So check that the `dest` is still there (still "attached") and skip it entirely
+      // otherwise.
+      if (!dest.isAttached()) {
+        continue;
+      }
       for (const name of names) {
         this.mergeAppliedDirective(name, sources, dest);
       }

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix error when a skipped enum value had directives applied [PR #2232](https://github.com/apollographql/federation/pull/2232).
 - Preserve default values of input object fields [PR #2218](https://github.com/apollographql/federation/pull/2218).
 
 ## 2.1.4


### PR DESCRIPTION
We sometimes have to call the method merging directives on a merged value that we end up removing later, and this because we need @inaccessible to be merged to decide if the value should be kept (this is case of enum value, but I think input field are also the same).

But since #2136, most directives (@inaccessible being the one exception) are not merged right away, but we simply "record" that they should be merged and merge them later. The result however is cases where when we later try the merging, the element is not attached to the schema anymore, and an assertion was triggered. This fixes this cases.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
