### PR TITLE
Use IResolvers instead of GraphQLResolverMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@apollo/query-graphs": "file:query-graphs-js",
         "@apollo/query-planner": "file:query-planner-js",
         "@apollo/subgraph": "file:subgraph-js",
-        "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js"
+        "apollo-federation-integration-testsuite": "file:federation-integration-testsuite-js",
+        "graphql-tools": "^8.3.12"
       },
       "devDependencies": {
         "@apollo/cache-control-types": "1.0.2",
@@ -307,7 +308,7 @@
     },
     "node_modules/@apollo/client": {
       "version": "3.6.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -2575,7 +2576,7 @@
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -5212,7 +5213,7 @@
     },
     "node_modules/@wry/context": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -5223,7 +5224,7 @@
     },
     "node_modules/@wry/equality": {
       "version": "0.5.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -5234,7 +5235,7 @@
     },
     "node_modules/@wry/trie": {
       "version": "0.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -9365,6 +9366,63 @@
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/graphql-tools": {
+      "version": "8.3.12",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-8.3.12.tgz",
+      "integrity": "sha512-pUGE7T801ikU+vF1t43/osOxlorQFhXOdRLotMQ9tDTKtgPdQSz8niFx7+jCNY3fF4wzUH7ajNWA9wfbBacMag==",
+      "dependencies": {
+        "@graphql-tools/schema": "9.0.10",
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@apollo/client": "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0 || ~3.6.0 || ~3.7.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/merge": {
+      "version": "8.3.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.12.tgz",
+      "integrity": "sha512-BFL8r4+FrqecPnIW0H8UJCBRQ4Y8Ep60aujw9c/sQuFmQTiqgWgpphswMGfaosP2zUinDE3ojU5wwcS2IJnumA==",
+      "dependencies": {
+        "@graphql-tools/utils": "9.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/schema": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.10.tgz",
+      "integrity": "sha512-lV0o4df9SpPiaeeDAzgdCJ2o2N9Wvsp0SMHlF2qDbh9aFCFQRsXuksgiDm2yTgT3TG5OtUes/t0D6uPjPZFUbQ==",
+      "dependencies": {
+        "@graphql-tools/merge": "8.3.12",
+        "@graphql-tools/utils": "9.1.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/utils": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.1.tgz",
+      "integrity": "sha512-DXKLIEDbihK24fktR2hwp/BNIVwULIHaSTNTNhXS+19vgT50eX9wndx1bPxGwHnVBOONcwjXy0roQac49vdt/w==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "node_modules/graphql-ws": {
       "version": "5.5.5",
       "dev": true,
@@ -9579,7 +9637,7 @@
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
@@ -12333,7 +12391,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -13179,7 +13237,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -14426,7 +14484,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14638,7 +14696,7 @@
     },
     "node_modules/optimism": {
       "version": "0.16.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@wry/context": "^0.6.0",
@@ -15340,7 +15398,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -15562,7 +15620,7 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/read": {
@@ -17630,7 +17688,7 @@
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -17939,7 +17997,7 @@
     },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -18543,7 +18601,6 @@
     },
     "node_modules/value-or-promise": {
       "version": "1.0.11",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -19121,12 +19178,12 @@
     },
     "node_modules/zen-observable": {
       "version": "0.8.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "zen-observable": "0.8.15"
@@ -19204,7 +19261,7 @@
     },
     "@apollo/client": {
       "version": "3.6.9",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.6.0",
@@ -20924,7 +20981,7 @@
     },
     "@graphql-typed-document-node/core": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -22959,21 +23016,21 @@
     },
     "@wry/context": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@wry/equality": {
       "version": "0.5.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@wry/trie": {
       "version": "0.3.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -25891,6 +25948,51 @@
         "tslib": "^2.1.0"
       }
     },
