### PR TITLE
Adds debug query planner option to skip query planning for a single s…

### DIFF
--- a/.changeset/shaggy-knives-exercise.md
+++ b/.changeset/shaggy-knives-exercise.md
@@ -1,0 +1,9 @@
+---
+"@apollo/query-planner": minor
+"@apollo/gateway": minor
+---
+
+Adds debug/testing query planner options (`debug.bypassPlannerForSingleSubgraph`) to bypass the query planning
+process for federated supergraph having only a single subgraph. The option is disabled by default, is not recommended
+for production, and is not supported (it may be removed later). It is meant for debugging/testing purposes.
+  

--- a/gateway-js/src/__tests__/gateway/queryPlannerConfig.test.ts
+++ b/gateway-js/src/__tests__/gateway/queryPlannerConfig.test.ts
@@ -1,0 +1,101 @@
+import gql from 'graphql-tag';
+import { startSubgraphsAndGateway, Services } from './testUtils'
+
+let services: Services;
+
+afterEach(async () => {
+  if (services) {
+    await services.stop();
+  }
+});
+
+describe('`debug.bypassPlannerForSingleSubgraph` config', () => {
+  const subgraph = {
+    name: 'A',
+    url: 'https://A',
+    typeDefs: gql`
+      type Query {
+        a: A
+      }
+
+      type A {
+        b: B
+      }
+
+      type B {
+        x: Int
+        y: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        a: () => ({
+          b: {
+            x: 1,
+            y: 'foo',
+          }
+        }),
+      }
+    }
+  };
+
+  const query = `
+    {
+      a {
+        b {
+          x
+          y
+        }
+      }
+    }
+  `;
+
+  const expectedResult = `
+    Object {
+      "data": Object {
+        "a": Object {
+          "b": Object {
+            "x": 1,
+            "y": "foo",
+          },
+        },
+      },
+    }
+  `;
+
+  it('is disabled by default', async () => {
+    services = await startSubgraphsAndGateway([subgraph]);
+
+    const response = await services.queryGateway(query);
+    const result = await response.json();
+    expect(result).toMatchInlineSnapshot(expectedResult);
+
+    const queryPlanner = services.gateway.__testing().queryPlanner!;
+    // If the query planner is genuinely used, we shoud have evaluated 1 plan.
+    expect(queryPlanner.lastGeneratedPlanStatistics()?.evaluatedPlanCount).toBe(1);
+  });
+
+  it('works when enabled', async () => {
+    services = await startSubgraphsAndGateway(
+      [subgraph],
+      {
+        gatewayConfig: {
+          queryPlannerConfig: {
+            debug: {
+              bypassPlannerForSingleSubgraph: true,
+            }
+          }
+        }
+      }
+    );
+
+    const response = await services.queryGateway(query);
+    const result = await response.json();
+    expect(result).toMatchInlineSnapshot(expectedResult);
+
+    const queryPlanner = services.gateway.__testing().queryPlanner!;
+    // The `bypassPlannerForSingleSubgraph` doesn't evaluate anything. It's use is the only case where `evaluatedPlanCount` can be 0.
+    expect(queryPlanner.lastGeneratedPlanStatistics()?.evaluatedPlanCount).toBe(0);
+  });
+});
+

--- a/gateway-js/src/__tests__/gateway/reporting.test.ts
+++ b/gateway-js/src/__tests__/gateway/reporting.test.ts
@@ -1,20 +1,17 @@
 import { gunzipSync } from 'zlib';
 import nock from 'nock';
 import gql from 'graphql-tag';
-import { buildSubgraphSchema } from '@apollo/subgraph';
-import { ApolloServer } from 'apollo-server';
 import { ApolloServerPluginUsageReporting } from 'apollo-server-core';
 import { execute } from '@apollo/client/link/core';
 import { toPromise } from '@apollo/client/link/utils';
 import { createHttpLink } from '@apollo/client/link/http';
 import fetch from 'node-fetch';
-import { ApolloGateway } from '../..';
 import { Plugin, Config, Refs } from 'pretty-format';
 import { Report, Trace } from '@apollo/usage-reporting-protobuf';
 import { fixtures } from 'apollo-federation-integration-testsuite';
 import { nockAfterEach, nockBeforeEach } from '../nockAssertions';
-import { GraphQLSchemaModule } from '@apollo/subgraph/src/schema-helper';
 import resolvable, { Resolvable } from '@josephg/resolvable';
+import { startSubgraphsAndGateway, Services } from './testUtils'
 
 // Normalize specific fields that change often (eg timestamps) to static values,
 // to make snapshot testing viable.  (If these helpers are more generally
@@ -80,17 +77,8 @@ expect.addSnapshotSerializer(
   }),
 );
 
-async function startFederatedServer(modules: GraphQLSchemaModule[]) {
-  const schema = buildSubgraphSchema(modules);
-  const server = new ApolloServer({ schema });
-  const { url } = await server.listen({ port: 0 });
-  return { url, server };
-}
-
 describe('reporting', () => {
-  let backendServers: ApolloServer[];
-  let gatewayServer: ApolloServer;
-  let gatewayUrl: string;
+  let services: Services;
   let reportPromise: Resolvable<any>;
 
   beforeEach(async () => {
@@ -104,38 +92,27 @@ describe('reporting', () => {
         return 'ok';
       });
 
-    backendServers = [];
-    const serviceList = [];
-    for (const fixture of fixtures) {
-      const { server, url } = await startFederatedServer([fixture]);
-      backendServers.push(server);
-      serviceList.push({ name: fixture.name, url });
-    }
-
-    const gateway = new ApolloGateway({ serviceList });
-    const { schema, executor } = await gateway.load();
-    gatewayServer = new ApolloServer({
-      schema,
-      executor,
-      apollo: {
-        key: 'service:foo:bar',
-        graphRef: 'foo@current',
-      },
-      plugins: [
-        ApolloServerPluginUsageReporting({
-          sendReportsImmediately: true,
-        }),
-      ],
-    });
-    ({ url: gatewayUrl } = await gatewayServer.listen({ port: 0 }));
+    services = await startSubgraphsAndGateway(
+      fixtures,
+      {
+        gatewayServerConfig: {
+          apollo: {
+            key: 'service:foo:bar',
+            graphRef: 'foo@current',
+          },
+          plugins: [
+            ApolloServerPluginUsageReporting({
+              sendReportsImmediately: true,
+            }),
+          ],
+        },
+      }
+    );
   });
 
   afterEach(async () => {
-    for (const server of backendServers) {
-      await server.stop();
-    }
-    if (gatewayServer) {
-      await gatewayServer.stop();
+    if (services) {
+      await services.stop();
     }
 
     nockAfterEach();
@@ -157,7 +134,7 @@ describe('reporting', () => {
     `;
 
     const result = await toPromise(
-      execute(createHttpLink({ uri: gatewayUrl, fetch: fetch as any }), {
+      execute(createHttpLink({ uri: services.gatewayUrl, fetch: fetch as any }), {
         query,
       }),
     );

--- a/gateway-js/src/__tests__/gateway/testUtils.ts
+++ b/gateway-js/src/__tests__/gateway/testUtils.ts
@@ -1,0 +1,73 @@
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { ApolloServer } from 'apollo-server';
+import { GraphQLSchemaModule } from '@apollo/subgraph/src/schema-helper';
+import { ApolloServerPluginInlineTrace } from 'apollo-server-core';
+import { ApolloGateway, GatewayConfig } from '../..';
+import { ServiceDefinition } from '@apollo/federation-internals';
+import { ApolloServerExpressConfig, } from 'apollo-server-express';
+import fetch, { Response } from 'node-fetch';
+
+export class Services {
+  constructor(
+    readonly subgraphServers: ApolloServer[],
+    readonly gateway: ApolloGateway,
+    readonly gatewayServer: ApolloServer,
+    readonly gatewayUrl: string,
+  ) {
+  }
+
+  async queryGateway(query: string): Promise<Response> {
+    return fetch(this.gatewayUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query }),
+    });
+  }
+
+  async stop() {
+    for (const server of this.subgraphServers) {
+      await server.stop();
+    }
+    await this.gatewayServer.stop();
+  }
+}
+
+async function startFederatedServer(modules: GraphQLSchemaModule[]) {
+  const schema = buildSubgraphSchema(modules);
+  const server = new ApolloServer({
+    schema,
+    // Manually installing the inline trace plugin means it doesn't log a message.
+    plugins: [ApolloServerPluginInlineTrace()],
+  });
+  const { url } = await server.listen({ port: 0 });
+  return { url, server };
+}
+
+export async function startSubgraphsAndGateway(
+  servicesDefs: ServiceDefinition[],
+  config?: {
+    gatewayConfig?: GatewayConfig,
+    gatewayServerConfig?: ApolloServerExpressConfig,
+  }
+): Promise<Services> {
+  const backendServers = [];
+  const serviceList = [];
+  for (const serviceDef of servicesDefs) {
+    const { server, url } = await startFederatedServer([serviceDef]);
+    backendServers.push(server);
+    serviceList.push({ name: serviceDef.name, url });
+  }
+
+  const gateway = new ApolloGateway({ 
+    serviceList,
+    ...config?.gatewayConfig,
+  });
+  const gatewayServer = new ApolloServer({
+    gateway,
+    ...config?.gatewayServerConfig,
+  });
+  const { url: gatewayUrl } = await gatewayServer.listen({ port: 0 });
+  return new Services(backendServers, gateway, gatewayServer, gatewayUrl);
+}

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -973,6 +973,7 @@ export class ApolloGateway implements GatewayInterface {
       state: this.state,
       compositionId: this.compositionId,
       supergraphSdl: this.supergraphSdl,
+      queryPlanner: this.queryPlanner,
     };
   }
 }

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -91,6 +91,7 @@ import {
   getLocallySatisfiableKey,
   createInitialOptions,
   buildFederatedQueryGraph,
+  FEDERATED_GRAPH_ROOT_SOURCE,
 } from "@apollo/query-graphs";
 import { stripIgnoredCharacters, print, parse, OperationTypeNode } from "graphql";
 import { DeferredNode, FetchDataInputRewrite, FetchDataOutputRewrite } from ".";
