### PR TITLE
docs: update link imports to reference fed v2.3

### DIFF
--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -206,7 +206,7 @@ We're done! `Bill` is now resolved in a new subgraph, and it was resolvable duri
 
 ```graphql {3} title="Billing subgraph"
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key", "@shareable", "@override"])
 ```
 

--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -10,7 +10,7 @@ To use federated directives in a Federation 2 subgraph schema, apply the `@link`
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key", "@shareable"])
 ```
 
@@ -26,7 +26,7 @@ If an imported directive's default name matches one of your own custom directive
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: [{ name: "@key", as: "@primaryKey"}, "@shareable"])
 ```
 
@@ -38,7 +38,7 @@ If you _don't_ [import a particular directive](#importing-directives) from a lin
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key"])
 
 type Book @federation__shareable {
@@ -54,7 +54,7 @@ You can customize a particular specification's namespace prefix by providing the
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         as: "fed")
 
 type Book @fed__shareable {
@@ -530,7 +530,7 @@ Applies arbitrary string metadata to a schema location. Custom tooling can use t
 
 ```graphql
 extend schema
-    @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])
+    @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"])
 
 type Query {
   customer(id: String!): Customer @tag(name: "team-customers")
@@ -601,7 +601,7 @@ Indicates to composition that all uses of a particular custom [type system direc
 ```graphql
 extend schema
     @link(url: "https://specs.apollo.dev/link/v1.0")
-    @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@composeDirective"])
+    @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective"])
     @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", { name: "@anotherDirective", as: "@hello" }])
     # highlight-start
     @composeDirective(name: "@myDirective")

--- a/docs/source/federated-types/overview.mdx
+++ b/docs/source/federated-types/overview.mdx
@@ -48,7 +48,7 @@ type User @key(fields: "id") {
 # this to opt in to
 # Federation 2 features.)
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key", "@shareable"])
 ```
 
@@ -64,7 +64,7 @@ type Product @key(fields: "upc") {
 }
 
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key", "@shareable"])
 ```
 
@@ -89,7 +89,7 @@ type Product @key(fields: "upc") {
 # (This subgraph uses additional
 # federated directives)
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key", "@shareable", "@provides", "@external"])
 ```
 

--- a/docs/source/federated-types/sharing-types.mdx
+++ b/docs/source/federated-types/sharing-types.mdx
@@ -59,7 +59,7 @@ To use `@shareable` in a subgraph schema, you first need to add the following sn
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key", "@shareable"])
 ```
 
@@ -132,7 +132,7 @@ To make `Position.z` shareable, you can do one of the following:
 
     ```graphql
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.2", import: ["@shareable"]) #highlight-line
+      @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@shareable"]) #highlight-line
 
     extend type Position @shareable { #highlight-line
       z: Int!
@@ -424,7 +424,7 @@ To use `@inaccessible` in a subgraph, first make sure you include it in the `imp
 
 ```graphql {3} title="Subgraph A"
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key", "@shareable", "@inaccessible"])
 ```
 

--- a/docs/source/subgraph-spec.mdx
+++ b/docs/source/subgraph-spec.mdx
@@ -122,7 +122,7 @@ For example, consider this Federation 2 subgraph schema:
 
 ```graphql title="schema.graphql"
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
+  @link(url: "https://specs.apollo.dev/federation/v2.3",
         import: ["@key"])
 
 type Query {


### PR DESCRIPTION
Our docs currently reference Federation spec v2.0. This is confusing to our users as they may not be aware that there are newer spec releases that introduced some additional functionality.