### PR TITLE
changing debug.maxEvaluatedPlans changeset to patch release

### DIFF
--- a/.changeset/nasty-panthers-chew.md
+++ b/.changeset/nasty-panthers-chew.md
@@ -1,5 +1,5 @@
 ---
-"@apollo/query-planner": minor
+"@apollo/query-planner": patch
 ---
 
 Adds `debug.maxEvaluatedPlans` query planning configuration options. This option limits the maximum number of query plan


### PR DESCRIPTION
So we can release 2.4.6 instead of 2.5.0