### PR TITLE
Update docs to use 2.4 instead of 2.3

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@apollo/composition": "2.3.3",
+    "apollo-federation-integration-testsuite": "2.3.3",
+    "@apollo/gateway": "2.3.3",
+    "@apollo/federation-internals": "2.3.3",
+    "@apollo/query-graphs": "2.3.3",
+    "@apollo/query-planner": "2.3.3",
+    "@apollo/subgraph": "2.3.3"
+  },
+  "changesets": []
+}

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -206,7 +206,7 @@ We're done! `Bill` is now resolved in a new subgraph, and it was resolvable duri
 
 ```graphql {3} title="Billing subgraph"
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key", "@shareable", "@override"])
 ```
 

--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -10,7 +10,7 @@ To use federated directives in a Federation 2 subgraph schema, apply the `@link`
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key", "@shareable"])
 ```
 
@@ -26,7 +26,7 @@ If an imported directive's default name matches one of your own custom directive
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: [{ name: "@key", as: "@primaryKey"}, "@shareable"])
 ```
 
@@ -38,7 +38,7 @@ If you _don't_ [import a particular directive](#importing-directives) from a lin
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key"])
 
 type Book @federation__shareable {
@@ -54,7 +54,7 @@ You can customize a particular specification's namespace prefix by providing the
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         as: "fed")
 
 type Book @fed__shareable {
@@ -530,7 +530,7 @@ Applies arbitrary string metadata to a schema location. Custom tooling can use t
 
 ```graphql
 extend schema
-    @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"])
+    @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@tag"])
 
 type Query {
   customer(id: String!): Customer @tag(name: "team-customers")
@@ -601,7 +601,7 @@ Indicates to composition that all uses of a particular custom [type system direc
 ```graphql
 extend schema
     @link(url: "https://specs.apollo.dev/link/v1.0")
-    @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective"])
+    @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@composeDirective"])
     @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", { name: "@anotherDirective", as: "@hello" }])
     # highlight-start
     @composeDirective(name: "@myDirective")

--- a/docs/source/federated-types/interfaces.mdx
+++ b/docs/source/federated-types/interfaces.mdx
@@ -93,13 +93,13 @@ To use entity interfaces and `@interfaceObject`, your supergraph must adhere to 
 ### Enabling support
 
 - If they don't already, _all_ of your subgraph schemas **must** use the [`@link` directive](./federated-directives/#importing-directives) to enable Federation 2 features.
-- Any subgraph schema that uses the `@interfaceObject` directive _or_ applies `@key` to an `interface` **must** target `v2.3` or later of the Apollo Federation specfication:
+- Any subgraph schema that uses the `@interfaceObject` directive _or_ applies `@key` to an `interface` **must** target `v2.3` or later of the Apollo Federation specification:
 
     ```graphql
     extend schema
       @link(
       #highlight-start
-      url: "https://specs.apollo.dev/federation/v2.3"
+      url: "https://specs.apollo.dev/federation/v2.4"
       import: ["@key", "@interfaceObject"]
       #highlight-end
       )

--- a/docs/source/federated-types/overview.mdx
+++ b/docs/source/federated-types/overview.mdx
@@ -48,7 +48,7 @@ type User @key(fields: "id") {
 # this to opt in to
 # Federation 2 features.)
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key", "@shareable"])
 ```
 
@@ -64,7 +64,7 @@ type Product @key(fields: "upc") {
 }
 
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key", "@shareable"])
 ```
 
@@ -89,7 +89,7 @@ type Product @key(fields: "upc") {
 # (This subgraph uses additional
 # federated directives)
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key", "@shareable", "@provides", "@external"])
 ```
 

--- a/docs/source/federated-types/sharing-types.mdx
+++ b/docs/source/federated-types/sharing-types.mdx
@@ -59,7 +59,7 @@ To use `@shareable` in a subgraph schema, you first need to add the following sn
 
 ```graphql
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key", "@shareable"])
 ```
 
@@ -132,7 +132,7 @@ To make `Position.z` shareable, you can do one of the following:
 
     ```graphql
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@shareable"]) #highlight-line
+      @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@shareable"]) #highlight-line
 
     extend type Position @shareable { #highlight-line
       z: Int!
@@ -424,7 +424,7 @@ To use `@inaccessible` in a subgraph, first make sure you include it in the `imp
 
 ```graphql {3} title="Subgraph A"
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key", "@shareable", "@inaccessible"])
 ```
 

--- a/docs/source/federation-versions.mdx
+++ b/docs/source/federation-versions.mdx
@@ -11,7 +11,7 @@ This article describes notable changes and additions introduced in each minor ve
 
     ```graphql
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3", #highlight-line
+      @link(url: "https://specs.apollo.dev/federation/v2.4", #highlight-line
             import: ["@key", "@shareable", "@interfaceObject"])
     ```
 

--- a/docs/source/subgraph-spec.mdx
+++ b/docs/source/subgraph-spec.mdx
@@ -122,7 +122,7 @@ For example, consider this Federation 2 subgraph schema:
 
 ```graphql title="schema.graphql"
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3",
+  @link(url: "https://specs.apollo.dev/federation/v2.4",
         import: ["@key"])
 
 type Query {

--- a/gateway-js/src/__tests__/executeQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/executeQueryPlan.test.ts
@@ -3829,7 +3829,7 @@ describe('executeQueryPlan', () => {
         name: 'S1',
         typeDefs: gql`
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+            @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key"])
 
           type Query {
             iFromS1: I
@@ -3875,7 +3875,7 @@ describe('executeQueryPlan', () => {
         name: 'S2',
         typeDefs: gql`
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@interfaceObject"])
+            @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@interfaceObject"])
 
           type Query {
             iFromS2: I
@@ -4341,7 +4341,7 @@ describe('executeQueryPlan', () => {
         name: 'products',
         typeDefs: gql`
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+            @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key"])
 
           type Query {
             products: [Product!]!
@@ -4390,7 +4390,7 @@ describe('executeQueryPlan', () => {
         name: 'reviews',
         typeDefs: gql`
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@interfaceObject"])
+            @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@interfaceObject"])
 
           type Query {
             allReviewedProducts: [Product!]!

--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -212,7 +212,7 @@ test('reject @interfaceObject usage if not all subgraphs are fed2', () => {
 
   const s1 = `
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3", import: [ "@key", "@interfaceObject"])
+      @link(url: "https://specs.apollo.dev/federation/v2.4", import: [ "@key", "@interfaceObject"])
 
     type Query {
       a: A

--- a/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
@@ -1321,6 +1321,73 @@ describe('buildSubgraphSchema', () => {
         }
       `);
     });
+
+    it('expands federation 2.4 correctly', async () => {
+      // For 2.3, we expect in everything from 2.2 plus:
+      // - the @interfaceObject directive
+      // - the @tag directive to additionally have the SCHEMA location
+      await testVersion('2.4', `
+        schema
+          @link(url: \"https://specs.apollo.dev/link/v1.0\")
+        {
+          query: Query
+        }
+
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key"])
+
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+        directive @federation__extends on OBJECT | INTERFACE
+
+        directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        directive @federation__override(from: String!) on FIELD_DEFINITION
+
+        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+        directive @federation__interfaceObject on OBJECT
+
+        type Query {
+          x: Int
+          _service: _Service!
+        }
+
+        enum link__Purpose {
+          """
+          \`SECURITY\` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+
+          """
+          \`EXECUTION\` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
+
+        scalar link__Import
+
+        scalar federation__FieldSet
+
+        scalar _Any
+
+        type _Service {
+          sdl: String
+        }
+      `);
+    });
   });
 });
 


### PR DESCRIPTION
Also, please look at https://github.com/apollographql/federation/commit/b0765a753a5c92562d0c8a8ee665a21c705893d1 which I accidentally nakedly committed to `next`. Will update branch protections.