### PR TITLE
Exposes `debug.maxEvaluatedPlans` planning config

### DIFF
--- a/.changeset/nasty-panthers-chew.md
+++ b/.changeset/nasty-panthers-chew.md
@@ -1,0 +1,9 @@
+---
+"@apollo/query-planner": minor
+---
+
+Adds `debug.maxEvaluatedPlans` query planning configuration options. This option limits the maximum number of query plan
+that may have to be evaluated during a query planning phase, thus capping the maximum query planning runtime, but at the
+price of potentially reducing the optimality of the generated query plan (which may mean slower query executions). This
+option is exposed for debugging purposes, but it is recommended to rely on the default in production.
+  

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -401,7 +401,7 @@ export function printHumanReadableList(
 }
 
 export type Concrete<Type> = {
-  [Property in keyof Type]-?: Type[Property];
+  [Property in keyof Type]-?: Concrete<Type[Property]>;
 };
 
 // for use with Array.filter

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -558,9 +558,7 @@ class QueryPlanningTraversal<RV extends Vertex> {
     debug.log(() => `Query has ${planCount} possible plans`);
 
     let firstBranch = this.closedBranches[0];
-    // Note: typing is not able to know that `maxEvaluatedPlans` is guaranteed to be set here, but it is
-    // due to early call to `enforceQueryPlannerConfigDefaults`.
-    const maxPlansToCompute = this.parameters.config.debug.maxEvaluatedPlans!;
+    const maxPlansToCompute = this.parameters.config.debug.maxEvaluatedPlans;
     while (planCount > maxPlansToCompute && firstBranch.length > 1) {
       // we remove the right-most option of the first branch, and them move that branch to it's new place.
       const prevSize = firstBranch.length;
@@ -1331,7 +1329,7 @@ class FetchGroup {
   }
 
   toPlanNode(
-    queryPlannerConfig: QueryPlannerConfig,
+    queryPlannerConfig: Concrete<QueryPlannerConfig>,
     handledConditions: Conditions,
     variableDefinitions: VariableDefinitions,
     fragments?: RebasedFragments,
@@ -3320,7 +3318,7 @@ function fetchGroupToPlanProcessor({
   operationName,
   assignedDeferLabels,
 }: {
-  config: QueryPlannerConfig,
+  config: Concrete<QueryPlannerConfig>,
   variableDefinitions: VariableDefinitions,
   fragments?: RebasedFragments,
   operationName?: string,

--- a/query-planner-js/src/config.ts
+++ b/query-planner-js/src/config.ts
@@ -110,9 +110,9 @@ export function enforceQueryPlannerConfigDefaults(
 }
 
 export function validateQueryPlannerConfig(
-  config: QueryPlannerConfig,
+  config: Concrete<QueryPlannerConfig>,
 ) {
-  if (config.debug?.maxEvaluatedPlans !== undefined && config.debug?.maxEvaluatedPlans < 1) {
+  if (config.debug.maxEvaluatedPlans < 1) {
     throw new Error(`Invalid value for query planning configuration "debug.maxEvaluatedPlans"; expected a number >= 1 but got ${config.debug.maxEvaluatedPlans}`);
   }
 }


### PR DESCRIPTION
So far, the maximum number of query plan evaluated (above which the query planning eliminate choices to evaluated, thus potentially reducing the generated plan quality) has only be hard-coded. This exposes a config option to set that cap, mostly to help debugging query planning runtime issues.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
