### PR TITLE
Tweak managed fed docs to decommission duplicates in router

### DIFF
--- a/docs/source/managed-federation/federated-schema-checks.mdx
+++ b/docs/source/managed-federation/federated-schema-checks.mdx
@@ -2,7 +2,7 @@
 title: Federated schema checks
 ---
 
-> For an introduction to schema checks, see [Schema checks](https://www.apollographql.com/docs/studio/schema-checks/).
+> For an introduction to schema checks, see [Schema checks](/graphos/delivery/schema-checks/).
 
 Whenever you make changes to a subgraph schema, running `rover subgraph check` helps ensure that _all_ your subgraph schemas still compose to a valid supergraph schema. This helps teams work independently on their portion of your federated graph without negatively affecting your users or other teams.
 
@@ -22,7 +22,7 @@ There are two types of failures that can occur during validation: failed usage c
 
 In _most_ cases, you should run `rover subgraph publish` only after a successful run of `rover subgraph check`. However, certain workflows require intentionally publishing a subgraph schema that fails composition (such as [migrating an entity or field between subgraphs](../entities-advanced/#migrating-entities-and-fields)).
 
-Even after `rover subgraph check` succeeds, however, it's possible that `rover subgraph publish` encounters composition errors because of simultaneous changes to _another_ subgraph. When this occurs, your subgraph's registered schema is still updated as long as it is spec-compliant. However, **the supergraph schema is not updated**. This means that your gateway's configuration is _also_ not updated.
+Even after `rover subgraph check` succeeds, however, it's possible that `rover subgraph publish` encounters composition errors because of simultaneous changes to _another_ subgraph. When this occurs, your subgraph's registered schema is still updated as long as it is spec-compliant. However, **the supergraph schema is not updated**. This means that your router's configuration is _also_ not updated.
 
 An example output of this behavior looks like this:
 
@@ -41,4 +41,4 @@ There can be only one type named "Book".
 
 The reasoning behind this functionality is that the Apollo schema registry should always reflect what is running in your infrastructure. Even if that means that composition is failing in your infrastructure, the registry should reflect that.
 
-However, you still want your gateway to function as it was before the most recent deployment. Additionally, this functionality can be used to make dependent changes, like smoothly migrating a field from one subgraph to another or introducing a circular dependency.
+However, you still want your router to function as it was before the most recent deployment. Additionally, this functionality can be used to make dependent changes, like smoothly migrating a field from one subgraph to another or introducing a circular dependency.

--- a/docs/source/managed-federation/overview.mdx
+++ b/docs/source/managed-federation/overview.mdx
@@ -11,13 +11,13 @@ On composition success, GraphOS updates your supergraph's latest configuration, 
 ```mermaid
 graph LR;
   subgraph "Your infrastructure"
-  serviceA[Products subgraph];
-  serviceB[Reviews subgraph];
+  serviceA[Products<br/>subgraph];
+  serviceB[Reviews<br/>subgraph];
   router([Router]);
   end
   subgraph "Apollo GraphOS"
-    registry{{Schema Registry}};
-    uplink{{Uplink}}
+    registry{{Apollo Schema<br/>Registry}};
+    uplink{{Apollo<br/>Uplink}}
   end
   serviceA & serviceB -->|Publishes<br/>schema| registry;
   registry -->|Updates<br/>config| uplink;

--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -3,30 +3,65 @@ title: Setting up managed federation
 ---
 
 import ObtainGraphApiKey from '../../shared/obtain-graph-api-key.mdx';
-import RegisterFederatedCli from '../../shared/register-federated-cli.mdx';
 
-This article describes how to set up Apollo Studio for a graph that uses Apollo Federation.
+This article describes how to connect your supergraph to [Apollo GraphOS](/graphos/) to enable managed federation features.
 
-> As with all changes, you should first set up managed federation in a non-production environment, such as staging. To support this, you can use [variants](https://www.apollographql.com/docs/studio/schema/registry/#managing-environments-with-variants), which are distinct versions of the same graph for different environments.
+> As with all changes, you should first set up managed federation in a non-production environment, such as staging. To support this, you can create multiple [variants](/graphos/graphs/#variants) of your supergraph in GraphOS Studio. Each variant represents a distinct version of the same graph for different environments.
 
 ## 1. Get started
 
-If you haven't yet, complete the first two steps from the Apollo Studio getting started guide:
+First, complete the **Set up Apollo tools** step from [this tutorial](/graphos/quickstart/self-hosted#1-set-up-apollo-tools), including:
 
-1. [Create your account](https://www.apollographql.com/docs/studio/getting-started/#1-create-your-account)
-2. [Create your first graph](https://www.apollographql.com/docs/studio/getting-started/#2-create-your-first-graph)
+- Creating an Apollo account
+- Creating a graph in Studio
+- Installing and authenticating the Rover CLI
 
-> In the [Register your schema](https://www.apollographql.com/docs/studio/getting-started/#3-register-your-schema) step, make sure you follow the instructions for a GraphQL server that uses Apollo Federation.
+Then return here.
 
-## 2. Register all subgraph schemas
+## 2. Publish all subgraph schemas
 
-<RegisterFederatedCli />
+In a supergraph architecture, each of your [subgraphs](../building-supergraphs/subgraphs-overview/) uses the Rover CLI to publish its schema to GraphOS:
 
-## 3. Modify the gateway (if necessary)
+```mermaid
+graph LR;
+  subgraph " "
+  router([Router]);
+  subgraphA[Products subgraph];
+  subgraphB[Reviews subgraph];
+  subgraphC[Inventory subgraph];
+  end
+  registry{{GraphOS<br/>Schema Registry}};
+  router --- subgraphA & subgraphB & subgraphC;
+  subgraphA & subgraphB & subgraphC -.->|<code>rover subgraph publish</code>| registry;
+  class registry secondary;
+```
 
-> This section assumes you are using Apollo Server with the `@apollo/gateway` library as your gateway.
+**Do the following for each of your subgraphs**:
 
-If you've already set up Apollo Federation _without_ Apollo Studio, the constructor of your `ApolloGateway` instance probably includes a `supergraphSdl` option, like this:
+1. Obtain the following values, which are required for the `rover subgraph publish` command:
+
+    * The name that uniquely identifies the subgraph within your graph (e.g., `products`).
+    * The URL that your router will use to communicate with the subgraph (e.g., `http://products-graphql.svc.cluster.local:4001/`).
+
+2. Run the `rover subgraph publish` command, providing it your subgraph's schema in one of the ways shown:
+
+    ```bash
+    # Provide a local .graphql file path
+    rover subgraph publish my-graph@my-variant --name products --routing-url http://products-graphql.svc.cluster.local:4001/ --schema ./schema.graphql 
+
+    # Provide an introspection result via stdin
+    rover subgraph introspect http://localhost:4000 | rover subgraph publish my-graph@my-variant --name products --routing-url http://products-graphql.svc.cluster.local:4001/ --schema -
+    ```
+
+As you register your subgraph schemas, the schema registry attempts to **compose** their latest versions into a single **supergraph schema**. Whenever composition succeeds, your managed router can fetch the latest supergraph schema from GraphOS.
+
+You can also manually fetch your latest supergraph schema with the `rover supergraph fetch` command, or retrieve it from your graph's **Schema > SDL** tab in GraphOS Studio.
+
+## 3. Modify your router's startup command
+
+<ExpansionPanel title="Using Apollo Gateway?">
+
+If you've already set up Apollo Federation _without_ conneting your gateway to GraphOS, the constructor of your `ApolloGateway` instance probably includes a `supergraphSdl` option, like this:
 
 ```js {2}
 const gateway = new ApolloGateway({
@@ -36,7 +71,7 @@ const gateway = new ApolloGateway({
 
 This option is specific to _non_-managed federation, in which supergraph schema composition is performed via the Rover CLI.
 
-With managed federation, composition is instead performed by _Apollo_, and the gateway regularly polls Apollo for an updated schema. This enables you to add, remove, and modify your subgraphs _without_ needing to restart your gateway.
+With managed federation, composition is instead performed by _GraphOS_, and the gateway regularly polls for an updated schema. This enables you to add, remove, and modify your subgraphs _without_ needing to restart your gateway.
 
 Remove the `supergraphSdl` argument from your `ApolloGateway` constructor entirely:
 
@@ -44,27 +79,41 @@ Remove the `supergraphSdl` argument from your `ApolloGateway` constructor entire
 const gateway = new ApolloGateway();
 ```
 
-## 4. Connect the gateway to Studio
+> When running your gateway in an environment where outbound traffic to the internet is restricted, consult the [directions for configuring a proxy](/apollo-server/security/proxy-configuration) within Apollo Server.
 
-Like your subgraphs, your gateway uses a graph API key to identify itself to Studio.
+</ExpansionPanel>
+
+If you've already set up Apollo Federation _without_ connecting your router to GraphOS, you're probably passing the `--supergraph` (or `-s`) option to the Apollo Router's startup command:
+
+```sh
+./router --config ./router.yaml --supergraph ./your-local-supergraph.graphql
+```
+
+The `--supergraph` option is specific to _non_-managed federation, in which supergraph schema composition is performed via the Rover CLI and provided via a file path.
+
+_Remove_ the `--supergraph` option (but leave `--config` if it's present):
+
+```sh
+./router --config ./router.yaml
+```
+
+> With managed federation, composition is instead performed by _GraphOS_, and the router regularly polls for an updated schema. This enables you to add, remove, and modify your subgraphs _without_ needing to restart your router.
+
+
+## 4. Connect your router to GraphOS
+
+Like your subgraphs, your router uses a graph API key to identify itself to GraphOS.
 
 <ObtainGraphApiKey />
 
-After obtaining your graph API key, you set two environment variables in your gateway's environment. If you're using a `.env` file with a library like [`dotenv`](https://www.npmjs.com/package/dotenv), those environment variables look like this:
+After obtaining your graph API key, you set the following environment variables in your router's environment:
 
-```sh title=".env"
-APOLLO_KEY=<YOUR_GRAPH_API_KEY>
-APOLLO_GRAPH_REF=<YOUR_GRAPH_ID>@<VARIANT>
-```
+- `APOLLO_KEY` (set this to your graph API key)
+- `APOLLO_GRAPH_REF`
+    - This variable tells the router which variant of which graph to use (for example, `docs-example-graph@production`). You can find your variant's graph ref at the very top of its README page in GraphOS Studio.
 
-You can also set this value directly in the command you use to start your gateway.
+## 5. Deploy the modified router
 
-The `APOLLO_GRAPH_REF` environment variable tells the gateway which variant of which graph to use (for example, `my-graph-id@production`). You can find your variant's graph ref at the very top of its README page in Studio.
+You can now deploy your modified router to begin fetching your supergraph schema from GraphOS instead of using a locally generated one.
 
-> When running your gateway in an environment where outbound traffic to the internet is restricted, consult the [directions for configuring a proxy](/apollo-server/security/proxy-configuration) within Apollo Server.
-
-## 5. Deploy the modified gateway
-
-You can now deploy your modified gateway to begin fetching your federated schema from Studio instead of directly from your subgraphs.
-
-On startup, your gateway will use its API key to fetch its federation config from Apollo. It can then begin executing operations across your subgraphs.
+On startup, your router will use its API key to fetch its federation config from GraphOS. It can then begin executing operations across your subgraphs.

--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -61,7 +61,7 @@ You can also manually fetch your latest supergraph schema with the `rover superg
 
 <ExpansionPanel title="Using Apollo Gateway?">
 
-If you've already set up Apollo Federation _without_ conneting your gateway to GraphOS, the constructor of your `ApolloGateway` instance probably includes a `supergraphSdl` option, like this:
+If you've already set up Apollo Federation _without_ connecting your gateway to GraphOS, the constructor of your `ApolloGateway` instance probably includes a `supergraphSdl` option, like this:
 
 ```js {2}
 const gateway = new ApolloGateway({
@@ -114,6 +114,4 @@ After obtaining your graph API key, you set the following environment variables 
 
 ## 5. Deploy the modified router
 
-You can now deploy your modified router to begin fetching your supergraph schema from GraphOS instead of using a locally generated one.
-
-On startup, your router will use its API key to fetch its federation config from GraphOS. It can then begin executing operations across your subgraphs.
+You can now deploy your modified router, which will fetch its supergraph schema from GraphOS on startup. It can then begin executing operations across your subgraphs.


### PR DESCRIPTION
We duplicate some managed federation content in the Router docs. These updates fold in changes made on the Router side so that we can decommission those duplicates