### PR TITLE
Improve deprecation script

### DIFF
--- a/scripts/deprecate-old-versions.sh
+++ b/scripts/deprecate-old-versions.sh
@@ -12,21 +12,18 @@
 
 set -e
 
+if [ -z "$OTP" ]; then
+  echo "Error: OTP required to run npm deprecation. Set the OTP env var (OTP=xyz) and run again."
+  exit 1
+fi
+
 deprecate_all_v0_of_package_with_message() {
   local package_name=$1
   local deprecation_message=$2
-
-  # Get all the versions of the package, trim double quotes
-  versions=$(npm view $package_name versions --json | tr -d '[],"')
-  for version in $versions; do
-    # Filter for versions starting with 0. only
-    if [[ $version == 0.* ]]; then
-      # Print the version
-      echo "Deprecating version: $package_name@$version"
-      # Deprecate the version
-      npm deprecate "$package_name@$version" "$deprecation_message"
-    fi
-  done
+  # Print the version
+  echo "Deprecating version range: $package_name@0.x"
+  # Deprecate the entire 0.x version range
+  npm deprecate "$package_name@0.x" "$deprecation_message" --otp=$OTP &
 }
 
 deprecate_all_v0_of_package_with_message "@apollo/gateway" "All v0.x versions of @apollo/gateway are now deprecated (end-of-life September 22, 2023). Apollo recommends upgrading to v2.x or migrating to the Apollo Router as soon as possible. For more details, see our announcement blog post (https://www.apollographql.com/blog/announcement/backend/announcing-the-end-of-life-schedule-for-apollo-gateway-v0-x/) and documentation (https://www.apollographql.com/docs/federation/federation-2/backward-compatibility/#is-official-support-ending-for-apollogateway-v0x)."


### PR DESCRIPTION
The script was struggling to run deprecate on so many things - OTP would expire before it finished, or the token would hit a rate limit.

I found out that `npm deprecate` accepts a version _range_ which means we can run just 4 commands instead of a command for every 0.x version that exists. Much better 😄