### PR TITLE
Improve fragment reuse

### DIFF
--- a/.changeset/rich-kings-obey.md
+++ b/.changeset/rich-kings-obey.md
@@ -1,0 +1,11 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+"@apollo/gateway": patch
+---
+
+Improves reuse of named fragments in subgraph fetches. When a question has named fragments, the code tries to reuse
+those fragment in subgraph fetches is those can apply (so when the fragment is fully queried in a single subgraph fetch).
+However, the existing was only able to reuse those fragment in a small subset of cases. This change makes it much more
+likely that _if_ a fragment can be reused, it will be.
+  

--- a/gateway-js/src/__tests__/integration/requires.test.ts
+++ b/gateway-js/src/__tests__/integration/requires.test.ts
@@ -218,13 +218,13 @@ it('collapses nested requires with user-defined fragments', async () => {
           {
             user {
               __typename
-              id
               preferences {
                 favorites {
-                  animal
                   color
+                  animal
                 }
               }
+              id
             }
           }
         },

--- a/gateway-js/src/__tests__/integration/value-types.test.ts
+++ b/gateway-js/src/__tests__/integration/value-types.test.ts
@@ -98,14 +98,7 @@ describe('value types', () => {
                     reviews {
                       metadata {
                         __typename
-                        ... on KeyValue {
-                          key
-                          value
-                        }
-                        ... on Error {
-                          code
-                          message
-                        }
+                        ...Metadata
                       }
                     }
                   }
@@ -113,16 +106,20 @@ describe('value types', () => {
                     reviews {
                       metadata {
                         __typename
-                        ... on KeyValue {
-                          key
-                          value
-                        }
-                        ... on Error {
-                          code
-                          message
-                        }
+                        ...Metadata
                       }
                     }
+                  }
+                }
+                
+                fragment Metadata on MetadataOrError {
+                  ... on KeyValue {
+                    key
+                    value
+                  }
+                  ... on Error {
+                    code
+                    message
                   }
                 }
               },

--- a/query-planner-js/src/__tests__/features/basic/value-types.feature
+++ b/query-planner-js/src/__tests__/features/basic/value-types.feature
@@ -79,7 +79,7 @@ Scenario: resolves value types within their respective services
                 ],
                 "variableUsages": [],
                 "operationKind": "query",
-                "operation": "query ProducsWithMetadata__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}...on Furniture{reviews{metadata{__typename ...on KeyValue{key value}...on Error{code message}}}}}}",
+                "operation": "query ProducsWithMetadata__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{metadata{__typename ...Metadata}}}...on Furniture{reviews{metadata{__typename ...Metadata}}}}}fragment Metadata on MetadataOrError{...on KeyValue{key value}...on Error{code message}}",
                 "operationName": "ProducsWithMetadata__reviews__1"
               }
             },


### PR DESCRIPTION
The code to try to reuse named fragments inside subgraph queries was a bit "crude" and there was plenty of cases where fragments weren't being reused. The main culprit was know and described in [this todo](https://github.com/apollographql/federation/blob/main/internals-js/src/operations.ts#L1872-L1897), but there is a few other small points addressed by this PR.