### PR TITLE
Fix possible assertion error during query planning

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 - Adds support for `@interfaceObject` and keys on interfaces [PR #2279](https://github.com/apollographql/federation/pull/2279).
 - Preserves source of union members and enum values in supergraph [PR #2288](https://github.com/apollographql/federation/pull/2288).
+- Fix possible assertion error during query planning [PR #2299](https://github.com/apollographql/federation/pull/2299).
 
 ## 2.2.2
 

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -44,6 +44,8 @@ import {
   isAbstractType,
   DeferDirectiveArgs,
   Variable,
+  possibleRuntimeTypes,
+  Type,
 } from "./definitions";
 import { ERRORS } from "./error";
 import { isDirectSubtype, sameType } from "./types";
@@ -223,21 +225,41 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
       return this.withUpdatedDefinition(selectionParent.typenameField()!);
     }
 
-    // There is 2 valid cases were we could get here:
+    validate(
+      this.canRebaseOn(selectionParent),
+      () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${selectionParent}"`
+    );
+    const fieldDef = selectionParent.field(this.name);
+    validate(fieldDef, () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${selectionParent}" (that does not declare that field)`);
+    return this.withUpdatedDefinition(fieldDef);
+  }
+
+  private canRebaseOn(parentType: CompositeType) {
+    // There is 2 valid cases we want to allow:
     //  1. either `selectionParent` and `fieldParent` are the same underlying type (same name) but from different underlying schema. Typically,
     //    happens when we're building subgraph queries but using selections from the original query which is against the supergraph API schema.
     //  2. or they are not the same underlying type, and we only accept this if we're adding an interface field to a selection of one of its
     //    subtype, and this for convenience. Note that in that case too, `selectinParent` and `fieldParent` may or may be from the same exact
     //    underlying schema, and so we avoid relying on `isDirectSubtype` in the check. 
     // In both cases, we just get the field from `selectionParent`, ensuring the return field parent _is_ `selectionParent`.
-    validate(
-      selectionParent.name == fieldParent.name
-      || (isInterfaceType(fieldParent) && fieldParent.allImplementations().some(i => i.name == selectionParent.name)),
-      () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${selectionSet.parentType}"`
-    );
-    const fieldDef = selectionParent.field(this.name);
-    validate(fieldDef, () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${selectionParent}" (that does not declare that field)`);
-    return this.withUpdatedDefinition(fieldDef);
+    const fieldParentType = this.definition.parent
+    return parentType.name === fieldParentType.name
+      || (isInterfaceType(fieldParentType) && fieldParentType.allImplementations().some(i => i.name === parentType.name));
+  }
+
+  typeIfAddedTo(parentType: CompositeType): Type | undefined {
+    const fieldParentType = this.definition.parent;
+    if (parentType == fieldParentType) {
+      return this.definition.type;
+    }
+
+    if (this.name === typenameFieldName) {
+      return parentType.typenameField()?.type;
+    }
+
+    return this.canRebaseOn(parentType)
+      ? parentType.field(this.name)?.type
+      : undefined;
   }
 
   hasDefer(): boolean {
@@ -327,21 +349,41 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     const selectionParent = selectionSet.parentType;
     const fragmentParent = this.parentType;
     const typeCondition = this.typeCondition;
-    if (selectionParent != fragmentParent) {
-      // This usually imply that the fragment is not from the same sugraph than then selection. So we need
-      // to update the source type of the fragment, but also "rebase" the condition to the selection set
-      // schema.
-      let updatedTypeCondition: CompositeType | undefined = undefined;
-      if (typeCondition) {
-        const typeInSchema = selectionParent.schema().type(typeCondition.name);
-        validate(typeInSchema, () => `Cannot add ${this} to selection of parent type ${selectionParent}: cannot find condition type in schema of parent type`);
-        validate(isCompositeType(typeInSchema), () => `Cannot add ${this} to selection of parent type ${selectionParent}: condition type in schema is a ${typeInSchema.kind}`);
-        validate(runtimeTypesIntersects(selectionParent, typeInSchema), () => `Cannot add ${this} to selection of parent type ${selectionParent}: condition type in schema does not intersect ${selectionParent}`);
-        updatedTypeCondition = typeInSchema;
-      }
-      return this.withUpdatedTypes(selectionParent, updatedTypeCondition);
+    if (selectionParent === fragmentParent) {
+      return this;
     }
-    return this;
+
+    // This usually imply that the fragment is not from the same sugraph than then selection. So we need
+    // to update the source type of the fragment, but also "rebase" the condition to the selection set
+    // schema.
+    const { canRebase, rebasedCondition } = this.canRebaseOn(selectionParent);
+    validate(
+      canRebase, 
+      () => `Cannot add fragment of condition "${typeCondition}" (runtimes: [${possibleRuntimeTypes(typeCondition!)}]) to selection set of parent type "${selectionParent}" (runtimes: ${possibleRuntimeTypes(selectionParent)})`
+    );
+    return this.withUpdatedTypes(selectionParent, rebasedCondition);
+  }
+
+  private canRebaseOn(parentType: CompositeType): { canRebase: boolean, rebasedCondition?: CompositeType } {
+    if (!this.typeCondition) {
+      return { canRebase: true, rebasedCondition: undefined };
+    }
+
+    const rebasedCondition = parentType.schema().type(this.typeCondition.name);
+    if (!rebasedCondition || !isCompositeType(rebasedCondition) || !runtimeTypesIntersects(parentType, rebasedCondition)) {
+      return { canRebase: false };
+    }
+
+    return { canRebase: true, rebasedCondition };
+  }
+
+  castedTypeIfAddedTo(parentType: CompositeType): CompositeType | undefined {
+    if (parentType == this.parentType) {
+      return this.castedType();
+    }
+
+    const { canRebase, rebasedCondition } = this.canRebaseOn(parentType);
+    return canRebase ? (rebasedCondition ? rebasedCondition : parentType) : undefined;
   }
 
   hasDefer(): boolean {
@@ -1315,6 +1357,41 @@ export class SelectionSet extends Freezable<SelectionSet> {
     return true;
   }
 
+  /**
+   * Returns a selection set that correspond to this selection set but where any of the selections in the
+   * provided selection set have been remove.
+   */
+  minus(that: SelectionSet): SelectionSet {
+    const updated = new SelectionSet(this.parentType, this.fragments);
+    for (const [key, thisSelections] of this._selections) {
+      const thatSelections = that._selections.get(key);
+      if (!thatSelections) {
+        updated._selections.set(key, thisSelections);
+      } else {
+        for (const thisSelection  of thisSelections) {
+          const thatSelection = thatSelections.find((s) => thisSelection.element().equals(s.element()));
+          if (thatSelection) {
+            // If there is a subset, then we compute the diff of the subset and add that (if not empty).
+            // Otherwise, we just skip `thisSelection` and do nothing
+            if (thisSelection.selectionSet && thatSelection.selectionSet) {
+              const updatedSubSelectionSet = thisSelection.selectionSet.minus(thatSelection.selectionSet);
+              if (!updatedSubSelectionSet.isEmpty()) {
+                updated._selections.add(key, thisSelection.withUpdatedSubSelection(updatedSubSelectionSet));
+              }
+            }
+          } else {
+            updated._selections.add(key, thisSelection);
+          }
+        }
+      }
+    }
+    return updated;
+  }
+
+  canRebaseOn(parentTypeToTest: CompositeType): boolean {
+    return this.selections().every((selection) => selection.canAddTo(parentTypeToTest));
+  }
+
   validate() {
     validate(!this.isEmpty(), () => `Invalid empty selection set`);
     for (const selection of this.selections()) {
@@ -1665,6 +1742,27 @@ export class FieldSelection extends Freezable<FieldSelection> {
     return new FieldSelection(updatedField, updatedSelectionSet);
   }
 
+  /**
+   * Essentially checks if `updateForAddingTo` would work on an selecion set of the provide parent type.
+   */
+  canAddTo(parentType: CompositeType): boolean {
+    if (this.field.parentType === parentType) {
+      return true;
+    }
+
+    const type = this.field.typeIfAddedTo(parentType);
+    if (!type) {
+      return false;
+    }
+
+    const base = baseType(type);
+    if (this.selectionSet && this.selectionSet.parentType !== base) {
+      assert(isCompositeType(base), () => `${this.field} should have a selection set as it's type is not a composite`);
+      return this.selectionSet.selections().every((s) => s.canAddTo(base));
+    }
+    return true;
+  }
+
   toSelectionNode(): FieldNode {
     const alias: NameNode | undefined = this.field.alias ? { kind: Kind.NAME, value: this.field.alias, } : undefined;
     return {
@@ -1772,6 +1870,8 @@ export abstract class FragmentSelection extends Freezable<FragmentSelection> {
    * See `FielSelection.updateForAddingTo` for a discussion of why this method exists and what it does.
    */
   abstract updateForAddingTo(selectionSet: SelectionSet): FragmentSelection;
+
+  abstract canAddTo(parentType: CompositeType): boolean;
 
   abstract withUpdatedSubSelection(newSubSelection: SelectionSet | undefined): FragmentSelection;
 
@@ -1884,6 +1984,22 @@ class InlineFragmentSelection extends FragmentSelection {
     }
 
     return new InlineFragmentSelection(updatedFragment, updatedSelectionSet);
+  }
+
+  canAddTo(parentType: CompositeType): boolean {
+    if (this.element().parentType === parentType) {
+      return true;
+    }
+
+    const type = this.element().castedTypeIfAddedTo(parentType);
+    if (!type) {
+      return false;
+    }
+
+    if (this.selectionSet.parentType !== type) {
+      return this.selectionSet.selections().every((s) => s.canAddTo(type));
+    }
+    return true;
   }
 
 
@@ -2067,6 +2183,11 @@ class FragmentSpreadSelection extends FragmentSelection {
     // expand the spread, as that would compromise the code that optimize subgraph fetches to re-use named
     // fragments.
     return this;
+  }
+
+  canAddTo(_: CompositeType): boolean {
+    // Mimicking the logic of `updateForAddingTo`.
+    return true;
   }
 
   expandFragments(names?: string[], updateSelectionSetFragments: boolean = true): FragmentSelection | readonly Selection[] {

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix possible assertion error during query planning [PR #2299](https://github.com/apollographql/federation/pull/2299).
+
 ## 2.2.2
 
 - Fix issue with path in query plan's deferred nodes [PR #2281](https://github.com/apollographql/federation/pull/2281).

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -669,7 +669,7 @@ class FetchGroup {
     readonly rootKind: SchemaRootKind,
     readonly parentType: CompositeType,
     readonly isEntityFetch: boolean,
-    private readonly _selection: LazySelectionSet,
+    private _selection: LazySelectionSet,
     private _inputs?: LazySelectionSet,
     readonly mergeAt?: ResponsePath,
     readonly deferRef?: string,
@@ -927,6 +927,13 @@ class FetchGroup {
 
   canMergeChildIn(child: FetchGroup): boolean {
     return this.deferRef === child.deferRef && !!child.parentRelation(this)?.path;
+  }
+
+  removeInputsFromSelection() {
+    const inputs = this.inputs;
+    if (inputs) {
+      this._selection = new LazySelectionSet(this.selection.minus(inputs));
+    }
   }
 
   /**
@@ -1644,6 +1651,7 @@ class FetchDependencyGraph {
     subgraphName,
     inputsTypeName,
     mergeAt,
+    type,
     parent,
     conditionsGroups,
     deferRef,
@@ -1651,6 +1659,7 @@ class FetchDependencyGraph {
     subgraphName: string,
     inputsTypeName: string,
     mergeAt: ResponsePath,
+    type: CompositeType,
     parent: ParentRelation,
     conditionsGroups: FetchGroup[],
     deferRef?: string,
@@ -1658,12 +1667,16 @@ class FetchDependencyGraph {
     // Let's look if we can reuse a group we have, that is an existing child of the parent that:
     // 1. is for the same subgraph
     // 2. has the same mergeAt
-    // 3. is not part of our conditions or our conditions ancestors (meaning that we annot reuse a group if it fetches something we take as input).
+    // 3. is for the same entity type (we don't reuse groups for different entities just yet, as this can create unecessary dependencies that
+    //   gets in the way of some optimizations; the final optimizations in `reduceAndOptimize` will however later merge groups on the same subgraph
+    //   and mergeAt when possibleA).
+    // 4. is not part of our conditions or our conditions ancestors (meaning that we annot reuse a group if it fetches something we take as input).
     for (const existing of parent.group.children()) {
       if (existing.subgraphName === subgraphName
         && existing.mergeAt
         && sameMergeAt(existing.mergeAt, mergeAt)
         && inputsTypeName === existing.inputs?.parentType?.name
+        && existing.selection.selections().every((s) => s.kind === 'FragmentSelection' && s.element().castedType() === type)
         && !this.isInGroupsOrTheirAncestors(existing, conditionsGroups)
         && existing.deferRef === deferRef
       ) {
@@ -3361,6 +3374,7 @@ function computeGroupsForTree(
               subgraphName: edge.tail.source,
               mergeAt: path.inResponse(),
               inputsTypeName: destType.name,
+              type: destType,
               parent: { group, path: pathInParent },
               conditionsGroups,
               deferRef: updatedDeferContext.activeDeferRef,
@@ -3630,12 +3644,24 @@ function addTypenameFieldForAbstractTypes(selectionSet: SelectionSet) {
   }
 }
 
-function withoutTypename(selectionSet: SelectionSet): SelectionSet {
-  return selectionSet.filter((selection) => selection.kind !== 'FieldSelection' || selection.element().name === '__typename');
-}
-
 function pathHasOnlyFragments(path: OperationPath): boolean {
   return path.every((element) => element.kind === 'FragmentElement');
+}
+
+function typeAtPath(parentType: CompositeType, path: OperationPath): CompositeType {
+  let type = parentType;
+  for (const element of path) {
+    if (element.kind === 'Field') {
+      const fieldType = baseType(type.field(element.name)?.type!);
+      assert(isCompositeType(fieldType), () => `Invalid call fro ${path} starting at ${parentType}: ${element.definition.coordinate} is not composite`);
+      type = fieldType;
+    } else if (element.typeCondition) {
+      const rebasedType = parentType.schema().type(element.typeCondition.name);
+      assert(rebasedType && isCompositeType(rebasedType), () => `Type condition of ${element} should be composite`);
+      type = rebasedType;
+    }
+  }
+  return type;
 }
 
 function handleRequires(
@@ -3699,23 +3725,19 @@ function handleRequires(
     }
 
     // We know the @require needs createdGroups. We do want to know however if any of the conditions was
-    // fetched from our `newGroup`. If not, then this means that `createdGroup` don't really depend on
-    // the current `group`, but can be dependencies of the parent (or even merged into this parent).
-    // To know this, we check if `newGroup` inputs contains its inputs (meaning the fetch is
-    // useless: we jump to it but didn't get anything new). Not that this isn't perfect because
-    // in the case of multiple keys between `newGroup` and its parent, we could theoretically take a
-    // different key on the way in that on the way back. In other words, `newGroup` selection may only
-    // be fetching a key that happens to not be the one in its inputs, and in that case the code below
-    // will not remove `newGroup` even though it would be more efficient to do so. Handling this properly
-    // is more complex however and it's sufficiently unlikely to happpen that we ignore that "optimization"
-    // for now. If someone run into this and notice, we can optimize then.
+    // fetched from our `newGroup`. If not, then this means that the `createdGroups` don't really depend on
+    // the current `group` and can be dependencies of the parent (or even merged into this parent).
+    //
+    // So we want to know if anything in `newGroup` selection cannot be fetched directly from the parent.
+    // For that, we first remove any of `newGroup` inputs from its selection: in most case, `newGroup`
+    // will just contain the key needed to jump back to its parent, and those would usually be the same
+    // as the inputs. And since by definition we know `newGroup`'s inputs are already fetched, we
+    // know they are not things that we need. Then, we check if what remains (often empty) can be
+    // directly fetched from the parent. If it can, then we can just merge `newGroup` into that parent.
+    // Otherwise, we will have to "keep it".
     // Note: it is to be sure this test is not poluted by other things in `group` that we created `newGroup`.
-    // Note2: `__typename` selections adds a bit of complexity. That is, if `newGroup` selection is not
-    // strictly contained in its inputs but only due to the selection of some `__typename`, then we
-    // still want to ignore that group, because `__typename` are always trivially queriable from any
-    // type in any subgraph and so that `__typename` can always be fetched from the parent. Which is
-    // what the `newGroupIsUnneeded` check ignores `__typename` in the selection.
-    const newGroupIsUnneeded = newGroup.inputs!.contains(withoutTypename(newGroup.selection)) && parent.path;
+    newGroup.removeInputsFromSelection();
+    let newGroupIsUnneeded = parent.path && newGroup.selection.canRebaseOn(typeAtPath(parent.group.selection.parentType, parent.path));
     const unmergedGroups = [];
 
     if (newGroupIsUnneeded) {
@@ -3803,7 +3825,7 @@ function handleRequires(
     // If we get here, it means that @require needs the information from `unmergedGroups` (plus whatever has
     // been merged before) _and_ those rely on some information from the current `group` (if they hadn't, we
     // would have been able to merge `newGroup` to `group`'s parent). So the group we should return, which
-    // is the group where the "post-@require" fields will be add, needs to a be a new group that depends
+    // is the group where the "post-@require" fields will be added, needs to a be a new group that depends
     // on all those `unmergedGroups`.
     const postRequireGroup = dependencyGraph.newKeyFetchGroup({
       subgraphName: group.subgraphName,


### PR DESCRIPTION
The code for handling @requires was, in rare cases, trying to add some selections to a subgraph that couldn't handle them. This fixes that issue by ensuring we only try the merging in question if the subgraph can handle the selection.