+    "graphql-tools": {
+      "version": "8.3.12",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-8.3.12.tgz",
+      "integrity": "sha512-pUGE7T801ikU+vF1t43/osOxlorQFhXOdRLotMQ9tDTKtgPdQSz8niFx7+jCNY3fF4wzUH7ajNWA9wfbBacMag==",
+      "requires": {
+        "@apollo/client": "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0 || ~3.6.0 || ~3.7.0",
+        "@graphql-tools/schema": "9.0.10",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@graphql-tools/merge": {
+          "version": "8.3.12",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.12.tgz",
+          "integrity": "sha512-BFL8r4+FrqecPnIW0H8UJCBRQ4Y8Ep60aujw9c/sQuFmQTiqgWgpphswMGfaosP2zUinDE3ojU5wwcS2IJnumA==",
+          "requires": {
+            "@graphql-tools/utils": "9.1.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@graphql-tools/schema": {
+          "version": "9.0.10",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.10.tgz",
+          "integrity": "sha512-lV0o4df9SpPiaeeDAzgdCJ2o2N9Wvsp0SMHlF2qDbh9aFCFQRsXuksgiDm2yTgT3TG5OtUes/t0D6uPjPZFUbQ==",
+          "requires": {
+            "@graphql-tools/merge": "8.3.12",
+            "@graphql-tools/utils": "9.1.1",
+            "tslib": "^2.4.0",
+            "value-or-promise": "1.0.11"
+          }
+        },
+        "@graphql-tools/utils": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.1.tgz",
+          "integrity": "sha512-DXKLIEDbihK24fktR2hwp/BNIVwULIHaSTNTNhXS+19vgT50eX9wndx1bPxGwHnVBOONcwjXy0roQac49vdt/w==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
     "graphql-ws": {
       "version": "5.5.5",
       "dev": true,
@@ -26035,7 +26137,7 @@
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -27946,7 +28048,7 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "dev": true
+      "devOptional": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -28570,7 +28672,7 @@
     },
     "loose-envify": {
       "version": "1.4.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -29478,7 +29580,7 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "dev": true
+      "devOptional": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -29615,7 +29717,7 @@
     },
     "optimism": {
       "version": "0.16.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@wry/context": "^0.6.0",
         "@wry/trie": "^0.3.0"
@@ -30099,7 +30201,7 @@
     },
     "prop-types": {
       "version": "15.8.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -30249,7 +30351,7 @@
     },
     "react-is": {
       "version": "16.13.1",
-      "dev": true
+      "devOptional": true
     },
     "read": {
       "version": "1.0.7",
@@ -31710,7 +31812,7 @@
     },
     "symbol-observable": {
       "version": "4.0.0",
-      "dev": true
+      "devOptional": true
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -31926,7 +32028,7 @@
     },
     "ts-invariant": {
       "version": "0.10.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -32318,8 +32420,7 @@
       }
     },
     "value-or-promise": {
-      "version": "1.0.11",
-      "dev": true
+      "version": "1.0.11"
     },
     "vary": {
       "version": "1.1.2",
@@ -32728,11 +32829,11 @@
     },
     "zen-observable": {
       "version": "0.8.15",
-      "dev": true
+      "devOptional": true
     },
     "zen-observable-ts": {
       "version": "1.2.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "zen-observable": "0.8.15"
       }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "deep-freeze": "0.0.1",
     "graphql": "16.6.0",
     "graphql-tag": "2.12.6",
+    "graphql-tools": "^8.3.12",
     "jest": "29.2.2",
     "jest-config": "29.2.2",
     "jest-cucumber": "3.0.1",

--- a/subgraph-js/src/buildSubgraphSchema.ts
+++ b/subgraph-js/src/buildSubgraphSchema.ts
@@ -6,17 +6,18 @@ import {
 } from 'graphql';
 import {
   GraphQLSchemaModule,
-  GraphQLResolverMap,
   addResolversToSchema,
   modulesFromSDL,
 } from './schema-helper';
+import { IResolvers } from "@graphql-tools/utils";
+
 
 import { assert, buildSubgraph, FEDERATION_UNNAMED_SUBGRAPH_NAME, printSchema } from '@apollo/federation-internals';
 import { entitiesResolver } from './types';
 
 type LegacySchemaModule = {
   typeDefs: DocumentNode | DocumentNode[];
-  resolvers?: GraphQLResolverMap<unknown>;
+  resolvers?: IResolvers;
 };
 
 export { GraphQLSchemaModule };

--- a/subgraph-js/src/schema-helper/buildSchemaFromSDL.ts
+++ b/subgraph-js/src/schema-helper/buildSchemaFromSDL.ts
@@ -23,8 +23,9 @@ import {
   ASTNode,
   StringValueNode,
 } from 'graphql';
+import { IResolvers } from "@graphql-tools/utils";
 
-import { GraphQLResolverMap, GraphQLSchemaModule } from './resolverMap';
+import { GraphQLSchemaModule } from './resolverMap';
 import {
   PossibleTypeExtensionsRule,
   KnownTypeNamesRule,
@@ -106,7 +107,7 @@ export function modulesFromSDL(
 
 export function addResolversToSchema(
   schema: GraphQLSchema,
-  resolvers: GraphQLResolverMap<any>
+  resolvers: IResolvers,
 ) {
   for (const [typeName, fieldConfigs] of Object.entries(resolvers)) {
     const type = schema.getType(typeName);

--- a/subgraph-js/src/schema-helper/resolverMap.ts
+++ b/subgraph-js/src/schema-helper/resolverMap.ts
@@ -1,11 +1,13 @@
 import { GraphQLFieldResolver, GraphQLScalarType, DocumentNode } from 'graphql';
+import { IResolvers } from "@graphql-tools/utils";
 
 export interface GraphQLSchemaModule {
   typeDefs: DocumentNode;
-  resolvers?: GraphQLResolverMap<any>;
+  resolvers?: IResolvers;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
+// Deprecating this type, use IResolvers instead for interactions with buildSubgraphSchema
 export interface GraphQLResolverMap<TContext = {}> {
   [typeName: string]:
     | {


### PR DESCRIPTION
Switch buildSubgraphSchema to use IResolvers rather than GraphQLResolverMap. Since IResolvers is a superset, this is a backward compatible change. 

Fixes #2283
