### PR TITLE
Preserves source of union members and enum values in supergraph

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Preserves source of union members and enum values in supergraph [PR #2288](https://github.com/apollographql/federation/pull/2288).
+
 ## 2.2.0
 
 - __BREAKING__: composition now rejects `@shareable` on interface fields. The `@shareable` directive is about

--- a/composition-js/src/__tests__/__snapshots__/compose.composeDirective.test.ts.snap
+++ b/composition-js/src/__tests__/__snapshots__/compose.composeDirective.test.ts.snap
@@ -20,6 +20,10 @@ directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: j
 
 directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
 directive @mytag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @tag(name: String!, prop: String!) on FIELD_DEFINITION | OBJECT

--- a/composition-js/src/__tests__/compose.composeDirective.test.ts
+++ b/composition-js/src/__tests__/compose.composeDirective.test.ts
@@ -365,7 +365,7 @@ describe('composing custom core directives', () => {
   });
 
   it.each([
-    '@join__field', '@join__graph', '@join__implements', '@join__type',
+    '@join__field', '@join__graph', '@join__implements', '@join__type', '@join__unionMember', '@join__enumValue'
   ])('join spec directives should result in an error', (directive) => {
     const subgraphA = generateSubgraph({
       name: 'subgraphA',
@@ -376,6 +376,8 @@ describe('composing custom core directives', () => {
         directive @join__graph(name: String!, url: String!) on ENUM_VALUE
         directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
         directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+        directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+        directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
         scalar join__FieldSet
 
@@ -735,7 +737,7 @@ describe('composing custom core directives', () => {
   });
 
   it.each([
-    '@join__field', '@join__graph', '@join__implements', '@join__type'
+    '@join__field', '@join__graph', '@join__implements', '@join__type', '@join__unionMember', '@join__enumValue'
   ])('naming conflict with join spec directives', (directive) => {
     const subgraphA = generateSubgraph({
       name: 'subgraphA',

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -35,6 +35,12 @@ describe('composition', () => {
         type T @key(fields: "k") {
           k: ID
         }
+
+        type S {
+          x: Int
+        }
+
+        union U = S | T
       `
     }
 
@@ -46,6 +52,11 @@ describe('composition', () => {
           k: ID
           a: Int
           b: String
+        }
+
+        enum E {
+          V1
+          V2
         }
       `
     }
@@ -75,6 +86,13 @@ describe('composition', () => {
 
       directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+      enum E
+        @join__type(graph: SUBGRAPH2)
+      {
+        V1 @join__enumValue(graph: SUBGRAPH2)
+        V2 @join__enumValue(graph: SUBGRAPH2)
+      }
+
       scalar join__FieldSet
 
       enum join__Graph {
@@ -103,6 +121,12 @@ describe('composition', () => {
         t: T @join__field(graph: SUBGRAPH1)
       }
 
+      type S
+        @join__type(graph: SUBGRAPH1)
+      {
+        x: Int
+      }
+
       type T
         @join__type(graph: SUBGRAPH1, key: "k")
         @join__type(graph: SUBGRAPH2, key: "k")
@@ -111,12 +135,27 @@ describe('composition', () => {
         a: Int @join__field(graph: SUBGRAPH2)
         b: String @join__field(graph: SUBGRAPH2)
       }
+
+      union U
+        @join__type(graph: SUBGRAPH1)
+        @join__unionMember(graph: SUBGRAPH1, member: "S")
+        @join__unionMember(graph: SUBGRAPH1, member: "T")
+       = S | T
     `);
 
     const [_, api] = schemas(result);
     expect(printSchema(api)).toMatchString(`
+      enum E {
+        V1
+        V2
+      }
+
       type Query {
         t: T
+      }
+
+      type S {
+        x: Int
       }
 
       type T {
@@ -124,6 +163,8 @@ describe('composition', () => {
         a: Int
         b: String
       }
+
+      union U = S | T
     `);
   })
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -61,6 +61,8 @@ describe('composition', () => {
         query: Query
       }
 
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
       directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
@@ -68,6 +70,8 @@ describe('composition', () => {
       directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
       directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
       directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
@@ -2140,6 +2144,8 @@ describe('composition', () => {
         query: Query
       }
 
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
       directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
@@ -2147,6 +2153,8 @@ describe('composition', () => {
       directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
       directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
       directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 

--- a/composition-js/src/__tests__/matchers/index.ts
+++ b/composition-js/src/__tests__/matchers/index.ts
@@ -1,1 +1,2 @@
 import './toMatchString';
+import './toMatchSubgraph';

--- a/composition-js/src/__tests__/matchers/toMatchSubgraph.ts
+++ b/composition-js/src/__tests__/matchers/toMatchSubgraph.ts
@@ -1,0 +1,30 @@
+import { defaultPrintOptions, orderPrintedDefinitions, Subgraph } from "@apollo/federation-internals";
+
+// Make this file a module (See: https://github.com/microsoft/TypeScript/issues/17736)
+export {};
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toMatchSubgraph(actual: Subgraph): R;
+    }
+  }
+}
+
+expect.extend({
+  toMatchSubgraph(expected: Subgraph, actual: Subgraph) {
+    // Note: we use `Subgraph.toString`, not `printSchema()` because 1) it's simpler and 2) the former skips federation
+    // specific definitions, making errors diffs more readable.
+    const printOptions = orderPrintedDefinitions(defaultPrintOptions);
+    const expectedString = expected.toString(printOptions);
+    const actualString = actual.toString(printOptions);
+    const pass = this.equals(expectedString, actualString);
+    const msgBase = `For subgraph ${expected.name}\n`
+      + this.utils.matcherHint('toMatchSubgraph', undefined, undefined)
+      + '\n\n'
+    const message = pass
+      ? () => msgBase + `Expected: not ${this.printExpected(expectedString)}`
+      : () =>  msgBase + this.utils.printDiffOrStringify(expectedString, actualString, 'Expected', 'Received', true);
+    return {actual, expected, message, name: 'toMatchString', pass};
+  }
+});

--- a/composition-js/src/__tests__/supergraph_reversibility.test.ts
+++ b/composition-js/src/__tests__/supergraph_reversibility.test.ts
@@ -1,0 +1,92 @@
+import { assertCompositionSuccess, composeAsFed2Subgraphs } from "./testHelper";
+import gql from 'graphql-tag';
+import { asFed2SubgraphDocument, buildSubgraph, buildSupergraphSchema, extractSubgraphsFromSupergraph, ServiceDefinition } from "@apollo/federation-internals";
+import './matchers';
+
+function composeAndTestReversibility(subgraphs: ServiceDefinition[]) {
+  const result = composeAsFed2Subgraphs(subgraphs);
+  assertCompositionSuccess(result);
+
+  const extracted = extractSubgraphsFromSupergraph(buildSupergraphSchema(result.supergraphSdl)[0]);
+  for (const expectedSubgraph of subgraphs) {
+    const actual = extracted.get(expectedSubgraph.name)!;
+    // Note: the subgraph extracted from the supergraph are created with their `@link` on the schema definition, not as an extension (no
+    // strong reason for that, it's how the code was written), so let's match that so our follwoing `toMatchSubgraph` don't fail for that.
+    const expected = buildSubgraph(expectedSubgraph.name, '', asFed2SubgraphDocument(expectedSubgraph.typeDefs, { addAsSchemaExtension: false }));
+    expect(actual).toMatchSubgraph(expected);
+  }
+}
+
+it('preserves the source of union members', () => {
+  const s1 = {
+    typeDefs: gql`
+      type Query {
+        uFromS1: U
+      }
+
+      union U = A | B
+
+      type A {
+        a: Int
+      }
+
+      type B {
+        b: Int @shareable
+      }
+    `,
+    name: 'S1',
+  };
+
+  const s2 = {
+    typeDefs: gql`
+      type Query {
+        uFromS2: U
+      }
+
+      union U = B | C
+
+      type B {
+        b: Int @shareable
+      }
+
+      type C {
+        c: Int
+      }
+    `,
+    name: 'S2',
+  };
+
+  composeAndTestReversibility([s1, s2]);
+});
+
+it('preserves the source of enum values', () => {
+  const s1 = {
+    typeDefs: gql`
+      type Query {
+        eFromS1: E
+      }
+
+      enum E {
+        A,
+        B
+      }
+    `,
+    name: 'S1',
+  };
+
+  const s2 = {
+    typeDefs: gql`
+      type Query {
+        eFromS2: E
+      }
+
+      enum E {
+        B,
+        C
+      }
+    `,
+    name: 'S2',
+  };
+
+  composeAndTestReversibility([s1, s2]);
+});

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 ## vNext
 
 - Adds support for `@interfaceObject` and keys on interfaces [PR #2279](https://github.com/apollographql/federation/pull/2279).
-
+- Preserves source of union members and enum values in supergraph [PR #2288](https://github.com/apollographql/federation/pull/2288).
 
 ## 2.2.2
 

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -147,7 +147,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
-      '97f11725be210d703ced94cd941ef00d72ab26a9e04bdb724207b9e89e87359e',
+      'ed8cb418d55e7cd069f11d093b2ea29316e1a913a5757f383cc78ed399414104',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/__tests__/extractSubgraphsFromSupergraph.test.ts
+++ b/internals-js/src/__tests__/extractSubgraphsFromSupergraph.test.ts
@@ -596,7 +596,6 @@ test('preserves default values of input object fields', () => {
   expect(inputFieldA?.defaultValue).toBe(1234)
 })
 
-
 test('throw meaningful error for invalid federation directive fieldSet', () => {
   const supergraph = `
     schema

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -201,6 +201,8 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
     const implementsDirective = joinSpec.implementsDirective(supergraph);
     const ownerDirective = joinSpec.ownerDirective(supergraph);
     const fieldDirective = joinSpec.fieldDirective(supergraph);
+    const unionMemberDirective = joinSpec.unionMemberDirective(supergraph);
+    const enumValueDirective = joinSpec.enumValueDirective(supergraph);
 
     const getSubgraph = (application: Directive<any, { graph?: string }>) => {
       const graph = application.arguments().graph;
@@ -406,23 +408,40 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
               continue;
             }
             assert(isEnumType(subgraphEnum), () => `${subgraphEnum} should be an enum but found a ${subgraphEnum.kind}`);
+
             for (const value of type.values) {
-              subgraphEnum.addValue(value.name);
+              // Before version 0.3 of the join spec (before `enumValueDirective`), we were not recording which subgraph defined which values,
+              // and instead aded all values to all subgraphs (at least if the type existed there).
+              const addValue = !enumValueDirective 
+                || value.appliedDirectivesOf(enumValueDirective).some((d) =>
+                  graphEnumNameToSubgraphName.get(d.arguments().graph) === subgraph.name
+                );
+              if (addValue) {
+                subgraphEnum.addValue(value.name);
+              }
             }
           }
           break;
         case 'UnionType':
-          // TODO: Same as for enums. We need to know in which subgraph each member is defined.
-          // But for now, we also add every members to all subgraphs (as long as the subgraph has both the union type
-          // and the member in question).
           for (const subgraph of subgraphs) {
             const subgraphUnion = subgraph.schema.type(type.name);
             if (!subgraphUnion) {
               continue;
             }
             assert(isUnionType(subgraphUnion), () => `${subgraphUnion} should be an enum but found a ${subgraphUnion.kind}`);
-            for (const memberType of type.types()) {
-              const subgraphType = subgraph.schema.type(memberType.name);
+            let membersInSubgraph: string[];
+            if (unionMemberDirective) {
+              membersInSubgraph = type
+                .appliedDirectivesOf(unionMemberDirective)
+                .filter((d) => graphEnumNameToSubgraphName.get(d.arguments().graph) === subgraph.name)
+                .map((d) => d.arguments().member);
+            } else {
+              // Before version 0.3 of the join spec, we were not recording which subgraph defined which members,
+              // and instead aded all members to all subgraphs (at least if the type existed there).
+              membersInSubgraph = type.types().map((t) => t.name);
+            }
+            for (const memberTypeName of membersInSubgraph) {
+              const subgraphType = subgraph.schema.type(memberTypeName);
               if (subgraphType) {
                 subgraphUnion.addType(subgraphType as ObjectType);
               }

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -412,7 +412,7 @@ export function extractSubgraphsFromSupergraph(supergraph: Schema): Subgraphs {
             for (const value of type.values) {
               // Before version 0.3 of the join spec (before `enumValueDirective`), we were not recording which subgraph defined which values,
               // and instead aded all values to all subgraphs (at least if the type existed there).
-              const addValue = !enumValueDirective 
+              const addValue = !enumValueDirective
                 || value.appliedDirectivesOf(enumValueDirective).some((d) =>
                   graphEnumNameToSubgraphName.get(d.arguments().graph) === subgraph.name
                 );

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -97,6 +97,17 @@ export class JoinSpecDefinition extends FeatureDefinition {
       joinImplements.addArgument('interface', new NonNullType(schema.stringType()));
     }
 
+    if (this.version >= (new FeatureVersion(0, 3))) {
+      const joinUnionMember = this.addDirective(schema, 'unionMember').addLocations(DirectiveLocation.UNION);
+      joinUnionMember.repeatable = true;
+      joinUnionMember.addArgument('graph', new NonNullType(graphEnum));
+      joinUnionMember.addArgument('member', new NonNullType(schema.stringType()));
+
+      const joinEnumValue = this.addDirective(schema, 'enumValue').addLocations(DirectiveLocation.ENUM_VALUE);
+      joinEnumValue.repeatable = true;
+      joinEnumValue.addArgument('graph', new NonNullType(graphEnum));
+    }
+
     if (this.isV01()) {
       const joinOwner = this.addDirective(schema, 'owner').addLocations(DirectiveLocation.OBJECT);
       joinOwner.addArgument('graph', new NonNullType(graphEnum));
@@ -181,6 +192,14 @@ export class JoinSpecDefinition extends FeatureDefinition {
     usedOverridden?: boolean,
   }> {
     return this.directive(schema, 'field')!;
+  }
+
+  unionMemberDirective(schema: Schema): DirectiveDefinition<{graph: string, member: string}> | undefined {
+    return this.directive(schema, 'unionMember');
+  }
+
+  enumValueDirective(schema: Schema): DirectiveDefinition<{graph: string}> | undefined {
+    return this.directive(schema, 'enumValue');
   }
 
   ownerDirective(schema: Schema): DirectiveDefinition<{graph: string}> | undefined {


### PR DESCRIPTION
While composition allows unions and enums to differ between subgraphs (at least under certain conditions), the supergraph currently was not preserving which subgraph defined which union member/enum value, and in particular the query planner made the (sometimes incorrect) assumption that unions and enums were defined the same in all the subgraphs in which they are defined.

As shown in #2256, this was leading to genuine issues in the case of unions, where the query planner was generating invalid subgraph queries. I am not sure this created similar issues for enum values due to a combination of how the merging rule for enum work and the fact that values of enum are not types, but it is nonetheless a bad idea to run the query planner with incorrect information on the subgraph it generates queries for, and this can get in the way of other toolings that wants to use the supergraph (for instance, this gets in the way of #2250).

To fix this, this patch ensures the supergraph preserve the information regarding which subgraph defines which union member and enum values in the supergraph by adding 2 new dedicated "join spec" directives.
