### PR TITLE
Update lockfile and fix workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           title: "release: on branch ${{ github.ref_name }}"
           createGithubReleases: true
+          # workaround for https://github.com/changesets/action/issues/203, includes an `npm i` after running the version command
+          version: npm run changeset-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,10 +16,10 @@ More details can be found in [the `changeset` docs for publishing](https://githu
 1. You will need to have a GITHUB_TOKEN set up to use changesets. Create a token with your account with permissions `read:user` and `repo:status` and make sure it is assigned to the GITHUB_TOKEN environment variable
 1. If alpha/beta/preview release:
    1. `npx changeset pre enter <alpha|beta|preview>`
-   2. `npx changeset version` to bump versions, create changelog entries, etc.
+   2. `npm run changeset-version` to bump versions, create changelog entries, etc.
    3. `npx changeset pre exit`
 1. Otherwise this is a major/minor/patch release:
-   1. `npx changeset version` to bump versions, create changelog entries, etc.
+   1. `npm run changeset-version` to bump versions, create changelog entries, etc.
 1. Review the changes to make sure they look correct. Note that there may be some log entries that may have been added without changesets that may need to be merged manually. Once everything looks good, commit the changes. 
 1. `gh pr create --title "Release $FEDERATION_RELEASE_VERSION" --body-file ./.github/PULL_REQUEST_TEMPLATE/APOLLO_RELEASE_TEMPLATE.md`
 ~~1. Tag the commit to begin the publishing process[^publishing]

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,11 +69,11 @@
     },
     "composition-js": {
       "name": "@apollo/composition",
-      "version": "2.3.0-beta.2",
+      "version": "2.3.0-beta.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@apollo/federation-internals": "2.3.0-beta.2",
-        "@apollo/query-graphs": "2.3.0-beta.2"
+        "@apollo/federation-internals": "2.3.0-beta.3",
+        "@apollo/query-graphs": "2.3.0-beta.3"
       },
       "engines": {
         "node": ">=14.15.0"
@@ -93,12 +93,12 @@
     },
     "gateway-js": {
       "name": "@apollo/gateway",
-      "version": "2.3.0-beta.2",
+      "version": "2.3.0-beta.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@apollo/composition": "2.3.0-beta.2",
-        "@apollo/federation-internals": "2.3.0-beta.2",
-        "@apollo/query-planner": "2.3.0-beta.2",
+        "@apollo/composition": "2.3.0-beta.3",
+        "@apollo/federation-internals": "2.3.0-beta.3",
+        "@apollo/query-planner": "2.3.0-beta.3",
         "@apollo/server-gateway-interface": "^1.0.2",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",
@@ -286,7 +286,7 @@
     },
     "internals-js": {
       "name": "@apollo/federation-internals",
-      "version": "2.3.0-beta.2",
+      "version": "2.3.0-beta.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -16096,10 +16096,10 @@
     },
     "query-graphs-js": {
       "name": "@apollo/query-graphs",
-      "version": "2.3.0-beta.2",
+      "version": "2.3.0-beta.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@apollo/federation-internals": "2.3.0-beta.2",
+        "@apollo/federation-internals": "2.3.0-beta.3",
         "@types/uuid": "^8.3.4",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0",
@@ -16125,11 +16125,11 @@
     },
     "query-planner-js": {
       "name": "@apollo/query-planner",
-      "version": "2.3.0-beta.2",
+      "version": "2.3.0-beta.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@apollo/federation-internals": "2.3.0-beta.2",
-        "@apollo/query-graphs": "2.3.0-beta.2",
+        "@apollo/federation-internals": "2.3.0-beta.3",
+        "@apollo/query-graphs": "2.3.0-beta.3",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^29.0.0"
@@ -16143,11 +16143,11 @@
     },
     "subgraph-js": {
       "name": "@apollo/subgraph",
-      "version": "2.3.0-beta.2",
+      "version": "2.3.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/federation-internals": "2.3.0-beta.2"
+        "@apollo/federation-internals": "2.3.0-beta.3"
       },
       "engines": {
         "node": ">=14.15.0"
@@ -16183,8 +16183,8 @@
     "@apollo/composition": {
       "version": "file:composition-js",
       "requires": {
-        "@apollo/federation-internals": "2.3.0-beta.2",
-        "@apollo/query-graphs": "2.3.0-beta.2"
+        "@apollo/federation-internals": "2.3.0-beta.3",
+        "@apollo/query-graphs": "2.3.0-beta.3"
       }
     },
     "@apollo/federation-internals": {
@@ -16197,9 +16197,9 @@
     "@apollo/gateway": {
       "version": "file:gateway-js",
       "requires": {
-        "@apollo/composition": "2.3.0-beta.2",
-        "@apollo/federation-internals": "2.3.0-beta.2",
-        "@apollo/query-planner": "2.3.0-beta.2",
+        "@apollo/composition": "2.3.0-beta.3",
+        "@apollo/federation-internals": "2.3.0-beta.3",
+        "@apollo/query-planner": "2.3.0-beta.3",
         "@apollo/server-gateway-interface": "^1.0.2",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",
@@ -16355,7 +16355,7 @@
     "@apollo/query-graphs": {
       "version": "file:query-graphs-js",
       "requires": {
-        "@apollo/federation-internals": "2.3.0-beta.2",
+        "@apollo/federation-internals": "2.3.0-beta.3",
         "@types/uuid": "^8.3.4",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0",
@@ -16373,8 +16373,8 @@
     "@apollo/query-planner": {
       "version": "file:query-planner-js",
       "requires": {
-        "@apollo/federation-internals": "2.3.0-beta.2",
-        "@apollo/query-graphs": "2.3.0-beta.2",
+        "@apollo/federation-internals": "2.3.0-beta.3",
+        "@apollo/query-graphs": "2.3.0-beta.3",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^29.0.0"
@@ -16393,7 +16393,7 @@
       "version": "file:subgraph-js",
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/federation-internals": "2.3.0-beta.2"
+        "@apollo/federation-internals": "2.3.0-beta.3"
       }
     },
     "@apollo/usage-reporting-protobuf": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "error-code-doc:check": "npm run error-code-doc && git diff --exit-code",
     "hints-doc": "ts-node ./composition-js/src/genHintDoc.ts > ./docs/source/hints.md",
     "hints-doc:check": "npm run hints-doc && git diff --exit-code",
-    "gen-test-supergraph": "ts-node ./query-planner-js/src/__tests__/genTestSupergraph.ts"
+    "gen-test-supergraph": "ts-node ./query-planner-js/src/__tests__/genTestSupergraph.ts",
+    "changeset-version": "changeset version && npm i"
   },
   "engines": {
     "node": ">=14.15.0",


### PR DESCRIPTION
There's a known issue in changesets where the lockfile isn't updated as part of the `version` command.
https://github.com/changesets/action/issues/203

This updates the lockfile from last release and implements the same workaround we've taken in the server repo.