### PR TITLE
Fix potential issue with nested `@defer` in non-deferrable case

### DIFF
--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -17,6 +17,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
   must resolve the same way in all the subgraphs, but this is impossible if the concrete runtime types have no
   intersection at all [PR #1556](https://github.com/apollographql/federation/pull/1556). 
 - Adds support for the 0.3 version of the tag spec, which adds `@tag` directive support for the `SCHEMA` location [PR #2314](https://github.com/apollographql/federation/pull/2314).
+- Fix potential issue with nested `@defer` in non-deferrable case [PR #2312](https://github.com/apollographql/federation/pull/2312).
 
 ## 2.2.2
 

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -341,7 +341,9 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
                 edgeConditions: withReplacedLastElement(this.props.edgeConditions, conditionsResolution.pathTree ?? null),
                 edgeToTail: updatedEdge,
                 runtimeTypesOfTail: runtimeTypesWithoutPreviousCast,
-                deferOnTail: defer,
+                // We know the edge is a DownCast, so if there is no new `defer` taking precedence, we just inherit the
+                // prior version.
+                deferOnTail: defer ?? this.props.deferOnTail,
               });
             }
           }
@@ -392,7 +394,10 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
       edgeToTail: edge,
       runtimeTypesOfTail: updateRuntimeTypes(this.props.runtimeTypesOfTail, edge),
       runtimeTypesBeforeTailIfLastIsCast: edge?.transition?.kind === 'DownCast' ? this.props.runtimeTypesOfTail : undefined,
-      deferOnTail: defer,
+      // If there is no new `defer` taking precedence, and the edge is downcast, then we inherit the prior version. This
+      // is because we only try to re-enter subgraphs for @defer on concrete fields, and so as long as we add downcasts,
+      // we should remember that we still need to try re-entering the subgraph.
+      deferOnTail: defer ?? (edge && edge.transition.kind === 'DownCast' ? this.props.deferOnTail : undefined),
     });
   }
 