@@ -2460,6 +2461,10 @@ export class QueryPlanner {
     this.config = enforceQueryPlannerConfigDefaults(config);
     this.federatedQueryGraph = buildFederatedQueryGraph(supergraphSchema, true);
     this.collectInterfaceTypesWithInterfaceObjects();
+
+    if (this.config.debug.bypassPlannerForSingleSubgraph && this.config.incrementalDelivery.enableDefer) {
+      throw new Error(`Cannot use the "debug.bypassPlannerForSingleSubgraph" query planner option when @defer support is enabled`);
+    }
   }
 
   private collectInterfaceTypesWithInterfaceObjects() {
@@ -2491,6 +2496,25 @@ export class QueryPlanner {
       evaluatedPlanCount: 0,
     };
     this._lastGeneratedPlanStatistics = statistics;
+
+    if (this.config.debug.bypassPlannerForSingleSubgraph) {
+      // A federated query graph always have 1 more sources than there is subgraph, because the root vertices
+      // belong to no subgraphs and use a special source named '_'. So we skip that "fake" source.
+      const subgraphs = mapKeys(this.federatedQueryGraph.sources).filter((name) => name !== FEDERATED_GRAPH_ROOT_SOURCE);
+      if (subgraphs.length === 1) {
+        const operationDocument = operationToDocument(operation);
+        const node: FetchNode = {
+          kind: 'Fetch',
+          serviceName: subgraphs[0],
+          variableUsages: operation.selectionSet.usedVariables().map(v => v.name),
+          operation: stripIgnoredCharacters(print(operationDocument)),
+          operationKind: schemaRootKindToOperationKind(operation.rootKind),
+          operationName: operation.name,
+          operationDocumentNode: this.config.exposeDocumentNodeInFetchNode ? operationDocument : undefined,
+        };
+        return { kind: 'QueryPlan', node  };
+      }
+    }
 
     const reuseQueryFragments = this.config.reuseQueryFragments ?? true;
     let fragments = operation.selectionSet.fragments

--- a/query-planner-js/src/config.ts
+++ b/query-planner-js/src/config.ts
@@ -49,7 +49,21 @@ export type QueryPlannerConfig = {
      */
     enableDefer?: boolean,
   }
+
   cache?: QueryPlanCache,
+
+  /**
+   * A sub-set of configurations that are meant for debugging or testing. All the configurations in this
+   * sub-set are provided without guarantees of stability (they may be dangerous) or continued support (they
+   * may be removed without warning).
+   */
+  debug?: {
+    /**
+     * If used and the supergraph is built from a single subgraph, then user queries do not go through the
+     * normal query planning and instead a fetch to the one subgraph is built directly from the input query. 
+     */
+    bypassPlannerForSingleSubgraph?: boolean,
+  },
 }
 
 export function enforceQueryPlannerConfigDefaults(
@@ -58,10 +72,15 @@ export function enforceQueryPlannerConfigDefaults(
   return {
     exposeDocumentNodeInFetchNode: false,
     reuseQueryFragments: true,
-    incrementalDelivery: {
-      enableDefer: false,
-    },
     cache: new InMemoryLRUCache<QueryPlan>({maxSize: Math.pow(2, 20) * 50 }),
     ...config,
+    incrementalDelivery: {
+      enableDefer: false,
+      ...config?.incrementalDelivery,
+    },
+    debug: {
+      bypassPlannerForSingleSubgraph: false,
+      ...config?.debug,
+    },
   };
 }


### PR DESCRIPTION
…ubgraph

This commit adds a new option to the query planner config that, when used and when the supergraph is built from only a single subgraph, skip the query planning algorithm and instead generates a single fetch (to the one subgraph) that directly uses the gateway "input" query.

This option is disabled by default and marked as a "debug" option as it is a bit of a hack and so we're not suggesting committing to supporting it forever. But it is easy enough to have now and can be convenient at least for testing/debugging.

Note in particular that, when used, some of the features enabled by the query planner (for instance `@defer`) cannot be enabled. The option will also stop having any effect as soon as another subgraph is added, not matter what that 2nd subgraph contains.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
