### PR TITLE
Loosen validation of @shareable on interface fields

### DIFF
--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -210,7 +210,9 @@ type Position @shareable {
 }
 ```
 
-If a field is marked `@shareable` in _any_ subgraph, it **must** be marked as either `@shareable` or [`@external`](#external) in _every_ Federation 2 subgraph that defines it.
+If an object type field is marked `@shareable` in _any_ subgraph, it **must** be marked as either `@shareable` or [`@external`](#external) in _every_ Federation 2 subgraph that defines it.
+
+The `@shareable` directive is usually only used on object types, but is supported on an interface field to _force_ all the implementations of that field _within_ the current subgraph to be declared with `@shareable`. Note that `@shareable` is never required on interface field and we do not generally recommend its usage. 
 
 > If a Federation 2 supergraph includes a Federation 1 subgraph, all value types in the Federation 1 subgraph are automatically considered `@shareable` by the Federation 2 composition algorithm.
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -8,6 +8,13 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
   - This change decreases memory consumption in general (which is the reason for disabling this by
     default), but users that have custom code making use of `GraphQLDataSourceProcessOptions.document`
     will now need to explicitly set `GatewayConfig.queryPlannerConfig.exposeDocumentNodeInFetchNode`.
+- __BREAKING__: validate `@shareable` on interface fields:
+  - marking an interface field as `@shareable` was syntactically allowed, but was not validated in any way, or had any
+    effect. In this release, we allow `@shareable` on interface fields, but _only_ as way to force all the
+    implementation to mark the field `@shareable`. As a consequence, if a field was previously marked as
+    `@shareable` in an interface but not in some/all implementations of that interface, an error will
+    now be raise. The simplest fix is to remove `@shareable` in the interface definition: it is *never*
+    required to mark an interface field `@shareable` and it will never break to remove it.
 - Allows `@shareable` to be repeatable so it can be allowed on both a type definition and its extensions [PR #2175](https://github.com/apollographql/federation/pull/2175).
   - Note that this require the use of the new 2.2 version of the federation spec introduced in this change.
 - Preserve default values of input object fields [PR #2218](https://github.com/apollographql/federation/pull/2218).


### PR DESCRIPTION
The `@shareable` directive was always intended to be only on object types. However, its location being `FIELD_DEFINITION`, it is syntactically allowed on interface fields, and due to an oversight of the original code, doing so had not been propertly rejected (but it had no effects whatsoever).

This oversight was noticed during #2175 and a validation was added to reject a `@shareable` on interface fields. Unfortunately, it appears a number of users had started putting such `@shareable` instances, so the added validation breaks composition for those users on upgrades (the "fix" for those user is trivial, just removing `@shareable` on any interface field, it did nothing and so will have no other impact).

However, sticking with the status quo is highly undesirable: continuing to allow `@shareable` on interface fields but having it do nothing whatsoever is guaranteed to create confusion, and can even be harmful if a user is falsly led to believe that it does something it does not.

So this patch explores a middle-ground alternative: it gives a meaning to `@shareable` on interface fields. That meaning is to force implementations to also mark the field as `@shareable`, as this feel like the most intuitive behaviour that can be done simply. Note that this is a middle ground in the sense that a subset of the users that had started using `@shareable` on interface fields may still see composition break on upgrades, if their implementation does not "manually inherit" those `@shareable` already. But experimentally, it appears that this patch avoids breaking for almost all the cases we have access to.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