@@ -1712,9 +1717,10 @@ export function advanceSimultaneousPathsWithOperation<V extends Vertex>(
     let options: SimultaneousPaths<V>[] | undefined = undefined;
 
     debug.group(() => `Computing options for ${path}`);
+    const shouldReenterSubgraph = path.deferOnTail && operation.kind === 'Field';
     // If we're just entering a deferred section, then we will need to re-enter subgraphs, so we should not consider
     // direct options and instead force an indirect path.
-    if (!path.deferOnTail) {
+    if (!shouldReenterSubgraph) {
       debug.group(() => `Direct options`);
       const { options: advanceOptions, hasOnlyTypeExplodedResults } = advanceWithOperation(
         supergraphSchema,
@@ -1750,41 +1756,43 @@ export function advanceSimultaneousPathsWithOperation<V extends Vertex>(
 
     // If there was not valid direct path (or we didn't check those because we enter a defer), that's ok, we'll just try with non-collecting edges.
     options = options ?? [];
-    debug.group(`Computing indirect paths:`);
-    // Then adds whatever options can be obtained by taking some non-collecting edges first.
-    const pathsWithNonCollecting = subgraphSimultaneousPaths.indirectOptions(updatedContext, i);
-    debug.groupEnd(() => pathsWithNonCollecting.paths.length == 0 ? `no indirect paths` : `${pathsWithNonCollecting.paths.length} indirect paths`);
-    if (pathsWithNonCollecting.paths.length > 0) {
-      debug.group('Validating indirect options:');
-      for (const pathWithNonCollecting of pathsWithNonCollecting.paths) {
-        debug.group(() => `For indirect path ${pathWithNonCollecting}:`);
-        const { options: pathWithOperation } = advanceWithOperation(
-          supergraphSchema,
-          pathWithNonCollecting,
-          operation,
-          updatedContext,
-          subgraphSimultaneousPaths.conditionResolver
-        );
-        // If we can't advance the operation after that path, ignore it, it's just not an option.
-        if (!pathWithOperation) {
-          debug.groupEnd(() => `Ignoring: cannot be advanced with ${operation}`);
-          continue;
+    if (operation.kind === 'Field') {
+      debug.group(`Computing indirect paths:`);
+      // Then adds whatever options can be obtained by taking some non-collecting edges first.
+      const pathsWithNonCollecting = subgraphSimultaneousPaths.indirectOptions(updatedContext, i);
+      debug.groupEnd(() => pathsWithNonCollecting.paths.length == 0 ? `no indirect paths` : `${pathsWithNonCollecting.paths.length} indirect paths`);
+      if (pathsWithNonCollecting.paths.length > 0) {
+        debug.group('Validating indirect options:');
+        for (const pathWithNonCollecting of pathsWithNonCollecting.paths) {
+          debug.group(() => `For indirect path ${pathWithNonCollecting}:`);
+          const { options: pathWithOperation } = advanceWithOperation(
+            supergraphSchema,
+            pathWithNonCollecting,
+            operation,
+            updatedContext,
+            subgraphSimultaneousPaths.conditionResolver
+          );
+          // If we can't advance the operation after that path, ignore it, it's just not an option.
+          if (!pathWithOperation) {
+            debug.groupEnd(() => `Ignoring: cannot be advanced with ${operation}`);
+            continue;
+          }
+          debug.groupEnd(() => `Adding valid option: ${pathWithOperation}`);
+          // advancedWithOperation can return an empty list only if the operation if a fragment with a condition that, on top of the "current" type
+          // is unsatisfiable. But as we've only taken type preserving transitions, we cannot get an empty results at this point if we haven't
+          // had one when testing direct transitions above (in which case we have exited the method early).
+          assert(pathWithOperation.length > 0, () => `Unexpected empty options after non-collecting path ${pathWithNonCollecting} for ${operation}`);
+          options = options.concat(pathWithOperation);
         }
-        debug.groupEnd(() => `Adding valid option: ${pathWithOperation}`);
-        // advancedWithOperation can return an empty list only if the operation if a fragment with a condition that, on top of the "current" type
-        // is unsatisfiable. But as we've only taken type preserving transitions, we cannot get an empty results at this point if we haven't
-        // had one when testing direct transitions above (in which case we have exited the method early).
-        assert(pathWithOperation.length > 0, () => `Unexpected empty options after non-collecting path ${pathWithNonCollecting} for ${operation}`);
-        options = options.concat(pathWithOperation);
+        debug.groupEnd();
       }
-      debug.groupEnd();
     }
 
     // If we were entering a @defer, we've skipped the potential "direct" options because we need an "indirect" one (a key/root query)
     // to be able to actualy defer. But in rare cases, it's possible we actually couldn't resolve the key fields needed to take a key
     // but could still find a direct path. If so, it means it's a corner case where we cannot do query-planner-based-@defer and have
     // to fall back on not deferring.
-    if (options.length === 0 && path.deferOnTail) {
+    if (options.length === 0 && shouldReenterSubgraph) {
       debug.group(() => `Cannot defer (no indirect options); falling back to direct options`);
       const { options: advanceOptions } = advanceWithOperation(
         supergraphSchema,

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix potential issue with nested `@defer` in non-deferrable case [PR #2312](https://github.com/apollographql/federation/pull/2312).
 - Fix possible assertion error during query planning [PR #2299](https://github.com/apollographql/federation/pull/2299).
 
 ## 2.2.2

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -276,6 +276,7 @@ class QueryPlanningTaversal<RV extends Vertex> {
 
   private handleOpenBranch(selection: Selection, options: SimultaneousPathsWithLazyIndirectPaths<RV>[]) {
     const operation = selection.element();
+    debug.group(() => `Handling open branch: ${operation}`);
     let newOptions: SimultaneousPathsWithLazyIndirectPaths<RV>[] = [];
     for (const option of options) {
       const followupForOption = advanceSimultaneousPathsWithOperation(this.supergraphSchema, option, operation);
@@ -313,6 +314,7 @@ class QueryPlanningTaversal<RV extends Vertex> {
         if (operation.kind === 'FragmentElement') {
           this.closedBranches.push(options.map((o) => o.paths.map(p => terminateWithNonRequestedTypenameField(p))));
         }
+        debug.groupEnd(() => `Terminating branch with no possible results`);
         return;
       }
       newOptions = newOptions.concat(followupForOption);
@@ -324,13 +326,14 @@ class QueryPlanningTaversal<RV extends Vertex> {
       // This should never happen for a top-level query planning (unless the supergraph has *not* been
       // validated), but can happen when computing sub-plans for a key condition.
       if (this.isTopLevel) {
-        debug.log(`No valid options to advance ${selection} from ${advanceOptionsToString(options)}`);
+        debug.groupEnd(() => `No valid options to advance ${selection} from ${advanceOptionsToString(options)}`);
         throw new Error(`Was not able to find any options for ${selection}: This shouldn't have happened.`);
       } else {
         // We clear both open branches and closed ones as a mean to terminate the plan computation with
         // no plan
         this.stack.splice(0, this.stack.length);
         this.closedBranches.splice(0, this.closedBranches.length);
+        debug.groupEnd(() => `No possible plan for ${selection} from ${advanceOptionsToString(options)}; terminating condition`);
         return;
       }
     }
@@ -339,9 +342,11 @@ class QueryPlanningTaversal<RV extends Vertex> {
       for (const branch of mapOptionsToSelections(selection.selectionSet, newOptions)) {
         this.stack.push(branch);
       }
+      debug.groupEnd();
     } else {
       const updated = this.maybeEliminateStrictlyMoreCostlyPaths(newOptions);
       this.closedBranches.push(updated);
+      debug.groupEnd(() => `Branch finished with ${updated.length} options`);
     }
   }
 


### PR DESCRIPTION
The code handling `@defer` works roughly like this:
1. as we cross a query element (field or spread) with a `@defer`, we remember that we just "entered" a deferred section.
2. as we handle the initial elements within that `@defer`, we notice that we just entered a `@defer`, ignore in which subgraph we were, and instead attempt to "re-enter" subgraphs using a key.
3. if that work, we continue from whichever possible subgraphs we just re-entered.
4. Otherwise, if we can't handle the new element by re-entering a subgraph, then we fall back to "normal" operation and try to handle the element from the original subgraph in which we were before entering the @defer: this correspond to case where we cannot do a router-based-defer due to not having proper @key to do it.

The issue however is that we were trying to re-enter subgraphs even when the next element was a fragment. This meant that we re-entered any subgraphs that had a key, but that may exclude the one subgraph in which we previously were. If we get a new `@defer` followed by a field that was only in the "original" subgraph, then we could end up not being able to find that field _even_ when falling back to step 4 above, because we had already re-entered different subgraphs due to the 1st `@defer`.

The solution implemented by this commit consists in delaying the subgraph re-entry until we actually get to a field, since this is where we _have_ to re-enter.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
