### PR TITLE
Refactor selection set implementation to be immutable

### DIFF
--- a/.changeset/curvy-balloons-flash.md
+++ b/.changeset/curvy-balloons-flash.md
@@ -1,0 +1,11 @@
+---
+"@apollo/composition": patch
+"@apollo/gateway": patch
+"@apollo/federation-internals": patch
+"@apollo/query-graphs": patch
+"@apollo/query-planner": patch
+---
+
+Refactor the internal implementation of selection sets used by the query planner to decrease the code complexity and
+improve query plan generation performance in many cases.
+  

--- a/composition-js/src/validate.ts
+++ b/composition-js/src/validate.ts
@@ -210,7 +210,7 @@ function buildWitnessNextStep(edges: Edge[], index: number): SelectionSet | unde
     // ellipsis instead make it immediately clear after which part of the query there is an issue.
     const lastType = edges[edges.length -1].tail.type;
     // Note that vertex types are named type and output ones, so if it's not a leaf it is guaranteed to be selectable.
-    return isLeafType(lastType) ? undefined : SelectionSet.empty(lastType as CompositeType);
+    return isLeafType(lastType) ? undefined : new SelectionSet(lastType as CompositeType);
   }
 
   const edge = edges[index];

--- a/composition-js/src/validate.ts
+++ b/composition-js/src/validate.ts
@@ -28,6 +28,7 @@ import {
   selectionOfElement,
   SelectionSet,
   SubgraphASTNode,
+  selectionSetOf,
   typenameFieldName,
   validateSupergraph,
   VariableDefinitions
@@ -209,7 +210,7 @@ function buildWitnessNextStep(edges: Edge[], index: number): SelectionSet | unde
     // ellipsis instead make it immediately clear after which part of the query there is an issue.
     const lastType = edges[edges.length -1].tail.type;
     // Note that vertex types are named type and output ones, so if it's not a leaf it is guaranteed to be selectable.
-    return isLeafType(lastType) ? undefined : new SelectionSet(lastType as CompositeType);
+    return isLeafType(lastType) ? undefined : SelectionSet.empty(lastType as CompositeType);
   }
 
   const edge = edges[index];
@@ -235,9 +236,7 @@ function buildWitnessNextStep(edges: Edge[], index: number): SelectionSet | unde
       assert(false, `Invalid edge ${edge} found in supergraph path`);
   }
   // If we get here, the edge is either a downcast or a field, so the edge head must be selectable.
