### PR TITLE
Fix issue where the query planner was incorrectly not querying `__typ…

### DIFF
--- a/.changeset/weak-clouds-argue.md
+++ b/.changeset/weak-clouds-argue.md
@@ -1,0 +1,7 @@
+---
+"@apollo/gateway": patch
+"@apollo/query-planner": patch
+---
+
+Fix issue where the query planner was incorrectly not querying `__typename` in a subgraph fetch when `@interfaceObject` is involved
+  

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -881,6 +881,7 @@ describe('buildQueryPlan', () => {
                         __typename
                         ... on Image {
                           ... on NamedObject @include(if: $b) {
+                            __typename
                             name
                           }
                         }

--- a/query-planner-js/src/__tests__/buildPlan.interfaceObject.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.interfaceObject.test.ts
@@ -122,6 +122,7 @@ describe('basic @key on interface/@interfaceObject handling', () => {
               } =>
               {
                 ... on I {
+                  __typename
                   x
                 }
               }
@@ -347,6 +348,7 @@ describe('basic @key on interface/@interfaceObject handling', () => {
               } =>
               {
                 ... on I {
+                  __typename
                   ... on A {
                     x
                   }
@@ -651,6 +653,7 @@ it('handles @interfaceObject in nested entity', () => {
             } =>
             {
               ... on I {
+                __typename
                 a
               }
             }

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -4797,6 +4797,7 @@ describe('merged abstract types handling', () => {
             u {
               __typename
               ... on I {
+                __typename
                 v
               }
             }
@@ -5094,6 +5095,7 @@ describe('merged abstract types handling', () => {
             i1 {
               __typename
               ... on I2 {
+                __typename
                 v
               }
             }


### PR DESCRIPTION
…ename` in a subgraph fetch when `@interfaceObject` is involved

When we fetch data for abstract types (typically interface), we usually need to make sure that `__typename` is queried as the code that post-process responses may have to know the concrete type of an object in the response (to know if it should be included or not).

There is a method that `__typename` for abstract types in fetch selections, but that method was not doing it for fragments for some reason (a oversight really). While this never created an issue before, this is now problematique in some case with `@interfaceObject` and so this commit ensure `__typename` is always added, even for fragments.

Working on this issue, I also noticed that the part of the code that in the query planner that eliminates useless fetches (sometimes, due to how the query planner process work, some fetches are created but end up not querying anything useful (meaning that they only query things already queried)) had not been updated for `@interfaceObject` and was not doing its job in some case. This lead to query plans including unecessary fetches (which can have a non-negligible impact). This commit also fix that issue.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
