### PR TITLE
When we publish a release, kick off workflows in federation-rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - next
+      - clenfest/federation-rs-build-step
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -41,11 +42,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       
       - name: Kick off release in federation-rs
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        uses: benc-uk/workflow-dispatch@v1
+        # if: steps.changesets.outputs.hasChangesets == 'false'
+        uses: actions/github-script@v6
         with:
-          token: ${{ secrets.ACTION_PAT }}
-          workflow: Release Components
-          repo: apollographql/federation-rs
-          inputs: '{ "version": "${{ env.FEDERATION_VERSION }}" }'
-          ref: main
+          github-token: ${{ secrets.ACTION_PAT }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: 'apollographql',
+            repo: 'federation-rs',
+            workflow_id: 'Release Components',
+            ref: 'master',
+            inputs: { 
+              version: "${{ env.FEDERATION_VERSION }}"
+            }
+          })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - next
-      - clenfest/federation-rs-build-step
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -42,7 +41,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       
       - name: Kick off release in federation-rs
-        # if: steps.changesets.outputs.hasChangesets == 'false'
+        if: steps.changesets.outputs.hasChangesets == 'false'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.ACTION_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install Dependencies
         run: npm i
         
+      - name: Set env
+        run: echo "FEDERATION_VERSION=$(npm --prefix ./internals-js version --json |jq -r '.["@apollo/federation-internals"]')" >> $GITHUB_ENV
+
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@v1
@@ -36,4 +39,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
+      
+      - name: Kick off release in federation-rs
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          token: ${{ secrets.ACTION_PAT }}
+          workflow: Release Components
+          repo: apollographql/federation-rs
+          inputs: '{ "version": "${{ env.FEDERATION_VERSION }}" }'
+          ref: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
               owner: 'apollographql',
               repo: 'federation-rs',
-              workflow_id: 'Release Components',
+              workflow_id: '.github/workflows/release.yml',
               ref: 'clenfest/automate_create_release',
               inputs: { 
                 version: "${{ env.FEDERATION_VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
               owner: 'apollographql',
               repo: 'federation-rs',
               workflow_id: '.github/workflows/release.yml',
-              ref: 'clenfest/automate_create_release',
+              ref: 'main',
               inputs: { 
                 version: "${{ env.FEDERATION_VERSION }}"
               }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,13 +46,13 @@ jobs:
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.ACTION_PAT }}
-        script: |
-          await github.rest.actions.createWorkflowDispatch({
-            owner: 'apollographql',
-            repo: 'federation-rs',
-            workflow_id: 'Release Components',
-            ref: 'master',
-            inputs: { 
-              version: "${{ env.FEDERATION_VERSION }}"
-            }
-          })
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'apollographql',
+              repo: 'federation-rs',
+              workflow_id: 'Release Components',
+              ref: 'clenfest/automate_create_release',
+              inputs: { 
+                version: "${{ env.FEDERATION_VERSION }}"
+              }
+            })


### PR DESCRIPTION
If we publish a release, kick off workflows in federation-rs to create PRs for router-bridge and harmonizer. 