### PR TITLE
Fix assertion error with overlapping fragments and subtyping

### DIFF
--- a/.changeset/brave-dryers-drop.md
+++ b/.changeset/brave-dryers-drop.md
@@ -1,0 +1,9 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+---
+
+Fix assertion error in some overlapping fragment cases. In some cases, when fragments overlaps on some sub-selections
+and some interface field implementation relied on sub-typing, an assertion error could be raised with a message of
+the form `Cannot add selection of field X to selection set of parent type Y` and this fixes this problem.
+  


### PR DESCRIPTION
When checking for name fragments to reuse, when some fields implementing interfaces use subtyping (meaning that the type of the field implementation is a sub-type of the type declared for that field in the interface), an assertion error of the form `Cannot add selection of field X to selection set of parent type Y` was sometimes raised (see the comments in the commit for mode details).

Fixes #2592.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
