### PR TITLE
Add preamble to fed changelog and fix broken links

### DIFF
--- a/docs/source/building-supergraphs/router.mdx
+++ b/docs/source/building-supergraphs/router.mdx
@@ -15,7 +15,7 @@ Apollo actively supports the following options for your router:
 
 - **The Apollo Router (recommended):** This is a high-performance, precompiled Rust binary.
 
-    > If you're getting started with federation, we recommend [creating a **cloud supergraph**](/studio/getting-started) with Apollo GraphOS. With a cloud supergraph, GraphOS provisions and manages routing for you!
+    > If you're getting started with federation, we recommend [creating a **cloud supergraph**](/graphos/quickstart/cloud/) with Apollo GraphOS. With a cloud supergraph, GraphOS provisions and manages routing for you!
 
     You can also host your own Apollo Router instances:
 

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -28,7 +28,7 @@
     "Building Your Supergraph": {
       "Subgraphs": "/building-supergraphs/subgraphs-overview",
       "Supported subgraph libraries": "/building-supergraphs/supported-subgraphs",
-      "Router/gateway": "/building-supergraphs/router",
+      "Router / Gateway": "/building-supergraphs/router",
       "Apollo Server subgraphs": "https://apollographql.com/docs/apollo-server/using-federation/apollo-subgraph-setup"
     },
     "Federated Schemas": {

--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -522,7 +522,7 @@ Examples:
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 ```
 
-Applies arbitrary string metadata to a schema location. Custom tooling can use this metadata during any step of the schema delivery flow, including composition, static analysis, and documentation. Apollo Studio's enterprise [contracts feature](/studio/contracts/) uses `@tag` with its inclusion and exclusion filters.
+Applies arbitrary string metadata to a schema location. Custom tooling can use this metadata during any step of the schema delivery flow, including composition, static analysis, and documentation. Apollo Studio's enterprise [contracts feature](/graphos/delivery/contracts/) uses `@tag` with its inclusion and exclusion filters.
 
 > ⚠️ Unlike with most directives, composition _preserves_ uses of this directive in the generated supergraph schema. To preserve uses of _other_ directives, see [`@composeDirective`](#composedirective).
 >

--- a/docs/source/federation-versions.mdx
+++ b/docs/source/federation-versions.mdx
@@ -3,6 +3,24 @@ title: Federation version changelog
 description: Understand changes between federation versions
 ---
 
+This article describes notable changes and additions introduced in each minor version release of Apollo Federation. Most of these changes involve additions or modifications to [federation-specific directives](./federated-types/federated-directives/).
+
+> For a _comprehensive_ changelog for Apollo Federation and its associated libraries, see [GitHub](https://github.com/apollographql/federation/blob/main/CHANGELOG.md).
+
+- **To use a feature introduced in a particular federation version,** make sure your subgraph schema's `@link` directive targets that version (or higher):
+
+    ```graphql
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.3", #highlight-line
+            import: ["@key", "@shareable", "@interfaceObject"])
+    ```
+
+    The example above must target at least Federation v2.3, because the `@interfaceObject` directive was introduced in that version.
+
+    > ⚠️ **Before you increment a subgraph's federation version, update your router and build pipeline!** For details, see [Updating your graph safely](/graphos/graphs/updating/).
+
+- **If you maintain a [subgraph-compatible library](./building-supergraphs/supported-subgraphs/),** consult this article to stay current with recently added directives. All of these directive definitions are also listed in the [subgraph specification](./subgraph-spec/#subgraph-schema-additions).
+
 ## v2.3
 
 **Directive changes**
@@ -25,7 +43,7 @@ description: Understand changes between federation versions
 </td>
 <td>
 
-Introduced. [Learn more.](/federation/federated-types/interfaces)
+Introduced. [Learn more.](./federated-types/interfaces)
 
 ```graphql
 directive @interfaceObject on OBJECT
@@ -34,37 +52,23 @@ directive @interfaceObject on OBJECT
 </td>
 </tr>
 
-</tbody>
-</table>
-
-**Subgraph changes**
-
-
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-
-<tbody>
 <tr>
 <td>
 
-Interfaces
+##### `@key`
 
 </td>
 <td>
 
