### PR TITLE
Add missing dependencies for `@apollo/utils.keyvaluecache`

### DIFF
--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -33,6 +33,7 @@
     "@apollo/utils.createhash": "^2.0.0",
     "@apollo/utils.fetcher": "^2.0.0",
     "@apollo/utils.isnodelike": "^2.0.0",
+    "@apollo/utils.keyvaluecache": "^2.1.0",
     "@apollo/utils.logger": "^2.0.0",
     "@josephg/resolvable": "^1.0.1",
     "@opentelemetry/api": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "@apollo/utils.createhash": "^2.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0",
         "@josephg/resolvable": "^1.0.1",
         "@opentelemetry/api": "^1.0.1",
@@ -118,6 +119,18 @@
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
+      }
+    },
+    "gateway-js/node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "gateway-js/node_modules/@apollo/utils.logger": {
@@ -197,8 +210,9 @@
       }
     },
     "gateway-js/node_modules/lru-cache": {
-      "version": "7.13.1",
-      "license": "ISC",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
         "node": ">=12"
       }
@@ -16893,6 +16907,7 @@
       "dependencies": {
         "@apollo/federation-internals": "2.3.3",
         "@apollo/query-graphs": "2.3.3",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^29.0.0"
@@ -16902,6 +16917,34 @@
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
+      }
+    },
+    "query-planner-js/node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "query-planner-js/node_modules/@apollo/utils.logger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
+      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "query-planner-js/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "subgraph-js": {
@@ -16982,6 +17025,7 @@
         "@apollo/utils.createhash": "^2.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0",
         "@josephg/resolvable": "^1.0.1",
         "@opentelemetry/api": "^1.0.1",
@@ -16993,6 +17037,15 @@
         "node-fetch": "^2.6.7"
       },
       "dependencies": {
+        "@apollo/utils.keyvaluecache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+          "requires": {
+            "@apollo/utils.logger": "^2.0.0",
+            "lru-cache": "^7.14.1"
+          }
+        },
         "@apollo/utils.logger": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
@@ -17047,7 +17100,9 @@
           }
         },
         "lru-cache": {
-          "version": "7.13.1"
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
         },
         "make-fetch-happen": {
           "version": "11.0.1",
@@ -17151,9 +17206,31 @@
       "requires": {
         "@apollo/federation-internals": "2.3.3",
         "@apollo/query-graphs": "2.3.3",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^29.0.0"
+      },
+      "dependencies": {
+        "@apollo/utils.keyvaluecache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+          "requires": {
+            "@apollo/utils.logger": "^2.0.0",
+            "lru-cache": "^7.14.1"
+          }
+        },
+        "@apollo/utils.logger": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
+          "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
+        },
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+        }
       }
     },
     "@apollo/server-gateway-interface": {

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@apollo/federation-internals": "2.3.3",
     "@apollo/query-graphs": "2.3.3",
+    "@apollo/utils.keyvaluecache": "^2.1.0",
     "chalk": "^4.1.0",
     "deep-equal": "^2.0.5",
     "pretty-format": "^29.0.0"


### PR DESCRIPTION
Looks like I missed this in review for https://github.com/apollographql/federation/pull/2385