### PR TITLE
Fix fed1 schema upgraded when `@external` is on a type.

### DIFF
--- a/.changeset/flat-pandas-cross.md
+++ b/.changeset/flat-pandas-cross.md
@@ -1,0 +1,6 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fix fed1 schema upgraded when `@external` is on a type.
+  

--- a/.changeset/flat-pandas-cross.md
+++ b/.changeset/flat-pandas-cross.md
@@ -2,5 +2,6 @@
 "@apollo/federation-internals": patch
 ---
 
-Fix fed1 schema upgraded when `@external` is on a type.
-  
+Fix unexpected composition error about @shareable field when `@external` is on a type in a fed1 schema (one without
+`@link`)
+

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,7 +4,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
-- Fix fed1 schema upgraded when @external is on a type [PR #2343](https://github.com/apollographql/federation/pull/2343).
+- Fix unexpected composition error about `@shareable` field when `@external` is on a type in a fed1 schema (one without `@link`) [PR #2343](https://github.com/apollographql/federation/pull/2343).
 
 ## 2.3.0-beta.3
 - Rewrites gateway response post-processing to avoid `@interfaceObject` related issues [PR 2335](https://github.com/apollographql/federation/pull/2335).

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix fed1 schema upgraded when @external is on a type [PR #2343](https://github.com/apollographql/federation/pull/2343).
+
 ## 2.3.0-beta.3
 - Rewrites gateway response post-processing to avoid `@interfaceObject` related issues [PR 2335](https://github.com/apollographql/federation/pull/2335).
 - Generates correct response error paths for errors thrown during entity fetches [PR #2304](https://github.com/apollographql/federation/pull/2304).

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 2.3.0
+
+- Fix fed1 schema upgraded when @external is on a type [PR #2343](https://github.com/apollographql/federation/pull/2343).
+
 ## 2.2.1
 
 - Fix federation spec always being expanded to the last version [PR #2274](https://github.com/apollographql/federation/pull/2274).

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.3.0
 
-- Fix fed1 schema upgraded when @external is on a type [PR #2343](https://github.com/apollographql/federation/pull/2343).
+- Fix incorrect handling of `@external` on a type when dealing when adding `@shareable` during fed1 schema upgrades [PR #2343](https://github.com/apollographql/federation/pull/2343).
 
 ## 2.2.1
 

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -1827,9 +1827,10 @@ class ExternalTester {
   }
 
   private collectExternalsOnType() {
-    // We do not collect @external on types for fed1 schema as those are ignored and will be discarded by the schema upgrader
-    // Do note however that the schema upgrader relying on the methods of this tester to figure out if a subgraph resolves
-    // a field in order to know when @shareable should be automatically added, hence the need for the short-cut here.
+    // We do not collect @external on types for fed1 schema since those will be discarded by the schema upgrader.
+    // The schema upgrader, through calls to `isExternal`, relies on the populated `externalFieldsOnType` object to
+    // inform when @shareable should be automatically added. In the fed1 case, if the map is populated then @shareable won't
+    // be added in places where it should have.
     if (!this.isFed2Schema) {
       return;
     }


### PR DESCRIPTION
For historical reasons, `@external` was legal to put on an object type since about forever (even in federation 1) but it used to be completely ignored. We "fixed" this support in #2214, but to limit surprised on upgrades from fed1, the schema upgrader had been modified to drop any `@external` on an object type (since again, those were legal but ignored in fed1). However, the code for adding @shareable in that same schema upgrader was not updated correctly and so it _was_ taking `@external` on types into account, and thus it ended up _not_ adding `@shareable` in some cases where it should have.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
