### PR TITLE
Fix assertion error due to not ignoring some unsatisfiable branches

### DIFF
--- a/.changeset/lovely-walls-sneeze.md
+++ b/.changeset/lovely-walls-sneeze.md
@@ -1,0 +1,7 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fix assertion error during query planning in some cases where queries has some unsatisfiable branches (a part of the
+query goes through type conditions that no runtime types satisfies).
+  

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -2272,10 +2272,12 @@ class InlineFragmentSelection extends FragmentSelection {
       // If the current type is an object, then we never need to keep the current fragment because:
       // - either the fragment is also an object, but we've eliminated the case where the 2 types are the same,
       //   so this is just an unsatisfiable branch.
-      // - or it's not an object, but then the current type is more precise and no poitn in "casting" to a
-      //   less precise interface/union.
+      // - or it's not an object, but then the current type is more precise and no point in "casting" to a
+      //   less precise interface/union. And if the current type is not even a valid runtime of said interface/union,
+      //   then we should completely ignore the branch (or, since we're eliminating `thisCondition`, we would be
+      //   building an invalid selection). 
       if (isObjectType(currentType)) {
-        if (isObjectType(thisCondition)) {
+        if (isObjectType(thisCondition) || !possibleRuntimeTypes(thisCondition).includes(currentType)) {
           return undefined;
         } else {
           const trimmed = this.selectionSet.trimUnsatisfiableBranches(currentType);
@@ -2339,7 +2341,6 @@ class InlineFragmentSelection extends FragmentSelection {
 
     return this.selectionSet === trimmedSelectionSet ? this : this.withUpdatedSelectionSet(trimmedSelectionSet);
   }
-
 
   expandAllFragments(): FragmentSelection {
     return this.mapToSelectionSet((s) => s.expandAllFragments());


### PR DESCRIPTION
Code was added in #2449 which "optimize" selections by removing unecessary inline fragments and branches that can't be satisfied (when we cross type conditions so that the intersection of types leading here is empty).

Unfortunately that code misses some cases of when a branch is impossible, which leads to trying to build a selection set that is invalid and this in turn triggers an assertion error.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