-`@key` directive can now be used on interface definitions.
+Can now be applied to interface definitions to support [entity interfaces](./federated-types/interfaces/).
+
+(Previous versions of composition threw an error if `@key` was applied to an interface definition.)
 
 </td>
 </tr>
 
 </tbody>
 </table>
-
 
 ## v2.2
 
@@ -94,41 +98,13 @@ Added `repeatable` to the directive definition.
 directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 ```
 
-</td>
-</tr>
-
-</tbody>
-</table>
-
-**Subgraph changes**
-
-
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-
-<tbody>
-<tr>
-<td>
-
-Interfaces
-
-</td>
-<td>
-
-Composition now rejects `@shareable` on interface fields.
+Additionally, composition now throws an error if `@shareable` is applied to fields of an `interface` definition.
 
 </td>
 </tr>
 
 </tbody>
 </table>
-
-
 
 ## v2.1
 
@@ -151,7 +127,7 @@ Composition now rejects `@shareable` on interface fields.
 </td>
 <td>
 
-Introduced. [Learn more.](/federation/federated-types/federated-directives#composedirective)
+Introduced. [Learn more.](./federated-types/federated-directives#composedirective)
 
 ```graphql
 directive @composeDirective(name: String!) repeatable on SCHEMA

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -121,7 +121,7 @@ graph LR;
 **The router** is one of the following:
 
 - [The Apollo Router](https://www.apollographql.com/docs/router/) (recommended): a high-performance, precompiled Rust executable
-    - If you're getting started with federation, we recommend [creating a **cloud supergraph**](/studio/getting-started) with Apollo GraphOS. With a cloud supergraph, GraphOS provisions and manages routing for you!
+    - If you're getting started with federation, we recommend [creating a **cloud supergraph**](/graphos/quickstart/cloud/) with Apollo GraphOS. With a cloud supergraph, GraphOS provisions and manages routing for you!
 - An instance of Apollo Server using special extensions from the [`@apollo/gateway`](/apollo-server/using-federation/api/apollo-gateway) library
 
 **Subgraphs** can each use any [subgraph-compatible GraphQL server library](./building-supergraphs/supported-subgraphs/).
@@ -347,7 +347,7 @@ These resulting schemas provide the best of both worlds:
 
 ### Managed federation
 
-Your router can operate in **managed federation** mode, where [Apollo GraphOS](/studio/) acts as the source of truth for your supergraph's configuration:
+Your router can operate in **managed federation** mode, where [Apollo GraphOS](/graphos/) acts as the source of truth for your supergraph's configuration:
 
 ```mermaid
 graph LR;

--- a/docs/source/managed-federation/deployment.mdx
+++ b/docs/source/managed-federation/deployment.mdx
@@ -20,7 +20,7 @@ rover subgraph publish my-supergraph@my-variant \
 
 ## Pushing configuration updates safely
 
-Whenever possible, you should update your subgraph configuration in a way that is backward compatible to avoid downtime. As suggested above, the best way to do this is to run `rover subgraph check` before updating. You should also generally seek to minimize the number of [breaking changes](/studio/schema-checks/#potentially-breaking-changes) you make to your schemas.
+Whenever possible, you should update your subgraph configuration in a way that is backward compatible to avoid downtime. As suggested above, the best way to do this is to run `rover subgraph check` before updating. You should also generally seek to minimize the number of [breaking changes](/graphos/delivery/schema-checks/#potentially-breaking-changes) you make to your schemas.
 
 Additionally, **call `rover subgraph publish` for a subgraph only after all replicas of that subgraph are deployed**. This ensures that resolvers are in place for all operations that are executable against your graph, and operations can't attempt to access fields that do not yet exist.
 
@@ -119,7 +119,7 @@ The next time it starts up or polls, your router obtains an updated configuratio
 
 With managed federation, you can control which version of your graph a fleet of routers are using. In the majority of cases, rolling over all of your router instances to a new schema version is safe, assuming you've used [schema checks](./federated-schema-checks/) to confirm that your changes are backward compatible.
 
-However, changes at the router level might involve a variety of different updates, such as [migrating entities](../entities-advanced/#migrating-entities-and-fields) from one subgraph to another. If your infrastructure requires a more advanced deployment process, you can use [graph variants](/studio/org/graphs/#variants) to manage different fleets of routers running with different configurations.
+However, changes at the router level might involve a variety of different updates, such as [migrating entities](../entities-advanced/#migrating-entities-and-fields) from one subgraph to another. If your infrastructure requires a more advanced deployment process, you can use [graph variants](/graphos/graphs/overview/#variants) to manage different fleets of routers running with different configurations.
 
 ### Example
 
@@ -143,7 +143,7 @@ To configure a canary deployment, you might maintain two production graph varian
     rover subgraph publish my-supergraph@prod --name=launches --schema ./launches/schema.graphql
     ```
 
-If your canary variant [reports metrics to GraphOS](/studio/metrics/usage-reporting/), you can use [Apollo Studio](https://studio.apollographql.com) to verify a canary's performance before rolling out changes to the rest of the graph. You can also use variants to support a variety of other advanced deployment workflows, such as blue/green deployments.
+If your canary variant [reports metrics to GraphOS](/graphos/metrics/usage-reporting/), you can use [Apollo Studio](https://studio.apollographql.com) to verify a canary's performance before rolling out changes to the rest of the graph. You can also use variants to support a variety of other advanced deployment workflows, such as blue/green deployments.
 
 ## Modifying query-planning logic
 

--- a/docs/source/managed-federation/overview.mdx
+++ b/docs/source/managed-federation/overview.mdx
@@ -2,26 +2,26 @@
 title: Managed federation overview
 ---
 
-Apollo provides free **managed federation** support for graphs that use Apollo Federation.
+[Apollo GraphOS](/graphos/) provides **managed federation** support for graphs that use Apollo Federation.
 
-With managed federation, your subgraphs each publish their schemas to the Apollo, which verifies that they successfully [compose](../federated-types/composition/) into a federated schema.
+With managed federation, your subgraphs each publish their schemas to GraphOS, which verifies that they successfully [compose](../federated-types/composition/) into a supergraph schema.
 
-On composition success, Studio updates your graph's latest configuration, which is available at a special endpoint (called the **uplink**) that your gateway regularly polls for updates:
+On composition success, GraphOS updates your supergraph's latest configuration, which is available at a special endpoint (called the **uplink**) that your router regularly polls for updates:
 
 ```mermaid
 graph LR;
   subgraph "Your infrastructure"
-  serviceA[Products<br/>subgraph];
-  serviceB[Reviews<br/>subgraph];
-  gateway([Gateway]);
+  serviceA[Products subgraph];
+  serviceB[Reviews subgraph];
+  router([Router]);
   end
-  subgraph "Apollo cloud"
-    registry{{Apollo Schema<br/>Registry}};
-    uplink{{Apollo<br/>Uplink}}
+  subgraph "Apollo GraphOS"
+    registry{{Schema Registry}};
+    uplink{{Uplink}}
   end
   serviceA & serviceB -->|Publishes schema| registry;
   registry -->|Updates config| uplink;
-  gateway -->|Polls for config changes| uplink;
+  router -->|Polls for config changes| uplink;
   class registry secondary;
   class uplink secondary;
 ```
@@ -30,27 +30,22 @@ graph LR;
 
 Managed federation helps your organization safely validate, coordinate, deploy, and monitor changes to your graph. It provides:
 
-### Gateway stability
+### Router stability
 
-You can modify subgraph schemas (and even add or remove entire subgraphs) _without_ needing to modify or redeploy your gateway. Your gateway is the point of entry to your entire graph, and it should maximize its uptime.
+You can modify subgraph schemas (and even add or remove entire subgraphs) _without_ needing to modify or redeploy your router. Your router is the point of entry to your entire graph, and it should maximize its uptime.
 
 ### Composition stability
 
-Whenever your gateway obtains an updated configuration from Apollo, it knows that the updated set of subgraph schemas will compose, because the configuration includes the composed supergraph schema.
+Whenever your router obtains an updated configuration from Apollo, it knows that the updated set of subgraph schemas will compose, because the configuration includes the composed supergraph schema.
 
-The gateway _also_ knows that your subgraphs are prepared to handle operations against the updated set of schemas. This is because your subgraphs should register their updated schemas as part of their deployment, meaning they're definitely running by the time the gateway is aware of the configuration change.
+The router _also_ knows that your subgraphs are prepared to handle operations against the updated set of schemas. This is because your subgraphs should publish their updated schemas as part of their deployment, meaning they're definitely running by the time the router is aware of the configuration change.
 
-And whenever a subgraph accidentally pushes a schema change that _doesn't_ compose, Apollo continues to provide the most recent _valid_ configuration to your gateway.
-
+And whenever a subgraph accidentally pushes a schema change that _doesn't_ compose, GraphOS continues to provide the most recent _valid_ configuration to your router.
 
 ### Schema flexibility
 
-By using a configuration manager that's external to your gateway, you help ensure the safety of certain schema changes. For example, if you want to migrate a type or field from one subgraph's schema to another, you can perform this migration safely _only_ if you externalize your configuration.
+By using a configuration manager that's external to your router, you help ensure the safety of certain schema changes. For example, if you want to migrate a type or field from one subgraph's schema to another, you can perform this migration safely _only_ if you externalize your configuration.
 
 <hr/>
 
 Ready to try it out? Continue to [Setup](./setup/).
-
-## Manual composition
-
-**Managed federation is strongly recommended for all production environments.** For non-production environments (such as local development), it can be helpful instead to [manually compose the supergraph schema](/technotes/TN0006-unmanaged-federation/).

--- a/docs/source/managed-federation/uplink.mdx
+++ b/docs/source/managed-federation/uplink.mdx
@@ -3,22 +3,22 @@ title: Apollo Uplink
 description: Fetch your managed gateway's configuration
 ---
 
-When using [managed federation](./overview/), your federated gateway regularly polls an endpoint called **Apollo Uplink** for its latest supergraph schema and other configuration:
+When using [managed federation](./overview/), your supergraph's router regularly polls an endpoint called **Apollo Uplink** for its latest supergraph schema and other configuration:
 
 ```mermaid
 graph LR;
   subgraph "Your infrastructure"
   serviceA[Products subgraph];
   serviceB[Reviews subgraph];
-  gateway([Gateway]);
+  router([Router]);
   end
-  subgraph "Apollo cloud"
-  registry{{Apollo Schema Registry}};
-  uplink{{Apollo Uplink}}
+  subgraph "Apollo GraphOS"
+  registry{{Schema Registry}};
+  uplink{{Uplink}}
   end
   serviceA & serviceB -->|Pushes schema| registry;
   registry -->|Updates config| uplink;
-  gateway -->|Polls for config changes| uplink;
+  router -->|Polls for config changes| uplink;
   class registry secondary;
   class uplink secondary;
 ```
@@ -117,4 +117,4 @@ APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT=https://aws.uplink.api.apollographql.com/
 
 Supergraph schemas provided by Uplink cannot exceed 6MB in size. The _vast_ majority of supergraph schemas are well below this limit.
 
-If your supergraph schema _does_ exceed 6MB, you can set up a [build status webhook](/studio/build-status-notification/) for your graph. Whenever you're notified of a successful supergraph schema composition, your webhook can fetch the latest supergraph schema via the Rover CLI.
+If your supergraph schema _does_ exceed 6MB, you can set up a [build status webhook](/graphos/notifications/build-status-notification/) for your graph. Whenever you're notified of a successful supergraph schema composition, your webhook can fetch the latest supergraph schema via the Rover CLI.

--- a/docs/source/metrics.md
+++ b/docs/source/metrics.md
@@ -3,16 +3,16 @@ title: Federated trace data
 description: How federated tracing works
 ---
 
-One of the many benefits of using GraphQL as an API layer is that it enables fine-grained [tracing](/studio/metrics/usage-reporting) of every API call. The Apollo platform supports consuming and aggregating these traces to provide detailed insights into your GraphQL layer's performance and usage.
+One of the many benefits of using GraphQL as an API layer is that it enables fine-grained [tracing](/graphos/metrics/usage-reporting/) of every API call. The Apollo platform supports consuming and aggregating these traces to provide detailed insights into your GraphQL layer's performance and usage.
 
-Apollo Federation supports sending **federated traces** from your graph router, which are constructed from timing and error information provided by your subgraphs. These federated traces capture the subgraph-level details in the shape of the query plan, which is sent to Apollo's [metrics ingress](/studio/metrics/usage-reporting) by default, and aggregated into query-level stats and field-level stats. The overall flow of a federated trace is as follows:
+Apollo Federation supports sending **federated traces** from your graph router, which are constructed from timing and error information provided by your subgraphs. These federated traces capture the subgraph-level details in the shape of the query plan, which is sent to Apollo's [metrics ingress](/graphos/metrics/usage-reporting) by default, and aggregated into query-level stats and field-level stats. The overall flow of a federated trace is as follows:
 
 1. The router receives an operation from a client.
 2. The router constructs a query plan for the operation, delegating sub-queries to subgraphs.
 3. For each fetch to a subgraph, a response is received.
 4. The [`extensions`](/resources/graphql-glossary/#extensions) of each response includes a trace from the sub-query.
 5. The router collects the set of sub-query traces from subgraphs and arranges them in the shape of the query plan.
-6. The federated trace is sent to the Apollo [metrics ingress](/studio/metrics/usage-reporting/) for processing.
+6. The federated trace is sent to the Apollo [metrics ingress](/graphos/metrics/usage-reporting/) for processing.
 
 In summary, subgraphs report timing and error information to the router, and the router is responsible for reporting those metrics to Apollo.
 

--- a/docs/source/performance/caching.mdx
+++ b/docs/source/performance/caching.mdx
@@ -28,7 +28,7 @@ Cache hints can also be set [dynamically in subgraph resolvers](/apollo-server/p
 
 ### Setting entity cache hints
 
-Subgraph schemas contain an `_entities` root field on the `Query` type, so all query plans that require entity resolution have a [`maxAge` of `0` set by default](/apollo-server/performance/caching/#default-maxagee). To override this default behavior, you can add a `@cacheControl` directive to an entity's definition:
+Subgraph schemas define an `_entities` root field on the `Query` type, so all query plans that require entity resolution have a [`maxAge` of `0` set by default](/apollo-server/performance/caching/#default-maxage). To override this default behavior, you can add a `@cacheControl` directive to an entity's definition:
 
 ```graphql
 type Book @key(fields: "isbn") @cacheControl(maxAge: 30) {

--- a/docs/source/query-plans.mdx
+++ b/docs/source/query-plans.mdx
@@ -440,13 +440,13 @@ Now that you've learned about each query plan node, take another look at the exa
 
 You can view the query plan for a particular operation in any of the following ways:
 
-* [In the Apollo Studio Explorer](/studio/explorer/additional-features/#query-plans-for-supergraphs)
-    * Note that you must [register your federated graph](./managed-federation/setup/) with Apollo Studio to view query plans in the Explorer.
+* [In the Apollo Studio Explorer](/graphos/explorer/additional-features#query-plans-for-supergraphs)
+    * Note that you must [register your federated graph](./managed-federation/setup/) with GraphOS to view query plans in the Explorer.
 * As direct output from the `@apollo/gateway` library (see below)
 
 ### Outputting query plans with `@apollo/gateway`
 
-Your gateway can output the query plan for each incoming operation as it's calculated.  To do so, add the following to the file where you initalize your `ApolloGateway` instance:
+Your gateway can output the query plan for each incoming operation as it's calculated. To do so, add the following to the file where you initalize your `ApolloGateway` instance:
 
 1. Import the `serializeQueryPlan` function from the `@apollo/query-planner` library:
 

--- a/docs/source/quickstart/local-subgraphs.mdx
+++ b/docs/source/quickstart/local-subgraphs.mdx
@@ -112,7 +112,7 @@ After you've registered your first subgraph schema, you can try out one of Apoll
 
 With schema checks, you can check whether some changes you want to make to your schema will affect any of the existing clients that use your supergraph. This feature is at its most powerful in your CI/CD environment, where you can automatically detect breaking schema changes before they're deployed to production.
 
-1. [Learn about the basics of schema checks](/studio/schema-checks/)
+1. [Learn about the basics of schema checks](/graphos/delivery/schema-checks/)
 2. [Learn about using schema checks with Apollo Federation](../managed-federation/federated-schema-checks/)
 3. [Learn how to use Rover in a CI/CD environment](/rover/ci-cd/)
 


### PR DESCRIPTION
Genuine content additions are limited to `federation-versions.mdx`. The rest of the edits are to fix broken links / update terminology