### PR TITLE
revert removal of url import

### DIFF
--- a/.changeset/dirty-phones-refuse.md
+++ b/.changeset/dirty-phones-refuse.md
@@ -1,0 +1,6 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Revert #2293. Removing URL import causes a problem when running under deno.
+  

--- a/internals-js/src/coreSpec.ts
+++ b/internals-js/src/coreSpec.ts
@@ -1,4 +1,5 @@
 import { ASTNode, DirectiveLocation, GraphQLError, StringValueNode } from "graphql";
+import { URL } from "url";
 import { CoreFeature, Directive, DirectiveDefinition, EnumType, ErrGraphQLAPISchemaValidationFailed, ErrGraphQLValidationFailed, InputType, ListType, NamedType, NonNullType, ScalarType, Schema, SchemaDefinition, SchemaElement, sourceASTs } from "./definitions";
 import { sameType } from "./types";
 import { assert, firstOf } from './utils';


### PR DESCRIPTION
Revert change made in #2293, the router uses deno for the router-bridge, and url is not built in