### PR TITLE
fix: Handle defaulted variables correctly during post-processing

### DIFF
--- a/.changeset/gentle-rockets-roll.md
+++ b/.changeset/gentle-rockets-roll.md
@@ -1,0 +1,11 @@
+---
+"@apollo/federation-internals": patch
+"@apollo/gateway": patch
+---
+
+Handle defaulted variables correctly during post-processing.
+
+Users who tried to use built-in conditional directives (skip/include) with _defaulted_ variables and no variable provided would encounter an error thrown by operation post-processing saying that the variables weren't provided. The defaulted values went unaccounted for, so the operation would validate but then fail an assertion while resolving the conditional.
+
+With this change, defaulted variable values are now collected and provided to post-processing (with defaults being overwritten by variables that are actually provided).
+  

--- a/gateway-js/src/__tests__/resultShaping.test.ts
+++ b/gateway-js/src/__tests__/resultShaping.test.ts
@@ -249,7 +249,7 @@ describe('gateway post-processing', () => {
         }
       `);
 
-      let res = computeResponse({
+      const res = computeResponse({
         operation: operationNonNullable,
         input,
         introspectionHandling,
@@ -280,7 +280,7 @@ describe('gateway post-processing', () => {
         }
       `);
 
-      let res = computeResponse({
+      const res = computeResponse({
         operation: operationNonNullable,
         input,
         introspectionHandling,
@@ -365,7 +365,7 @@ describe('gateway post-processing', () => {
     `);
 
     const input = {
-      "x": 'foo', 
+      "x": 'foo',
     }
 
     const operation = parseOperation(schema, `
@@ -529,5 +529,37 @@ describe('gateway post-processing', () => {
         "errors": Array [],
       }
     `);
+  });
+
+  test('Handles defaulted `if` conditions', () => {
+    const schema = buildSchemaFromAST(gql`
+      type Query {
+        hello: String!
+      }
+    `);
+
+    const input = {
+      "hello": "world"
+    }
+
+    const operation = parseOperation(schema, `
+      query DefaultedIfCondition($if: Boolean = true) {
+        hello @skip(if: $if)
+      }
+    `);
+
+    expect(() => computeResponse({
+      operation,
+      input,
+      introspectionHandling,
+    })).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected value undefined for variable $if of @skip(if: $if)"`,
+    );
+
+    // expect(computeResponse({
+    //   operation,
+    //   input,
+    //   introspectionHandling,
+    // })).toMatchInlineSnapshot();
   });
 })

--- a/gateway-js/src/resultShaping.ts
+++ b/gateway-js/src/resultShaping.ts
@@ -72,7 +72,7 @@ export function computeResponse({
     schema: operation.schema,
     variables: {
       ...operation.collectDefaultedVariableValues(),
-      // overwrite and defaulted variables if they are provided
+      // overwrite any defaulted variables if they are provided
       ...variables,
     },
     errors: [],

--- a/gateway-js/src/resultShaping.ts
+++ b/gateway-js/src/resultShaping.ts
@@ -26,7 +26,7 @@ import { GraphQLError } from "graphql";
  * Performs post-query plan execution processing of internally fetched data to produce the final query response.
  *
  * The reason for this post-processing are the following ones:
- * 1. executing the query plan will usually query more fields that are strictly requested. That is because key, required 
+ * 1. executing the query plan will usually query more fields that are strictly requested. That is because key, required
  *   and __typename fields must often be requested to subgraphs even when they are not part of the query. So this method
  *   will filter out anything that has been fetched but isn't part of the user query.
  * 2. query plan execution does not guarantee that in the data fetched, the fields will respect the ordering that the
@@ -60,7 +60,7 @@ export function computeResponse({
   variables?: Record<string, any>,
   input: Record<string, any> | null | undefined,
   introspectionHandling: (introspectionSelection: FieldSelection) => any,
-}): { 
+}): {
   data: Record<string, any> | null | undefined,
   errors: GraphQLError[],
 } {
@@ -70,7 +70,11 @@ export function computeResponse({
 
   const parameters = {
     schema: operation.schema,
-    variables: variables ?? {},
+    variables: {
+      ...operation.collectDefaultedVariableValues(),
+      // overwrite and defaulted variables if they are provided
+      ...variables,
+    },
     errors: [],
     introspectionHandling,
   };
@@ -119,7 +123,7 @@ function ifValue(directive: Directive<any, { if: boolean | Variable }>, variable
   }
 }
 
-enum ApplyResult { OK, NULL_BUBBLE_UP };
+enum ApplyResult { OK, NULL_BUBBLE_UP }
 
 function typeConditionApplies(
   schema: Schema,

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -240,7 +240,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     //    happens when we're building subgraph queries but using selections from the original query which is against the supergraph API schema.
     //  2. or they are not the same underlying type, and we only accept this if we're adding an interface field to a selection of one of its
     //    subtype, and this for convenience. Note that in that case too, `selectinParent` and `fieldParent` may or may be from the same exact
-    //    underlying schema, and so we avoid relying on `isDirectSubtype` in the check. 
+    //    underlying schema, and so we avoid relying on `isDirectSubtype` in the check.
     // In both cases, we just get the field from `selectionParent`, ensuring the return field parent _is_ `selectionParent`.
     const fieldParentType = this.definition.parent
     return parentType.name === fieldParentType.name
@@ -358,7 +358,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     // schema.
     const { canRebase, rebasedCondition } = this.canRebaseOn(selectionParent);
     validate(
-      canRebase, 
+      canRebase,
       () => `Cannot add fragment of condition "${typeCondition}" (runtimes: [${possibleRuntimeTypes(typeCondition!)}]) to selection set of parent type "${selectionParent}" (runtimes: ${possibleRuntimeTypes(selectionParent)})`
     );
     return this.withUpdatedTypes(selectionParent, rebasedCondition);
@@ -691,6 +691,16 @@ export class Operation {
       assignedDeferLabels: normalizer.assignedLabels,
       deferConditions: normalizer.deferConditions,
     };
+  }
+
+  collectDefaultedVariableValues(): Record<string, any> {
+    const defaultedVariableValues: Record<string, any> = {};
+    for (const { variable, defaultValue } of this.variableDefinitions.definitions()) {
+      if (defaultValue !== undefined) {
+        defaultedVariableValues[variable.name] = defaultValue;
+      }
+    }
+    return defaultedVariableValues;
   }
 
   toString(expandFragments: boolean = false, prettyPrint: boolean = true): string {


### PR DESCRIPTION
Fixes #300
(more like https://github.com/apollographql/federation/issues/300#issuecomment-1458660420)

Post-processing doesn't currently account for defaulted variable values in an operation at all. This surfaces as a problem when using conditional directives (`@skip`/`@include`) that use variables with defaulted values (and no corresponding variable provided).

We should collect defaulted variable values from the operation and pass them along with the `variables` we provide to `computeResponse` so these are accounted for.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
