### PR TITLE
Don't validate out introspection type names

### DIFF
--- a/internals-js/src/buildSchema.ts
+++ b/internals-js/src/buildSchema.ts
@@ -55,6 +55,7 @@ import {
   NamedSchemaElement,
 } from "./definitions";
 import { ERRORS, errorCauses, withModifiedErrorNodes } from "./error";
+import { introspectionTypeNames } from "./introspection";
 
 function buildValue(value?: ValueNode): any {
   return value ? valueFromASTUntyped(value) : undefined;
@@ -210,6 +211,10 @@ function buildNamedTypeAndDirectivesShallow(documentNode: DocumentNode, schema: 
       case 'UnionTypeDefinition':
       case 'EnumTypeDefinition':
       case 'InputObjectTypeDefinition':
+        // Like graphql-js, we just silently ignore definitions for introspection types
+        if (introspectionTypeNames.includes(definitionNode.name.value)) {
+          continue;
+        }
         typeDefinitions.push(definitionNode);
         let type = schema.type(definitionNode.name.value);
         // Note that the type may already exists due to an extension having been processed first, but we know we
@@ -240,6 +245,10 @@ function buildNamedTypeAndDirectivesShallow(documentNode: DocumentNode, schema: 
       case 'UnionTypeExtension':
       case 'EnumTypeExtension':
       case 'InputObjectTypeExtension':
+        // Like graphql-js, we just silently ignore definitions for introspection types
+        if (introspectionTypeNames.includes(definitionNode.name.value)) {
+          continue;
+        }
         typeExtensions.push(definitionNode);
         const existing = schema.type(definitionNode.name.value);
         // In theory, graphQL does not let you have an extension without a corresponding definition. However,

--- a/internals-js/src/introspection.ts
+++ b/internals-js/src/introspection.ts
@@ -2,6 +2,16 @@ import { DirectiveLocation } from "graphql";
 import { EnumType, FieldDefinition, ListType, NonNullType, ObjectType, Schema } from "./definitions";
 
 export const introspectionFieldNames = [ '__schema', '__type' ];
+export const introspectionTypeNames = [
+  '__Schema',
+  '__Directive',
+  '__DirectiveLocation',
+  '__Type',
+  '__Field',
+  '__InputValue',
+  '__EnumValue',
+  '__TypeKind',
+]
 
 export function isIntrospectionName(name: string): boolean {
   return name.startsWith('__');

--- a/internals-js/src/validate.ts
+++ b/internals-js/src/validate.ts
@@ -18,7 +18,7 @@ import {
 } from "./definitions";
 import { assertName, ASTNode, GraphQLError, GraphQLErrorOptions } from "graphql";
 import { isValidValue, valueToString } from "./values";
-import { isIntrospectionName } from "./introspection";
+import { introspectionTypeNames, isIntrospectionName } from "./introspection";
 import { isSubtype, sameType } from "./types";
 import { ERRORS } from "./error";
 
@@ -79,7 +79,10 @@ class Validator {
 
   validate(): GraphQLError[] {
     for (const type of this.schema.types()) {
-      this.validateName(type);
+
+      if (!introspectionTypeNames.includes(type.name)) {
+        this.validateName(type);
+      }
       switch (type.kind) {
         case 'ObjectType':
         case 'InterfaceType':


### PR DESCRIPTION
The fix for #2237 has been a bit over-zealous, at least to some extent, as `graphql-js` accepts a schema that manually redeclare the introspection types but those are now rejected.

It's a bit unclear why `graphql-js` makes that particular exception, in particular since:
1. it makes no such special cases for the introspection fields (being it `__typename`, `__schema` or `type(name)`). Particuarly strange when `__schema` and `__type` are the actual "entry point" for those introspection types in the first place ...
2. it does not seem to otherwise validate that those introspection types are valid, though "manual" definitions seems to be silently discarded so have no impact.

But in any case, being consistent with `graphql-js` makes sense, so this patch re-allow definitions of introspection types, but ignores them.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
