### PR TITLE
Fixes composition issues with @interfaceObject

### DIFF
--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -15,6 +15,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
   must resolve the same way in all the subgraphs, but this is impossible if the concrete runtime types have no
   intersection at all [PR #1556](https://github.com/apollographql/federation/pull/1556). 
 - Uses the 0.3 version of the tag spec in the supergraph, which adds `@tag` directive support for the `SCHEMA` location [PR #2314](https://github.com/apollographql/federation/pull/2314).
+- Fixes composition issues with `@interfaceObject` [PR #2318](https://github.com/apollographql/federation/pull/2318).
 
 ## 2.2.0
 

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -18,6 +18,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
   intersection at all [PR #1556](https://github.com/apollographql/federation/pull/1556). 
 - Adds support for the 0.3 version of the tag spec, which adds `@tag` directive support for the `SCHEMA` location [PR #2314](https://github.com/apollographql/federation/pull/2314).
 - Fix potential issue with nested `@defer` in non-deferrable case [PR #2312](https://github.com/apollographql/federation/pull/2312).
+- Fixes composition issues with `@interfaceObject` [PR #2318](https://github.com/apollographql/federation/pull/2318).
 
 ## 2.2.2
 

--- a/internals-js/src/types.ts
+++ b/internals-js/src/types.ts
@@ -7,12 +7,10 @@ import {
   InterfaceType,
   isInterfaceType,
   isListType,
+  isNamedType,
   isNonNullType,
   isObjectType,
   isUnionType,
-  ListType,
-  NamedType,
-  NonNullType,
   ObjectType,
   Type,
   UnionType
@@ -32,26 +30,25 @@ export type SubtypingRule = typeof ALL_SUBTYPING_RULES[number];
 export const DEFAULT_SUBTYPING_RULES = ALL_SUBTYPING_RULES.filter(r => r !== "list_upgrade");
 
 /**
- * Tests whether 2 types are the same type.
+ * Tests whether 2 types are the "same" type.
  *
- * To be the same type, for this method, is defined as having the same "kind"
- * and either the same name, for named types or, for wrapper types, the same
- * wrapped type (applying this method recursively).
+ * To be the same type, for this method, is defined as having the samee name for named types
+ * or, for wrapper types, the same wrapper type and recursively same wrapped one.
  *
- * This method does not check that both types are from the same schema and does
- * not validate that the structure of named types is the same.
+ * This method does not check that both types are from the same schema and does not validate
+ * that the structure of named types is the same. Also note that it does not check the "kind"
+ * of the type, which is actually relied on due to @interfaceObject (where the "same" type 
+ * can be an interface in one subgraph but an object type in another, while fundamentally being
+ * the same type).
  */
 export function sameType(t1: Type, t2: Type): boolean {
-  if (t1.kind !== t2.kind) {
-    return false;
-  }
   switch (t1.kind) {
     case 'ListType':
-      return sameType(t1.ofType, (t2 as ListType<any>).ofType);
+      return isListType(t2) && sameType(t1.ofType, t2.ofType);
     case 'NonNullType':
-      return sameType(t1.ofType, (t2 as NonNullType<any>).ofType);
+      return isNonNullType(t2) && sameType(t1.ofType, t2.ofType);
     default:
-      return t1.name === (t2 as NamedType).name;
+      return isNamedType(t2) && t1.name === t2.name;
   }
 }
 

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -159,6 +159,8 @@ type PathProps<TTrigger, RV extends Vertex = Vertex, TNullEdge extends null | ne
   /** If the last edge (the one getting to tail) was a DownCast, the runtime types before that edge. */
   readonly runtimeTypesBeforeTailIfLastIsCast?: readonly ObjectType[],
 
+  readonly lastIsInterfaceObjectFakeCastAfterNonCollecting: boolean,
+
   readonly deferOnTail?: DeferDirectiveArgs,
 }
 
@@ -206,7 +208,8 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
       edgeConditions: [],
       ownPathIds: [],
       overriddingPathIds: [],
-      runtimeTypesOfTail: runtimeTypes
+      runtimeTypesOfTail: runtimeTypes,
+      lastIsInterfaceObjectFakeCastAfterNonCollecting: false,
     });
   }
 
@@ -283,6 +286,10 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
     return this.props.runtimeTypesOfTail;
   }
 
+  lastIsIntefaceObjectFakeDownCastAfterNonCollecting(): boolean {
+    return this.props.lastIsInterfaceObjectFakeCastAfterNonCollecting;
+  }
+
   /**
    * Creates the new path corresponding to appending to this path the provided `edge`.
    *
@@ -341,6 +348,7 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
                 edgeConditions: withReplacedLastElement(this.props.edgeConditions, conditionsResolution.pathTree ?? null),
                 edgeToTail: updatedEdge,
                 runtimeTypesOfTail: runtimeTypesWithoutPreviousCast,
+                lastIsInterfaceObjectFakeCastAfterNonCollecting: false,
                 // We know the edge is a DownCast, so if there is no new `defer` taking precedence, we just inherit the
                 // prior version.
                 deferOnTail: defer ?? this.props.deferOnTail,
@@ -375,9 +383,11 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
             edgeTriggers: withReplacedLastElement(this.props.edgeTriggers, trigger),
             edgeIndexes: withReplacedLastElement(this.props.edgeIndexes, edge.index),
             edgeConditions: withReplacedLastElement(this.props.edgeConditions, conditionsResolution.pathTree ?? null),
+            subgraphEnteringEdge,
             edgeToTail: edge,
             runtimeTypesOfTail: updateRuntimeTypes(this.props.runtimeTypesOfTail, edge),
             runtimeTypesBeforeTailIfLastIsCast: undefined, // we know last is not a cast
+            lastIsInterfaceObjectFakeCastAfterNonCollecting: false,
             deferOnTail: defer,
           });
         }
@@ -394,6 +404,7 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
       edgeToTail: edge,
       runtimeTypesOfTail: updateRuntimeTypes(this.props.runtimeTypesOfTail, edge),
       runtimeTypesBeforeTailIfLastIsCast: edge?.transition?.kind === 'DownCast' ? this.props.runtimeTypesOfTail : undefined,
+      lastIsInterfaceObjectFakeCastAfterNonCollecting: edge?.transition.kind === 'InterfaceObjectFakeDownCast' && !!this.props.edgeToTail?.changesSubgraph(),
       // If there is no new `defer` taking precedence, and the edge is downcast, then we inherit the prior version. This
       // is because we only try to re-enter subgraphs for @defer on concrete fields, and so as long as we add downcasts,
       // we should remember that we still need to try re-entering the subgraph.
@@ -436,7 +447,7 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
     });
   }
 
-  checkDirectPathFomPreviousSubgraphTo(
+  checkDirectPathFromPreviousSubgraphTo(
     typeName: string,
     triggerToEdge: (graph: QueryGraph, vertex: Vertex, t: TTrigger) => Edge | null | undefined
   ): Vertex | undefined {
@@ -1116,6 +1127,25 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
   convertTransitionWithCondition: (transition: Transition, context: PathContext) => TTrigger,
   triggerToEdge: (graph: QueryGraph, vertex: Vertex, t: TTrigger) => Edge | null | undefined
 ): IndirectPaths<TTrigger, V, TNullEdge, TDeadEnds>  {
+  // If we're asked for indirect paths after an "@interfaceObject fake down cast" but that down cast comes just after a non-collecting edges, then
+  // we can ignore it (skip indirect paths from there). The reason is that the presence of the non-collecting just before the fake down-cast means
+  // we add looked at indirect paths just before that down cast, but that fake downcast really does nothing in practice with the subgraph it's on,
+  // so any indirect path from that fake down cast will have a valid indirect path _before_ it, and so will have been taken into account independently.
+  if (path.lastIsIntefaceObjectFakeDownCastAfterNonCollecting()) {
+    // Note: we need to register a dead-end for every subgraphs we "could" be going to, or the code calling this may try to infer a reason on its own
+    // and we'll run into some assertion.
+    const reachableSubgraphs = new Set(path.nextEdges().filter((e) => !e.transition.collectOperationElements && e.tail.source !== path.tail.source).map((e) => e.tail.source));
+    return {
+      paths: [],
+      deadEnds: new Unadvanceables(Array.from(reachableSubgraphs).map((s) => ({
+        sourceSubgraph: path.tail.source,
+        destSubgraph: s,
+        reason: UnadvanceableReason.IGNORED_INDIRECT_PATH,
+        details: `ignoring moving from "${path.tail.source}" to "${s}" as a more direct option exists`,
+      }))) as TDeadEnds,
+    };
+  }
+
   const isTopLevelPath = path.isOnTopLevelQueryRoot();
   const typeName = isFederatedGraphRootType(path.tail.type) ? undefined : path.tail.type.name;
   const originalSource = path.tail.source;
@@ -1251,7 +1281,7 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
         // loop when calling `hasValidDirectKeyEdge` in that case without additional care and it's not useful because this
         // very method already ensure we don't create unnecessary chains of keys for the "current type"
         if (subgraphEnteringEdge && edge.transition.kind === 'KeyResolution' && subgraphEnteringEdge.edge.tail.type.name !== typeName) {
-          const prevSubgraphVertex = toAdvance.checkDirectPathFomPreviousSubgraphTo(edge.tail.type.name, triggerToEdge);
+          const prevSubgraphVertex = toAdvance.checkDirectPathFromPreviousSubgraphTo(edge.tail.type.name, triggerToEdge);
           const backToPreviousSubgraph = subgraphEnteringEdge.edge.head.source === edge.tail.source;
           const maxCost = toAdvance.subgraphEnteringEdge.cost + (backToPreviousSubgraph ? 0 : conditionResolution.cost);
           if (prevSubgraphVertex

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -174,7 +174,7 @@ export class Edge {
   }
 
   matchesSupergraphTransition(otherTransition: Transition): boolean {
-    assert(otherTransition.collectOperationElements, "Supergraphs shouldn't have transition that don't collect elements");
+    assert(otherTransition.collectOperationElements, () => `Supergraphs shouldn't have transition that don't collect elements; got ${otherTransition}"`);
     const transition = this.transition;
     switch (transition.kind) {
       case 'FieldCollection': return otherTransition.kind === 'FieldCollection' && transition.definition.name === otherTransition.definition.name;
@@ -182,6 +182,10 @@ export class Edge {
       case 'InterfaceObjectFakeDownCast': return otherTransition.kind === 'DownCast' && transition.castedTypeName === otherTransition.castedType.name;
       default: return false;
     }
+  }
+
+  changesSubgraph(): boolean {
+    return this.head.source !== this.tail.source;
   }
 
   label(): string {


### PR DESCRIPTION
This commit fixes two main problems:
1. merging a shareable field whose return type was an `@interfaceObject` was not working properly.
2. some metadata was not properly computed on a path added for `@interfaceObject` and this led to a potential assertion errors during composition validation on some cases.

For the merging of shareable fields, the main issue was that the code checking if 2 types are "the same" was relying on the type "kind", which was fine before but broke with `@interfaceObject` in the sense that some type type T can be an interface type in one subgraph but an object type in another (through `@interfaceObject`) and we were not considering those "the same type". But with that fixed, a small issue remained in that the check added in #1556 had not been updated for `@interfaceObject` and needed to ignore those.

For the 2nd issue, the core bug was that when building a `GraphPath`, we keep track of the edge that made us enter the current graph, and some assertion is essentially checking that there is no "key" edges between that edge and the end of the path, but that "edge entering the subgraph" info was not properly set on a path added for `@interfaceObject` and that triggered the assertion. This commit fix this issue, but this was also highlighting some ineffeciency whereby we were generating unecessary paths (path moving to a subgraph and then moving back again right away), so the patch also fix that inefficiency.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
