### PR TITLE
Resolve `Promise` references for interface types before handing off to `resolveType` fn

### DIFF
--- a/.changeset/weak-dryers-sort.md
+++ b/.changeset/weak-dryers-sort.md
@@ -1,0 +1,21 @@
+---
+"@apollo/subgraph": patch
+---
+
+Resolve `Promise` references before calling `__resolveType` on interface
+
+Since the introduction of entity interfaces, users could not return
+a `Promise` from `__resolveReference` while implementing a synchronous,
+custom `__resolveType` function. This change fixes/permits this use case.
+
+Additional background / implementation details:
+
+Returning a `Promise` from `__resolveReference` has historically never
+been an issue. However, with the introduction of entity interfaces, the
+calling of an interface's `__resolveType` function became a new concern.
+
+`__resolveType` functions expect a reference (and shouldn't be concerned
+with whether those references are wrapped in a `Promise`). In order to
+address this, we can `await` the reference before calling the
+`__resolveType` (this handles both the non-`Promise` and `Promise` case).
+  

--- a/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
@@ -429,12 +429,16 @@ describe('buildSubgraphSchema', () => {
         contextValue: null,
         variableValues: variables,
       });
-      expect(errors).toMatchInlineSnapshot(`
-        Array [
-          [GraphQLError: Could not resolve type, received: [object Promise]],
-        ]
+      expect(errors).toBeUndefined();
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "_entities": Array [
+            Object {
+              "name": "My book",
+            },
+          ],
+        }
       `);
-      expect(data).toMatchInlineSnapshot(`null`);
     });
   });
 

--- a/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
@@ -373,6 +373,69 @@ describe('buildSubgraphSchema', () => {
       expect(errors).toBeUndefined();
       expect((data as any)?._entities[0].name).toEqual('Apollo Gateway');
     });
+
+    it('correctly resolves Promise values from `resolveReference` for `resolveType`', async () => {
+      const query = `#graphql
+        query ($representations: [_Any!]!) {
+          _entities(representations: $representations) {
+            ... on Product {
+              name
+            }
+          }
+        }
+      `;
+
+      const variables = {
+        representations: [{ __typename: 'Product', id: 1 }],
+      };
+
+      const schema = buildSubgraphSchema([
+        {
+          typeDefs: gql`
+            extend schema
+              @link(
+                url: "https://specs.apollo.dev/federation/v2.4"
+                import: ["@key"]
+              )
+            interface Product @key(fields: "id") {
+              id: ID!
+              name: String
+            }
+            type Book implements Product @key(fields: "id") {
+              id: ID!
+              name: String
+              author: String!
+            }
+          `,
+          resolvers: {
+            Product: {
+              async __resolveReference() {
+                return { id: '1', name: 'My book', author: 'Author' };
+              },
+              __resolveType(ref) {
+                if ('author' in ref) return 'Book';
+                throw new Error(
+                  'Could not resolve type, received: ' + ref.toString(),
+                );
+              },
+            },
+          },
+        },
+      ]);
+      const { data, errors } = await graphql({
+        schema,
+        source: query,
+        rootValue: null,
+        contextValue: null,
+        variableValues: variables,
+      });
+      expect(errors).toMatchInlineSnapshot(`
+        Array [
+          [GraphQLError: Could not resolve type, received: [object Promise]],
+        ]
+      `);
+      expect(data).toMatchInlineSnapshot(`null`);
+    });
   });
 
   describe('_service root field', () => {

--- a/subgraph-js/src/types.ts
+++ b/subgraph-js/src/types.ts
@@ -134,7 +134,7 @@ function ensureValidRuntimeType(
   return runtimeType;
 }
 
-function withResolvedType<T>({
+async function withResolvedType<T>({
   type,
   value,
   context,
@@ -146,9 +146,9 @@ function withResolvedType<T>({
   context: any,
   info: GraphQLResolveInfo,
   callback: (runtimeType: GraphQLObjectType) => PromiseOrValue<T>,
-}): PromiseOrValue<T> {
+}): Promise<T> {
   const resolveTypeFn = type.resolveType ?? defaultTypeResolver;
-  const runtimeType = resolveTypeFn(value, context, info, type);
+  const runtimeType = resolveTypeFn(await value, context, info, type);
   if (isPromise(runtimeType)) {
     return runtimeType.then((name) => (
       callback(ensureValidRuntimeType(name, info.schema, type, value))


### PR DESCRIPTION
Fixes #2552

Commits in order first reproduce the issue then resolve it.

Interface entities are a relatively new thing, but I'm surprised this hasn't surfaced yet since it seems like it'd be a showstopper for anyone trying to use it. If my understanding of the issue is correct, this seems like a reasonable solution... though it's possible the _issue_ is wrong.

FWIW, none of our `__resolveReference` functions in tests return `Promise`s, it might be more realistic if they did.