### PR TITLE
Start running `graphql-http` spec test suite against gateway

### DIFF
--- a/gateway-js/src/__tests__/httpSpec.test.ts
+++ b/gateway-js/src/__tests__/httpSpec.test.ts
@@ -12,7 +12,6 @@ describe('httpSpecTests.ts', () => {
   beforeAll(async () => {
     gatewayServer = new ApolloServer({
       gateway: new ApolloGateway({
-        // serviceList: [{ name: 'subgraph', url: subgraphUrl }],
         supergraphSdl: getTestingSupergraphSdl()
       }),
       // The test doesn't know we should send apollo-require-preflight along

--- a/gateway-js/src/__tests__/httpSpec.test.ts
+++ b/gateway-js/src/__tests__/httpSpec.test.ts
@@ -1,0 +1,77 @@
+import { serverAudits } from 'graphql-http';
+import fetch from 'node-fetch';
+import { ApolloGateway } from '..';
+import { ApolloServer } from '@apollo/server';
+import { startStandaloneServer } from '@apollo/server/standalone';
+import { getTestingSupergraphSdl } from './execution-utils';
+
+describe('httpSpecTests.ts', () => {
+  let gatewayServer: ApolloServer;
+  let gatewayUrl: string;
+
+  beforeAll(async () => {
+    gatewayServer = new ApolloServer({
+      gateway: new ApolloGateway({
+        // serviceList: [{ name: 'subgraph', url: subgraphUrl }],
+        supergraphSdl: getTestingSupergraphSdl()
+      }),
+      // The test doesn't know we should send apollo-require-preflight along
+      // with GETs. We could override `fetchFn` to add it but this seems simple enough.
+      csrfPrevention: false,
+    });
+    ({ url: gatewayUrl } = await startStandaloneServer(gatewayServer, {
+      listen: { port: 0 },
+    }));
+  });
+
+  afterAll(async () => {
+    await gatewayServer.stop();
+  });
+
+  for (const audit of serverAudits({
+    url: () => gatewayUrl,
+    fetchFn: fetch,
+  })) {
+    test(audit.name, async () => {
+      const result = await audit.fn();
+
+      if (result.status === 'ok') {
+        return;
+      }
+      if (result.status === 'error') {
+        throw new Error(result.reason);
+      }
+
+      if (result.status !== 'warn') {
+        throw new Error(`unknown status ${result.status}`);
+      }
+
+      // We failed an optional audit. That's OK, but let's make sure it's
+      // one of the ones we expect to fail!
+
+      // The spec has a bunch of optional suggestions which say that you
+      // should use 200 rather than 400 for various errors unless opting in to
+      // the new application/graphql-response+json response type. That's based
+      // on the theory that "400 + application/json" might come from some
+      // random proxy layer rather than an actual GraphQL processor and so it
+      // shouldn't be relied on. (It *does* expect you to use 400 for these
+      // errors when returning `application/graphql-response+json`, and we
+      // pass those tests.) For now, we ignore these optional failures but we
+      // should fix them in the next major version.
+      const expectedWarning400InsteadOf200Ids = [
+        '572B', // SHOULD use 200 status code on document parsing failure when accepting application/json
+        'FDE2', // SHOULD use 200 status code on validation failure when accepting application/json
+        '7B9B', // SHOULD use a status code of 200 on variable coercion failure when accepting application/json
+      ];
+
+      if (
+        expectedWarning400InsteadOf200Ids.includes(audit.id) &&
+        result.response.status === 400
+      ) {
+        return;
+      }
+
+      throw new Error(result.reason);
+    });
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "bunyan": "1.8.15",
         "cspell": "6.31.1",
         "graphql": "16.6.0",
+        "graphql-http": "1.18.0",
         "graphql-tag": "2.12.6",
         "jest": "29.5.0",
         "jest-config": "29.5.0",
@@ -8336,6 +8337,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.18.0.tgz",
+      "integrity": "sha512-r2sIo6jCTQi1aj7s+Srg7oU3+r5pUUgxgDD5JDZOmFzrbXVGz+yMhIKhvqW0cV10DcnVIFCOzuFuc1qvnjJ7yQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/graphql-request": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "bunyan": "1.8.15",
     "cspell": "6.31.1",
     "graphql": "16.6.0",
+    "graphql-http": "1.18.0",
     "graphql-tag": "2.12.6",
     "jest": "29.5.0",
     "jest-config": "29.5.0",


### PR DESCRIPTION
This PR adds an additional test suite against the gateway provided by the `graphql-http` package. This suite enforces the spec laid out by the GraphQL over HTTP working group.

https://graphql.github.io/graphql-over-http/draft/
https://github.com/graphql/graphql-http

Note that a couple of the tests failures are intentionally skipped/ignored. This is fine, they are "SHOULD"s in the spec and we should only make an error code change in a major version.