### PR TITLE
Fix possible fragment-related assertion error during query planning.

### DIFF
--- a/.changeset/tender-bears-call.md
+++ b/.changeset/tender-bears-call.md
@@ -1,0 +1,9 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+---
+
+Fix possible fragment-related assertion error during query planning. This prevents a rare case where an assertion with a
+message of the form `Cannot add fragment of condition X (runtimes: ...) to parent type Y (runtimes: ...)` could fail
+during query planning.
+  

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -71,13 +71,13 @@ describe('fragments optimization', () => {
         b: Int
       }
 
-      type T1 {
+      type T1 implements I {
         a: Int
         b: Int
         u: U
       }
 
-      type T2 {
+      type T2 implements I {
         x: String
         y: String
         b: Int


### PR DESCRIPTION
The assertion throw had message of the form `Cannot add fragment of condition X (runtimes: ...) to parent type Y (runtimes: ...)` and was due to not always properly maintaining the "parent type" information when fragment spreads expanding into some other spread.

Additionally, this commit fixes a small issue in the code computing the "diff" of what remains in a selection set after a fragment has be "reused", which could lead to inefficient (and weird looking) selections in fetches.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
