### PR TITLE
support for composing federation directives into supergraph

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -714,7 +714,7 @@ class Merger {
     this.recordAppliedDirectivesToMerge(sources, dest);
     switch (dest.kind) {
       case 'ScalarType':
-        // Since we don't handle applied directives yet, we have nothing specific to do for scalars.
+        this.federationDirectiveComposition.mergeSchemaElements(sources, dest);
         break;
       case 'ObjectType':
         this.mergeObject(sources as (ObjectType | undefined)[], dest);
@@ -798,7 +798,7 @@ class Merger {
     const isValueType = !isEntity && !dest.isRootType();
 
     this.addFieldsShallow(sources, dest);
-    this.federationDirectiveComposition.mergeObject(sources, dest);
+    this.federationDirectiveComposition.mergeSchemaElements(sources, dest);
 
     if (!dest.hasFields()) {
       // This can happen for a type that existing in the subgraphs but had only non-merged fields
@@ -1259,7 +1259,7 @@ class Merger {
   }
 
   private mergeField(sources: FieldOrUndefinedArray, dest: FieldDefinition<any>, mergeContext: FieldMergeContext = new FieldMergeContext(sources)) {
-    this.federationDirectiveComposition.mergeField(sources, dest);
+    this.federationDirectiveComposition.mergeSchemaElements(sources, dest);
     if (sources.every((s, i) => s === undefined ? this.fieldsInSourceIfAbstractedByInterfaceObject(dest, i).every((f) => this.isExternal(i, f)) : this.isExternal(i, s))) {
       const definingSubgraphs = sources.map((source, i) => {
         if (source) {
@@ -1717,6 +1717,7 @@ class Merger {
   }
 
   private mergeArgument(sources: (ArgumentDefinition<any> | undefined)[], dest: ArgumentDefinition<any>) {
+    this.federationDirectiveComposition.mergeSchemaElements(sources, dest);
     this.mergeDescription(sources, dest);
     this.recordAppliedDirectivesToMerge(sources, dest);
     this.mergeTypeReference(sources, dest, true);
@@ -1931,6 +1932,7 @@ class Merger {
   }
 
   private mergeEnum(sources: (EnumType | undefined)[], dest: EnumType) {
+    this.federationDirectiveComposition.mergeSchemaElements(sources, dest);
     let usage = this.enumUsages.get(dest.name);
     if (!usage) {
       // If the enum is unused, we have a choice to make. We could skip the enum entirely (after all, exposing an unreferenced type mostly "pollutes" the supergraph API), but
@@ -2129,6 +2131,7 @@ class Merger {
   }
 
   private mergeInputField(sources: (InputFieldDefinition | undefined)[], dest: InputFieldDefinition) {
+    this.federationDirectiveComposition.mergeSchemaElements(sources, dest);
     this.mergeDescription(sources, dest);
     this.recordAppliedDirectivesToMerge(sources, dest);
     const allTypesEqual = this.mergeTypeReference(sources, dest, true);

--- a/internals-js/src/__tests__/directiveCompositionRules.test.ts
+++ b/internals-js/src/__tests__/directiveCompositionRules.test.ts
@@ -1,8 +1,10 @@
 // write a jest test for directiveCompositionRules.ts
 
 import { DirectiveLocation } from 'graphql';
-import { Directive, DirectiveDefinition, ListType, NonNullType, ObjectType, Schema } from '../definitions';
-import { DirectiveCompositionEntry, DirectiveCompositionStrategy, DirectivePropagationStrategy, FederationDirectiveCompositionManager, FieldPropagationStrategy } from '../directiveCompositionRules';
+import gql from 'graphql-tag';
+import { Directive, DirectiveDefinition, FieldDefinition, ListType, NonNullType, ObjectType, Schema } from '../definitions';
+import { DirectiveCompositionEntry, FederationDirectiveCompositionManager, FieldPropagationStrategy } from '../directiveCompositionRules';
+import { buildSubgraph } from '../federation';
 
 describe('directive composition entry tests', () => {
   it.each([
@@ -22,39 +24,19 @@ describe('directive composition entry tests', () => {
     expect(() => {
       new DirectiveCompositionEntry(
         definition,
-        DirectiveCompositionStrategy.COLLAPSE,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT
       );
     }).toThrowError(`Directive @foo has unsupported locations: ${location}.`);
   });
 
-  it.each([
-    DirectiveCompositionStrategy.COLLAPSE,
-    DirectiveCompositionStrategy.COLLAPSE_FROM_ALL,
-  ])('collapse directive is repeatable', (strategy) => {
+  it('collapse directive is repeatable', () => {
     const definition = new DirectiveDefinition('foo');
     definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
     definition.repeatable = true;
     expect(() => {
       new DirectiveCompositionEntry(
         definition,
-        strategy,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT
       );
-    }).toThrowError(`Directive @foo is repeatable, but its composition strategy is ${strategy}.`);
-  });
-
-  it(('propagation strategy is inherit from object and directive is repeatable'), () => {
-    const definition = new DirectiveDefinition('foo');
-    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
-    definition.repeatable = true;
-    expect(() => {
-      new DirectiveCompositionEntry(
-        definition,
-        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT
-      );
-    }).toThrowError(`Directive @foo is repeatable, but its propagation strategy is inheritFromObject.`);
+    }).toThrowError(`Directive @foo is repeatable. Repeatable directives are not supported yet.`);
   });
 
   it('composition entry specifies unknown arguments', () => {
@@ -63,8 +45,6 @@ describe('directive composition entry tests', () => {
     expect(() => {
       new DirectiveCompositionEntry(
         definition,
-        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
         new Map([['value', FieldPropagationStrategy.MAX]]),
       );
     }).toThrowError(`Directive @foo does not have an argument named value.`);
@@ -79,8 +59,6 @@ describe('directive composition entry tests', () => {
     expect(() => {
       new DirectiveCompositionEntry(
         definition,
-        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
       );
     }).toThrowError(`Directive @foo has arguments that are not in the field strategies map.`);
   });
@@ -94,8 +72,6 @@ describe('directive composition entry tests', () => {
     expect(() => {
       new DirectiveCompositionEntry(
         definition,
-        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
         new Map([['value', FieldPropagationStrategy.MAX]]),
       );
     }).toThrowError(`Directive @foo has one or more optional arguments. Optional arguments are not supported yet.`);
@@ -105,7 +81,6 @@ describe('directive composition entry tests', () => {
     [FieldPropagationStrategy.MAX, (schema: Schema) => schema.stringType(), 'Int!'],
     [FieldPropagationStrategy.MIN, (schema: Schema) => schema.stringType(), 'Int!'],
     [FieldPropagationStrategy.SUM, (schema: Schema) => schema.stringType(), 'Int!'],
-    [FieldPropagationStrategy.AVERAGE, (schema: Schema) => schema.stringType(), 'Int!'],
     [FieldPropagationStrategy.AND, (schema: Schema) => schema.intType(), 'Boolean!'],
     [FieldPropagationStrategy.OR, (schema: Schema) => schema.intType(), 'Boolean!'],
     [FieldPropagationStrategy.INTERSECTION, (schema: Schema) => schema.intType(), '[T]!'],
@@ -119,84 +94,50 @@ describe('directive composition entry tests', () => {
     expect(() => {
       new DirectiveCompositionEntry(
         definition,
-        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
         new Map([['value', strategy]]),
       );
     }).toThrowError(`Directive @foo has a field strategy of ${strategy} for argument value, but the argument is not of type ${typeAsString}`);
   });
-
-  it('make sure that FIELD_DEFINITION is a valid location if INHERIT_FROM_OBJECT is used', () => {
-    const schema = new Schema();
-    const definition = new DirectiveDefinition('foo');
-    schema.addDirectiveDefinition(definition);
-    definition.addLocations(DirectiveLocation.OBJECT);
-    expect(() => {
-      new DirectiveCompositionEntry(
-        definition,
-        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
-      );
-    }).toThrowError(`Directive @foo is marked as inheritFromObject, but FIELD_DEFINITION is not one of its locations.`);
-  });
-
 });
 
 describe('field directive processing tests', () => {
+  const getPrimitiveType = (schema: Schema, type: string) => {
+    if (type === 'int') {
+      return schema.intType();
+    } else if (type === 'float') {
+      return schema.floatType();
+    } else if (type === 'string') {
+      return schema.stringType();
+    }
+    throw new Error('getPrimitiveType: unknown type');
+  }
+
   it.each([
-    [FieldPropagationStrategy.EXACT, [ { value: 1 }, { value: 2 } ]],
-  ])('match exact should not combine directives', (strategy, expectedResult) => {
+    [FieldPropagationStrategy.SUM, 1, 3, [ { value: 4 } ], 'int'],
+    [FieldPropagationStrategy.MAX, 1, 3, [ { value: 3 } ], 'int'],
+    [FieldPropagationStrategy.MIN, 1, 3, [ { value: 1 } ], 'int'],
+    [FieldPropagationStrategy.SUM, 0.5, 3.5, [ { value: 4 } ], 'float'],
+    [FieldPropagationStrategy.MAX, 0.5, 3.5, [ { value: 3.5 } ], 'float'],
+    [FieldPropagationStrategy.MIN, 0.5, 3.5, [ { value: 0.5 } ], 'float'],
+  ])('combination of directives (int/float)', (strategy, a, b, expectedResult, type) => {
     const schema = new Schema();
     const query = new ObjectType('Query');
     schema.addType(query);
-    query.addField('a', schema.intType());
+    query.addField('a', getPrimitiveType(schema, type));
 
     const definition = new DirectiveDefinition('foo');
     schema.addDirectiveDefinition(definition);
     definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
     definition.addArgument('value', new NonNullType(schema.intType()));
-    definition.repeatable = true;
+    definition.repeatable = false;
 
     const entry = new DirectiveCompositionEntry(
       definition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
       new Map([['value', strategy]]),
     );
 
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1 });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 2 });
-    const directives = query.fields()[0].appliedDirectives;
-
-    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual(expectedResult);
-  });
-
-  it.each([
-    [FieldPropagationStrategy.SUM, [ { value: 4 } ]],
-    [FieldPropagationStrategy.MAX, [ { value: 3 } ]],
-    [FieldPropagationStrategy.MIN, [ { value: 1 } ]],
-    [FieldPropagationStrategy.AVERAGE, [ { value: 2 } ]],
-  ])('combination of directives (int)', (strategy, expectedResult) => {
-    const schema = new Schema();
-    const query = new ObjectType('Query');
-    schema.addType(query);
-    query.addField('a', schema.intType());
-
-    const definition = new DirectiveDefinition('foo');
-    schema.addDirectiveDefinition(definition);
-    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
-    definition.addArgument('value', new NonNullType(schema.intType()));
-    definition.repeatable = true;
-
-    const entry = new DirectiveCompositionEntry(
-      definition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
-      new Map([['value', strategy]]),
-    );
-
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1 });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 3 });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: a });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: b });
     const directives = query.fields()[0].appliedDirectives;
 
     expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual(expectedResult);
@@ -217,12 +158,10 @@ describe('field directive processing tests', () => {
     schema.addDirectiveDefinition(definition);
     definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
     definition.addArgument('value', new NonNullType(schema.booleanType()));
-    definition.repeatable = true;
+    definition.repeatable = false;
 
     const entry = new DirectiveCompositionEntry(
       definition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
       new Map([['value', strategy]]),
     );
 
@@ -232,45 +171,6 @@ describe('field directive processing tests', () => {
     const directives = query.fields()[0].appliedDirectives;
 
     expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual(expectedResult);
-  });
-
-  it('more complicated example of combinations', () => {
-    const schema = new Schema();
-    const query = new ObjectType('Query');
-    schema.addType(query);
-    query.addField('a', schema.intType());
-
-    const definition = new DirectiveDefinition('foo');
-    schema.addDirectiveDefinition(definition);
-    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
-    definition.addArgument('value', new NonNullType(schema.intType()));
-    definition.addArgument('otherValue', new NonNullType(schema.intType()));
-    definition.addArgument('label', new NonNullType(schema.stringType()));
-    definition.repeatable = true;
-
-    const entry = new DirectiveCompositionEntry(
-      definition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
-      new Map([['value', FieldPropagationStrategy.SUM], ['otherValue', FieldPropagationStrategy.MAX], ['label', FieldPropagationStrategy.EXACT]]),
-    );
-
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 1, label: 'a' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 2, label: 'b' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 3, label: 'c' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 4, label: 'a' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 5, label: 'a' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 6, label: 'b' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 7, label: 'c' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 8, label: 'c' });
-    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 9, label: 'c' });
-    const directives = query.fields()[0].appliedDirectives;
-
-    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual([
-      { value: 3, otherValue: 5, label: 'a'},
-      { value: 2, otherValue: 6, label: 'b'},
-      { value: 4, otherValue: 9, label: 'c'},
-    ]);
   });
 
   it('union field propagation strategy', () => {
@@ -283,12 +183,10 @@ describe('field directive processing tests', () => {
     schema.addDirectiveDefinition(definition);
     definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
     definition.addArgument('value', new NonNullType(new ListType(schema.intType())));
-    definition.repeatable = true;
+    definition.repeatable = false;
 
     const entry = new DirectiveCompositionEntry(
       definition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
       new Map([['value', FieldPropagationStrategy.UNION]]),
     );
 
@@ -312,12 +210,10 @@ describe('field directive processing tests', () => {
     schema.addDirectiveDefinition(definition);
     definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
     definition.addArgument('value', new NonNullType(new ListType(schema.intType())));
-    definition.repeatable = true;
+    definition.repeatable = false;
 
     const entry = new DirectiveCompositionEntry(
       definition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
       new Map([['value', FieldPropagationStrategy.INTERSECTION]]),
     );
 
@@ -333,146 +229,73 @@ describe('field directive processing tests', () => {
 });
 
 describe('test with full federated schemas', () => {
-  it('test through composition manager', () => {
-    const schema1 = new Schema();
-    const query1 = new ObjectType('Query');
-    schema1.addType(query1);
-    query1.addField('a', schema1.intType());
+  it('test through composition manager with red herring renamed directive', () => {
+    const subgraph1 = buildSubgraph(
+      'Subgraph1',
+      'https://Subgraph1',
+      gql`
+        extend schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(
+          url: "https://specs.apollo.dev/foo/v0.1"
+          import: ["@foo"]
+        )
 
-    const schema2 = new Schema();
-    const query2 = new ObjectType('Query');
-    schema2.addType(query2);
-    query2.addField('a', schema2.intType());
+        directive @foo(value: Int!, otherValue: Int!) on FIELD_DEFINITION
 
-    const supergraphSchema = new Schema();
-    const supergraphQuery = new ObjectType('Query');
-    supergraphSchema.addType(supergraphQuery);
-    supergraphQuery.addField('a', supergraphSchema.intType());
+        type Query {
+          a: Int @foo(value: 1, otherValue: 1)
+        }
+      `);
 
-    const generateFooDirectiveDefinitionForSchema = (schema: Schema) => {
-      const definition = new DirectiveDefinition('foo');
-      schema.addDirectiveDefinition(definition);
-      definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
-      definition.addArgument('value', new NonNullType(schema.intType()));
-      definition.addArgument('otherValue', new NonNullType(schema.intType()));
-      definition.addArgument('label', new NonNullType(schema.stringType()));
-      definition.repeatable = true;
-      return definition;
-    };
+    const subgraph2 = buildSubgraph(
+      'Subgraph2',
+      'https://Subgraph2',
+      gql`
+        extend schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(
+          url: "https://specs.apollo.dev/foo/v0.1"
+          import: [{ name: "@foo", as: "@bar" }]
+        )
 
-    const definition1 = generateFooDirectiveDefinitionForSchema(schema1);
-    const definition2 = generateFooDirectiveDefinitionForSchema(schema2);
-    const supergraphDefinition = generateFooDirectiveDefinitionForSchema(supergraphSchema);
+        directive @bar(value: Int!, otherValue: Int!) on FIELD_DEFINITION
+        directive @foo(value: Int!) on FIELD_DEFINITION
 
-    query1.fields()[0].applyDirective(definition1, { name: 'value', value: 1, otherValue: 1, label: 'a' });
-    query2.fields()[0].applyDirective(definition2, { name: 'value', value: 2, otherValue: 7, label: 'a' });
-    query2.fields()[0].applyDirective(definition2, { name: 'value', value: 4, otherValue: 4, label: 'b' });
+        type Query {
+          a: Int @bar(value: 2, otherValue: 7) @foo(value: 3)
+        }
+      `);
 
-    const entry = new DirectiveCompositionEntry(
-      supergraphDefinition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
-      new Map([['value', FieldPropagationStrategy.SUM], ['otherValue', FieldPropagationStrategy.MAX], ['label', FieldPropagationStrategy.EXACT]]),
-    );
+      const supergraph = buildSubgraph(
+        'Supergraph',
+        'https://Supergraph',
+        gql`
+          extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(
+            url: "https://specs.apollo.dev/foo/v0.1"
+            import: ["@foo"]
+          )
 
-    const mgr = new FederationDirectiveCompositionManager([schema1, schema2], [entry])
-    mgr.mergeField([query1.fields()[0], query2.fields()[0]], supergraphQuery.fields()[0]);
-    const appliedDirectives = supergraphQuery.fields()[0].appliedDirectives;
-    expect(appliedDirectives.toString()).toBe('@foo(value: 3, otherValue: 7, label: "a"),@foo(value: 4, otherValue: 4, label: "b")');
-  });
+          directive @foo(value: Int!, otherValue: Int!) on FIELD_DEFINITION
 
-  it('mergeObject without propagation to fields', () => {
-    const schema1 = new Schema();
-    const query1 = new ObjectType('Query');
-    schema1.addType(query1);
-    query1.addField('a', schema1.intType());
-
-    const schema2 = new Schema();
-    const query2 = new ObjectType('Query');
-    schema2.addType(query2);
-    query2.addField('a', schema2.intType());
-
-    const supergraphSchema = new Schema();
-    const supergraphQuery = new ObjectType('Query');
-    supergraphSchema.addType(supergraphQuery);
-    supergraphQuery.addField('a', supergraphSchema.intType());
-
-    const generateFooDirectiveDefinitionForSchema = (schema: Schema) => {
-      const definition = new DirectiveDefinition('foo');
-      schema.addDirectiveDefinition(definition);
-      definition.addLocations(DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.OBJECT);
-      definition.addArgument('label', new NonNullType(schema.stringType()));
-      definition.repeatable = true;
-      return definition;
-    };
-
-    const definition1 = generateFooDirectiveDefinitionForSchema(schema1);
-    const definition2 = generateFooDirectiveDefinitionForSchema(schema2);
-    const supergraphDefinition = generateFooDirectiveDefinitionForSchema(supergraphSchema);
-
-    query1.applyDirective(definition1, { label: 'a' });
-    query2.applyDirective(definition2, { label: 'b' });
+          type Query {
+            a: Int
+          }
+        `);
 
     const entry = new DirectiveCompositionEntry(
-      supergraphDefinition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.CONSISTENT_LOCATION,
-      new Map([['label', FieldPropagationStrategy.EXACT]]),
+      supergraph.schema.directive('foo') as any,
+      new Map([['value', FieldPropagationStrategy.SUM], ['otherValue', FieldPropagationStrategy.MAX]]),
     );
 
-    const mgr = new FederationDirectiveCompositionManager([schema1, schema2], [entry])
-    mgr.mergeObject([query1, query2], supergraphQuery);
-    const appliedDirectives = supergraphQuery.appliedDirectives;
-    expect(appliedDirectives.toString()).toBe('@foo(label: "a"),@foo(label: "b")');
-    expect(supergraphQuery.fields()[0].appliedDirectives.toString()).toBe('');
-  });
-
-  it('mergeObject with propagation to fields', () => {
-    const schema1 = new Schema();
-    const query1 = new ObjectType('Query');
-    schema1.addType(query1);
-    query1.addField('a', schema1.intType());
-
-    const schema2 = new Schema();
-    const query2 = new ObjectType('Query');
-    schema2.addType(query2);
-    query2.addField('a', schema2.intType());
-
-    const supergraphSchema = new Schema();
-    const supergraphQuery = new ObjectType('Query');
-    supergraphSchema.addType(supergraphQuery);
-    supergraphQuery.addField('a', supergraphSchema.intType());
-
-    const generateFooDirectiveDefinitionForSchema = (schema: Schema) => {
-      const definition = new DirectiveDefinition('foo');
-      schema.addDirectiveDefinition(definition);
-      definition.addLocations(DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.OBJECT);
-      definition.addArgument('value', new NonNullType(schema.intType()));
-      return definition;
-    };
-
-    const definition1 = generateFooDirectiveDefinitionForSchema(schema1);
-    const definition2 = generateFooDirectiveDefinitionForSchema(schema2);
-    const supergraphDefinition = generateFooDirectiveDefinitionForSchema(supergraphSchema);
-
-    query1.applyDirective(definition1, { value: 1 });
-    query1.fields()[0].applyDirective(definition1, { value: 6 });
-    query2.applyDirective(definition2, { value: 2 });
-
-    const entry = new DirectiveCompositionEntry(
-      supergraphDefinition,
-      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
-      DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
-      new Map([['value', FieldPropagationStrategy.SUM]]),
-    );
-
-    const mgr = new FederationDirectiveCompositionManager([schema1, schema2], [entry])
-    mgr.mergeObject([query1, query2], supergraphQuery);
-    const appliedDirectives = supergraphQuery.appliedDirectives;
-    expect(appliedDirectives.toString()).toBe('@foo(value: 3)');
-
-    mgr.mergeField([query1.fields()[0], query2.fields()[0]], supergraphQuery.fields()[0]);
-
-    expect(supergraphQuery.fields()[0].appliedDirectives.toString()).toBe('@foo(value: 8)');
+    const mgr = new FederationDirectiveCompositionManager([subgraph1.schema, subgraph2.schema], [entry])
+    mgr.mergeField([
+      subgraph1.schema.elementByCoordinate('Query.a') as FieldDefinition<any>,
+      subgraph2.schema.elementByCoordinate('Query.a') as FieldDefinition<any>,
+    ], supergraph.schema.elementByCoordinate('Query.a') as FieldDefinition<any>);
+    const appliedDirectives = (supergraph.schema.elementByCoordinate('Query.a') as FieldDefinition<any>).appliedDirectives;
+    expect(appliedDirectives.toString()).toBe('@foo(value: 3, otherValue: 7)');
   });
 });

--- a/internals-js/src/__tests__/directiveCompositionRules.test.ts
+++ b/internals-js/src/__tests__/directiveCompositionRules.test.ts
@@ -10,7 +10,6 @@ describe('directive composition entry tests', () => {
   it.each([
     DirectiveLocation.INTERFACE,
     DirectiveLocation.SCHEMA,
-    DirectiveLocation.SCALAR,
     DirectiveLocation.INTERFACE,
     DirectiveLocation.UNION,
     DirectiveLocation.ENUM_VALUE,
@@ -288,7 +287,7 @@ describe('test with full federated schemas', () => {
     );
 
     const mgr = new FederationDirectiveCompositionManager([subgraph1.schema, subgraph2.schema], [entry])
-    mgr.mergeField([
+    mgr.mergeSchemaElements([
       subgraph1.schema.elementByCoordinate('Query.a') as FieldDefinition<any>,
       subgraph2.schema.elementByCoordinate('Query.a') as FieldDefinition<any>,
     ], supergraph.schema.elementByCoordinate('Query.a') as FieldDefinition<any>);
@@ -358,7 +357,7 @@ describe('test with full federated schemas', () => {
     );
 
     const mgr = new FederationDirectiveCompositionManager([subgraph1.schema, subgraph2.schema], [entry])
-    mgr.mergeObject([
+    mgr.mergeSchemaElements([
       subgraph1.schema.elementByCoordinate('Query') as ObjectType,
       subgraph2.schema.elementByCoordinate('Query') as ObjectType,
     ], supergraph.schema.elementByCoordinate('Query') as ObjectType);

--- a/internals-js/src/__tests__/directiveCompositionRules.test.ts
+++ b/internals-js/src/__tests__/directiveCompositionRules.test.ts
@@ -11,13 +11,10 @@ describe('directive composition entry tests', () => {
     DirectiveLocation.INTERFACE,
     DirectiveLocation.SCHEMA,
     DirectiveLocation.SCALAR,
-    DirectiveLocation.ARGUMENT_DEFINITION,
     DirectiveLocation.INTERFACE,
     DirectiveLocation.UNION,
-    DirectiveLocation.ENUM,
     DirectiveLocation.ENUM_VALUE,
     DirectiveLocation.INPUT_OBJECT,
-    DirectiveLocation.INPUT_FIELD_DEFINITION,
   ])('directive has invalid locations', (location) => {
     const definition = new DirectiveDefinition('foo');
     definition.addLocations(location);

--- a/internals-js/src/__tests__/directiveCompositionRules.test.ts
+++ b/internals-js/src/__tests__/directiveCompositionRules.test.ts
@@ -1,0 +1,478 @@
+// write a jest test for directiveCompositionRules.ts
+
+import { DirectiveLocation } from 'graphql';
+import { Directive, DirectiveDefinition, ListType, NonNullType, ObjectType, Schema } from '../definitions';
+import { DirectiveCompositionEntry, DirectiveCompositionStrategy, DirectivePropagationStrategy, FederationDirectiveCompositionManager, FieldPropagationStrategy } from '../directiveCompositionRules';
+
+describe('directive composition entry tests', () => {
+  it.each([
+    DirectiveLocation.INTERFACE,
+    DirectiveLocation.SCHEMA,
+    DirectiveLocation.SCALAR,
+    DirectiveLocation.ARGUMENT_DEFINITION,
+    DirectiveLocation.INTERFACE,
+    DirectiveLocation.UNION,
+    DirectiveLocation.ENUM,
+    DirectiveLocation.ENUM_VALUE,
+    DirectiveLocation.INPUT_OBJECT,
+    DirectiveLocation.INPUT_FIELD_DEFINITION,
+  ])('directive has invalid locations', (location) => {
+    const definition = new DirectiveDefinition('foo');
+    definition.addLocations(location);
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        DirectiveCompositionStrategy.COLLAPSE,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT
+      );
+    }).toThrowError(`Directive @foo has unsupported locations: ${location}.`);
+  });
+
+  it.each([
+    DirectiveCompositionStrategy.COLLAPSE,
+    DirectiveCompositionStrategy.COLLAPSE_FROM_ALL,
+  ])('collapse directive is repeatable', (strategy) => {
+    const definition = new DirectiveDefinition('foo');
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.repeatable = true;
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        strategy,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT
+      );
+    }).toThrowError(`Directive @foo is repeatable, but its composition strategy is ${strategy}.`);
+  });
+
+  it(('propagation strategy is inherit from object and directive is repeatable'), () => {
+    const definition = new DirectiveDefinition('foo');
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.repeatable = true;
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT
+      );
+    }).toThrowError(`Directive @foo is repeatable, but its propagation strategy is inheritFromObject.`);
+  });
+
+  it('composition entry specifies unknown arguments', () => {
+    const definition = new DirectiveDefinition('foo');
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
+        new Map([['value', FieldPropagationStrategy.MAX]]),
+      );
+    }).toThrowError(`Directive @foo does not have an argument named value.`);
+  });
+
+  it('directive has arguments that are not specified in the field strategies', () => {
+    const schema = new Schema();
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(schema.intType()));
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
+      );
+    }).toThrowError(`Directive @foo has arguments that are not in the field strategies map.`);
+  });
+
+  it('directive has optional argument', () => {
+    const schema = new Schema();
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', schema.intType());
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
+        new Map([['value', FieldPropagationStrategy.MAX]]),
+      );
+    }).toThrowError(`Directive @foo has one or more optional arguments. Optional arguments are not supported yet.`);
+  });
+
+  it.each([
+    [FieldPropagationStrategy.MAX, (schema: Schema) => schema.stringType(), 'Int!'],
+    [FieldPropagationStrategy.MIN, (schema: Schema) => schema.stringType(), 'Int!'],
+    [FieldPropagationStrategy.SUM, (schema: Schema) => schema.stringType(), 'Int!'],
+    [FieldPropagationStrategy.AVERAGE, (schema: Schema) => schema.stringType(), 'Int!'],
+    [FieldPropagationStrategy.AND, (schema: Schema) => schema.intType(), 'Boolean!'],
+    [FieldPropagationStrategy.OR, (schema: Schema) => schema.intType(), 'Boolean!'],
+    [FieldPropagationStrategy.INTERSECTION, (schema: Schema) => schema.intType(), '[T]!'],
+    [FieldPropagationStrategy.UNION, (schema: Schema) => schema.intType(), '[T]!'],
+  ])('make sure that field propagation strategies match their types', (strategy, getType, typeAsString) => {
+    const schema = new Schema();
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(getType(schema)));
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
+        new Map([['value', strategy]]),
+      );
+    }).toThrowError(`Directive @foo has a field strategy of ${strategy} for argument value, but the argument is not of type ${typeAsString}`);
+  });
+
+  it('make sure that FIELD_DEFINITION is a valid location if INHERIT_FROM_OBJECT is used', () => {
+    const schema = new Schema();
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.OBJECT);
+    expect(() => {
+      new DirectiveCompositionEntry(
+        definition,
+        DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+        DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
+      );
+    }).toThrowError(`Directive @foo is marked as inheritFromObject, but FIELD_DEFINITION is not one of its locations.`);
+  });
+
+});
+
+describe('field directive processing tests', () => {
+  it.each([
+    [FieldPropagationStrategy.EXACT, [ { value: 1 }, { value: 2 } ]],
+  ])('match exact should not combine directives', (strategy, expectedResult) => {
+    const schema = new Schema();
+    const query = new ObjectType('Query');
+    schema.addType(query);
+    query.addField('a', schema.intType());
+
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(schema.intType()));
+    definition.repeatable = true;
+
+    const entry = new DirectiveCompositionEntry(
+      definition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['value', strategy]]),
+    );
+
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1 });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 2 });
+    const directives = query.fields()[0].appliedDirectives;
+
+    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual(expectedResult);
+  });
+
+  it.each([
+    [FieldPropagationStrategy.SUM, [ { value: 4 } ]],
+    [FieldPropagationStrategy.MAX, [ { value: 3 } ]],
+    [FieldPropagationStrategy.MIN, [ { value: 1 } ]],
+    [FieldPropagationStrategy.AVERAGE, [ { value: 2 } ]],
+  ])('combination of directives (int)', (strategy, expectedResult) => {
+    const schema = new Schema();
+    const query = new ObjectType('Query');
+    schema.addType(query);
+    query.addField('a', schema.intType());
+
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(schema.intType()));
+    definition.repeatable = true;
+
+    const entry = new DirectiveCompositionEntry(
+      definition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['value', strategy]]),
+    );
+
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1 });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 3 });
+    const directives = query.fields()[0].appliedDirectives;
+
+    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual(expectedResult);
+  });
+
+  it.each([
+    [FieldPropagationStrategy.AND, [false, false, true], [ { value: false } ]],
+    [FieldPropagationStrategy.AND, [true, true, true], [ { value: true } ]],
+    [FieldPropagationStrategy.OR, [false, false, false], [ { value: false } ]],
+    [FieldPropagationStrategy.OR, [false, false, true], [ { value: true } ]],
+  ])('combination of directives (bool)', (strategy, values, expectedResult) => {
+    const schema = new Schema();
+    const query = new ObjectType('Query');
+    schema.addType(query);
+    query.addField('a', schema.intType());
+
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(schema.booleanType()));
+    definition.repeatable = true;
+
+    const entry = new DirectiveCompositionEntry(
+      definition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['value', strategy]]),
+    );
+
+    query.fields()[0].applyDirective(definition, { name: 'value', value: values[0] });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: values[1] });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: values[2] });
+    const directives = query.fields()[0].appliedDirectives;
+
+    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual(expectedResult);
+  });
+
+  it('more complicated example of combinations', () => {
+    const schema = new Schema();
+    const query = new ObjectType('Query');
+    schema.addType(query);
+    query.addField('a', schema.intType());
+
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(schema.intType()));
+    definition.addArgument('otherValue', new NonNullType(schema.intType()));
+    definition.addArgument('label', new NonNullType(schema.stringType()));
+    definition.repeatable = true;
+
+    const entry = new DirectiveCompositionEntry(
+      definition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['value', FieldPropagationStrategy.SUM], ['otherValue', FieldPropagationStrategy.MAX], ['label', FieldPropagationStrategy.EXACT]]),
+    );
+
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 1, label: 'a' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 2, label: 'b' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 3, label: 'c' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 4, label: 'a' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 5, label: 'a' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 6, label: 'b' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 7, label: 'c' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 8, label: 'c' });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: 1, otherValue: 9, label: 'c' });
+    const directives = query.fields()[0].appliedDirectives;
+
+    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual([
+      { value: 3, otherValue: 5, label: 'a'},
+      { value: 2, otherValue: 6, label: 'b'},
+      { value: 4, otherValue: 9, label: 'c'},
+    ]);
+  });
+
+  it('union field propagation strategy', () => {
+    const schema = new Schema();
+    const query = new ObjectType('Query');
+    schema.addType(query);
+    query.addField('a', schema.intType());
+
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(new ListType(schema.intType())));
+    definition.repeatable = true;
+
+    const entry = new DirectiveCompositionEntry(
+      definition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['value', FieldPropagationStrategy.UNION]]),
+    );
+
+    query.fields()[0].applyDirective(definition, { name: 'value', value: [1,2] });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: [2] });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: [3] });
+    const directives = query.fields()[0].appliedDirectives;
+
+    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual([
+      { value: [1,2,3] },
+    ]);
+  });
+
+  it('intersection field propagation strategy', () => {
+    const schema = new Schema();
+    const query = new ObjectType('Query');
+    schema.addType(query);
+    query.addField('a', schema.intType());
+
+    const definition = new DirectiveDefinition('foo');
+    schema.addDirectiveDefinition(definition);
+    definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+    definition.addArgument('value', new NonNullType(new ListType(schema.intType())));
+    definition.repeatable = true;
+
+    const entry = new DirectiveCompositionEntry(
+      definition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['value', FieldPropagationStrategy.INTERSECTION]]),
+    );
+
+    query.fields()[0].applyDirective(definition, { name: 'value', value: [1,2,4] });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: [2,4,7] });
+    query.fields()[0].applyDirective(definition, { name: 'value', value: [2,3,4,9] });
+    const directives = query.fields()[0].appliedDirectives;
+
+    expect(entry.processFieldDirectives(directives as Directive<any>[])).toEqual([
+      { value: [2,4] },
+    ]);
+  });
+});
+
+describe('test with full federated schemas', () => {
+  it('test through composition manager', () => {
+    const schema1 = new Schema();
+    const query1 = new ObjectType('Query');
+    schema1.addType(query1);
+    query1.addField('a', schema1.intType());
+
+    const schema2 = new Schema();
+    const query2 = new ObjectType('Query');
+    schema2.addType(query2);
+    query2.addField('a', schema2.intType());
+
+    const supergraphSchema = new Schema();
+    const supergraphQuery = new ObjectType('Query');
+    supergraphSchema.addType(supergraphQuery);
+    supergraphQuery.addField('a', supergraphSchema.intType());
+
+    const generateFooDirectiveDefinitionForSchema = (schema: Schema) => {
+      const definition = new DirectiveDefinition('foo');
+      schema.addDirectiveDefinition(definition);
+      definition.addLocations(DirectiveLocation.FIELD_DEFINITION);
+      definition.addArgument('value', new NonNullType(schema.intType()));
+      definition.addArgument('otherValue', new NonNullType(schema.intType()));
+      definition.addArgument('label', new NonNullType(schema.stringType()));
+      definition.repeatable = true;
+      return definition;
+    };
+
+    const definition1 = generateFooDirectiveDefinitionForSchema(schema1);
+    const definition2 = generateFooDirectiveDefinitionForSchema(schema2);
+    const supergraphDefinition = generateFooDirectiveDefinitionForSchema(supergraphSchema);
+
+    query1.fields()[0].applyDirective(definition1, { name: 'value', value: 1, otherValue: 1, label: 'a' });
+    query2.fields()[0].applyDirective(definition2, { name: 'value', value: 2, otherValue: 7, label: 'a' });
+    query2.fields()[0].applyDirective(definition2, { name: 'value', value: 4, otherValue: 4, label: 'b' });
+
+    const entry = new DirectiveCompositionEntry(
+      supergraphDefinition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['value', FieldPropagationStrategy.SUM], ['otherValue', FieldPropagationStrategy.MAX], ['label', FieldPropagationStrategy.EXACT]]),
+    );
+
+    const mgr = new FederationDirectiveCompositionManager([schema1, schema2], [entry])
+    mgr.mergeField([query1.fields()[0], query2.fields()[0]], supergraphQuery.fields()[0]);
+    const appliedDirectives = supergraphQuery.fields()[0].appliedDirectives;
+    expect(appliedDirectives.toString()).toBe('@foo(value: 3, otherValue: 7, label: "a"),@foo(value: 4, otherValue: 4, label: "b")');
+  });
+
+  it('mergeObject without propagation to fields', () => {
+    const schema1 = new Schema();
+    const query1 = new ObjectType('Query');
+    schema1.addType(query1);
+    query1.addField('a', schema1.intType());
+
+    const schema2 = new Schema();
+    const query2 = new ObjectType('Query');
+    schema2.addType(query2);
+    query2.addField('a', schema2.intType());
+
+    const supergraphSchema = new Schema();
+    const supergraphQuery = new ObjectType('Query');
+    supergraphSchema.addType(supergraphQuery);
+    supergraphQuery.addField('a', supergraphSchema.intType());
+
+    const generateFooDirectiveDefinitionForSchema = (schema: Schema) => {
+      const definition = new DirectiveDefinition('foo');
+      schema.addDirectiveDefinition(definition);
+      definition.addLocations(DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.OBJECT);
+      definition.addArgument('label', new NonNullType(schema.stringType()));
+      definition.repeatable = true;
+      return definition;
+    };
+
+    const definition1 = generateFooDirectiveDefinitionForSchema(schema1);
+    const definition2 = generateFooDirectiveDefinitionForSchema(schema2);
+    const supergraphDefinition = generateFooDirectiveDefinitionForSchema(supergraphSchema);
+
+    query1.applyDirective(definition1, { label: 'a' });
+    query2.applyDirective(definition2, { label: 'b' });
+
+    const entry = new DirectiveCompositionEntry(
+      supergraphDefinition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.CONSISTENT_LOCATION,
+      new Map([['label', FieldPropagationStrategy.EXACT]]),
+    );
+
+    const mgr = new FederationDirectiveCompositionManager([schema1, schema2], [entry])
+    mgr.mergeObject([query1, query2], supergraphQuery);
+    const appliedDirectives = supergraphQuery.appliedDirectives;
+    expect(appliedDirectives.toString()).toBe('@foo(label: "a"),@foo(label: "b")');
+    expect(supergraphQuery.fields()[0].appliedDirectives.toString()).toBe('');
+  });
+
+  it('mergeObject with propagation to fields', () => {
+    const schema1 = new Schema();
+    const query1 = new ObjectType('Query');
+    schema1.addType(query1);
+    query1.addField('a', schema1.intType());
+
+    const schema2 = new Schema();
+    const query2 = new ObjectType('Query');
+    schema2.addType(query2);
+    query2.addField('a', schema2.intType());
+
+    const supergraphSchema = new Schema();
+    const supergraphQuery = new ObjectType('Query');
+    supergraphSchema.addType(supergraphQuery);
+    supergraphQuery.addField('a', supergraphSchema.intType());
+
+    const generateFooDirectiveDefinitionForSchema = (schema: Schema) => {
+      const definition = new DirectiveDefinition('foo');
+      schema.addDirectiveDefinition(definition);
+      definition.addLocations(DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.OBJECT);
+      definition.addArgument('value', new NonNullType(schema.intType()));
+      return definition;
+    };
+
+    const definition1 = generateFooDirectiveDefinitionForSchema(schema1);
+    const definition2 = generateFooDirectiveDefinitionForSchema(schema2);
+    const supergraphDefinition = generateFooDirectiveDefinitionForSchema(supergraphSchema);
+
+    query1.applyDirective(definition1, { value: 1 });
+    query1.fields()[0].applyDirective(definition1, { value: 6 });
+    query2.applyDirective(definition2, { value: 2 });
+
+    const entry = new DirectiveCompositionEntry(
+      supergraphDefinition,
+      DirectiveCompositionStrategy.REMOVE_DUPLICATES,
+      DirectivePropagationStrategy.INHERIT_FROM_OBJECT,
+      new Map([['value', FieldPropagationStrategy.SUM]]),
+    );
+
+    const mgr = new FederationDirectiveCompositionManager([schema1, schema2], [entry])
+    mgr.mergeObject([query1, query2], supergraphQuery);
+    const appliedDirectives = supergraphQuery.appliedDirectives;
+    expect(appliedDirectives.toString()).toBe('@foo(value: 3)');
+
+    mgr.mergeField([query1.fields()[0], query2.fields()[0]], supergraphQuery.fields()[0]);
+
+    expect(supergraphQuery.fields()[0].appliedDirectives.toString()).toBe('@foo(value: 8)');
+  });
+});

