### PR TITLE
Release 2.2.0

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+## 2.2.0
+
 - __BREAKING__: composition now rejects `@shareable` on interface fields. The `@shareable` directive is about
   controlling if multiple subgraphs can resolve a particular field, and as interface field are never directly resolved
   (it's their implementation that are), having `@shareable` on interface fields is not completely meaningful and

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/composition",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Apollo Federation composition utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-federation-integration-testsuite",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Apollo Federation Integrations / Test Fixtures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+## 2.2.0
+
 - __BREAKING__: Disable exposing full document to sub-query by default (introduced 2.1.0):
   - This change decreases memory consumption in general (which is the reason for disabling this by
     default), but users that have custom code making use of `GraphQLDataSourceProcessOptions.document`

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Apollo Gateway",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## 2.2.0
+
 - Preserve default values of input object fields [PR #2218](https://github.com/apollographql/federation/pull/2218).
 - Provide support for marking @external on object type [PR #2214](https://github.com/apollographql/federation/pull/2214)
 - Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-internals",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Apollo Federation internal utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -83,7 +83,7 @@
     },
     "federation-integration-testsuite-js": {
       "name": "apollo-federation-integration-testsuite",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "graphql-tag": "^2.12.6",
@@ -92,7 +92,7 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/composition": "file:../composition-js",
@@ -285,7 +285,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -19134,7 +19134,7 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -19165,7 +19165,7 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@apollo/federation-internals": "file:../internals-js",
@@ -19183,7 +19183,7 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## 2.2.0
+
 - Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)
 
 ## 2.1.0

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-graphs",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Apollo Federation library to work with 'query graphs'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -24,10 +24,10 @@
   },
   "dependencies": {
     "@apollo/federation-internals": "file:../internals-js",
+    "@types/uuid": "^8.3.4",
     "deep-equal": "^2.0.5",
     "ts-graphviz": "^0.16.0",
-    "uuid": "^9.0.0",
-    "@types/uuid": "^8.3.4"
+    "uuid": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+## 2.2.0
+
 - __BREAKING__: Disable exposing full document to sub-query by default (introduced in 2.1.0):
   - This change decreases memory consumption in general (which is the reason for disabling this by
     default), but users that have custom code making use of `GraphQLDataSourceProcessOptions.document`

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/query-planner",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Apollo Query Planner",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+## 2.2.0
+
 - Adds support for the 2.2 version of the federation spec (that is, `@link(url: "https://specs.apollo.dev/federation/v2.2")`), which:
 - allows `@shareable` to be repeatable so it can be allowed on both a type definition and its extensions [PR #2175](https://github.com/apollographql/federation/pull/2175).
 - Drop support for node12 [PR #2202](https://github.com/apollographql/federation/pull/2202)

--- a/subgraph-js/package.json
+++ b/subgraph-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/subgraph",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Apollo Subgraph Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/federation/issues?q=label%3A%22:label:%20release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release. 🙌 The version in the title of this PR should correspond to the appropriate branch.

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.
