### PR TITLE
Fix assertion errors when querying types with no common supertypes at…

### DIFF
--- a/.changeset/thin-weeks-refuse.md
+++ b/.changeset/thin-weeks-refuse.md
@@ -1,0 +1,6 @@
+---
+"@apollo/query-planner": patch
+---
+
+Fix query planner assertion error when types with no common supertypes are requested at the same path
+  


### PR DESCRIPTION
… the same path

Fetches input selections used to be based on the queried subgraph schema. However, those selections truly applies to the in-memory data maintained by the gateway/router, so the supergraph. This used to not matter (all input selection did correctly applied to the subgraph schema), but `@interfaceObject` made it so that some input selections could be invalid for the subgraph. Typically, a fetch that queries a subgraph with an `@interfaceObject` may look like:
```
Fetch(service: 'A') {
  {
    ... on Book {
      id
    }
  } => {
    ... on Product {
      <some fields>
    }
  }
}
```
where `Book` is a concrete implementation of `Product` but unknown to subgraph `A`.

However, basing the input selections on the supergraph schema means having the parent type, in the supergraph, for those selections, and because some fetches can query multiple different entities, this is not trivial.

The initial code for `@interfaceObject` make the (incorrect) assumption that, when a fetch does query multiple types, then we could always find a common supertype for all those types, and so was using that type as parent type.

Unfortunately, this isn't always true (see test in this PR, which uses a union type with types having a field with the same name but different (and unrelated) types).

So in pratice, fetch inputs cannot always have a common parent type. This patch thus changes the fetch inputs to be a map of type to selection sets instead of a single selection set.

Note that it does mean that the `requires` field of a `FetchGroup` is not a true valid "single" selection for the supergraph (or any subgraph for that matter), but it is more of a "fun fact" since the execution never relied on this anyway.

Fixes #2466

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
