### PR TITLE
Fix incorrectly rejected composition and subgraph issues with `@inter…

### DIFF
--- a/.changeset/hungry-berries-destroy.md
+++ b/.changeset/hungry-berries-destroy.md
@@ -1,0 +1,11 @@
+---
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+"@apollo/federation-internals": patch
+"@apollo/gateway": patch
+---
+
+Fix issues (incorrectly rejected composition and/or subgraph errors) with `@interfaceObject`. Those issues may occur
+either due to some use of `@requires` in an `@interfaceObject` type, or when some subgraph `S` defines a type that is an
+implementation of an interface `I` in the supergraph, and there is an `@interfaceObject` for `I` in another subgraph,
+but `S` does not itself defines `I`.

--- a/gateway-js/src/dataRewrites.ts
+++ b/gateway-js/src/dataRewrites.ts
@@ -1,0 +1,130 @@
+import { FetchDataRewrite } from "@apollo/query-planner";
+import { assert } from "console";
+import { GraphQLSchema, isAbstractType, isInterfaceType, isObjectType } from "graphql";
+
+const FRAGMENT_PREFIX = '... on ';
+
+export function applyRewrites(schema: GraphQLSchema, rewrites: FetchDataRewrite[] | undefined,  value: Record<string, any>) {
+  if (!rewrites) {
+    return;
+  }
+
+  for (const rewrite of rewrites) {
+    applyRewrite(schema, rewrite, value);
+  }
+}
+
+function applyRewrite(schema: GraphQLSchema, rewrite: FetchDataRewrite,  value: Record<string, any>) {
+  const splitted = splitPathLastElement(rewrite.path);
+  if (!splitted) {
+    return;
+  }
+
+  const [parent, last] = splitted;
+  const { kind, value: fieldName } = parsePathElement(last);
+  // So far, all rewrites finish by a field name. If this ever changes, this assertion will catch it early and we can update.
+  assert(kind === 'fieldName', () => `Unexpected fragment as last element of ${rewrite.path}`);
+  applyAtPath(schema, parent, value, rewriteAtPathFunction(rewrite, fieldName));
+}
+
+function rewriteAtPathFunction(rewrite: FetchDataRewrite, fieldAtPath: string): (obj: Record<string, any>) => void {
+  switch (rewrite.kind) {
+    case 'ValueSetter':
+      return (obj) => {
+        obj[fieldAtPath] = rewrite.setValueTo;
+      };
+    case 'KeyRenamer':
+      return (obj) => {
+        obj[rewrite.renameKeyTo] = obj[fieldAtPath];
+        obj[fieldAtPath] = undefined;
+      };
+  }
+}
+
+
+/**
+ * Given a path, separates the last element of path and the rest of it and return them as a pair.
+ * This will return `undefined` if the path is empty.
+ */
+function splitPathLastElement(path: string[]): [string[], string] | undefined {
+  if (path.length === 0) {
+    return undefined;
+  }
+
+  const lastIdx = path.length - 1;
+  return [path.slice(0, lastIdx), path[lastIdx]];
+}
+
+function applyAtPath(schema: GraphQLSchema, path: string[], value: any, fct: (objAtPath: Record<string, any>) => void) {
+  if (Array.isArray(value)) {
+    for (const arrayValue of value) {
+      applyAtPath(schema, path, arrayValue, fct);
+    }
+    return;
+  }
+
+  if (typeof value !== 'object') {
+    return;
+  }
+
+  if (path.length === 0) {
+    fct(value);
+    return;
+  }
+
+  const [first, ...rest] = path;
+  const { kind, value: eltValue } = parsePathElement(first);
+  switch (kind) {
+    case 'fieldName':
+      applyAtPath(schema, rest, value[eltValue], fct);
+      break;
+    case 'typeName':
+      // When we apply rewrites, we don't always have the __typename of all object we would need to, but the code expects that
+      // this does not stop the rewrite to applying, hence the modified to `true` when the object typename is not found.
+      if (isObjectOfType(schema, value, eltValue, true)) {
+        applyAtPath(schema, rest, value, fct);
+      }
+      break;
+  }
+}
+
+function parsePathElement(elt: string): { kind: 'fieldName' | 'typeName', value: string } {
+  if (elt.startsWith(FRAGMENT_PREFIX)) {
+    return { kind: 'typeName', value: elt.slice(FRAGMENT_PREFIX.length) };
+  } else {
+    return { kind: 'fieldName', value: elt };
+  }
+}
+
+
+export function isObjectOfType(
+  schema: GraphQLSchema,
+  obj: Record<string, any>,
+  typeCondition: string,
+  defaultOnUnknownObjectType: boolean = false,
+): boolean {
+  const objTypename = obj['__typename'];
+  if (!objTypename) {
+    return defaultOnUnknownObjectType;
+  }
+
+  if (typeCondition === objTypename) {
+    return true;
+  }
+
+  const type = schema.getType(objTypename);
+  if (!type) {
+    return false;
+  }
+
+  const conditionalType = schema.getType(typeCondition);
+  if (!conditionalType) {
+    return false;
+  }
+
+  if (isAbstractType(conditionalType)) {
+    return (isObjectType(type) || isInterfaceType(type)) && schema.isSubType(conditionalType, type);
+  }
+
+  return false;
+}

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -5,10 +5,7 @@ import {
   TypeNameMetaFieldDef,
   GraphQLFieldResolver,
   GraphQLFormattedError,
-  isAbstractType,
   GraphQLSchema,
-  isObjectType,
-  isInterfaceType,
   GraphQLErrorOptions,
   DocumentNode,
   executeSync,
@@ -26,17 +23,16 @@ import {
   QueryPlanSelectionNode,
   QueryPlanFieldNode,
   getResponseName,
-  FetchDataInputRewrite,
-  FetchDataOutputRewrite,
   evaluateCondition,
 } from '@apollo/query-planner';
 import { deepMerge } from './utilities/deepMerge';
 import { isNotNullOrUndefined } from './utilities/array';
 import { SpanStatusCode } from "@opentelemetry/api";
 import { OpenTelemetrySpanNames, tracer } from "./utilities/opentelemetry";
-import { assert, defaultRootName, errorCodeDef, ERRORS, isDefined, Operation, operationFromDocument, Schema } from '@apollo/federation-internals';
+import { assert, defaultRootName, errorCodeDef, ERRORS, Operation, operationFromDocument, Schema } from '@apollo/federation-internals';
 import { GatewayGraphQLRequestContext, GatewayExecutionResult } from '@apollo/server-gateway-interface';
 import { computeResponse } from './resultShaping';
+import { applyRewrites, isObjectOfType } from './dataRewrites';
 
 export type ServiceMap = {
   [serviceName: string]: GraphQLDataSource;
@@ -416,9 +412,12 @@ async function executeFetch(
 
       if (!fetch.requires) {
         const dataReceivedFromService = await sendOperation(variables);
+        if (dataReceivedFromService) {
+          applyRewrites(context.supergraphSchema, fetch.outputRewrites, dataReceivedFromService);
+        }
 
         for (const entity of entities) {
-          deepMerge(entity, withFetchRewrites(dataReceivedFromService, fetch.outputRewrites));
+          deepMerge(entity, dataReceivedFromService);
         }
       } else {
         const requires = fetch.requires;
@@ -434,9 +433,9 @@ async function executeFetch(
             context.supergraphSchema,
             entity,
             requires,
-            fetch.inputRewrites,
           );
           if (representation && representation[TypeNameMetaFieldDef.name]) {
+            applyRewrites(context.supergraphSchema, fetch.inputRewrites, representation);
             representations.push(representation);
             representationToEntity.push(index);
           }
@@ -473,8 +472,11 @@ async function executeFetch(
           );
         }
 
+
         for (let i = 0; i < entities.length; i++) {
-          deepMerge(entities[representationToEntity[i]], withFetchRewrites(receivedEntities[i], filterEntityRewrites(representations[i], fetch.outputRewrites)));
+          const receivedEntity = receivedEntities[i];
+          applyRewrites(context.supergraphSchema, fetch.outputRewrites, receivedEntity);
+          deepMerge(entities[representationToEntity[i]], receivedEntity);
         }
       }
     }
@@ -707,84 +709,6 @@ export function generateHydratedPaths(
   }
 }
 
-function applyOrMapRecursive(value: any | any[], fct: (v: any) => any | undefined): any | any[] | undefined {
-  if (Array.isArray(value)) {
-    const res = value.map((elt) => applyOrMapRecursive(elt, fct)).filter(isDefined);
-    return res.length === 0 ? undefined : res;
-  }
-  return fct(value);
-}
-
-function withFetchRewrites(fetchResult: ResultMap | null | void, rewrites: FetchDataOutputRewrite[] | undefined): ResultMap | null | void {
-  if (!rewrites || !fetchResult) {
-    return fetchResult;
-  }
-
-  for (const rewrite of rewrites) {
-    let obj: any = fetchResult;
-    let i = 0;
-    while (obj && i < rewrite.path.length - 1) {
-      const p = rewrite.path[i++];
-      if (p.startsWith('... on ')) {
-        const typename = p.slice('... on '.length);
-        // Filter only objects that match the condition.
-        obj = applyOrMapRecursive(obj, (elt) => elt[TypeNameMetaFieldDef.name] === typename ? elt : undefined);
-      } else {
-        obj = applyOrMapRecursive(obj, (elt) => elt[p]);
-      }
-    }
-    if (obj) {
-      applyOrMapRecursive(obj, (elt) => {
-        if (typeof elt === 'object') {
-          // We need to move the value at path[i] to `renameKeyTo`.
-          const removedKey = rewrite.path[i];
-          elt[rewrite.renameKeyTo] = elt[removedKey];
-          elt[removedKey] = undefined;
-        }
-      });
-    }
-  }
-  return fetchResult;
-}
-
-function filterEntityRewrites(entity: Record<string, any>, rewrites: FetchDataOutputRewrite[] | undefined): FetchDataOutputRewrite[] | undefined {
-  if (!rewrites) {
-    return undefined;
-  }
-
-  const typename = entity[TypeNameMetaFieldDef.name] as string;
-  const typenameAsFragment = `... on ${typename}`;
-  return rewrites.map((r) => r.path[0] === typenameAsFragment ? { ...r, path: r.path.slice(1) } : undefined).filter(isDefined)
-}
-
-function updateRewrites(rewrites: FetchDataInputRewrite[] | undefined, pathElement: string): {
-  updated: FetchDataInputRewrite[],
-  completeRewrite?: any,
-} | undefined {
-  if (!rewrites) {
-    return undefined;
-  }
-
-  let completeRewrite: any = undefined;
-  const updated = rewrites
-    .map((r) => {
-      let u: FetchDataInputRewrite | undefined = undefined;
-      if (r.path[0] === pathElement) {
-        const updatedPath = r.path.slice(1);
-        if (updatedPath.length === 0) {
-          completeRewrite = r.setValueTo;
-        } else {
-          u = { ...r, path: updatedPath };
-        }
-      }
-      return u;
-    })
-    .filter(isDefined);
-  return updated.length === 0 && completeRewrite === undefined
-    ? undefined
-    : { updated, completeRewrite };
-}
-
 /**
  *
  * @param source Result of GraphQL execution.
@@ -794,7 +718,6 @@ function executeSelectionSet(
   schema: GraphQLSchema,
   source: Record<string, any> | null,
   selections: QueryPlanSelectionNode[],
-  activeRewrites?: FetchDataInputRewrite[],
 ): Record<string, any> | null {
 
   // If the underlying service has returned null for the parent (source)
@@ -825,16 +748,10 @@ function executeSelectionSet(
           return null;
         }
 
-        const updatedRewrites = updateRewrites(activeRewrites, responseName);
-        if (updatedRewrites?.completeRewrite !== undefined) {
-          result[responseName] = updatedRewrites.completeRewrite;
-          continue;
-        }
-
         if (Array.isArray(source[responseName])) {
           result[responseName] = source[responseName].map((value: any) =>
             selections
-              ? executeSelectionSet(schema, value, selections, updatedRewrites?.updated)
+              ? executeSelectionSet(schema, value, selections)
               : value,
           );
         } else if (selections) {
@@ -842,23 +759,18 @@ function executeSelectionSet(
             schema,
             source[responseName],
             selections,
-            updatedRewrites?.updated,
           );
         } else {
           result[responseName] = source[responseName];
         }
         break;
       case Kind.INLINE_FRAGMENT:
-        if (!selection.typeCondition) continue;
+        if (!selection.typeCondition || !source) continue;
 
-        const typename = source && source['__typename'];
-        if (!typename) continue;
-
-        if (doesTypeConditionMatch(schema, selection.typeCondition, typename)) {
-          const updatedRewrites = activeRewrites ? updateRewrites(activeRewrites, `... on ${selection.typeCondition}`) : undefined;
+        if (isObjectOfType(schema, source, selection.typeCondition)) {
           deepMerge(
             result,
-            executeSelectionSet(schema, source, selection.selections, updatedRewrites?.updated),
+            executeSelectionSet(schema, source, selection.selections),
           );
         }
         break;
@@ -866,32 +778,6 @@ function executeSelectionSet(
   }
 
   return result;
-}
-
-function doesTypeConditionMatch(
-  schema: GraphQLSchema,
-  typeCondition: string,
-  typename: string,
-): boolean {
-  if (typeCondition === typename) {
-    return true;
-  }
-
-  const type = schema.getType(typename);
-  if (!type) {
-    return false;
-  }
-
-  const conditionalType = schema.getType(typeCondition);
-  if (!conditionalType) {
-    return false;
-  }
-
-  if (isAbstractType(conditionalType)) {
-    return (isObjectType(type) || isInterfaceType(type)) && schema.isSubType(conditionalType, type);
-  }
-
-  return false;
 }
 
 function moveIntoCursor(cursor: ResultCursor, pathInCursor: ResponsePath): ResultCursor | undefined {

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -974,7 +974,7 @@ export function advancePathWithTransition<V extends Vertex>(
   debug.group(`Computing indirect paths:`);
   const pathsWithNonCollecting = subgraphPath.indirectOptions();
   if (pathsWithNonCollecting.paths.length > 0) {
-    debug.groupEnd(() => `${pathsWithNonCollecting.paths.length} indirect paths`);
+    debug.groupEnd(() => `${pathsWithNonCollecting.paths.length} indirect paths: ${pathsWithNonCollecting.paths}`);
     debug.group('Validating indirect options:');
     for (const nonCollectingPath of pathsWithNonCollecting.paths) {
       debug.group(() => `For indirect path ${nonCollectingPath}:`);

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -664,42 +664,54 @@ function federateSubgraphs(supergraph: Schema, subgraphs: QueryGraph[]): QueryGr
           assert(isInterfaceType(type) || isObjectType(type), () => `Invalid "@key" application on non Object || Interface type "${type}"`);
           const isInterfaceObject = subgraphMetadata.isInterfaceObjectType(type);
           const conditions = parseFieldSetArgument({ parentType: type, directive: keyApplication });
+
+          // We'll look at adding edges from "other subgraphs" to the current type. So the tail of all the edges
+          // we'll build in this branch is always going to be the same.
+          const tail = copyPointers[i].copiedVertex(v);
           // Note that each subgraph has a key edge to itself (when i === j below). We usually ignore
           // this edges, but they exists for the special case of @defer, where we technically may have
           // to take such "edge-to-self" as a mean to "re-enter" a subgraph for a deferred section.
           for (const [j, otherSubgraph] of subgraphs.entries()) {
             const otherVertices = otherSubgraph.verticesForType(type.name);
-            if (otherVertices.length == 0) {
-              continue;
+            if (otherVertices.length > 0) {
+              // Note that later, when we've handled @provides, this might not be true anymore as @provides may create copy of a
+              // certain type. But for now, it's true.
+              assert(
+                otherVertices.length == 1,
+                () => `Subgraph ${j} should have a single vertex for type ${type.name} but got ${otherVertices.length}: ${inspect(otherVertices)}`);
+
+              const otherVertex = otherVertices[0];
+              // The edge goes from the otherSubgraph to the current one.
+              const head = copyPointers[j].copiedVertex(otherVertex);
+              const tail = copyPointers[i].copiedVertex(v);
+              builder.addEdge(head, tail, new KeyResolution(), conditions);
             }
-            // Note that later, when we've handled @provides, this might not be true anymore as @provides may create copy of a
-            // certain type. But for now, it's true.
-            assert(
-              otherVertices.length == 1,
-              () => `Subgraph ${j} should have a single vertex for type ${type.name} but got ${otherVertices.length}: ${inspect(otherVertices)}`);
 
-            const otherVertice = otherVertices[0];
-            // The edge goes from the otherSubgraph to the current one.
-            const head = copyPointers[j].copiedVertex(otherVertice);
-            const tail = copyPointers[i].copiedVertex(v);
-            builder.addEdge(head, tail, new KeyResolution(), conditions);
-
-            // Additionally, if the key is on an @interfaceObject and this "other" subgraph has the type as
-            // a proper interface, then we need an edge from each of those implementation (to the @interfaceObject).
+            // Additionally, if the key is on an @interfaceObject and this "other" subgraph has some of the implementations
+            // of the corresponding interface, then we need an edge from each of those implementations (to the @interfaceObject).
             // This is used when an entity of specific implementation is queried first, but then some of the
             // requested fields are only provided by that @interfaceObject.
-            const otherType = otherVertice.type;
-            if (isInterfaceObject && isInterfaceType(otherType)) {
-              for (const implemType of otherType.possibleRuntimeTypes()) {
-                // Note that we're only taking the implementation types from "otherSubgraph", so we're guaranteed
-                // to have a corresponding vertice (and only one for the same reason than mentioned in the assert above).
-                const implemVertice = otherSubgraph.verticesForType(implemType.name)[0];
+            if (isInterfaceObject) {
+              const typeInSupergraph = supergraph.type(type.name);
+              assert(typeInSupergraph && isInterfaceType(typeInSupergraph), () => `Type ${type} is an interfaceObject in subgraph ${i}; should be an interface in the supergraph`);
+              for (const implemTypeInSupergraph of typeInSupergraph.possibleRuntimeTypes()) {
+                // That implementation type may or may not exists in "otherSubgraph". If it doesn't, we just have nothing to
+                // do for that particular impelmentation. If it does, we'll add the proper edge, but note that we're guaranteed
+                // to have at most one vertex for the same reason than mentioned above (only the handling @provides will make it
+                // so that there can be more than one vertex per type).
+                const implemVertice = otherSubgraph.verticesForType(implemTypeInSupergraph.name)[0];
+                if (!implemVertice) {
+                  continue;
+                }
+
                 const implemHead = copyPointers[j].copiedVertex(implemVertice);
                 // The key goes from the implementation type to the @interfaceObject one, so the conditions
                 // will be "fetched" on the implementation type, but `conditions` has been parsed on the
                 // interface type, so it will use fields from the interface, not the implementation type.
                 // So we re-parse the condition using the implementation type: this could fail, but in
                 // that case it just mean that key is not usable.
+                const implemType = implemVertice.type;
+                assert(isCompositeType(implemType), () => `${implemType} should be composite since it implements ${typeInSupergraph} in the supergraph`);
                 try {
                   const implConditions = parseFieldSetArgument({ parentType: implemType, directive: keyApplication, validate: false });
                   builder.addEdge(implemHead, tail, new KeyResolution(), implConditions);

--- a/query-planner-js/src/QueryPlan.ts
+++ b/query-planner-js/src/QueryPlan.ts
@@ -46,29 +46,19 @@ export interface FetchNode {
   operationKind: OperationTypeNode;
   operationDocumentNode?: DocumentNode;
   // Optionally describe a number of "rewrites" that query plan executors should apply to the data that is sent as input of this fetch.
-  inputRewrites?: FetchDataInputRewrite[];
-  // Similar, but for optional "rewrites" to apply to the data that received from a fetch (and before it is apply to the current in-memory results).
-  outputRewrites?: FetchDataOutputRewrite[];
+  // Note that such rewrites should only impact the inputs of the fetch they are applied to (meaning that, as those inputs are collected 
+  // from the current in-memory result, the rewrite should _not_ impact said in-memory results, only what is sent in the fetch).
+  inputRewrites?: FetchDataRewrite[];
+  // Similar, but for optional "rewrites" to apply to the data that received from a fetch (and before it is applied to the current in-memory results).
+  outputRewrites?: FetchDataRewrite[];
 }
 
 /**
- * The type of rewrites currently supported on the input data of fetches.
+ * The type of rewrites currently supported on the input/output data of fetches.
  *
- * A rewrite usually identifies some subpart of the input data and some action to perform on that subpart.
- * Note that input rewrites should only impact the inputs of the fetch they are applied to (meaning that, as
- * those inputs are collected from the current in-memory result, the rewrite should _not_ impact said in-memory
- * results, only what is sent in the fetch).
+ * A rewrite usually identifies some subpart of thedata and some action to perform on that subpart.
  */
-export type FetchDataInputRewrite = FetchDataValueSetter;
-
-/**
- * The type of rewrites currently supported on the output data of fetches.
- *
- * A rewrite usually identifies some subpart of the ouput data and some action to perform on that subpart.
- * Note that ouput rewrites should only impact the outputs of the fetch they are applied to (meaning that
- * the rewrites must be applied before the data from the fetch is merged to the  current in-memory result).
- */
-export type FetchDataOutputRewrite = FetchDataKeyRenamer;
+export type FetchDataRewrite = FetchDataValueSetter | FetchDataKeyRenamer;
 
 /**
  * A rewrite that sets a value at the provided path of the data it is applied to.

--- a/query-planner-js/src/__tests__/buildPlan.interfaceObject.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.interfaceObject.test.ts
@@ -312,6 +312,7 @@ describe('basic @key on interface/@interfaceObject handling', () => {
     expect(rewrites).toBeDefined();
     expect(rewrites?.length).toBe(1);
     const rewrite = rewrites![0];
+    assert(rewrite.kind === 'ValueSetter', JSON.stringify(rewrite));
     expect(rewrite.path).toEqual(['... on A', '__typename']);
     expect(rewrite.setValueTo).toBe('I');
   });


### PR DESCRIPTION
…faceObject`

There is 2 main issues with the handling of `@interfaceObject` that this patch fixes:
1. given some `@interfaceObject` type `I` in some subgraph `S1`, if another subgraph `S2` was declaring an _implementation_ type `T` of `I` but _without_ declaring `I`, then the code missed creating an "edge" between `T` in `S2` and `I` in `S1`, which resulted in composition rejecting such cases, even though it should work.
2. there were an additional issue in the handling of `@requires` so that the "input rewrites" generated were not generic enough, leading to sometimes sending incorrect queries to subgraph (more precisely, we were sometimes not rewriting the typename when querying an `@interfaceObject` subgraph, leading that subgraph to complain that it is asked for type it doesn't know).

Note that fixing those 2 issues surfaced the fact that the handling of "rewrites" in the gateway was not working exactly as it should have. More precisely, hen a path had a fragment `... on I`, if `I` was an interface, then we would no select objects that implements `I` correctly. As it happens, the router implementation of those rewrites was both cleaner and didn't had that issue, so this patch also updates the handling of "rewrites" to mimick what the router implementation does (fixing the issue, and overall cleaning the code).

Fixes #2485

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