--- a/internals-js/src/directiveCompositionRules.ts
+++ b/internals-js/src/directiveCompositionRules.ts
@@ -1,0 +1,255 @@
+import { DirectiveLocation } from 'graphql';
+import { Directive, DirectiveDefinition, FieldDefinition, NamedSchemaElement, ObjectType, Schema } from './definitions'
+import { assert, isDefined, isNotNull } from './utils';
+
+export enum DirectiveCompositionStrategy {
+  COLLAPSE = 'collapse',
+  COLLAPSE_FROM_ALL = 'collapseFromAll',
+  REMOVE_DUPLICATES = 'removeDuplicates',
+}
+
+export enum DirectivePropagationStrategy {
+  INHERIT_FROM_OBJECT = 'inheritFromObject',
+  CONSISTENT_LOCATION = 'consistentLocation',
+}
+
+export enum FieldPropagationStrategy {
+  MAX = 'max',
+  MIN = 'min',
+  SUM = 'sum',
+  AVERAGE = 'average',
+  AND = 'and',
+  OR = 'or',
+  INTERSECTION = 'intersection',
+  UNION = 'union',
+  EXACT = 'exact',
+}
+
+const SUPPORTED_LOCATIONS = [
+  DirectiveLocation.FIELD_DEFINITION,
+  DirectiveLocation.OBJECT,
+];
+
+export class FederationDirectiveCompositionManager {
+  private readonly directiveNameLookup: Map<string, string>[];
+  constructor(
+    readonly schemas: readonly Schema[],
+    readonly entries: DirectiveCompositionEntry[],
+  ) {
+    // we need to create a map so that for each directive definition, we need to what the name is in each schema
+    this.directiveNameLookup = new Array(schemas.length);
+    for (let i = 0; i < schemas.length; i += 1) {
+      this.directiveNameLookup[i] = new Map();
+      schemas[i].directives().forEach(directive => {
+        const nameInSchema = schemas[i].coreFeatures?.getByIdentity('federation')?.directiveNameInSchema(directive.name) ?? directive.name;
+        if (nameInSchema !== undefined) {
+          this.directiveNameLookup[i].set(directive.name, nameInSchema);
+        }
+      });
+    }
+  }
+
+  private getDirectiveNameInSchema(directiveName: string, schemaIndex: number) {
+    return this.directiveNameLookup[schemaIndex].get(directiveName);
+  }
+
+  private mergeSchemaElement(sources: (NamedSchemaElement<any,any,any> | undefined)[], target: NamedSchemaElement<any,any,any>, entry: DirectiveCompositionEntry) {
+    // get all directives from sources, then filter out sources where the
+    // field isn't defined. If the directive is null, that means it does not exist on that field
+    // for the given subgraph
+    const directives = sources
+      .map((source, idx) => {
+        if (source === undefined) {
+          return undefined;
+        }
+        const directiveName = this.getDirectiveNameInSchema(entry.definition.name, idx);
+        if (directiveName) {
+          return source?.appliedDirectivesOf(directiveName);
+        }
+        return null;
+      })
+      .filter(isDefined);
+
+    if (directives.length === 0) {
+      return;
+    }
+    if (entry.compositionStrategy === DirectiveCompositionStrategy.COLLAPSE_FROM_ALL && directives.includes(null)) {
+      throw new Error(`Directive @${entry.definition.name} is marked as collapseFromAll, but not all subgraphs have the directive applied to the field.`);
+    }
+
+    // next we need to flatten the directives into a single array
+    const flattenedDirectives = directives
+      .filter(isNotNull)
+      .reduce((acc, val) => acc.concat(val), []);
+
+    const argArrays = entry.processFieldDirectives(flattenedDirectives);
+    argArrays.forEach(args => {
+      target.applyDirective(entry.definition, args);
+    });
+  }
+
+  mergeField(sources: (FieldDefinition<any> | undefined)[], target: FieldDefinition<any>) {
+    this.entries.forEach(entry => {
+      this.mergeSchemaElement(sources, target, entry);
+    });
+  }
+
+  mergeObject(sources: (ObjectType | undefined)[], target: ObjectType) {
+    sources.forEach((source, idx) => {
+      if (source === undefined) {
+        return;
+      }
+      this.propagateDirectivesToFields(source, idx);
+    });
+    this.entries.forEach(entry => {
+      this.mergeSchemaElement(sources, target, entry);
+    });
+  }
+
+  private propagateDirectivesToFields(object: ObjectType, schemaIndex: number) {
+    const entries = this.entries
+      .filter(entry => entry.propagationStrategy === DirectivePropagationStrategy.INHERIT_FROM_OBJECT);
+
+    entries.forEach(entry => {
+      object.fields().forEach(field => {
+        const directiveName = this.getDirectiveNameInSchema(entry.definition.name, schemaIndex);
+        if (directiveName === undefined) {
+          return;
+        }
+        const directive = object.appliedDirectivesOf(directiveName);
+        if (directive.length !== 1) {
+          return;
+        }
+        if (!field.hasAppliedDirective(directiveName)) {
+          const nameInSchema = this.schemas[schemaIndex].coreFeatures?.getByIdentity('federation')?.directiveNameInSchema(entry.definition.name) ?? entry.definition.name;
+          const definitionInSchema = this.schemas[schemaIndex].directive(nameInSchema);
+          assert(definitionInSchema !== undefined, `Directive ${nameInSchema} is not defined in schema ${schemaIndex}.`)
+          field.applyDirective(definitionInSchema, directive[0].arguments());
+        }
+      });
+    });
+  }
+}
+
+export class DirectiveCompositionEntry {
+  constructor(
+    readonly definition: DirectiveDefinition,
+    readonly compositionStrategy: DirectiveCompositionStrategy,
+    readonly propagationStrategy: DirectivePropagationStrategy,
+    readonly fieldStrategies: Map<string, FieldPropagationStrategy> = new Map(),
+  ) {
+    if (definition.locations.some(loc => !SUPPORTED_LOCATIONS.includes(loc))) {
+      throw new Error(`Directive @${definition.name} has unsupported locations: ${definition.locations.join(', ')}.`);
+    }
+
+    if (definition.repeatable && (compositionStrategy === DirectiveCompositionStrategy.COLLAPSE || compositionStrategy === DirectiveCompositionStrategy.COLLAPSE_FROM_ALL)) {
+      throw new Error(`Directive @${definition.name} is repeatable, but its composition strategy is ${compositionStrategy}.`)
+    }
+
+    if (definition.repeatable && propagationStrategy === DirectivePropagationStrategy.INHERIT_FROM_OBJECT) {
+      throw new Error(`Directive @${definition.name} is repeatable, but its propagation strategy is ${propagationStrategy}.`)
+    }
+
+    if (propagationStrategy === DirectivePropagationStrategy.INHERIT_FROM_OBJECT && !definition.locations.includes(DirectiveLocation.FIELD_DEFINITION)) {
+      throw new Error(`Directive @${definition.name} is marked as inheritFromObject, but FIELD_DEFINITION is not one of its locations.`);
+    }
+
+    if (!definition.arguments().every((arg) => fieldStrategies.has(arg.name))) {
+      throw new Error(`Directive @${definition.name} has arguments that are not in the field strategies map.`)
+    }
+
+    // ensure that all defined arguments are mandatory. We don't know what to do with optional arguments yet
+    if (!definition.arguments().every(arg => arg.type?.kind === 'NonNullType')) {
+      throw new Error(`Directive @${definition.name} has one or more optional arguments. Optional arguments are not supported yet.`);
+    }
+
+    Array.from(fieldStrategies.entries()).forEach(([argumentName, strategy]) => {
+      if (!definition.arguments().find(arg => arg.name === argumentName)) {
+        throw new Error(`Directive @${definition.name} does not have an argument named ${argumentName}.`)
+      }
+
+      const typeString = definition.arguments().find(arg => arg.name === argumentName)!.type!.toString();
+      switch(strategy) {
+        case FieldPropagationStrategy.MAX:
+        case FieldPropagationStrategy.MIN:
+        case FieldPropagationStrategy.SUM:
+        case FieldPropagationStrategy.AVERAGE:
+          assert(typeString === 'Int!', `Directive @${definition.name} has a field strategy of ${strategy} for argument ${argumentName}, but the argument is not of type Int!`);
+          break;
+        case FieldPropagationStrategy.AND:
+        case FieldPropagationStrategy.OR:
+          assert(typeString === 'Boolean!', `Directive @${definition.name} has a field strategy of ${strategy} for argument ${argumentName}, but the argument is not of type Boolean!`);
+          break;
+        case FieldPropagationStrategy.INTERSECTION:
+        case FieldPropagationStrategy.UNION:
+          assert(typeString.startsWith('[') && typeString.endsWith(']!'), `Directive @${definition.name} has a field strategy of ${strategy} for argument ${argumentName}, but the argument is not of type [T]!`);
+          break;
+      }
+    });
+  }
+
+  /**
+   * For a field, perform the propagation strategy for all values in each directive that contributes to it.
+   */
+  private static performStrategyForField(strategy: FieldPropagationStrategy, values: any[]) {
+    switch (strategy) {
+      case FieldPropagationStrategy.MAX:
+        return Math.max(...values);
+      case FieldPropagationStrategy.MIN:
+        return Math.min(...values);
+      case FieldPropagationStrategy.SUM:
+        return values.reduce((acc, val) => acc + val, 0);
+      case FieldPropagationStrategy.AVERAGE:
+        return values.reduce((acc, val) => acc + val, 0) / values.length;
+      case FieldPropagationStrategy.AND:
+        return values.every(val => val);
+      case FieldPropagationStrategy.OR:
+        return values.some(val => val);
+      case FieldPropagationStrategy.INTERSECTION:
+        return values.reduce((acc, val) => acc.filter((v: any) => val.includes(v)), values[0]);
+      case FieldPropagationStrategy.UNION:
+        return values.reduce((acc, val) => {
+          const newValues = val.filter((v: any) => !acc.includes(v));
+          return acc.concat(newValues);
+        }, []);
+      case FieldPropagationStrategy.EXACT:
+        // this should never happen
+        throw new Error('Exact field strategy should not be used for non-exact fields');
+    }
+  }
+
+  processFieldDirectives(directives: Directive<any>[]): any[][] {
+    const buckets: Directive<FieldDefinition<any>, { [key: string]: any }>[][] = [];
+    const exactMatchFields = Array.from(this.fieldStrategies.entries()).filter(([_, strategy]) => strategy === FieldPropagationStrategy.EXACT);
+    const nonExactMatchFields = Array.from(this.fieldStrategies.entries()).filter(([_, strategy]) => strategy !== FieldPropagationStrategy.EXACT).map(([fieldName, _]) => fieldName);
+
+    directives.forEach(directive => {
+      // find the bucket we should put this directive in
+      const bucket = buckets.find(bucket => {
+        return exactMatchFields.every(([fieldName, _]) => {
+          return bucket[0].arguments(true)[fieldName] === directive.arguments()[fieldName];
+        })
+      });
+
+      // if we found a matching bucket, add the directive to it. Otherwise, create a new bucket
+      if (bucket) {
+        bucket.push(directive);
+      } else {
+        buckets.push([directive]);
+      }
+    });
+
+    // now we need to transform each bucket into a single directive
+    return buckets.map(bucket => {
+      return Object.fromEntries(
+        nonExactMatchFields
+          .map(fieldName => {
+            const strategy = this.fieldStrategies.get(fieldName)!;
+            const fieldValues = bucket.map(directive => directive.arguments()[fieldName]);
+            return [fieldName, DirectiveCompositionEntry.performStrategyForField(strategy, fieldValues)];
+          })
+          .concat(exactMatchFields.map(([fieldName, _]) => [fieldName, bucket[0].arguments()[fieldName]]))
+      );
+    });
+  }
+}

