### PR TITLE
Optim local value types

### DIFF
--- a/.changeset/twenty-shirts-battle.md
+++ b/.changeset/twenty-shirts-battle.md
@@ -1,0 +1,12 @@
+---
+"apollo-federation-integration-testsuite": patch
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
+"@apollo/subgraph": patch
+"@apollo/gateway": patch
+---
+
+Optimises query plan generation for parts of queries that can statically be known to not cross across subgraphs
+  

--- a/gateway-js/src/__tests__/executeQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/executeQueryPlan.test.ts
@@ -3165,7 +3165,8 @@ describe('executeQueryPlan', () => {
                     data {
                       __typename
                       foo
-                      ... on Data {
+                      ... on Bar {
+                        __typename
                         bar
                       }
                     }

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "js-levenshtein": "^1.1.6",
-    "@types/uuid": "^8.3.4",
+    "@types/uuid": "^9.0.0",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,26 +121,6 @@
         "graphql": "^16.5.0"
       }
     },
-    "gateway-js/node_modules/@apollo/utils.keyvaluecache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
-      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
-      "dependencies": {
-        "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "^7.14.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "gateway-js/node_modules/@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "gateway-js/node_modules/@npmcli/fs": {
       "version": "3.0.0",
       "license": "ISC",
@@ -302,7 +282,7 @@
       "version": "2.4.0-alpha.1",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@types/uuid": "^8.3.4",
+        "@types/uuid": "^9.0.0",
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6",
         "uuid": "^9.0.0"
@@ -313,11 +293,6 @@
       "peerDependencies": {
         "graphql": "^16.5.0"
       }
-    },
-    "internals-js/node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "internals-js/node_modules/uuid": {
       "version": "9.0.0",
@@ -16766,34 +16741,6 @@
         "graphql": "^16.5.0"
       }
     },
-    "query-planner-js/node_modules/@apollo/utils.keyvaluecache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
-      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
-      "dependencies": {
-        "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "^7.14.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "query-planner-js/node_modules/@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "query-planner-js/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "subgraph-js": {
       "name": "@apollo/subgraph",
       "version": "2.4.0-alpha.1",
@@ -16857,17 +16804,12 @@
     "@apollo/federation-internals": {
       "version": "file:internals-js",
       "requires": {
-        "@types/uuid": "^8.3.4",
+        "@types/uuid": "^9.0.0",
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6",
         "uuid": "^9.0.0"
       },
       "dependencies": {
-        "@types/uuid": {
-          "version": "8.3.4",
-          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-          "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-        },
         "uuid": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -16898,20 +16840,6 @@
         "node-fetch": "^2.6.7"
       },
       "dependencies": {
-        "@apollo/utils.keyvaluecache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
-          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
-          "requires": {
-            "@apollo/utils.logger": "^2.0.0",
-            "lru-cache": "^7.14.1"
-          }
-        },
-        "@apollo/utils.logger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-          "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
-        },
         "@npmcli/fs": {
           "version": "3.0.0",
           "requires": {
@@ -17044,27 +16972,6 @@
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^29.0.0"
-      },
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
-          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
-          "requires": {
-            "@apollo/utils.logger": "^2.0.0",
-            "lru-cache": "^7.14.1"
-          }
-        },
-        "@apollo/utils.logger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-          "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
-        },
-        "lru-cache": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
-        }
       }
     },
     "@apollo/server": {

--- a/query-graphs-js/src/pathTree.ts
+++ b/query-graphs-js/src/pathTree.ts
@@ -273,6 +273,12 @@ export class PathTree<TTrigger, RV extends Vertex = Vertex, TNullEdge extends nu
     return this.merge(other);
   }
 
+  private mergeLocalSelectionsWith(other: PathTree<TTrigger, RV, TNullEdge>): readonly SelectionSet[] | undefined {
+    return this.localSelections
+      ? (other.localSelections ? this.localSelections.concat(other.localSelections) : this.localSelections)
+      : other.localSelections;
+  }
+
   merge(other: PathTree<TTrigger, RV, TNullEdge>): PathTree<TTrigger, RV, TNullEdge> {
     // If we somehow end up trying to merge a tree with itself, let's not waste work on it.
     if (this === other) {
@@ -288,9 +294,7 @@ export class PathTree<TTrigger, RV extends Vertex = Vertex, TNullEdge extends nu
       return other;
     }
 
-    const localSelections = this.localSelections
-      ? (other.localSelections ? this.localSelections.concat(other.localSelections) : this.localSelections)
-      : other.localSelections;
+    const localSelections = this.mergeLocalSelectionsWith(other);
 
     const mergeIndexes: number[] = new Array(other.childs.length);
     let countToAdd = 0;
@@ -346,9 +350,8 @@ export class PathTree<TTrigger, RV extends Vertex = Vertex, TNullEdge extends nu
     if (!this.childs.length) {
       return other;
     }
-    const localSelections = this.localSelections
-      ? (other.localSelections ? this.localSelections.concat(other.localSelections) : this.localSelections)
-      : other.localSelections;
+
+    const localSelections = this.mergeLocalSelectionsWith(other);
     const newChilds = this.childs.concat(other.childs);
     return new PathTree(this.graph, this.vertex, localSelections, this.triggerEquality, newChilds);
   }

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -4428,6 +4428,7 @@ describe('__typename handling', () => {
               } =>
               {
                 ... on S {
+                  __typename
                   t {
                     __typename
                     x
@@ -4939,10 +4940,8 @@ describe('merged abstract types handling', () => {
       `);
 
     const plan = queryPlanner.buildQueryPlan(operation);
-    // While `A` is a `I` in the supergraph while not in `Subgraph1`, since the `i` operation is resolved by
-    // `Subgraph1`, it cannot ever return a A, and so we should skip the whole `v` selection; or at the very
-    // least, we should not send a query with `... on U { ... on A { <stuff> }}` to `Subgraph1` since it
-    // would reject it as invalid.
+    // Here, `A` is a `I` in the supergraph while not in `Subgraph1`, and since the `i` operation is resolved by
+    // `Subgraph1`, it cannot ever return a A. And so we can skip the whole `... on U` sub-selection.
     expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Fetch(service: "Subgraph1") {
@@ -5229,10 +5228,8 @@ describe('merged abstract types handling', () => {
       `);
 
     const plan = queryPlanner.buildQueryPlan(operation);
-    // While `A` is a `U1` in the supergraph while not in `Subgraph1`, since the `u1` operation is resolved by
-    // `Subgraph1`, it cannot ever return a A, and so we should skip the whole `v` selection; or at the very
-    // least, we should not send a query with `u1 { ... on A { <stuff> }}` to `Subgraph1` since it
-    // would reject it as invalid.
+    // Similar case than in the `interface/union` case: the whole `... on U2` sub-selection happens to be
+    // unsatisfiable in practice.
     expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Fetch(service: "Subgraph1") {


### PR DESCRIPTION
Often times, value types only references either "leaf" types or other value types, but no entity type or root types. When a sub-part of a query arrives to such a type, then we know that the rest of the subselection is going to also be part of whichever fetch we're currently building. We can use that knowledge to save work.

This is what this commit does. First, it pre-computes when building the query planner which types have no reachable entity or root type starting from them. Then, when computing query plans, it checks when such types is reached, and when it is, it short-cuts the building of the `GraphPath`s and `PathTree`s for the remaining sub-selections.

When subgraphs have a large number of value types (especially some deeply nested ones), this can measurably speed up query plan generation. This is particularly true when one federate either a single subgraph or one subgraph is much large, which is a corner cases, but can happen in the process of migrating an existing monolith to federation).