### PR TITLE
First crack at an implementation of #2495

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -66,6 +66,11 @@ import {
   addSubgraphToError,
   printHumanReadableList,
   ArgumentMerger,
+  JoinSpecDefinition,
+  CoreSpecDefinition,
+  FeatureVersion,
+  FEDERATION_VERSIONS,
+  InaccessibleSpecDefinition,
 } from "@apollo/federation-internals";
 import { ASTNode, GraphQLError, DirectiveLocation } from "graphql";
 import {
@@ -79,12 +84,7 @@ import { inspect } from "util";
 import { collectCoreDirectivesToCompose, CoreDirectiveInSubgraphs } from "./coreDirectiveCollector";
 import { CompositionOptions } from "../compose";
 
-
-const linkSpec = LINK_VERSIONS.latest();
 type FieldOrUndefinedArray = (FieldDefinition<any> | undefined)[];
-
-const joinSpec = JOIN_VERSIONS.latest();
-const inaccessibleSpec = INACCESSIBLE_VERSIONS.latest();
 
 export type MergeResult = MergeSuccess | MergeFailure;
 
@@ -275,8 +275,17 @@ class Merger {
     sources: (SchemaElement<any, any> | undefined)[],
     dest: SchemaElement<any, any>,
   }[];
+  private joinSpec: JoinSpecDefinition;
+  private linkSpec: CoreSpecDefinition;
+  private inaccessibleSpec: InaccessibleSpecDefinition;
+  private latestFedVersionUsed: FeatureVersion;
 
   constructor(readonly subgraphs: Subgraphs, readonly options: CompositionOptions) {
+    this.latestFedVersionUsed = this.getLatestFederationVersionUsed();
+    this.joinSpec = JOIN_VERSIONS.getMinimumRequiredVersion(this.latestFedVersionUsed);
+    this.linkSpec = LINK_VERSIONS.getMinimumRequiredVersion(this.latestFedVersionUsed);
+    this.inaccessibleSpec = INACCESSIBLE_VERSIONS.getMinimumRequiredVersion(this.latestFedVersionUsed);
+
     this.names = subgraphs.names();
     this.composeDirectiveManager = new ComposeDirectiveManager(
       this.subgraphs,
@@ -293,12 +302,26 @@ class Merger {
     this.appliedDirectivesToMerge = [];
   }
 
+  private getLatestFederationVersionUsed(): FeatureVersion {
+    const latestVersion =  this.subgraphs.values().reduce((latest: FeatureVersion | undefined, subgraph) => {
+      const version = subgraph.metadata()?.federationFeature()?.url?.version;
+      if (!latest) {
+        return version;
+      }
+      if (!version) {
+        return latest;
+      }
+      return latest >= version ? latest : version;
+    }, undefined);
+    return latestVersion ? latestVersion : FEDERATION_VERSIONS.latest().version;
+  }
+
   private prepareSupergraph(): Map<string, string> {
     // TODO: we will soon need to look for name conflicts for @core and @join with potentially user-defined directives and
     // pass a `as` to the methods below if necessary. However, as we currently don't propagate any subgraph directives to
     // the supergraph outside of a few well-known ones, we don't bother yet.
-    linkSpec.addToSchema(this.merged);
-    const errors = linkSpec.applyFeatureToSchema(this.merged, joinSpec, undefined, joinSpec.defaultCorePurpose);
+    this.linkSpec.addToSchema(this.merged);
+    const errors = this.linkSpec.applyFeatureToSchema(this.merged, this.joinSpec, undefined, this.joinSpec.defaultCorePurpose);
     assert(errors.length === 0, "We shouldn't have errors adding the join spec to the (still empty) supergraph schema");
 
     const directivesMergeInfo = collectCoreDirectivesToCompose(this.subgraphs);
@@ -306,7 +329,7 @@ class Merger {
       this.validateAndMaybeAddSpec(mergeInfo);
     }
 
-    return joinSpec.populateGraphEnum(this.merged, this.subgraphs);
+    return this.joinSpec.populateGraphEnum(this.merged, this.subgraphs);
   }
 
   private validateAndMaybeAddSpec({feature, name, definitionsPerSubgraph, compositionSpec}: CoreDirectiveInSubgraphs) {
@@ -339,8 +362,8 @@ class Merger {
     // If we get here with `nameInSupergraph` unset, it means there is no usage for the directive at all and we
     // don't bother adding the spec to the supergraph.
     if (nameInSupergraph) {
-      const specInSupergraph = compositionSpec.supergraphSpecification();
-      const errors = linkSpec.applyFeatureToSchema(this.merged, specInSupergraph, nameInSupergraph === specInSupergraph.url.name ? undefined : nameInSupergraph, specInSupergraph.defaultCorePurpose);
+      const specInSupergraph = compositionSpec.supergraphSpecification(this.latestFedVersionUsed);
+      const errors = this.linkSpec.applyFeatureToSchema(this.merged, specInSupergraph, nameInSupergraph === specInSupergraph.url.name ? undefined : nameInSupergraph, specInSupergraph.defaultCorePurpose);
       assert(errors.length === 0, "We shouldn't have errors adding the join spec to the (still empty) supergraph schema");
       const argumentsMerger = compositionSpec.argumentsMerger?.call(null, this.merged);
       if (argumentsMerger instanceof GraphQLError) {
@@ -395,7 +418,7 @@ class Merger {
     this.addDirectivesShallow();
 
     const typesToMerge = this.merged.types()
-      .filter((type) => !linkSpec.isSpecType(type) && !joinSpec.isSpecType(type));
+      .filter((type) => !this.linkSpec.isSpecType(type) && !this.joinSpec.isSpecType(type));
 
     // Then, for object and interface types, we merge the 'implements' relationship, and we merge the unions.
     // We do this first because being able to know if a type is a subtype of another one (which relies on those
@@ -426,7 +449,7 @@ class Merger {
 
     for (const definition of this.merged.directives()) {
       // we should skip the supergraph specific directives, that is the @core and @join directives.
-      if (linkSpec.isSpecDirective(definition) || joinSpec.isSpecDirective(definition)) {
+      if (this.linkSpec.isSpecDirective(definition) || this.joinSpec.isSpecDirective(definition)) {
         continue;
       }
       this.mergeDirectiveDefinition(this.subgraphsSchema.map(s => s.directive(definition.name)), definition);
@@ -622,7 +645,7 @@ class Merger {
 
   private mergeImplements<T extends ObjectType | InterfaceType>(sources: (T | undefined)[], dest: T) {
     const implemented = new Set<string>();
-    const joinImplementsDirective = joinSpec.implementsDirective(this.merged)!;
+    const joinImplementsDirective = this.joinSpec.implementsDirective(this.merged)!;
     for (const [idx, source] of sources.entries()) {
       if (source) {
         const name = this.joinSpecName(idx);
@@ -753,7 +776,7 @@ class Merger {
   }
 
   private addJoinType(sources: (NamedType | undefined)[], dest: NamedType) {
-    const joinTypeDirective = joinSpec.typeDirective(this.merged);
+    const joinTypeDirective = this.joinSpec.typeDirective(this.merged);
     for (const [idx, source] of sources.entries()) {
       if (!source) {
         continue;
@@ -914,7 +937,7 @@ class Merger {
             // clarify to the later extraction process that this particular field doesn't come
             // from any particular subgraph (it comes indirectly from an @interfaceObject type,
             // but it's very much indirect so ...).
-            implemField.applyDirective(joinSpec.fieldDirective(this.merged), { graph: undefined });
+            implemField.applyDirective(this.joinSpec.fieldDirective(this.merged), { graph: undefined });
 
 
             // If we had to add a field here, it means that, for this particular implementation, the
@@ -937,7 +960,7 @@ class Merger {
     // implementation type when @interfaceObject is used. But we shouldn't copy the `join` spec directive
     // as those are for the interface field but are invalid for the implementation field.
     source.appliedDirectives.forEach((d) => {
-      if (!joinSpec.isSpecDirective(d.definition!)) {
+      if (!this.joinSpec.isSpecDirective(d.definition!)) {
         dest.applyDirective(d.name, {...d.arguments()})
       }
     });
@@ -1537,7 +1560,7 @@ class Merger {
     })) {
       return;
     }
-    const joinFieldDirective = joinSpec.fieldDirective(this.merged);
+    const joinFieldDirective = this.joinSpec.fieldDirective(this.merged);
     for (const [idx, source] of sources.entries()) {
       const usedOverridden = mergeContext.isUsedOverridden(idx);
       const unusedOverridden = mergeContext.isUnusedOverridden(idx);
@@ -1892,7 +1915,7 @@ class Merger {
   }
 
   private addJoinUnionMember(sources: (UnionType | undefined)[], dest: UnionType, member: ObjectType) {
-    const joinUnionMemberDirective = joinSpec.unionMemberDirective(this.merged);
+    const joinUnionMemberDirective = this.joinSpec.unionMemberDirective(this.merged);
     // We should always be merging with the latest join spec, so this should exists, but well, in prior versions where
     // the directive didn't existed, we simply did had any replacement so ...
     if (!joinUnionMemberDirective) {
@@ -1989,7 +2012,7 @@ class Merger {
     this.recordAppliedDirectivesToMerge(valueSources, value);
     this.addJoinEnumValue(valueSources, value);
 
-    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(inaccessibleSpec.inaccessibleDirectiveSpec.name);
+    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(this.inaccessibleSpec.inaccessibleDirectiveSpec.name);
     const isInaccessible = inaccessibleInSupergraph && value.hasAppliedDirective(inaccessibleInSupergraph.definition);
     // The merging strategy depends on the enum type usage:
     //  - if it is _only_ used in position of Input type, we merge it with an "intersection" strategy (like other input types/things).
@@ -2038,7 +2061,7 @@ class Merger {
   }
 
   private addJoinEnumValue(sources: (EnumValue | undefined)[], dest: EnumValue) {
-    const joinEnumValueDirective = joinSpec.enumValueDirective(this.merged);
+    const joinEnumValueDirective = this.joinSpec.enumValueDirective(this.merged);
     // We should always be merging with the latest join spec, so this should exists, but well, in prior versions where
     // the directive didn't existed, we simply did had any replacement so ...
     if (!joinEnumValueDirective) {
@@ -2080,7 +2103,7 @@ class Merger {
   }
 
   private mergeInput(sources: (InputObjectType | undefined)[], dest: InputObjectType) {
-    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(inaccessibleSpec.inaccessibleDirectiveSpec.name);
+    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(this.inaccessibleSpec.inaccessibleDirectiveSpec.name);
 
     // Like for other inputs, we add all the fields found in any subgraphs initially as a simple mean to have a complete list of
     // field to iterate over, but we will remove those that are not in all subgraphs.
@@ -2355,7 +2378,7 @@ class Merger {
   // is @inaccessible, which is necessary to exist in the supergraph for EnumValues to properly
   // determine whether the fact that a value is both input / output will matter
   private recordAppliedDirectivesToMerge(sources: (SchemaElement<any, any> | undefined)[], dest: SchemaElement<any, any>) {
-    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(inaccessibleSpec.inaccessibleDirectiveSpec.name);
+    const inaccessibleInSupergraph = this.mergedFederationDirectiveInSupergraph.get(this.inaccessibleSpec.inaccessibleDirectiveSpec.name);
     const inaccessibleName = inaccessibleInSupergraph?.definition.name;
     const names = this.gatherAppliedDirectiveNames(sources);
 

--- a/internals-js/src/directiveAndTypeSpecification.ts
+++ b/internals-js/src/directiveAndTypeSpecification.ts
@@ -22,7 +22,7 @@ import { valueEquals, valueToString } from "./values";
 import { sameType } from "./types";
 import { arrayEquals, assert } from "./utils";
 import { ArgumentCompositionStrategy } from "./argumentCompositionStrategies";
-import { FeatureDefinition } from "./coreSpec";
+import { FeatureDefinition, FeatureVersion } from "./coreSpec";
 
 export type DirectiveSpecification = {
   name: string,
@@ -31,7 +31,7 @@ export type DirectiveSpecification = {
 }
 
 export type DirectiveCompositionSpecification = {
-  supergraphSpecification: () => FeatureDefinition,
+  supergraphSpecification: (federationVersion: FeatureVersion) => FeatureDefinition,
   argumentsMerger?: (schema: Schema) => ArgumentMerger | GraphQLError,
 }
 
@@ -80,7 +80,7 @@ export function createDirectiveSpecification({
   repeatable?: boolean,
   args?: DirectiveArgumentSpecification[],
   composes?: boolean,
-  supergraphSpecification?: () => FeatureDefinition,
+  supergraphSpecification?: (fedVersion: FeatureVersion) => FeatureDefinition,
 }): DirectiveSpecification {
   let composition: DirectiveCompositionSpecification | undefined = undefined;
   if (composes) {

--- a/internals-js/src/federationSpec.ts
+++ b/internals-js/src/federationSpec.ts
@@ -116,7 +116,7 @@ export class FederationSpecDefinition extends FeatureDefinition {
       repeatable: version >= (new FeatureVersion(2, 2)),
     }));
 
-    this.registerDirective(INACCESSIBLE_VERSIONS.latest().inaccessibleDirectiveSpec);
+    this.registerDirective(INACCESSIBLE_VERSIONS.getMinimumRequiredVersion(version).inaccessibleDirectiveSpec);
 
     this.registerDirective(createDirectiveSpecification({
       name: FederationDirectiveName.OVERRIDE,

--- a/internals-js/src/inaccessibleSpec.ts
+++ b/internals-js/src/inaccessibleSpec.ts
@@ -39,8 +39,8 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
   public readonly inaccessibleDirectiveSpec: DirectiveSpecification;
   private readonly printedInaccessibleDefinition: string;
 
-  constructor(version: FeatureVersion) {
-    super(new FeatureUrl(inaccessibleIdentity, 'inaccessible', version));
+  constructor(version: FeatureVersion, firstFedVersion?: FeatureVersion) {
+    super(new FeatureUrl(inaccessibleIdentity, 'inaccessible', version), firstFedVersion);
     this.inaccessibleLocations = [
       DirectiveLocation.FIELD_DEFINITION,
       DirectiveLocation.OBJECT,
@@ -63,7 +63,7 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
       name: 'inaccessible',
       locations: this.inaccessibleLocations,
       composes: true,
-      supergraphSpecification: () => INACCESSIBLE_VERSIONS.latest(),
+      supergraphSpecification: (fedVersion) => INACCESSIBLE_VERSIONS.getMinimumRequiredVersion(fedVersion),
     });
     this.registerDirective(this.inaccessibleDirectiveSpec);
   }
@@ -95,7 +95,7 @@ export class InaccessibleSpecDefinition extends FeatureDefinition {
 
 export const INACCESSIBLE_VERSIONS = new FeatureDefinitions<InaccessibleSpecDefinition>(inaccessibleIdentity)
   .add(new InaccessibleSpecDefinition(new FeatureVersion(0, 1)))
-  .add(new InaccessibleSpecDefinition(new FeatureVersion(0, 2)));
+  .add(new InaccessibleSpecDefinition(new FeatureVersion(0, 2), new FeatureVersion(2, 4)));
 
 registerKnownFeature(INACCESSIBLE_VERSIONS);
 

--- a/internals-js/src/joinSpec.ts
+++ b/internals-js/src/joinSpec.ts
@@ -31,8 +31,8 @@ function sanitizeGraphQLName(name: string) {
 }
 
 export class JoinSpecDefinition extends FeatureDefinition {
-  constructor(version: FeatureVersion) {
-    super(new FeatureUrl(joinIdentity, 'join', version));
+  constructor(version: FeatureVersion, firstFedVersion?: FeatureVersion) {
+    super(new FeatureUrl(joinIdentity, 'join', version), firstFedVersion);
   }
 
   private isV01() {
@@ -220,6 +220,6 @@ export class JoinSpecDefinition extends FeatureDefinition {
 export const JOIN_VERSIONS = new FeatureDefinitions<JoinSpecDefinition>(joinIdentity)
   .add(new JoinSpecDefinition(new FeatureVersion(0, 1)))
   .add(new JoinSpecDefinition(new FeatureVersion(0, 2)))
-  .add(new JoinSpecDefinition(new FeatureVersion(0, 3)));
+  .add(new JoinSpecDefinition(new FeatureVersion(0, 3), new FeatureVersion(2,4)));
 
 registerKnownFeature(JOIN_VERSIONS);

--- a/internals-js/src/tagSpec.ts
+++ b/internals-js/src/tagSpec.ts
@@ -13,8 +13,8 @@ export class TagSpecDefinition extends FeatureDefinition {
   public readonly tagDirectiveSpec: DirectiveSpecification;
   private readonly printedTagDefinition: string;
 
-  constructor(version: FeatureVersion) {
-    super(new FeatureUrl(tagIdentity, 'tag', version));
+  constructor(version: FeatureVersion, firstFedVersion?: FeatureVersion) {
+    super(new FeatureUrl(tagIdentity, 'tag', version), firstFedVersion);
     this.tagLocations = [
       DirectiveLocation.FIELD_DEFINITION,
       DirectiveLocation.OBJECT,
@@ -43,7 +43,7 @@ export class TagSpecDefinition extends FeatureDefinition {
       repeatable: true,
       args: [{ name: 'name', type: (schema) => new NonNullType(schema.stringType()) }],
       composes: true,
-      supergraphSpecification: () => TAG_VERSIONS.latest(),
+      supergraphSpecification: (fedVersion) => TAG_VERSIONS.getMinimumRequiredVersion(fedVersion),
     });
     this.registerDirective(this.tagDirectiveSpec);
   }
@@ -77,6 +77,6 @@ export class TagSpecDefinition extends FeatureDefinition {
 export const TAG_VERSIONS = new FeatureDefinitions<TagSpecDefinition>(tagIdentity)
   .add(new TagSpecDefinition(new FeatureVersion(0, 1)))
   .add(new TagSpecDefinition(new FeatureVersion(0, 2)))
-  .add(new TagSpecDefinition(new FeatureVersion(0, 3)));
+  .add(new TagSpecDefinition(new FeatureVersion(0, 3), new FeatureVersion(2, 4)));
 
 registerKnownFeature(TAG_VERSIONS);

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -431,3 +431,12 @@ export function isNonEmptyArray<T>(array: T[]): array is NonEmptyArray<T> {
   return array.length > 0;
 }
 
+export function findLast<T>(array: T[], predicate: (t: T) => boolean): T | undefined {
+  for (let i = array.length - 1; i >= 0; i--) {
+    const t = array[i];
+    if (predicate(t)) {
+      return t;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Important points
- We get the the version of any core feature implied by that version of federation, unless there has been a major version bump
- If there has been a major version bump of the core spec, we get the minimum required version that matches the major version of latest

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