-  const selectionSet = new SelectionSet(edge.head.type as CompositeType);
-  selectionSet.add(selection);
-  return selectionSet;
+  return selectionSetOf(edge.head.type as CompositeType, selection);
 }
 
 function buildWitnessField(definition: FieldDefinition<any>): Field {
@@ -743,7 +742,7 @@ class ConditionValidationResolver {
       const pathsOptions = advanceSimultaneousPathsWithOperation(
         this.supergraphSchema,
         paths,
-        state.selection.element(),
+        state.selection.element,
       );
       if (!pathsOptions) {
         continue;

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -189,7 +189,7 @@ export async function executeQueryPlan(
             operation,
             variables: requestContext.request.variables,
             input: unfilteredData,
-            introspectionHandling: (f) => executeIntrospection(operationContext.schema, f.expandFragments().toSelectionNode()),
+            introspectionHandling: (f) => executeIntrospection(operationContext.schema, f.expandAllFragments().toSelectionNode()),
           }));
 
           // If we have errors during the post-processing, we ignore them if any other errors have been thrown during

--- a/gateway-js/src/resultShaping.ts
+++ b/gateway-js/src/resultShaping.ts
@@ -161,12 +161,12 @@ function applySelectionSet({
   parentType: CompositeType,
 }): ApplyResult {
   for (const selection of selectionSet.selections()) {
-    if (shouldSkip(selection.element(), parameters)) {
+    if (shouldSkip(selection.element, parameters)) {
       continue;
     }
 
     if (selection.kind === 'FieldSelection') {
-      const field = selection.element();
+      const field = selection.element;
       const fieldType = field.definition.type!;
       const responseName = field.responseName();
       const outputValue = output[responseName];
@@ -241,7 +241,7 @@ function applySelectionSet({
         return ApplyResult.NULL_BUBBLE_UP;
       }
     } else {
-      const fragment = selection.element();
+      const fragment = selection.element;
       const typename = input[typenameFieldName];
       assert(!typename || typeof typename === 'string', () => `Got unexpected value for __typename: ${typename}`);
       if (typeConditionApplies(parameters.schema, fragment.typeCondition, typename, parentType)) {

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -24,7 +24,9 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "js-levenshtein": "^1.1.6"
+    "js-levenshtein": "^1.1.6",
+    "@types/uuid": "^8.3.4",
+    "uuid": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -4,7 +4,7 @@ import {
   SchemaRootKind,
 } from '../../dist/definitions';
 import { buildSchema } from '../../dist/buildSchema';
-import { Field, FieldSelection, Operation, operationFromDocument, parseOperation, SelectionSet } from '../../dist/operations';
+import { MutableSelectionSet, Operation, operationFromDocument, parseOperation } from '../../dist/operations';
 import './matchers';
 import { DocumentNode, FieldNode, GraphQLError, Kind, OperationDefinitionNode, OperationTypeNode, SelectionNode, SelectionSetNode } from 'graphql';
 
@@ -242,124 +242,6 @@ describe('fragments optimization', () => {
   });
 });
 
-describe('selection set freezing', () => {
-  const schema = parseSchema(`
-    type Query {
-      t: T
-    }
-
-    type T {
-      a: Int
-      b: Int
-    }
-  `);
-
-  const tField = schema.schemaDefinition.rootType('query')!.field('t')!;
-
-  it('throws if one tries to modify a frozen selection set', () => {
-    // Note that we use parseOperation to help us build selection/selection sets because it's more readable/convenient
-    // thant to build the object "programmatically".
-    const s1 = parseOperation(schema, `{ t { a } }`).selectionSet;
-    const s2 = parseOperation(schema, `{ t { b } }`).selectionSet;
-
-    const s = new SelectionSet(schema.schemaDefinition.rootType('query')!);
-
-    // Control: check we can add to the selection set while not yet frozen
-    expect(s.isFrozen()).toBeFalsy();
-    expect(() => s.mergeIn(s1)).not.toThrow();
-
-    s.freeze();
-    expect(s.isFrozen()).toBeTruthy();
-    expect(() => s.mergeIn(s2)).toThrowError('Cannot add to frozen selection: { t { a } }');
-  });
-
-  it('it does not clone non-frozen selections when adding to another one', () => {
-    // This test is a bit debatable because what it tests is not so much a behaviour
-    // we *need* absolutely to preserve, but rather test how things happens to
-    // behave currently and illustrate the current contrast between frozen and
-    // non-frozen selection set.
-    // That is, this test show what happens if the test
-    //   "it automaticaly clones frozen selections when adding to another one"
-    // is done without freezing.
-
-    const s1 = parseOperation(schema, `{ t { a } }`).selectionSet;
-    const s2 = parseOperation(schema, `{ t { b } }`).selectionSet;
-    const s = new SelectionSet(schema.schemaDefinition.rootType('query')!);
-
-    s.mergeIn(s1);
-    s.mergeIn(s2);
-
-    expect(s.toString()).toBe('{ t { a b } }');
-
-    // This next assertion is where differs from the case where `s1` is frozen. Namely,
-    // when we do `s.mergeIn(s1)`, then `s` directly references `s1` without cloning
-    // and thus the next modification (`s.mergeIn(s2)`) ends up modifying both `s` and `s1`.
-    // Note that we don't mean by this test that the fact that `s.mergeIn(s1)` does
-    // not clone `s1` is a behaviour one should *rely* on, but it currently done for
-    // efficiencies sake: query planning does a lot of selection set building through
-    // `SelectionSet::mergeIn` and `SelectionSet::add` and we often pass to those method
-    // newly constructed selections as input, so cloning them would wast CPU and early
-    // query planning benchmarking showed that this could add up on the more expansive
-    // plan computations. This is why freezing exists: it allows us to save cloning
-    // in general, but to protect those selection set we know should be immutable
-    // so they do get cloned in such situation.
-    expect(s1.toString()).toBe('{ t { a b } }');
-    expect(s2.toString()).toBe('{ t { b } }');
-  });
-
-  it('it automaticaly clones frozen field selections when merging to another one', () => {
-    const s1 = parseOperation(schema, `{ t { a } }`).selectionSet.freeze();
-    const s2 = parseOperation(schema, `{ t { b } }`).selectionSet.freeze();
-    const s = new SelectionSet(schema.schemaDefinition.rootType('query')!);
-
-    s.mergeIn(s1);
-    s.mergeIn(s2);
-
-    // We check S is what we expect...
-    expect(s.toString()).toBe('{ t { a b } }');
-
-    // ... but more importantly for this test, that s1/s2 were not modified.
-    expect(s1.toString()).toBe('{ t { a } }');
-    expect(s2.toString()).toBe('{ t { b } }');
-  });
-
-  it('it automaticaly clones frozen fragment selections when merging to another one', () => {
-    // Note: needlessly complex queries, but we're just ensuring the cloning story works when fragments are involved
-    const s1 = parseOperation(schema, `{ ... on Query { t { ... on T { a } } } }`).selectionSet.freeze();
-    const s2 = parseOperation(schema, `{ ... on Query { t { ... on T { b } } } }`).selectionSet.freeze();
-    const s = new SelectionSet(schema.schemaDefinition.rootType('query')!);
-
-    s.mergeIn(s1);
-    s.mergeIn(s2);
-
-    expect(s.toString()).toBe('{ ... on Query { t { ... on T { a b } } } }');
-
-    expect(s1.toString()).toBe('{ ... on Query { t { ... on T { a } } } }');
-    expect(s2.toString()).toBe('{ ... on Query { t { ... on T { b } } } }');
-  });
-
-  it('it automaticaly clones frozen field selections when adding to another one', () => {
-    const s1 = parseOperation(schema, `{ t { a } }`).selectionSet.freeze();
-    const s2 = parseOperation(schema, `{ t { b } }`).selectionSet.freeze();
-    const s = new SelectionSet(schema.schemaDefinition.rootType('query')!);
-    const tSelection = new FieldSelection(new Field(tField));
-    s.add(tSelection);
-
-    // Note that this test both checks the auto-cloning for the `add` method, but
-    // also shows that freezing dose apply deeply (since we freeze the whole `s1`/`s2`
-    // but only add some sub-selection of it).
-    tSelection.selectionSet!.add(s1.selections()[0].selectionSet!.selections()[0]);
-    tSelection.selectionSet!.add(s2.selections()[0].selectionSet!.selections()[0]);
-
-    // We check S is what we expect...
-    expect(s.toString()).toBe('{ t { a b } }');
-
-    // ... but more importantly for this test, that s1/s2 were not modified.
-    expect(s1.toString()).toBe('{ t { a } }');
-    expect(s2.toString()).toBe('{ t { b } }');
-  });
-});
-
 describe('validations', () => {
   test.each([
     { directive: '@defer', rootKind: 'mutation' },
@@ -515,5 +397,152 @@ describe('empty branches removal', () => {
         astField('u'),
       )
     )).toBe('{ u }');
+  });
+});
+
+describe('basic operations', () => {
+  const schema = parseSchema(`
+    type Query {
+      t: T
+      i: I
+    }
+
+    type T {
+      v1: Int
+      v2: String
+      v3: I
+    }
+
+    interface I {
+      x: Int
+      y: Int
+    }
+
+    type A implements I {
+      x: Int
+      y: Int
+      a1: String
+      a2: String
+    }
+
+    type B implements I {
+      x: Int
+      y: Int
+      b1: Int
+      b2: T
+    }
+  `);
+
+  const operation = parseOperation(schema, `
+    {
+      t {
+        v1
+        v3 {
+          x
+        }
+      }
+      i {
+        ... on A {
+          a1
+          a2
+        }
+        ... on B {
+          y
+          b2 {
+           v2
+          }
+        }
+      }
+    }
+  `);
+
+  test('forEachElement', () => {
+    // We collect a pair of (parent type, field-or-fragment).
+    const actual: [string, string][] = [];
+    operation.selectionSet.forEachElement((elt) => actual.push([elt.parentType.name, elt.toString()]));
+    expect(actual).toStrictEqual([
+      ['Query', 't'],
+      ['T', 'v1'],
+      ['T', 'v3'],
+      ['I', 'x'],
+      ['Query', 'i'],
+      ['I', '... on A'],
+      ['A', 'a1'],
+      ['A', 'a2'],
+      ['I', '... on B'],
+      ['B', 'y'],
+      ['B', 'b2'],
+      ['T', 'v2'],
+    ]);
+  })
+});
+
+
+describe('MutableSelectionSet', () => {
+  test('memoizer', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        v1: Int
+        v2: String
+        v3: Int
+        v4: Int
+      }
+    `);
+
+    type Value = {
+      count: number
+    };
+
+    let calls = 0;
+    const sets: string[] = [];
+
+    const queryType = schema.schemaDefinition.rootType('query')!;
+    const ss = MutableSelectionSet.emptyWithMemoized<Value>(
+      queryType,
+      (s) => {
+        sets.push(s.toString());
+        return { count: ++calls };
+      }
+    );
+
+    expect(ss.memoized().count).toBe(1);
+    // Calling a 2nd time with no change to make sure we're not re-generating the value.
+    expect(ss.memoized().count).toBe(1);
+
+    ss.updates().add(parseOperation(schema, `{ t { v1 } }`).selectionSet);
+
+    expect(ss.memoized().count).toBe(2);
+    expect(sets).toStrictEqual(['{}', '{ t { v1 } }']);
+
+    ss.updates().add(parseOperation(schema, `{ t { v3 } }`).selectionSet);
+
+    expect(ss.memoized().count).toBe(3);
+    expect(sets).toStrictEqual(['{}', '{ t { v1 } }', '{ t { v1 v3 } }']);
+
+    // Still making sure we don't re-compute without updates.
+    expect(ss.memoized().count).toBe(3);
+
+    const cloned = ss.clone();
+    expect(cloned.memoized().count).toBe(3);
+
+    cloned.updates().add(parseOperation(schema, `{ t { v2 } }`).selectionSet);
+
+    // The value of `ss` should not have be recomputed, so it should still be 3.
+    expect(ss.memoized().count).toBe(3);
+    // But that of the clone should have changed.
+    expect(cloned.memoized().count).toBe(4);
+    expect(sets).toStrictEqual(['{}', '{ t { v1 } }', '{ t { v1 v3 } }', '{ t { v1 v3 v2 } }']);
+
+    // And here we make sure that if we update the fist selection, we don't have v3 in the set received
+    ss.updates().add(parseOperation(schema, `{ t { v4 } }`).selectionSet);
+    // Here, only `ss` memoized value has been recomputed. But since both increment the same `calls` variable,
+    // the total count should be 5 (even if the previous count for `ss` was only 3).
+    expect(ss.memoized().count).toBe(5);
+    expect(cloned.memoized().count).toBe(4);
+    expect(sets).toStrictEqual(['{}', '{ t { v1 } }', '{ t { v1 v3 } }', '{ t { v1 v3 v2 } }', '{ t { v1 v3 v4 } }']);
   });
 });

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -32,7 +32,16 @@ import {
   removeAllCoreFeatures,
 } from "./coreSpec";
 import { assert, mapValues, MapWithCachedArrays, removeArrayElement } from "./utils";
-import { withDefaultValues, valueEquals, valueToString, valueToAST, variablesInValue, valueFromAST, valueNodeToConstValueNode, argumentsEquals } from "./values";
+import {
+  withDefaultValues,
+  valueEquals,
+  valueToString,
+  valueToAST,
+  valueFromAST,
+  valueNodeToConstValueNode,
+  argumentsEquals,
+  collectVariablesInValue
+} from "./values";
 import { removeInaccessibleElements } from "./inaccessibleSpec";
 import { printDirectiveDefinition, printSchema } from './print';
 import { sameType } from './types';
@@ -399,8 +408,10 @@ export class DirectiveTargetElement<T extends DirectiveTargetElement<T>> {
       : ' ' + this.appliedDirectives.join(' ');
   }
 
-  variablesInAppliedDirectives(): Variables {
-    return this.appliedDirectives.reduce((acc: Variables, d) => mergeVariables(acc, variablesInArguments(d.arguments())), []);
+  collectVariablesInAppliedDirectives(collector: VariableCollector) {
+    for (const applied of this.appliedDirectives) {
+      collector.collectInArguments(applied.arguments());
+    }
   }
 }
 
@@ -3054,7 +3065,7 @@ export class Directive<
   // applied to a field that is part of an extension, the field will have its extension set, but not the underlying directive.
   private _extension?: Extension<any>;
 
-  constructor(readonly name: string, private _args: TArgs) {
+  constructor(readonly name: string, private _args: TArgs = Object.create(null)) {
     super();
   }
 
@@ -3299,36 +3310,36 @@ export class Variable {
 
 export type Variables = readonly Variable[];
 
-export function mergeVariables(v1s: Variables, v2s: Variables): Variables {
-  if (v1s.length == 0) {
-    return v2s;
+export class VariableCollector {
+  private readonly _variables = new Map<string, Variable>();
+
+  add(variable: Variable) {
+    this._variables.set(variable.name, variable);
   }
-  if (v2s.length == 0) {
-    return v1s;
-  }
-  const res: Variable[] = v1s.concat();
-  for (const v of v2s) {
-    if (!containsVariable(v1s, v)) {
-      res.push(v);
+
+  addAll(variables: Variables) {
+    for (const variable of variables) {
+      this.add(variable);
     }
   }
-  return res;
-}
 
-export function containsVariable(variables: Variables, toCheck: Variable): boolean {
-  return variables.some(v => v.name == toCheck.name);
+  collectInArguments(args: {[key: string]: any}) {
+    for (const value of Object.values(args)) {
+      collectVariablesInValue(value, this);
+    }
+  }
+
+  variables() {
+    return mapValues(this._variables);
+  }
+
+  toString(): string {
+    return this.variables().toString();
+  }
 }
 
 export function isVariable(v: any): v is Variable {
   return v instanceof Variable;
-}
-
-export function variablesInArguments(args: {[key: string]: any}): Variables {
-  let variables: Variables = [];
-  for (const value of Object.values(args)) {
-    variables = mergeVariables(variables, variablesInValue(value));
-  }
-  return variables;
 }
 
 export class VariableDefinition extends DirectiveTargetElement<VariableDefinition> {

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -347,9 +347,9 @@ export class DirectiveTargetElement<T extends DirectiveTargetElement<T>> {
 
   constructor(
     private readonly _schema: Schema,
-    directives?: readonly Directive<any>[],
+    directives: readonly Directive<any>[] = [],
   ) {
-    this.appliedDirectives = directives?.map((d) => this.attachDirective(d)) ?? [];
+    this.appliedDirectives = directives.map((d) => this.attachDirective(d));
   }
 
   schema(): Schema {

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -48,7 +48,7 @@ import {
 } from "graphql";
 import { KnownTypeNamesInFederationRule } from "./validation/KnownTypeNamesInFederationRule";
 import { buildSchema, buildSchemaFromAST } from "./buildSchema";
-import { parseSelectionSet, selectionOfElement, SelectionSet } from './operations';
+import { parseSelectionSet, SelectionSet } from './operations';
 import { TAG_VERSIONS } from "./tagSpec";
 import {
   errorCodeDef,
@@ -129,7 +129,7 @@ function validateFieldSetSelections({
   allowFieldsWithArguments: boolean,
 }): void {
   for (const selection of selectionSet.selections()) {
-    const appliedDirectives = selection.element().appliedDirectives;
+    const appliedDirectives = selection.element.appliedDirectives;
     if (appliedDirectives.length > 0) {
       onError(ERROR_CATEGORIES.DIRECTIVE_IN_FIELDS_ARG.get(directiveName).err(
         `cannot have directive applications in the @${directiveName}(fields:) argument but found ${appliedDirectives.join(', ')}.`,
@@ -137,7 +137,7 @@ function validateFieldSetSelections({
     }
 
     if (selection.kind === 'FieldSelection') {
-      const field = selection.element().definition;
+      const field = selection.element.definition;
       const isExternal = metadata.isFieldExternal(field);
       if (!allowFieldsWithArguments && field.hasArguments()) {
         onError(ERROR_CATEGORIES.FIELDS_HAS_ARGS.get(directiveName).err(
@@ -1817,12 +1817,17 @@ class ExternalTester {
   private collectProvidedFields() {
     for (const provides of this.metadata().providesDirective().applications()) {
       const parent = provides.parent as FieldDefinition<CompositeType>;
-      collectTargetFields({
-        parentType: baseType(parent.type!) as CompositeType,
-        directive: provides as Directive<any, {fields: any}>,
-        includeInterfaceFieldsImplementations: true,
-        validate: false,
-      }).forEach((f) => this.providedFields.add(f.coordinate));
+      const parentType = baseType(parent.type!);
+      // If `parentType` is not a composite, that means an invalid @provides, but we ignore such errors
+      // for now (also why we pass 'validate: false'). Proper errors will be thrown later during validation.
+      if (isCompositeType(parentType)) {
+        collectTargetFields({
+          parentType,
+          directive: provides as Directive<any, {fields: any}>,
+          includeInterfaceFieldsImplementations: true,
+          validate: false,
+        }).forEach((f) => this.providedFields.add(f.coordinate));
+      }
     }
   }
 
@@ -1854,7 +1859,7 @@ class ExternalTester {
 
   selectsAnyExternalField(selectionSet: SelectionSet): boolean {
     for (const selection of selectionSet.selections()) {
-      if (selection.kind === 'FieldSelection' && this.isExternal(selection.element().definition)) {
+      if (selection.kind === 'FieldSelection' && this.isExternal(selection.element.definition)) {
         return true;
       }
       if (selection.selectionSet) {
@@ -1966,7 +1971,7 @@ function selectsNonExternalLeafField(selection: SelectionSet): boolean {
   return selection.selections().some(s => {
     if (s.kind === 'FieldSelection') {
       // If it's external, we're good and don't need to recurse.
-      if (isExternalOrHasExternalImplementations(s.field.definition)) {
+      if (isExternalOrHasExternalImplementations(s.element.definition)) {
         return false;
       }
       // Otherwise, we select a non-external if it's a leaf, or the sub-selection does.
@@ -1978,25 +1983,24 @@ function selectsNonExternalLeafField(selection: SelectionSet): boolean {
 }
 
 function withoutNonExternalLeafFields(selectionSet: SelectionSet): SelectionSet {
-  const newSelectionSet = new SelectionSet(selectionSet.parentType);
-  for (const selection of selectionSet.selections()) {
+  return selectionSet.lazyMap((selection) => {
     if (selection.kind === 'FieldSelection') {
-      if (isExternalOrHasExternalImplementations(selection.field.definition)) {
+      if (isExternalOrHasExternalImplementations(selection.element.definition)) {
         // That field is external, so we can add the selection back entirely.
-        newSelectionSet.add(selection);
-        continue;
+        return selection;
       }
     }
-    // Note that for fragments will always be true (and we just recurse), while
-    // for fields, we'll only get here if the field is not external, and so
-    // we want to add the selection only if it's not a leaf and even then, only
-    // the part where we've recursed.
     if (selection.selectionSet) {
+      // Note that for fragments this will always be true (and we just recurse), while
+      // for fields, we'll only get here if the field is not external, and so
+      // we want to add the selection only if it's not a leaf and even then, only
+      // the part where we've recursed.
       const updated = withoutNonExternalLeafFields(selection.selectionSet);
       if (!updated.isEmpty()) {
-        newSelectionSet.add(selectionOfElement(selection.element(), updated));
+        return selection.withUpdatedSelectionSet(updated);
       }
     }
-  }
-  return newSelectionSet;
+    // We skip that selection.
+    return undefined;
+  });
 }

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -341,7 +341,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
  * Computes a string key representing a directive application, so that if 2 directive applications have the same key, they they
  * represents the same application.
  *
- * Note that this is mostly just the `toString` representation of the directive, but for 2 subtlelty:
+ * Note that this is mostly just the `toString` representation of the directive, but for 2 subtlety:
  * 1. for a handful of directives (really just `@defer` for now), we never want to consider directive applications the same, no
  *    matter that the arguments of the directive match, and this for the same reason as documented on the `sameDirectiveApplications`
  *    method in `definitions.ts`.

--- a/internals-js/src/precompute.ts
+++ b/internals-js/src/precompute.ts
@@ -6,6 +6,7 @@ import {
   FieldDefinition,
   collectTargetFields,
   Schema,
+  isCompositeType,
 } from ".";
 
 export function computeShareables(schema: Schema): (field: FieldDefinition<CompositeType>) => boolean {
@@ -41,18 +42,23 @@ export function computeShareables(schema: Schema): (field: FieldDefinition<Compo
         shareableFields.add(field.coordinate);
       }
       for (const provides of field.appliedDirectivesOf(providesDirective)) {
-        collectTargetFields({
-          parentType: baseType(field.type!) as CompositeType,
-          directive: provides,
-          includeInterfaceFieldsImplementations: true,
-          validate: false,
-        }).forEach((f) => {
-          // Fed2 schema reject provides on non-external field, but fed1 doesn't (at least not always), and we actually
-          // call this on fed1 schema upgrader. So let's make sure we do ignore non-external fields.
-          if (metadata.isFieldExternal(f)) {
-            shareableFields.add(f.coordinate);
-          }
-        });
+        const parentType = baseType(field.type!);
+        // It's never valid to put a @provides on a non-composite type, but things haven't been fully validated when this
+        // code run and we just want to ignore non-sensical cases (this is also why we pass `validate: false` below).
+        if (isCompositeType(parentType)) {
+          collectTargetFields({
+            parentType,
+            directive: provides,
+            includeInterfaceFieldsImplementations: true,
+            validate: false,
+          }).forEach((f) => {
+            // Fed2 schema reject provides on non-external field, but fed1 doesn't (at least not always), and we actually
+            // call this on fed1 schema upgrader. So let's make sure we do ignore non-external fields.
+            if (metadata.isFieldExternal(f)) {
+              shareableFields.add(f.coordinate);
+            }
+          });
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,14 +302,29 @@
       "version": "2.3.3",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
+        "@types/uuid": "^8.3.4",
         "chalk": "^4.1.0",
-        "js-levenshtein": "^1.1.6"
+        "js-levenshtein": "^1.1.6",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": ">=14.15.0"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
+      }
+    },
+    "internals-js/node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "internals-js/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@apollo/cache-control-types": {
@@ -16842,8 +16857,22 @@
     "@apollo/federation-internals": {
       "version": "file:internals-js",
       "requires": {
+        "@types/uuid": "^8.3.4",
         "chalk": "^4.1.0",
-        "js-levenshtein": "^1.1.6"
+        "js-levenshtein": "^1.1.6",
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "@types/uuid": {
+          "version": "8.3.4",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+          "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
       }
     },
     "@apollo/gateway": {

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -1570,8 +1570,8 @@ function warnOnKeyFieldsMarkedExternal(type: CompositeType): string {
   for (const key of keys) {
     const fieldSet = parseFieldSetArgument({ parentType: type, directive: key });
     for (const selection of fieldSet.selections()) {
-      if (selection.kind === 'FieldSelection' && selection.field.definition.hasAppliedDirective(metadata.externalDirective())) {
-        const fieldName = selection.field.name;
+      if (selection.kind === 'FieldSelection' && selection.element.definition.hasAppliedDirective(metadata.externalDirective())) {
+        const fieldName = selection.element.name;
         if (!keyFieldMarkedExternal.includes(fieldName)) {
           keyFieldMarkedExternal.push(fieldName);
         }

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -198,10 +198,6 @@ export class Edge {
   }
 
   addToConditions(newConditions: SelectionSet) {
-    // As mentioned in the ctor, we freeze the conditions to avoid unexpected modifications once a query
-    // graph has bee fully built (this method is called _during_ the building, so can still mutate the
-    // edge freely). Which means we need to clone any existing conditions (so we can modify them), and need
-    // to re-freeze the result afterwards.
     this._conditions = this._conditions
       ? new SelectionSetUpdates().add(this._conditions).add(newConditions).toSelectionSet(this._conditions.parentType)
       : newConditions;

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -56,8 +56,12 @@ import {
   isInterfaceType,
   isNonNullType,
   Type,
-  FragmentSelection,
+  MutableSelectionSet,
+  SelectionSetUpdates,
+  AbstractType,
+  isDefined,
   InterfaceType,
+  FragmentSelection,
 } from "@apollo/federation-internals";
 import {
   advanceSimultaneousPathsWithOperation,
@@ -164,7 +168,7 @@ const defaultCostFunction: CostFunction = {
    * plus some constant "premium" to account for the fact than doing each fetch is costly (and that fetch cost often
    * dwarfted the actual cost of fields resolution).
    */
-  onFetchGroup: (group: FetchGroup, _: Conditions) => (fetchCost + selectionCost(group.selection)),
+  onFetchGroup: (group: FetchGroup) => (fetchCost + group.cost()),
 
   /**
    * We don't take conditions into account in costing for now as they don't really know anything on the condition
@@ -285,7 +289,7 @@ class QueryPlanningTaversal<RV extends Vertex> {
   }
 
   private handleOpenBranch(selection: Selection, options: SimultaneousPathsWithLazyIndirectPaths<RV>[]) {
-    const operation = selection.element();
+    const operation = selection.element;
     debug.group(() => `Handling open branch: ${operation}`);
     let newOptions: SimultaneousPathsWithLazyIndirectPaths<RV>[] = [];
     for (const option of options) {
@@ -552,7 +556,7 @@ class QueryPlanningTaversal<RV extends Vertex> {
     const { main, deferred } = dependencyGraph.process(this.costFunction, this.rootKind);
     return deferred.length === 0
       ? main
-      : this.costFunction.reduceDefer(main, dependencyGraph.deferTracking.primarySelection!, deferred);
+      : this.costFunction.reduceDefer(main, dependencyGraph.deferTracking.primarySelection!.get(), deferred);
   }
 
   private updatedDependencyGraph(dependencyGraph: FetchDependencyGraph, tree: OpPathTree<RV>): FetchDependencyGraph {
@@ -586,53 +590,6 @@ class QueryPlanningTaversal<RV extends Vertex> {
 type UnhandledGroups = [FetchGroup, UnhandledParentRelations][];
 type UnhandledParentRelations = ParentRelation[];
 
-class LazySelectionSet {
-
-  constructor(
-    private _computed?: SelectionSet,
-    private _conditions?: Conditions,
-    private readonly _toCloneOnWrite?: SelectionSet
-  ) {
-    assert(_computed || _toCloneOnWrite, 'Should have one of the argument');
-  }
-
-  parentType(): CompositeType {
-    return this.forRead().parentType;
-  }
-
-  forRead(): SelectionSet {
-    return this._computed ? this._computed : this._toCloneOnWrite!;
-  }
-
-  forWrite(): SelectionSet {
-    // Since we're going to write the set, we should make sure we recompute conditions when we need them.
-    this._conditions = undefined;
-    if (!this._computed) {
-      this._computed = this._toCloneOnWrite!.clone();
-    }
-    return this._computed;
-  }
-
-  conditions(): Conditions {
-    if (!this._conditions) {
-      this._conditions = conditionsOfSelectionSet(this.forRead());
-    }
-    return this._conditions;
-  }
-
-  clone(): LazySelectionSet {
-    if (this._computed) {
-      return new LazySelectionSet(undefined, this._conditions, this._computed);
-    } else {
-      return this;
-    }
-  }
-
-  toString() {
-    return this.forRead().toString();
-  }
-}
-
 /**
  * Used in `FetchDependencyGraph` to store, for a given group, information about one of its parent.
  * Namely, this structure stores:
@@ -649,6 +606,8 @@ type ParentRelation = {
   group: FetchGroup,
   path?: OperationPath,
 }
+
+const conditionsMemoizer = (selectionSet: SelectionSet) => ({ conditions: conditionsOfSelectionSet(selectionSet) });
 
 /**
  * Represents a subgraph fetch of a query plan, and is a vertex of a `FetchDependencyGraph` (and as such provides links to
@@ -672,10 +631,14 @@ class FetchGroup {
     readonly rootKind: SchemaRootKind,
     readonly parentType: CompositeType,
     readonly isEntityFetch: boolean,
-    private _selection: LazySelectionSet,
-    private _inputs?: LazySelectionSet,
+    private _selection: MutableSelectionSet<{ conditions: Conditions}>,
+    private _inputs?: MutableSelectionSet,
     readonly mergeAt?: ResponsePath,
     readonly deferRef?: string,
+    // Some of the processing on the dependency graph checks for groups to the same subgraph and same mergeAt, and we use this
+    // key for that. Having it here saves us from re-computing it more than once.
+    readonly subgraphAndMergeAtKey?: string,
+    private cachedCost?: number,
   ) {
   }
 
@@ -711,10 +674,11 @@ class FetchGroup {
       rootKind,
       parentType,
       !!inputsParentType,
-      new LazySelectionSet(new SelectionSet(parentType)),
-      inputsParentType ? new LazySelectionSet(new SelectionSet(inputsParentType)) : undefined,
+      MutableSelectionSet.emptyWithMemoized(parentType, conditionsMemoizer),
+      inputsParentType ? MutableSelectionSet.empty(inputsParentType) : undefined,
       mergeAt,
       deferRef,
+      inputsParentType ? `${toValidGraphQLName(subgraphName)}-${mergeAt?.join('::') ?? ''}` : undefined
     );
   }
 
@@ -730,7 +694,16 @@ class FetchGroup {
       this._inputs?.clone(),
       this.mergeAt,
       this.deferRef,
+      this.subgraphAndMergeAtKey,
+      this.cachedCost,
     );
+  }
+
+  cost(): number {
+    if (!this.cachedCost) {
+      this.cachedCost = selectionCost(this.selection);
+    }
+    return this.cachedCost;
   }
 
   set id(id: string | undefined) {
@@ -746,14 +719,17 @@ class FetchGroup {
     return !this.mergeAt;
   }
 
-  // It's important that the returned selection is never modified. Use the other modification methods of this method instead!
   get selection(): SelectionSet {
-    return this._selection.forRead();
+    return this._selection.get();
   }
 
-  // It's important that the returned selection is never modified. Use the other modification methods of this method instead!
+  private selectionUpdates(): SelectionSetUpdates {
+    this.cachedCost = undefined;
+    return this._selection.updates();
+  }
+
   get inputs(): SelectionSet | undefined {
-    return this._inputs?.forRead();
+    return this._inputs?.get();
   }
 
   addParents(parents: readonly ParentRelation[]) {
@@ -868,7 +844,7 @@ class FetchGroup {
     // that case, we still rely on the fact that they have a common "super type" (which they must
     // have if they are at the same mergeAt), but this may mean changing `this._inputs` in this
     // case.
-    const thisParentType = this._inputs.parentType();
+    const thisParentType = this._inputs.parentType;
     const schema = thisParentType.schema();
     const selectionParentType = selection.parentType;
     // Note that we check reference inequality first just to avoid the most costly 2nd test in the common case where the parent types are
@@ -878,10 +854,10 @@ class FetchGroup {
       // Because it is an entity fetch, we know the top-level selections must be fragments that selects a specific object type.
       const extractSelectedTypeName = (s: Selection) => {
         assert(s.kind === 'FragmentSelection', () => `Expected ${s} to be a fragment when adding inputs ${selection} to ${this}`);
-        return s.element().castedType().name;
+        return s.element.castedType().name;
       }
       const typesToAccountFor = new Set<string>(
-        this._inputs.forRead().selections().map(extractSelectedTypeName).concat(
+        this._inputs.get().selections().map(extractSelectedTypeName).concat(
           selection instanceof SelectionSet
           ? selection.selections().map(extractSelectedTypeName)
           : [extractSelectedTypeName(selection)]
@@ -899,33 +875,27 @@ class FetchGroup {
       // fragments within the selections: this ensure that if we try to merge the inputs with some other choice later, and we've make
       // the "wrong" choice here, it'll still work (because we won't look at the choice of parent made here, but rather the underlying
       // object types).
-      const newInputs = new SelectionSet(commonType);
-      newInputs.mergeIn(this._inputs.forRead());
-      this._inputs = new LazySelectionSet(newInputs);
+      this._inputs = this._inputs.rebaseOn(commonType);
     }
 
-    if (selection instanceof SelectionSet) {
-      this._inputs.forWrite().mergeIn(selection);
-    } else {
-      this._inputs.forWrite().add(selection);
-    }
+    this._inputs.updates().add(selection);
     if (rewrites) {
       rewrites.forEach((r) => this.inputRewrites.push(r));
     }
   }
 
-  copyInputsOf(other: FetchGroup, clone: boolean = false) {
+  copyInputsOf(other: FetchGroup) {
     if (other.inputs) {
-      this.addInputs(clone ? other.inputs.clone() : other.inputs, other.inputRewrites);
+      this.addInputs(other.inputs, other.inputRewrites);
     }
   }
 
-  addSelection(path: OperationPath, onPathEnd?: (finalSelectionSet: SelectionSet | undefined) => void) {
-    this._selection.forWrite().addPath(path, onPathEnd);
+  addAtPath(path: OperationPath, selection?: Selection | SelectionSet | readonly Selection[]) {
+    this.selectionUpdates().addAtPath(path, selection);
   }
 
   addSelections(selection: SelectionSet) {
-    this._selection.forWrite().mergeIn(selection);
+    this.selectionUpdates().add(selection);
   }
 
   canMergeChildIn(child: FetchGroup): boolean {
@@ -935,7 +905,8 @@ class FetchGroup {
   removeInputsFromSelection() {
     const inputs = this.inputs;
     if (inputs) {
-      this._selection = new LazySelectionSet(this.selection.minus(inputs));
+      this.cachedCost = undefined;
+      this._selection = MutableSelectionSet.ofWithMemoized(this.selection.minus(inputs), conditionsMemoizer);
     }
   }
 
@@ -961,7 +932,7 @@ class FetchGroup {
 
     const conditionInSupergraphIfInterfaceObject = (selection: Selection): InterfaceType | undefined => {
       if (selection.kind === 'FragmentSelection') {
-        const condition = selection.element().typeCondition;
+        const condition = selection.element.typeCondition;
         if (condition && isObjectType(condition)) {
           const conditionInSupergraph = this.dependencyGraph.supergraphSchema.type(condition.name);
           // Note that we're checking the true supergraph, not the API schema, so even @inaccessible types will be found.
@@ -993,7 +964,7 @@ class FetchGroup {
         // We know that fetch inputs are wrapped in fragments whose condition is an entity type:
         // that's how we build them and we couldn't select inputs correctly otherwise.
         assert(inputSelection.kind === 'FragmentSelection', () => `Unexpecting input selection ${inputSelection} on ${this}`);
-        const inputCondition = inputSelection.element().typeCondition;
+        const inputCondition = inputSelection.element.typeCondition;
         assert(inputCondition, () => `Unexpecting input selection ${inputSelection} on ${this} (missing condition)`);
         if (inputCondition.name == conditionInSupergraph.name) {
           interfaceInputSelections.push(inputSelection);
@@ -1122,24 +1093,14 @@ class FetchGroup {
   private mergeInInternal(merged: FetchGroup, path: OperationPath, mergeParentDependencies: boolean = false) {
     assert(!merged.isTopLevel, "Shouldn't remove top level groups");
 
-    // We merge the selection of `merged` into our own selection, but need to "rebase" it according to `path` first. As we do,
-    // we ignore redundant fragments. Typically, `merged` selection will always start by a type-cast into the entity type because
-    // that's what `_entities()` require, but that cast is probably useless when merging.
-    const mergePathConditionalDirectives = conditionalDirectivesInOperationPath(path);
-    let selectionSet: SelectionSet;
     if (path.length === 0) {
-      selectionSet = merged.selection;
+      this.addSelections(merged.selection);
     } else {
-      selectionSet = new SelectionSet(this.selection.parentType);
-      selectionSet.addPath(path, (endOfPathSet) => {
-        assert(endOfPathSet, () => `Merge path ${path} ends on a non-selectable type`);
-        for (const selection of merged.selection.selections()) {
-          const withoutUneededFragments = removeRedundantFragments(selection, endOfPathSet.parentType, mergePathConditionalDirectives);
-          addSelectionOrSelectionSet(endOfPathSet, withoutUneededFragments);
-        }
-      });
+      // The merged groups might have some @include/@skip at top-level that are already part of the path. If so,
+      // we clean things up a bit.
+      const mergePathConditionalDirectives = conditionalDirectivesInOperationPath(path);
+      this.addAtPath(path, removeUnneededTopLevelFragmentDirectives(merged.selection, mergePathConditionalDirectives));
     }
-    this._selection.forWrite().mergeIn(selectionSet);
 
     this.dependencyGraph.onModification();
     this.relocateChildrenOnMergedIn(merged, path);
@@ -1200,7 +1161,7 @@ class FetchGroup {
     }
   }
 
-  private finalizeSelection(handledConditions: Conditions): FetchDataOutputRewrite[] {
+  private finalizeSelection(handledConditions: Conditions): { selection: SelectionSet, outputRewrites: FetchDataOutputRewrite[] } {
     // Finalizing the selection involves the following:
     // 1. removing any @include/@skip that are not necessary because they are already handled earlier in the query plan by
     //    some `ConditionNode`.
@@ -1211,15 +1172,13 @@ class FetchGroup {
     //   changes the query, we could have violation of this. If that is the case, we introduce aliases to the selection to make it valid, and
     //   then generate a rewrite on the output of the fetch so that data aliased this way is rewritten back to the original/proper response name.
 
-    removeConditionsFromSelectionSet(this.selection, handledConditions);
+    const selectionWithoutConditions = removeConditionsFromSelectionSet(this.selection, handledConditions);
+    const selectionWithTypenames = addTypenameFieldForAbstractTypes(selectionWithoutConditions);
 
-    addTypenameFieldForAbstractTypes(this.selection);
+    const { updated: selection, outputRewrites } = addAliasesForNonMergingFields(selectionWithTypenames);
 
-    const rewrites: FetchDataOutputRewrite[] = [];
-    addAliasesForNonMergingFields([{ path: [], selections: this.selection }], rewrites);
-
-    this.selection.validate();
-    return rewrites;
+    selection.validate();
+    return { selection, outputRewrites };
   }
 
   /**
@@ -1230,7 +1189,7 @@ class FetchGroup {
    * the whole group selection).
    */
   conditions(): Conditions {
-    return this._selection.conditions();
+    return this._selection.memoized().conditions;
   }
 
   toPlanNode(
@@ -1244,11 +1203,11 @@ class FetchGroup {
       return undefined;
     }
 
-    const outputRewrites = this.finalizeSelection(handledConditions);
+    const { selection, outputRewrites } = this.finalizeSelection(handledConditions);
 
-    const inputs = this.inputs;
+    let inputs = this._inputs?.get();
     if (inputs) {
-      removeConditionsFromSelectionSet(inputs, handledConditions);
+      inputs = removeConditionsFromSelectionSet(inputs, handledConditions);
       inputs.validate();
     }
 
@@ -1258,14 +1217,14 @@ class FetchGroup {
     let operation = this.isEntityFetch
       ? operationForEntitiesFetch(
           subgraphSchema,
-          this.selection,
+          selection,
           variableDefinitions,
           operationName,
         )
       : operationForQueryFetch(
           subgraphSchema,
           this.rootKind,
-          this.selection,
+          selection,
           variableDefinitions,
           operationName,
         );
@@ -1278,7 +1237,7 @@ class FetchGroup {
       id: this.id,
       serviceName: this.subgraphName,
       requires: inputNodes ? trimSelectionNodes(inputNodes.selections) : undefined,
-      variableUsages: this.selection.usedVariables().map(v => v.name),
+      variableUsages: selection.usedVariables().map(v => v.name),
       operation: stripIgnoredCharacters(print(operationDocument)),
       operationKind: schemaRootKindToOperationKind(operation.rootKind),
       operationName: operation.name,
@@ -1335,15 +1294,21 @@ type SelectionSetAtPath = {
   selections: SelectionSet,
 }
 
-function addAliasesForNonMergingFields(selections: SelectionSetAtPath[], rewriteCollector: FetchDataOutputRewrite[]) {
+type FieldToAlias = {
+  path: string[],
+  responseName: string,
+  alias: string,
+}
+
+function computeAliasesForNonMergingFields(selections: SelectionSetAtPath[], aliasCollector: FieldToAlias[]) {
   const seenResponseNames = new Map<string, { fieldName: string, fieldType: Type, selections?: SelectionSetAtPath[] }>();
   const rebasedFieldsInSet = (s: SelectionSetAtPath) => (
-    s.selections.fieldsInSet().map(({ path, field, directParent }) => ({ fieldPath: s.path.concat(path), field, directParent }))
+    s.selections.fieldsInSet().map(({ path, field }) => ({ fieldPath: s.path.concat(path), field }))
   );
-  for (const { fieldPath, field, directParent } of selections.map((s) => rebasedFieldsInSet(s)).flat()) {
-    const fieldName = field.element().name;
-    const responseName = field.element().responseName();
-    const fieldType = field.element().definition.type!;
+  for (const { fieldPath, field } of selections.map((s) => rebasedFieldsInSet(s)).flat()) {
+    const fieldName = field.element.name;
+    const responseName = field.element.responseName();
+    const fieldType = field.element.definition.type!;
     const previous = seenResponseNames.get(responseName);
     if (previous) {
       if (previous.fieldName === fieldName && typesCanBeMerged(previous.fieldType, fieldType)) {
@@ -1361,15 +1326,14 @@ function addAliasesForNonMergingFields(selections: SelectionSetAtPath[], rewrite
         // at the level, but it's theoretically possible. By adding the alias to the seen names, we ensure that in the remote change that
         // this ever happen, we'll avoid the conflict by giving another alias to the followup occurence.
         const selections = field.selectionSet ? [{ path: fieldPath.concat(alias), selections: field.selectionSet }] : undefined;
+
         seenResponseNames.set(alias, { fieldName, fieldType, selections });
-        const wasRemoved = directParent.removeTopLevelField(responseName);
-        assert(wasRemoved, () => `Should have found and removed ${responseName} from ${directParent}`);
-        directParent.add(field.withUpdatedField(field.element().withUpdatedAlias(alias)));
+
         // Lastly, we record that the added alias need to be rewritten back to the proper response name post query.
-        rewriteCollector.push({
-          kind: 'KeyRenamer',
-          path: fieldPath.concat(alias),
-          renameKeyTo: responseName,
+        aliasCollector.push({
+          path: fieldPath,
+          responseName,
+          alias
         });
       }
     } else {
@@ -1381,21 +1345,94 @@ function addAliasesForNonMergingFields(selections: SelectionSetAtPath[], rewrite
     if (!selections.selections) {
       continue;
     }
-    addAliasesForNonMergingFields(selections.selections, rewriteCollector);
+    computeAliasesForNonMergingFields(selections.selections, aliasCollector);
   }
 }
 
-class DeferredInfo {
-  readonly subselection: SelectionSet;
+function addAliasesForNonMergingFields(selectionSet: SelectionSet): { updated: SelectionSet, outputRewrites: FetchDataOutputRewrite[] } {
+  const aliases: FieldToAlias[] = [];
+  computeAliasesForNonMergingFields([{ path: [], selections: selectionSet}], aliases);
+  const updated = withFieldAliased(selectionSet, aliases);
+  const outputRewrites = aliases.map<FetchDataOutputRewrite>(({path, responseName, alias}) => ({
+    kind: 'KeyRenamer',
+    path: path.concat(alias),
+    renameKeyTo: responseName,
+  }));
+  return { updated, outputRewrites };
+}
 
-  constructor(
+function withFieldAliased(selectionSet: SelectionSet, aliases: FieldToAlias[]): SelectionSet {
+  if (aliases.length === 0) {
+    return selectionSet;
+  }
+
+  const atCurrentLevel = new Map<string, FieldToAlias>();
+  const remaining = new Array<FieldToAlias>();
+  for (const alias of aliases) {
+    if (alias.path.length > 0) {
+      remaining.push(alias);
+    } else {
+      atCurrentLevel.set(alias.responseName, alias);
+    }
+  }
+
+  return selectionSet.lazyMap((selection) => {
+    const pathElement = selection.element.asPathElement();
+    const subselectionAliases = remaining.map((alias) => {
+      if (alias.path[0] === pathElement) {
+        return {
+          ...alias,
+          path: alias.path.slice(1),
+        };
+      } else {
+        return undefined;
+      }
+    }).filter(isDefined);
+    const updatedSelectionSet = selection.selectionSet
+      ? withFieldAliased(selection.selectionSet, subselectionAliases)
+      : undefined;
+
+    if (selection.kind === 'FieldSelection') {
+      const field = selection.element;
+      const alias = pathElement && atCurrentLevel.get(pathElement);
+      return !alias && selection.selectionSet === updatedSelectionSet
+        ? selection 
+        : selection.withUpdatedComponents(alias ? field.withUpdatedAlias(alias.alias) : field, updatedSelectionSet);
+    } else {
+      return selection.selectionSet === updatedSelectionSet
+        ? selection
+        : selection.withUpdatedSelectionSet(updatedSelectionSet!);
+    }
+  });
+}
+
+class DeferredInfo {
+
+  private constructor(
     readonly label: string,
     readonly path: GroupPath,
-    readonly parentType: CompositeType,
+    readonly subselection: MutableSelectionSet,
     readonly deferred = new Set<string>(),
     readonly dependencies = new Set<string>(),
   ) {
-    this.subselection = new SelectionSet(parentType);
+  }
+
+  static empty(label: string, path: GroupPath, parentType: CompositeType): DeferredInfo {
+    return new DeferredInfo(
+      label,
+      path,
+      MutableSelectionSet.empty(parentType),
+    );
+  }
+
+  clone(): DeferredInfo {
+    return new DeferredInfo(
+      this.label,
+      this.path,
+      this.subselection.clone(),
+      new Set(this.deferred),
+      new Set(this.dependencies),
+    );
   }
 }
 
@@ -1501,28 +1538,22 @@ class GroupPath {
 
 class DeferTracking {
   private readonly topLevelDeferred = new Set<string>();
-  readonly primarySelection: SelectionSet | undefined;
   private readonly deferred = new MapWithCachedArrays<string, DeferredInfo>();
 
-  constructor(rootType: CompositeType | undefined) {
-    this.primarySelection = rootType ? new SelectionSet(rootType) : undefined;
+  private constructor(
+    readonly primarySelection: MutableSelectionSet | undefined
+  ) {
+  }
+
+  static empty(rootType: CompositeType | undefined): DeferTracking {
+    return new DeferTracking(rootType ? MutableSelectionSet.empty(rootType) : undefined);
   }
 
   clone(): DeferTracking {
-    const cloned = new DeferTracking(this.primarySelection?.parentType);
+    const cloned = new DeferTracking(this.primarySelection?.clone());
     this.topLevelDeferred.forEach((label) => cloned.topLevelDeferred.add(label));
-    if (this.primarySelection) {
-      cloned.primarySelection?.mergeIn(this.primarySelection.clone());
-    }
     for (const deferredBlock of this.deferred.values()) {
-      const clonedInfo = new DeferredInfo(
-        deferredBlock.label,
-        deferredBlock.path,
-        deferredBlock.parentType,
-        new Set(deferredBlock.deferred),
-      );
-      clonedInfo.subselection.mergeIn(deferredBlock.subselection.clone());
-      cloned.deferred.set(deferredBlock.label, clonedInfo);
+      cloned.deferred.set(deferredBlock.label, deferredBlock.clone());
     }
     return cloned;
   }
@@ -1546,19 +1577,19 @@ class DeferTracking {
     assert(deferArgs.label, 'All @defer should have be labelled at this point');
     let deferredBlock = this.deferred.get(deferArgs.label);
     if (!deferredBlock) {
-      deferredBlock = new DeferredInfo(deferArgs.label, path, parentType);
+      deferredBlock = DeferredInfo.empty(deferArgs.label, path, parentType);
       this.deferred.set(deferArgs.label, deferredBlock);
     }
 
     const parentRef = deferContext.currentDeferRef;
     if (!parentRef) {
       this.topLevelDeferred.add(deferArgs.label);
-      this.primarySelection.addPath(deferContext.pathToDeferParent);
+      this.primarySelection.updates().addAtPath(deferContext.pathToDeferParent);
     } else {
       const parentInfo = this.deferred.get(parentRef);
       assert(parentInfo, `Cannot find info for parent ${parentRef} or ${deferArgs.label}`);
       parentInfo.deferred.add(deferArgs.label);
-      parentInfo.subselection.addPath(deferContext.pathToDeferParent);
+      parentInfo.subselection.updates().addAtPath(deferContext.pathToDeferParent);
     }
   }
 
@@ -1571,9 +1602,9 @@ class DeferTracking {
     if (parentRef) {
       const info = this.deferred.get(parentRef);
       assert(info, () => `Cannot find info for label ${parentRef}`);
-      info.subselection.addPath(deferContext.pathToDeferParent);
+      info.subselection.updates().addAtPath(deferContext.pathToDeferParent);
     } else {
-      this.primarySelection.addPath(deferContext.pathToDeferParent);
+      this.primarySelection.updates().addAtPath(deferContext.pathToDeferParent);
     }
   }
 
@@ -1630,7 +1661,7 @@ class FetchDependencyGraph {
       startingIdGen,
       new MapWithCachedArrays(),
       [],
-      new DeferTracking(rootTypeForDefer),
+      DeferTracking.empty(rootTypeForDefer),
     );
   }
 
@@ -1778,7 +1809,7 @@ class FetchDependencyGraph {
         && existing.mergeAt
         && sameMergeAt(existing.mergeAt, mergeAt)
         && inputsTypeName === existing.inputs?.parentType?.name
-        && existing.selection.selections().every((s) => s.kind === 'FragmentSelection' && s.element().castedType() === type)
+        && existing.selection.selections().every((s) => s.kind === 'FragmentSelection' && s.element.castedType() === type)
         && !this.isInGroupsOrTheirAncestors(existing, conditionsGroups)
         && existing.deferRef === deferRef
       ) {
@@ -1944,7 +1975,6 @@ class FetchDependencyGraph {
     if (this.isOptimized) {
       return;
     }
-
     this.reduce();
 
     for (const group of this.rootGroups.values()) {
@@ -2066,13 +2096,12 @@ class FetchDependencyGraph {
     // To find which groups are to the same subgraph and mergeAt somewhat efficient, we generate a simple string key from each
     // group subgraph name and mergeAt. We do "sanitize" subgraph name, but have no worries for `mergeAt` since it contains either
     // number of field names, and the later is restricted by graphQL so as to not be an issue.
-    const makeKey = (g: FetchGroup): string => `${toValidGraphQLName(g.subgraphName)}-${g.mergeAt?.join('::') ?? ''}`;
     const bySubgraphs = new MultiMap<string, FetchGroup>();
     for (const group of this.groups) {
       // we exclude groups without inputs because that's what we look for. In practice, this mostly just exclude
       // root groups, which we don't really want to bother with anyway.
       if (group.inputs) {
-        bySubgraphs.add(makeKey(group), group);
+        bySubgraphs.add(group.subgraphAndMergeAtKey!, group);
       }
     }
     for (const groups of bySubgraphs.values()) {
@@ -2383,7 +2412,7 @@ class FetchDependencyGraph {
       const mainReduced = processor.reduceSequence(mainSequenceOfDefer);
       const processed = deferredOfDefer.length === 0
         ? mainReduced
-        : processor.reduceDefer(mainReduced, defer.subselection, deferredOfDefer);
+        : processor.reduceDefer(mainReduced, defer.subselection.get(), deferredOfDefer);
       allDeferred.push(processor.reduceDeferred(defer, processed));
     }
     return { mainSequence, deferred: allDeferred };
@@ -2723,7 +2752,7 @@ export class QueryPlanner {
       if (
         !typenameSelection
         && selection.kind === 'FieldSelection'
-        && selection.field.name === typenameFieldName
+        && selection.element.name === typenameFieldName
         && !parentMaybeInterfaceObject
       ) {
         // The reason we check for `!typenameSelection` is that due to aliasing, there can be more than one __typename selection
@@ -2742,7 +2771,10 @@ export class QueryPlanner {
         if (updatedSubSelection === selection.selectionSet) {
           updated = selection;
         } else {
-          updated = selection.withUpdatedSubSelection(updatedSubSelection);
+          // Note that updateSubSelection can genuinely be undefined for leaf fields, but the type system can track it properly
+          // so we force it to accept it with `!` (to avoid it, we would have to duplicate the code for field and fragment
+          // separately, and that doesn't feel like it would be cleaner).
+          updated = selection.withUpdatedSelectionSet(updatedSubSelection!);
         }
         if (!firstFieldSelection && updated.kind === 'FieldSelection') {
           firstFieldSelection = updated;
@@ -2774,7 +2806,7 @@ export class QueryPlanner {
     if (typenameSelection) {
       if (firstFieldSelection) {
         // Note that as we tag the element, we also record the alias used if any since that needs to be preserved.
-        firstFieldSelection.element().addAttachement(SIBLING_TYPENAME_KEY, typenameSelection.field.alias ? typenameSelection.field.alias : '');
+        firstFieldSelection.element.addAttachement(SIBLING_TYPENAME_KEY, typenameSelection.element.alias ? typenameSelection.element.alias : '');
       } else {
         // If we have no other field selection, then we can't optimize __typename and we need to add
         // it back to the updated subselections (we add it first because that's usually where we
@@ -2782,7 +2814,7 @@ export class QueryPlanner {
         updatedSelections = [typenameSelection as Selection].concat(updatedSelections);
       }
     }
-    return new SelectionSet(selectionSet.parentType, selectionSet.fragments).addAll(updatedSelections)
+    return new SelectionSetUpdates().add(updatedSelections).toSelectionSet(selectionSet.parentType, selectionSet.fragments);
   }
 
   /**
@@ -2825,7 +2857,7 @@ function computePlanInternal({
   statistics: PlanningStatistics,
 }): PlanNode | undefined {
   let main: PlanNode | undefined = undefined;
-  let primarySelection: SelectionSet | undefined = undefined;
+  let primarySelection: MutableSelectionSet | undefined = undefined;
   let deferred: DeferredNode[] = [];
 
   if (operation.rootKind === 'mutation') {
@@ -2838,7 +2870,7 @@ function computePlanInternal({
       const newSelection = dependencyGraph.deferTracking.primarySelection;
       if (newSelection) {
         if (primarySelection) {
-          primarySelection.mergeIn(newSelection);
+          primarySelection.updates().add(newSelection.get());
         } else {
           primarySelection = newSelection.clone();
         }
@@ -2851,7 +2883,7 @@ function computePlanInternal({
   }
   if (deferred.length > 0) {
     assert(primarySelection, 'Should have had a primary selection created');
-    return processor.reduceDefer(main, primarySelection, deferred);
+    return processor.reduceDefer(main, primarySelection.get(), deferred);
   }
   return main;
 }
@@ -2915,7 +2947,7 @@ function generateConditionNodes(
 }
 
 function isIntrospectionSelection(selection: Selection): boolean {
-  return selection.kind == 'FieldSelection' && selection.element().definition.isIntrospectionField();
+  return selection.kind == 'FieldSelection' && selection.element.definition.isIntrospectionField();
 }
 
 function mapOptionsToSelections<RV extends Vertex>(
@@ -2923,7 +2955,7 @@ function mapOptionsToSelections<RV extends Vertex>(
   options: SimultaneousPathsWithLazyIndirectPaths<RV>[]
 ): [Selection, SimultaneousPathsWithLazyIndirectPaths<RV>[]][]  {
   // We reverse the selections because we're going to pop from `openPaths` and this ensure we end up handling things in the query order.
-  return selectionSet.selections(true).map(node => [node, options]);
+  return selectionSet.selectionsInReverseOrder().map(node => [node, options]);
 }
 
 function possiblePlans(closedBranches: SimultaneousPaths<any>[][]): number {
@@ -2951,6 +2983,7 @@ function selectionCost(selection?: SelectionSet, depth: number = 1): number {
   // deterministic (typically, if we have an interface with a single implementation, then we can have a choice between a query plan that type-explode a
   // field of the interface and one that doesn't, and both will be almost identical, except that the type-exploded field will be a different depth; by
   // favoring lesser depth in that case, we favor not type-expoding).
+  //return selection ? 10 + depth : 0;
   return selection ? selection.selections().reduce((prev, curr) => prev + depth + selectionCost(curr.selectionSet, depth + 1), 0) : 0;
 }
 
@@ -2962,11 +2995,10 @@ function withoutIntrospection(operation: Operation): Operation {
     return operation
   }
 
-  const newSelections = operation.selectionSet.selections().filter(s => !isIntrospectionSelection(s));
   return new Operation(
     operation.schema,
     operation.rootKind,
-    new SelectionSet(operation.selectionSet.parentType).addAll(newSelections),
+    operation.selectionSet.lazyMap((s) => isIntrospectionSelection(s) ? undefined : s),
     operation.variableDefinitions,
     operation.name
   );
@@ -3084,7 +3116,7 @@ function splitTopLevelFields(selectionSet: SelectionSet): SelectionSet[] {
     if (selection.kind === 'FieldSelection') {
       return [selectionSetOf(selectionSet.parentType, selection)];
     } else {
-      return splitTopLevelFields(selection.selectionSet).map(s => selectionSetOfElement(selection.element(), s));
+      return splitTopLevelFields(selection.selectionSet).map(s => selectionSetOfElement(selection.element, s));
     }
   });
 }
@@ -3156,7 +3188,7 @@ function fetchGroupToPlanProcessor({
       queryPath: operationPathToStringPath(deferInfo.path.full()),
       // Note that if the deferred block has nested @defer, then the `value` is going to be a `DeferNode` and we'll
       // use it's own `subselection`, so we don't need it here.
-      subselection: deferInfo.deferred.size === 0 ? sanitizeAndPrintSubselection(deferInfo.subselection) : undefined,
+      subselection: deferInfo.deferred.size === 0 ? sanitizeAndPrintSubselection(deferInfo.subselection.get()) : undefined,
       node: value,
     }),
     reduceDefer: (main: PlanNode | undefined, subselection: SelectionSet, deferredBlocks: DeferredNode[]) => ({
@@ -3258,8 +3290,7 @@ function addTypenameFieldForAbstractTypesInNamedFragments(fragments: NamedFragme
   const fragmentsMap = new Map<string, FragmentInfo>();
 
   for (const fragment of fragments.definitions()) {
-    const expandedSelectionSet = fragment.selectionSet.expandFragments();
-    addTypenameFieldForAbstractTypes(expandedSelectionSet);
+    const expandedSelectionSet = addTypenameFieldForAbstractTypes(fragment.selectionSet.expandAllFragments());
     const otherFragmentsUsages = new Map<string, number>();
     fragment.collectUsedFragmentNames(otherFragmentsUsages);
     fragmentsMap.set(fragment.name, {
@@ -3286,79 +3317,42 @@ function addTypenameFieldForAbstractTypesInNamedFragments(fragments: NamedFragme
   return optimizedFragments;
 }
 
-function addSelectionOrSelectionSet(selectionSet: SelectionSet, toAdd: Selection | SelectionSet) {
-  if (toAdd instanceof SelectionSet) {
-    selectionSet.mergeIn(toAdd);
-  } else {
-    selectionSet.add(toAdd);
-  }
-}
-
 /**
- * Given a selection select (`selectionSet`) starting on a given type (`type`) and given a set of directive applications
- * that can be eliminated (`unneededDirectives`; in practice those are conditionals (@skip and @include) already accounted
- * for), returns an equivalent selection set but with unecessary "starting" fragments removed (if any can).
- * Note that this very similar to the optimisation done in `operation.ts#concatOperationPaths`, but applied to the "concatenation"
- * of selection sets.
+ * Given a selection select (`selectionSet`) and given a set of directive applications that can be eliminated (`unneededDirectives`; in 
+ * practice those are conditionals (@skip and @include) already accounted for), returns an equivalent selection set but with unecessary 
+ * "starting" fragments having the unneeded condition/directives removed.
  */
-function removeRedundantFragmentsOfSet(
+function removeUnneededTopLevelFragmentDirectives(
   selectionSet: SelectionSet,
-  type: CompositeType,
   unneededDirectives: Directive<any, any>[],
 ): SelectionSet {
-  let newSet: SelectionSet | undefined = undefined;
-  const selections = selectionSet.selections();
-  for (let i = 0; i < selections.length; i++) {
-    const selection = selections[i];
-    const updated = removeRedundantFragments(selection, type, unneededDirectives);
-    if (newSet) {
-      addSelectionOrSelectionSet(newSet, updated);
-    } else if (selection !== updated) {
-      // We've found the firs selection that is changed. Create `newSet`
-      // and add any previous selection (which we now is unchanged).
-      newSet = new SelectionSet(type);
-      for (let j = 0; j < i; j++) {
-        newSet.add(selections[j]);
-      }
-      // and add the new one.
-      addSelectionOrSelectionSet(newSet, updated);
-    } // else, we just move on
-  }
-  return newSet ? newSet : selectionSet;
-}
+  return selectionSet.lazyMap((selection) => {
+    if (selection.kind !== 'FragmentSelection') {
+      return selection;
+    }
 
-function removeRedundantFragments(
-  selection: Selection,
-  type: CompositeType,
-  unneededDirectives: Directive<any, any>[],
-): Selection | SelectionSet {
-  if (selection.kind !== 'FragmentSelection') {
-    return selection;
-  }
+    const fragment = selection.element;
+    const fragmentType = fragment.typeCondition;
+    if (!fragmentType) {
+      return selection;
+    }
 
-  const fragment = selection.element();
-  const fragmentType = fragment.typeCondition;
-  if (!fragmentType) {
-    return selection;
-  }
+    let neededDirectives: Directive<any>[] = [];
+    if (fragment.appliedDirectives.length > 0) {
+      neededDirectives = directiveApplicationsSubstraction(fragment.appliedDirectives, unneededDirectives);
+    }
 
-  let neededDirectives: Directive[] = [];
-  if (fragment.appliedDirectives.length > 0) {
-    neededDirectives = directiveApplicationsSubstraction(fragment.appliedDirectives, unneededDirectives);
-  }
+    // We recurse, knowing that we'll stop as soon a we hit field selections, so this only cover the fragments
+    // at the "top-level" of the set.
+    const updated = removeUnneededTopLevelFragmentDirectives(selection.selectionSet, unneededDirectives);
+    if (neededDirectives.length === fragment.appliedDirectives.length) {
+      // We need all the directives that the fragment has. Return it unchanged.
+      return selection.selectionSet === updated ? selection : selection.withUpdatedSelectionSet(updated);
+    }
 
-  if (sameType(type, fragmentType) && neededDirectives.length === 0) {
-    // we can completely skip this fragment and recurse.
-    return removeRedundantFragmentsOfSet(selection.selectionSet, type, unneededDirectives);
-  } else if (neededDirectives.length === fragment.appliedDirectives.length) {
-    // This means we need all of the directives of the fragment, and so just return it.
-    return selection;
-  } else {
-    // We need the fragment, but we can skip some of its directive.
-    const updatedFragment = new FragmentElement(type, fragment.typeCondition);
-    neededDirectives.forEach((d) => updatedFragment.applyDirective(d.definition!, d.arguments()));
-    return selectionSetOfElement(updatedFragment, selection.selectionSet);
-  }
+    // We can skip some of the fragment directives directive.
+    return selection.withUpdatedComponents(fragment.withUpdatedDirectives(neededDirectives), updated);
+  });
 }
 
 function schemaRootKindToOperationKind(operation: SchemaRootKind): OperationTypeNode {
@@ -3451,25 +3445,26 @@ function wrapSelectionWithTypeAndConditions<TSelection>(
   wrapInFragment: (fragment: FragmentElement, current: TSelection) => TSelection,
   context: PathContext
 ): TSelection {
-  const typeCast = new FragmentElement(wrappingType, wrappingType.name);
-  let updatedSelection = wrapInFragment(typeCast, initialSelection);
   if (context.conditionals.length === 0) {
-    return updatedSelection;
+    return wrapInFragment(new FragmentElement(wrappingType, wrappingType.name), initialSelection);
   }
 
-  const schema = wrappingType.schema();
   // We add the first include/skip to the current typeCast and then wrap in additional type-casts for the next ones
   // if necessary. Note that we use type-casts (... on <type>), but, outside of the first one, we could well also
   // use fragments with no type-condition. We do the former mostly to preverve older behavior, but doing the latter
   // would technically produce slightly small query plans.
   const { kind: name0, value: ifs0 } = context.conditionals[0];
-  typeCast.applyDirective(schema.directive(name0)!, { 'if': ifs0 });
+  let updatedSelection = wrapInFragment(
+    new FragmentElement(wrappingType, wrappingType.name, [new Directive(name0, { 'if': ifs0 })]),
+    initialSelection,
+  );
 
   for (let i = 1; i < context.conditionals.length; i++) {
     const { kind: name, value: ifs } = context.conditionals[i];
-    const fragment = new FragmentElement(wrappingType, wrappingType.name);
-    fragment.applyDirective(schema.directive(name)!, { 'if': ifs });
-    updatedSelection = wrapInFragment(fragment, updatedSelection);
+    updatedSelection = wrapInFragment(
+      new FragmentElement(wrappingType, wrappingType.name, [new Directive(name, { 'if': ifs })]),
+      updatedSelection
+    );
   }
 
   return updatedSelection;
@@ -3524,7 +3519,7 @@ function computeGroupsForTree(
   while (stack.length > 0) {
     const { tree, group, path, context, deferContext } = stack.pop()!;
     if (tree.isLeaf()) {
-      group.addSelection(path.inGroup());
+      group.addAtPath(path.inGroup());
       dependencyGraph.deferTracking.updateSubselection(deferContext);
     } else {
       // We want to preserve the order of the elements in the child, but the stack will reverse everything, so we iterate
@@ -3583,14 +3578,14 @@ function computeGroupsForTree(
             // the supergraph does).
             const inputType = dependencyGraph.typeForFetchInputs(sourceType.name);
             const inputSelections = newCompositeTypeSelectionSet(inputType);
-            inputSelections.mergeIn(edge.conditions!);
+            inputSelections.updates().add(edge.conditions!);
             newGroup.addInputs(
-              wrapInputsSelections(inputType, inputSelections, newContext),
+              wrapInputsSelections(inputType, inputSelections.get(), newContext), 
               computeInputRewritesOnKeyFetch(inputType.name, destType),
             );
 
             // We also ensure to get the __typename of the current type in the "original" group.
-            group.addSelection(path.inGroup().concat(new Field(sourceType.typenameField()!)));
+            group.addAtPath(path.inGroup().concat(new Field(sourceType.typenameField()!)));
 
             stack.push({
               tree: child,
@@ -3617,7 +3612,7 @@ function computeGroupsForTree(
             // point in adding __typename because if we don't add any other selection, the group will be empty
             // and we've rather detect that and remove the group entirely later.
             if (path.inGroup().length > 0) {
-              group.addSelection(path.inGroup().concat(new Field((edge.head.type as CompositeType).typenameField()!)));
+              group.addAtPath(path.inGroup().concat(new Field((edge.head.type as CompositeType).typenameField()!)));
             }
 
             // We take the edge, creating a new group. Note that we always create a new group because this
@@ -3676,8 +3671,8 @@ function computeGroupsForTree(
             // We need to add the query __typename for the current type in the current group.
             // Note that the value of the "attachement" is the alias or '' if there is no alias
             const alias = typenameAttachment === '' ? undefined : typenameAttachment;
-            const typenameField = new Field(operation.parentType.typenameField()!, {}, new VariableDefinitions(), alias);
-            group.addSelection(path.inGroup().concat(typenameField));
+            const typenameField = new Field(operation.parentType.typenameField()!, {}, new VariableDefinitions(), undefined, alias);
+            group.addAtPath(path.inGroup().concat(typenameField));
             dependencyGraph.deferTracking.updateSubselection({
               ...deferContext,
               pathToDeferParent: deferContext.pathToDeferParent.concat(typenameField),
@@ -3690,7 +3685,7 @@ function computeGroupsForTree(
             deferContext,
             path,
           });
-          assert(updatedOperation, `Extracting @defer from ${operation} should not have resulted in no operation`);
+          assert(updatedOperation, () => `Extracting @defer from ${operation} should not have resulted in no operation`);
 
           const updated = {
             tree: child,
@@ -3821,24 +3816,39 @@ function extractDeferFromOperation({
   };
 }
 
-function addTypenameFieldForAbstractTypes(selectionSet: SelectionSet) {
-  for (const selection of selectionSet.selections()) {
-    if (selection.kind == 'FieldSelection') {
-      const fieldBaseType = baseType(selection.field.definition.type!);
-      if (isAbstractType(fieldBaseType)) {
-        selection.selectionSet!.add(new FieldSelection(new Field(fieldBaseType.typenameField()!)));
-      }
-      if (selection.selectionSet) {
-        addTypenameFieldForAbstractTypes(selection.selectionSet);
-      }
-    } else {
-      const conditionType = selection.element().typeCondition;
-      if (conditionType && isAbstractType(conditionType)) {
-        selection.selectionSet!.add(new FieldSelection(new Field(conditionType.typenameField()!)));
-      }
-      addTypenameFieldForAbstractTypes(selection.selectionSet);
-    }
+function subselectionTypeIfAbstract(selection: Selection): AbstractType | undefined {
+  if (selection.kind === 'FieldSelection') {
+    const fieldBaseType = baseType(selection.element.definition.type!);
+    return isAbstractType(fieldBaseType) ? fieldBaseType : undefined;
+  } else {
+    const conditionType = selection.element.typeCondition;
+    return conditionType && isAbstractType(conditionType) ? conditionType : undefined;
   }
+}
+
+function addTypenameFieldForAbstractTypes(selectionSet: SelectionSet, parentTypeIfAbstact?: AbstractType): SelectionSet {
+  const handleSelection = (selection: Selection): Selection => {
+      if (!selection.selectionSet) {
+        return selection;
+      }
+
+      const typeIfAbstract = subselectionTypeIfAbstract(selection);
+      const updatedSelectionSet = addTypenameFieldForAbstractTypes(selection.selectionSet, typeIfAbstract);
+      if (updatedSelectionSet === selection.selectionSet) {
+        return selection;
+      } else {
+        return selection.withUpdatedSelectionSet(updatedSelectionSet);
+      }
+  }
+
+  if (!parentTypeIfAbstact || selectionSet.hasTopLevelTypenameField()) {
+    return selectionSet.lazyMap((selection) => handleSelection(selection));
+  }
+
+  const updates = new SelectionSetUpdates();
+  updates.add(new FieldSelection(new Field(parentTypeIfAbstact.typenameField()!)));
+  selectionSet.selections().forEach((selection) => updates.add(handleSelection(selection)))
+  return updates.toSelectionSet(selectionSet.parentType);
 }
 
 function pathHasOnlyFragments(path: OperationPath): boolean {
@@ -3911,7 +3921,7 @@ function handleRequires(
       deferRef: group.deferRef
     });
     newGroup.addParent(parent);
-    newGroup.copyInputsOf(group, true);
+    newGroup.copyInputsOf(group);
     const createdGroups = computeGroupsForTree(dependencyGraph, requiresConditions, newGroup, path, deferContextForConditions(deferContext));
     if (createdGroups.length == 0) {
       // All conditions were local. Just merge the newly created group back in the current group (we didn't need it)
@@ -4120,16 +4130,13 @@ function addPostRequireInputs(
   if (keyInputs) {
     // It could be the key used to resume fetching after the @require is already fetched in the original group, but we cannot
     // guarantee it, so we add it now (and if it was already selected, this is a no-op).
-    preRequireGroup.addSelection(requirePath.inGroup(), (endOfPathSet) => {
-      assert(endOfPathSet, () => `Merge path ${requirePath} ends on a non-selectable type`);
-      endOfPathSet.addAll(keyInputs.selections());
-    });
+    preRequireGroup.addAtPath(requirePath.inGroup(), keyInputs.selections());
   }
 }
 
-function newCompositeTypeSelectionSet(type: CompositeType): SelectionSet {
-  const selectionSet = new SelectionSet(type);
-  selectionSet.add(new FieldSelection(new Field(type.typenameField()!)));
+function newCompositeTypeSelectionSet(type: CompositeType): MutableSelectionSet {
+  const selectionSet = MutableSelectionSet.empty(type);
+  selectionSet.updates().add(new FieldSelection(new Field(type.typenameField()!)));
   return selectionSet;
 }
 
@@ -4154,8 +4161,8 @@ function inputsForRequire(
   assert(inputType && isCompositeType(inputType), () => `Type ${inputTypeName} should exist in the supergraph and be a composite type`);
 
   const fullSelectionSet = newCompositeTypeSelectionSet(inputType);
-  fullSelectionSet.mergeIn(edge.conditions!);
-  let keyInputs: SelectionSet | undefined = undefined;
+  fullSelectionSet.updates().add(edge.conditions!);
+  let keyInputs: MutableSelectionSet | undefined = undefined;
   if (includeKeyInputs) {
     const keyCondition = getLocallySatisfiableKey(dependencyGraph.federatedQueryGraph, edge.head);
     assert(keyCondition, () => `Due to @require, validation should have required a key to be present for ${edge}`);
@@ -4168,22 +4175,20 @@ function inputsForRequire(
       // condition on the supergraph type (which is an interface) first, which lets the `mergeIn` work.
       const supergraphItfType = dependencyGraph.supergraphSchema.type(entityType.name);
       assert(supergraphItfType && isInterfaceType(supergraphItfType), () => `Type ${entityType} should be an interface in the supergraph`);
-      const rebasedKeyCondition = new SelectionSet(supergraphItfType);
-      rebasedKeyCondition.mergeIn(keyConditionAsInput);
-      keyConditionAsInput = rebasedKeyCondition;
+      keyConditionAsInput = keyConditionAsInput.rebaseOn(supergraphItfType);
     }
-    fullSelectionSet.mergeIn(keyConditionAsInput);
+    fullSelectionSet.updates().add(keyConditionAsInput);
 
     // Note that `keyInputs` are used to ensure those input are fetch on the original group, the one having `edge`. In
     // the case of an @interfaceObject downcast, that's the subgraph with said @interfaceObject, so in that case we
     // should just use `entityType` (that @interfaceObject type), not input type which will be an implementation the
     // subgraph does not know in that particular case.
     keyInputs = newCompositeTypeSelectionSet(entityType);
-    keyInputs.mergeIn(keyCondition);
+    keyInputs.updates().add(keyCondition);
   }
   return {
-    inputs: wrapInputsSelections(inputType, fullSelectionSet, context),
-    keyInputs,
+    inputs: wrapInputsSelections(inputType, fullSelectionSet.get(), context),
+    keyInputs: keyInputs?.get(),
   };
 }
 
@@ -4216,16 +4221,13 @@ function operationForEntitiesFetch(
   const entities = queryType.field(entitiesFieldName);
   assert(entities, `Subgraphs should always have the _entities field`);
 
-  const entitiesCall: SelectionSet = new SelectionSet(queryType);
-  entitiesCall.add(
-    new FieldSelection(
-      new Field(
-        entities,
-        { representations: representationsVariable },
-        variableDefinitions,
-      ),
-      selectionSet,
+  const entitiesCall = selectionSetOfElement(
+    new Field(
+      entities,
+      { representations: representationsVariable },
+      variableDefinitions,
     ),
+    selectionSet,
   );
 
   return new Operation(subgraphSchema, 'query', entitiesCall, variableDefinitions, operationName);


### PR DESCRIPTION
The current (before this commit) implementation of `SelectionSet` is inherently mutable: its `SelectionSet.add` method mutate the selection set it's called on. Which is at odds with the general query planner algorithm, which is the main user of `SelectionSet`, but is fundamentally based on dealing with immutable data (as we explore various "path" options and the possible plans, most things are shared (at least partly)).

This mismatch between the query planner that really want immutable selection sets but an implementation that is mutable leads to less than optimal code complexity and performance. More specificially, if we want to use a `SelectionSet` into 2 separate branch of the algorithm, we usually have to do defensive deep copies, which is inefficient. And to mitigate those inefficiencies, we sometimes don't do those copies, but this lead to code that fragile and easy to break and has lead to bug previously (where we save a copy, but then a branch mistakenly mutated and thus impacted another branch mistakenly). A few tricks had been added to the implementation to help mitigate the risks (the `freeze` behaviour, and the copy-on-write in `FetchGroup`), but they add complexity and aren't always optimal performance wise.

This commit thus rework the implementation/api of `SelectionSet` to make it an immutable data structure. Doing so makes the code a lot safer and easy to reason about. And it also provide some performance benefits: compared to current `main` over a set of production schema/query, this seem to provide around 20% improvement on average and up to almost 50% improvment on some specific cases for the computation of query plans (disclaimer: those benchmark are fairly unscientific so those numbers should be taken with a grain of salt, but the numbers are clear enough that this is a net measurable gain).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
