### PR TITLE
Fix assertion error on some multi-field `@requires` dependencies

### DIFF
--- a/.changeset/shaggy-crews-repair.md
+++ b/.changeset/shaggy-crews-repair.md
@@ -1,0 +1,11 @@
+---
+"@apollo/query-planner": patch
+---
+
+Fix potential assertion error during query planning in some multi-field `@requires` case. This error could be triggered
+when a field in a `@requires` depended on another field that was also part of that same requires (for instance, if a
+field has a `@requires(fields: "id otherField")` and that `id` is also a key necessary to reach the subgraph providing
+`otherField`).
+
+The assertion error thrown in that case contained the message `Root groups (...) should have no remaining groups unhandled (...)`
+  


### PR DESCRIPTION
When handling a `@requires`, the code gathers what it expected to be the set of "fetch groups" needed to fulfill the requirement, but in the rare cases, the same group can be added multiple times and in that case it was not de-duplicated. This duplication was unexpected by the rest of the code, ultimately leading to triggering an assertion.

This would happen when a `@requires` was on multiple fields, and one of those field was also a condition (say a key) for another of the required field.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
