### PR TITLE
Fix generating misleading "value type" hint on entity interfaces

### DIFF
--- a/.changeset/eighty-knives-beg.md
+++ b/.changeset/eighty-knives-beg.md
@@ -1,0 +1,6 @@
+---
+"@apollo/composition": patch
+---
+
+Stop generating misleading "hint" regarding value type fields for interface types that are entity interfaces (they have a `@key` defined).
+  

--- a/composition-js/src/__tests__/hints.test.ts
+++ b/composition-js/src/__tests__/hints.test.ts
@@ -312,6 +312,30 @@ test('hints on field of interface value type not being in all subgraphs', () => 
   );
 })
 
+test('*No* hint on field of interface _with @key_ not being in all subgraphs', () => {
+  const subgraph1 = gql`
+    type Query {
+      a: Int
+    }
+
+    interface T @key(fields: "id") {
+      id: ID!
+      a: Int
+      b: Int
+    }
+  `;
+
+  const subgraph2 = gql`
+    type T @interfaceObject @key(fields: "id") {
+      id: ID!
+      a: Int
+    }
+  `;
+
+  const result = mergeDocuments(subgraph1, subgraph2);
+  expect(result).toNotRaiseHints();
+})
+
 test('hints on field of input object value type not being in all subgraphs', () => {
   const subgraph1 = gql`
     type Query {


### PR DESCRIPTION
The code that generates the `INCONSISTENT_INTERFACE_VALUE_TYPE_FIELD` was run inconditionally on all interfaces. However, with the introduction of `@interfaceObject` and `@key` on interfaces, we now essentially support "entity" interfaces, and it is misleading to generate this hint for those interfaces. This commit fixes that.

Fixes #2397

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
