### PR TITLE
Fix QP bug querying some fields with `@interfaceObject`

### DIFF
--- a/.changeset/tidy-cherries-fly.md
+++ b/.changeset/tidy-cherries-fly.md
@@ -3,5 +3,5 @@
 "@apollo/query-planner": patch
 ---
 
-Fix assertion errors thrown by the query planner when querying fields for a specific inteface implementation in some cases where `@interfaceObject` is involved
+Fix assertion errors thrown by the query planner when querying fields for a specific interface implementation in some cases where `@interfaceObject` is involved
   

--- a/.changeset/tidy-cherries-fly.md
+++ b/.changeset/tidy-cherries-fly.md
@@ -1,0 +1,7 @@
+---
+"@apollo/query-graphs": patch
+"@apollo/query-planner": patch
+---
+
+Fix assertion errors thrown by the query planner when querying fields for a specific inteface implementation in some cases where `@interfaceObject` is involved
+  

--- a/gateway-js/src/__generated__/graphqlTypes.ts
+++ b/gateway-js/src/__generated__/graphqlTypes.ts
@@ -91,6 +91,8 @@ export type Query = {
   _empty?: Maybe<Scalars['String']>;
   /** Fetch the configuration for a router. If a valid configuration is available, it will be readable as cSDL. */
   routerConfig: RouterConfigResponse;
+  /** Fetch the current entitlements for a router. */
+  routerEntitlements: RouterEntitlementsResponse;
 };
 
 
@@ -98,6 +100,13 @@ export type QueryRouterConfigArgs = {
   apiKey: Scalars['String'];
   ifAfterId?: InputMaybe<Scalars['ID']>;
   ref: Scalars['String'];
+};
+
+
+export type QueryRouterEntitlementsArgs = {
+  apiKey: Scalars['String'];
+  ref: Scalars['String'];
+  unlessId?: InputMaybe<Scalars['ID']>;
 };
 
 export type Request = {
@@ -126,7 +135,37 @@ export type RouterConfigResult = {
   supergraphSDL: Scalars['String'];
 };
 
-/** Response indicating the router configuration available is not newer than the one passed in `ifAfterId`. */
+export type RouterEntitlement = {
+  __typename?: 'RouterEntitlement';
+  /** Which audiences this entitlemnt applies to. Cloud and on-premise routers each require the presence of their own audience. */
+  audience: Array<RouterEntitlementAudience>;
+  /** Router should stop serving requests after this time if commercial features are in use. */
+  haltAt?: Maybe<Scalars['Timestamp']>;
+  /** RFC 8037 Ed25519 JWT signed representation of sibling fields. */
+  jwt: Scalars['String'];
+  subject: Scalars['String'];
+  /** Router should warn users after this time if commercial features are in use. */
+  warnAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export enum RouterEntitlementAudience {
+  Cloud = 'CLOUD',
+  SelfHosted = 'SELF_HOSTED'
+}
+
+export type RouterEntitlementsResponse = FetchError | RouterEntitlementsResult | Unchanged;
+
+export type RouterEntitlementsResult = {
+  __typename?: 'RouterEntitlementsResult';
+  /** The best available entitlement if any. May have expired already. */
+  entitlement?: Maybe<RouterEntitlement>;
+  /** Unique identifier for this result, to be passed in as `entitlements(unlessId:)`. */
+  id: Scalars['ID'];
+  /** Minimum delay before the next fetch should occur, in seconds. */
+  minDelaySeconds: Scalars['Float'];
+};
+
+/** Response indicating the router configuration available is not newer than the one passed in `ifAfterId`, or the router entitlements currently match `unlessId`. */
 export type Unchanged = {
   __typename?: 'Unchanged';
   /** Variant-unique identifier for the configuration that remains in place. */


### PR DESCRIPTION
When an interface field is requested only for some implementation, and the query "transit" through a subgraph using `@interfaceObject`, then the query planning code was not recognizing early enough that the field was queried on an implementation type and not the interface itself, and this lead to a later assertion error.

This commit adds a reproduction test, and fix the issue by simply making sure, when we build the query plan "paths", to not use an interface field when it's an implementation field that is queried.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
