### PR TITLE
Add missing input rewrites in some case of @interfaceObject

### DIFF
--- a/.changeset/metal-roses-poke.md
+++ b/.changeset/metal-roses-poke.md
@@ -1,0 +1,7 @@
+---
+"@apollo/gateway": patch
+"@apollo/query-planner": patch
+---
+
+Fix issue with some `@interfaceObject` queries due to missing "input rewrites"
+  

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 ## vNext
 
 - Fix unexpected composition error about `@shareable` field when `@external` is on a type in a fed1 schema (one without `@link`) [PR #2343](https://github.com/apollographql/federation/pull/2343).
+- Fix issue with some `@interfaceObject` queries due to missing "input rewrites" [PR #2346](https://github.com/apollographql/federation/pull/2346).
 
 ## 2.3.0-beta.3
 - Rewrites gateway response post-processing to avoid `@interfaceObject` related issues [PR 2335](https://github.com/apollographql/federation/pull/2335).

--- a/gateway-js/src/resultShaping.ts
+++ b/gateway-js/src/resultShaping.ts
@@ -207,7 +207,7 @@ function applySelectionSet({
 
           // We're using the type pointed by our input value if there is one and it points to a genuine
           // type of the schema. Otherwise, we default to our parent type.
-          const type = inputValue !== null && typeof inputValue !== 'string'
+          const type = inputValue !== null && typeof inputValue === 'string'
             ? parameters.schema.type(inputValue) ?? parentType
             : parentType;
 
@@ -266,7 +266,6 @@ function pathLastElementDescription(path: ResponsePath, currentType: Type, paren
     ? `field ${parentType}.${element}`
     : `array element of type ${currentType} at index ${element}`;
 }
-
 
 /**
  * Given some partially computed output value (`outputValue`, possibly `undefined`) for a given `type` and the

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -4,6 +4,8 @@ This CHANGELOG pertains only to Apollo Federation packages in the 2.x range. The
 
 ## vNext
 
+- Fix issue with some `@interfaceObject` queries due to missing "input rewrites" [PR #2346](https://github.com/apollographql/federation/pull/2346).
+
 ## 2.3.0-beta.2
 - Fix potential issue with nested `@defer` in non-deferrable case [PR #2312](https://github.com/apollographql/federation/pull/2312).
 - Fix possible assertion error during query planning [PR #2299](https://github.com/apollographql/federation/pull/2299).


### PR DESCRIPTION
Fetches to subgraphs that use `@interfaceObject` needs to have some rewriting on their inputs to ensure we don't never send a __typename whose value is an implementation type for the `@interfaceObject` (such type is unknown to the particular subgraph).

The code was doing those rewrites in most cases, but in the case where only fields from the `@interfaceObject` were requested _but_ some type condition forced the resolution of the implementation, those rewrites were not populated. It resulted in the subgraph rejecting the `_entities` call due to some of the __typename not matching any known type (by this subgraph).

This commit ensures those rewrites are correctly populated.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