--- a/internals-js/src/directiveCompositionRules.ts
+++ b/internals-js/src/directiveCompositionRules.ts
@@ -51,7 +51,7 @@ export class FederationDirectiveCompositionManager {
         if (source === undefined) {
           return undefined;
         }
-        console.log(entry.definition.name, 'is name');
+
         const directiveName = this.getDirectiveNameInSchema(entry.definition.name, idx);
         if (directiveName) {
           return source?.appliedDirectivesOf(directiveName);
@@ -82,11 +82,6 @@ export class FederationDirectiveCompositionManager {
   }
 
   mergeObject(sources: (ObjectType | undefined)[], target: ObjectType) {
-    sources.forEach((source) => {
-      if (source === undefined) {
-        return;
-      }
-    });
     this.entries.forEach(entry => {
       this.mergeSchemaElement(sources, target, entry);
     });

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -17,6 +17,7 @@ import { TAG_VERSIONS } from "./tagSpec";
 import { federationMetadata } from "./federation";
 import { registerKnownFeature } from "./knownCoreFeatures";
 import { INACCESSIBLE_VERSIONS } from "./inaccessibleSpec";
+import { DirectiveCompositionEntry } from './directiveCompositionRules';
 
 export const federationIdentity = 'https://specs.apollo.dev/federation';
 
@@ -212,3 +213,5 @@ export const FEDERATION_VERSIONS = new FeatureDefinitions<FederationSpecDefiniti
   .add(new FederationSpecDefinition(new FeatureVersion(2, 3)));
 
 registerKnownFeature(FEDERATION_VERSIONS);
+
+export const FEDERATION_COMPOSITION_ENTRIES: DirectiveCompositionEntry[] = [];

--- a/internals-js/src/index.ts
+++ b/internals-js/src/index.ts
@@ -18,3 +18,4 @@ export * from './error';
 export * from './schemaUpgrader';
 export * from './suggestions';
 export * from './graphQLJSSchemaToAST';
+export * from './directiveCompositionRules';

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -409,7 +409,7 @@ export type Concrete<Type> = {
 //   const x = [1,2,undefined];
 //   const y: number[] = x.filter(isDefined);
 export const isDefined = <T>(t: T | undefined): t is T => t === undefined ? false : true;
-export const isNotNull = <T>(t: T | null): t is T => t === null ? false : true;
+
 /**
  * Removes the first occurrence of the provided element in the provided array, if said array contains said elements.
  *

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -409,7 +409,7 @@ export type Concrete<Type> = {
 //   const x = [1,2,undefined];
 //   const y: number[] = x.filter(isDefined);
 export const isDefined = <T>(t: T | undefined): t is T => t === undefined ? false : true;
-
+export const isNotNull = <T>(t: T | null): t is T => t === null ? false : true;
 /**
  * Removes the first occurrence of the provided element in the provided array, if said array contains said elements.
  *


### PR DESCRIPTION
Added some code to allow us to compose certain future federation directives automatically.

- There aren't any composition tests, those will come when we actually add a directive that uses this infrastructure, but should be fairly straightforward.
- You could maybe make the argument that the syntax is a little verbose. For example matching exact could potentially be implicit, COLLAPSE could potentially be inferred. But this is an internal function and I don't mind ensuring specificity so that whoever adds a directive make a choice at every step.

Refs #2315
