### PR TITLE
Query planning performance improvements

### DIFF
--- a/.changeset/friendly-lies-protect.md
+++ b/.changeset/friendly-lies-protect.md
@@ -1,0 +1,8 @@
+---
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+"@apollo/federation-internals": patch
+---
+
+Improves query planning time in some situations where entities use multiple keys.
+  

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1792,6 +1792,11 @@ export class SelectionSet {
       : ContainsResult.STRICTLY_CONTAINED;
   }
 
+  containsTopLevelField(field: Field): boolean {
+    const selection = this._keyedSelections.get(field.key());
+    return !!selection && selection.element.equals(field);
+  }
+
   /**
    * Returns a selection set that correspond to this selection set but where any of the selections in the
    * provided selection set have been remove.

--- a/query-graphs-js/src/__tests__/graphPath.test.ts
+++ b/query-graphs-js/src/__tests__/graphPath.test.ts
@@ -1,0 +1,216 @@
+import {
+  Field,
+  FieldDefinition,
+  Schema,
+  assert,
+  buildSupergraphSchema,
+} from "@apollo/federation-internals";
+import {
+  GraphPath,
+  OpGraphPath,
+  SimultaneousPathsWithLazyIndirectPaths,
+  advanceSimultaneousPathsWithOperation,
+  createInitialOptions
+} from "../graphPath";
+import { QueryGraph, Vertex, buildFederatedQueryGraph } from "../querygraph";
+import { emptyContext } from "../pathContext";
+import { simpleValidationConditionResolver } from "../conditionsValidation";
+
+function parseSupergraph(subgraphs: number, schema: string): { supergraph: Schema, api: Schema, queryGraph: QueryGraph } {
+  assert(subgraphs >= 1, 'Should have at least 1 subgraph');
+  const header = `
+      schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+      {
+        query: Query
+      }
+
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+      directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+      directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+      scalar join__FieldSet
+
+      scalar link__Import
+
+      enum link__Purpose {
+        SECURITY
+        EXECUTION
+      }
+
+      enum join__Graph {
+        ${[...Array(subgraphs).keys()].map((n) => `S${n+1} @join__graph(name: "S${n+1}", url: "https://S${n+1}")`).join('\n')}
+      }
+
+  `;
+
+  try {
+    const supergraph = buildSupergraphSchema(header + schema)[0];
+    return {
+      supergraph,
+      api: supergraph.toAPISchema(),
+      queryGraph: buildFederatedQueryGraph(supergraph, true),
+    };
+  } catch (e) {
+    throw new Error('Error parsing supergraph schema:\n' + e.toString());
+  }
+}
+
+function createOptions(supergraph: Schema, queryGraph: QueryGraph): SimultaneousPathsWithLazyIndirectPaths<Vertex>[] {
+  // We know we only use `Query` in the supergraph, so there is only that as root.
+  const root = queryGraph.roots()[0];
+  const initialPath: OpGraphPath<Vertex> = GraphPath.create(queryGraph, root);
+  return createInitialOptions(
+    initialPath,
+    emptyContext,
+    simpleValidationConditionResolver({ supergraph, queryGraph }),
+    [],
+    [],
+  );
+}
+
+function field(schema: Schema, coordinate: string): Field {
+  const def = schema.elementByCoordinate(coordinate) as FieldDefinition<any>;
+  return new Field(def);
+}
+
+describe("advanceSimultaneousPathsWithOperation", () => {
+  test("do not use key `x` to fetch `x`", () => {
+    const { supergraph, api, queryGraph } = parseSupergraph(3, `
+       type Query
+         @join__type(graph: S1)
+       {
+          t: T @join__field(graph: S1)
+       }
+
+       type T
+         @join__type(graph: S1)
+         @join__type(graph: S2, key: "otherId")
+         @join__type(graph: S2, key: "id")
+         @join__type(graph: S3, key: "id")
+       {
+          otherId: ID! @join__field(graph: S1) @join__field(graph: S2)
+          id: ID!      @join__field(graph: S2) @join__field(graph: S3)
+       }
+    `);
+
+    // Picking the first initial, the one going to S1
+    const initial = createOptions(supergraph, queryGraph)[0];
+
+    // Then picking `t`, which should be just the one option of picking it in S1 at this point.
+    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"));
+    assert(allAfterT, 'Should have advanced correctly');
+    expect(allAfterT).toHaveLength(1);
+    const afterT = allAfterT[0];
+    expect(afterT.toString()).toBe(`Query(S1) --[t]--> T(S1) (types: [T])`);
+
+    // Checking that, at this point, we technically have 2 options:
+    // 1. we can go to S2 using `otherId`.
+    // 2. we can go to S3 using `id`, assuming we first get `id` from S2 (using `otherId`).
+    const indirect = afterT.indirectOptions(afterT.context, 0);
+    expect(indirect.paths).toHaveLength(2);
+    expect(indirect.paths[0].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ otherId } ⊢ key()]--> T(S2) (types: [T])`);
+    expect(indirect.paths[1].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ id } ⊢ key()]--> T(S3) (types: [T])`);
+
+    const allForId = advanceSimultaneousPathsWithOperation(supergraph, afterT, field(api, "T.id"));
+    assert(allForId, 'Should have advanced correctly');
+
+    // Here, `id` is a direct path from both of our indirect paths. However, it makes no sense to use the 2nd
+    // indirect path above, since the condition to get to `S3` was `id`, and this means another indirect path
+    // is able to get to `id` more directly (the first one in this case).
+    // So ultimately, we should only keep the 1st option.
+    expect(allForId).toHaveLength(1);
+    const forId = allForId[0];
+    expect(forId.toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ otherId } ⊢ key()]--> T(S2) --[id]--> ID(S2)`);
+  });
+
+  test("do not use key containing `x` to fetch `x`", () => {
+    // Similar to the previous test, but the key used is not exactly the fetch field, it only contains
+    // it (but the optimisation should still work).
+    const { supergraph, api, queryGraph } = parseSupergraph(3, `
+       type Query
+         @join__type(graph: S1)
+       {
+          t: T @join__field(graph: S1)
+       }
+
+       type T
+         @join__type(graph: S1)
+         @join__type(graph: S2, key: "otherId")
+         @join__type(graph: S2, key: "id1 id2")
+         @join__type(graph: S3, key: "id1 id2")
+       {
+          otherId: ID! @join__field(graph: S1) @join__field(graph: S2)
+          id1: ID!      @join__field(graph: S2) @join__field(graph: S3)
+          id2: ID!      @join__field(graph: S2) @join__field(graph: S3)
+       }
+    `);
+
+    // Picking the first initial, the one going to S1
+    const initial = createOptions(supergraph, queryGraph)[0];
+
+    // Then picking `t`, which should be just the one option of picking it in S1 at this point.
+    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"));
+    assert(allAfterT, 'Should have advanced correctly');
+    expect(allAfterT).toHaveLength(1);
+    const afterT = allAfterT[0];
+    expect(afterT.toString()).toBe(`Query(S1) --[t]--> T(S1) (types: [T])`);
+
+    // Checking that, at this point, we technically have 2 options:
+    // 1. we can go to S2 using `otherId`.
+    // 2. we can go to S3 using `id1 id2`, assuming we first get `id1 id2` from S2 (using `otherId`).
+    const indirect = afterT.indirectOptions(afterT.context, 0);
+    expect(indirect.paths).toHaveLength(2);
+    expect(indirect.paths[0].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ otherId } ⊢ key()]--> T(S2) (types: [T])`);
+    expect(indirect.paths[1].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ id1 id2 } ⊢ key()]--> T(S3) (types: [T])`);
+
+    const allForId = advanceSimultaneousPathsWithOperation(supergraph, afterT, field(api, "T.id1"));
+    assert(allForId, 'Should have advanced correctly');
+
+    // Here, `id1` is a direct path from both of our indirect paths. However, it makes no sense to use the 2nd
+    // indirect path above, since the condition to get to `S3` was `id1 id2`, which includes `id1`.
+    expect(allForId).toHaveLength(1);
+    const forId = allForId[0];
+    expect(forId.toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ otherId } ⊢ key()]--> T(S2) --[id1]--> ID(S2)`);
+  });
+
+  test("avoids indirect path that needs a key to the same subgraph to validate its condition", () => {
+    const { supergraph, api, queryGraph } = parseSupergraph(2, `
+       type Query
+         @join__type(graph: S1)
+       {
+          t: T @join__field(graph: S1)
+       }
+
+       type T
+         @join__type(graph: S1)
+         @join__type(graph: S2, key: "id1")
+         @join__type(graph: S2, key: "id2")
+       {
+          id1: ID! @join__field(graph: S2)
+          id2: ID! @join__field(graph: S1) @join__field(graph: S2)
+       }
+    `);
+
+    // Picking the first initial, the one going to S1
+    const initial = createOptions(supergraph, queryGraph)[0];
+
+    // Then picking `t`, which should be just the one option of picking it in S1 at this point.
+    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"));
+    assert(allAfterT, 'Should have advanced correctly');
+    expect(allAfterT).toHaveLength(1);
+    const afterT = allAfterT[0];
+    expect(afterT.toString()).toBe(`Query(S1) --[t]--> T(S1) (types: [T])`);
+
+    // Technically, the `id1` key could be used to go to S2 by first getting `id1` from S2 using `id2`, but
+    // that's obviously unecessary to consider since we can just use `id2` to go to S2 in the first place.
+    const indirect = afterT.indirectOptions(afterT.context, 0);
+    expect(indirect.paths).toHaveLength(1);
+    expect(indirect.paths[0].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ id2 } ⊢ key()]--> T(S2) (types: [T])`);
+  });
+});

--- a/query-graphs-js/src/conditionsValidation.ts
+++ b/query-graphs-js/src/conditionsValidation.ts
@@ -1,0 +1,108 @@
+import { Schema, Selection } from "@apollo/federation-internals";
+import {
+    ConditionResolution,
+  ConditionResolver,
+  ExcludedConditions,
+  ExcludedDestinations,
+  GraphPath,
+  OpGraphPath,
+  SimultaneousPathsWithLazyIndirectPaths,
+  addConditionExclusion,
+  advanceOptionsToString,
+  advanceSimultaneousPathsWithOperation,
+  unsatisfiedConditionsResolution
+} from "./graphPath";
+import { Edge, QueryGraph } from "./querygraph";
+import { PathContext } from "./pathContext";
+import { cachingConditionResolver } from "./conditionsCaching";
+
+class ConditionValidationState {
+  constructor(
+    // Selection that belongs to the condition we're validating.
+    readonly selection: Selection,
+    // All the possible "simultaneous paths" we could be in the subgraph when we reach this state selection.
+    readonly subgraphOptions: SimultaneousPathsWithLazyIndirectPaths[]
+  ) {}
+
+  advance(supergraph: Schema): ConditionValidationState[] | null {
+    let newOptions: SimultaneousPathsWithLazyIndirectPaths[] = [];
+    for (const paths of this.subgraphOptions) {
+      const pathsOptions = advanceSimultaneousPathsWithOperation(
+        supergraph,
+        paths,
+        this.selection.element,
+      );
+      if (!pathsOptions) {
+        continue;
+      }
+      newOptions = newOptions.concat(pathsOptions);
+    }
+
+    // If we got no options, it means that particular selection of the conditions cannot be satisfied, so the
+    // overall condition cannot.
+    if (newOptions.length === 0) {
+      return null;
+    }
+    return this.selection.selectionSet ? this.selection.selectionSet.selections().map(s => new ConditionValidationState(s, newOptions)) : [];
+  }
+
+  toString(): string {
+    return `${this.selection} <=> ${advanceOptionsToString(this.subgraphOptions)}`;
+  }
+}
+
+/**
+ * Creates a `ConditionResolver` that only validates that the condition can be satisfied, but without
+ * trying compare/evaluate the potential various ways to validate said conditions. Concretely, the
+ * `ConditionResolution` values returned by the create resolver will never contain a `pathTree` (or
+ * an `unsatisfiedConditionReason` for that matter) and the cost will always default to 1 if the
+ * conditions are satisfied.
+ */
+export function simpleValidationConditionResolver({
+  supergraph,
+  queryGraph,
+  withCaching,
+}: {
+  supergraph: Schema,
+  queryGraph: QueryGraph,
+  withCaching?: boolean,
+}): ConditionResolver {
+  const resolver = (
+    edge: Edge,
+    context: PathContext,
+    excludedDestinations: ExcludedDestinations,
+    excludedConditions: ExcludedConditions,
+  ): ConditionResolution => {
+    const conditions = edge.conditions!;
+    excludedConditions = addConditionExclusion(excludedConditions, conditions);
+
+    const initialPath: OpGraphPath = GraphPath.create(queryGraph, edge.head);
+    const initialOptions = [
+      new SimultaneousPathsWithLazyIndirectPaths(
+        [initialPath],
+        context,
+        simpleValidationConditionResolver({supergraph, queryGraph, withCaching}),
+        excludedDestinations,
+        excludedConditions
+      )
+    ];
+
+    const stack: ConditionValidationState[] = [];
+    for (const selection of conditions.selections()) {
+      stack.push(new ConditionValidationState(selection, initialOptions));
+    }
+
+    while (stack.length > 0) {
+      const state = stack.pop()!;
+      const newStates = state.advance(supergraph);
+      if (newStates === null) {
+        return unsatisfiedConditionsResolution;
+      }
+      newStates.forEach(s => stack.push(s));
+    }
+    // If we exhaust the stack, it means we've been able to find "some" path for every possible selection in the condition, so the
+    // condition is validated. Note that we use a cost of 1 for all conditions as we don't care about efficiency.
+    return { satisfied: true, cost: 1 };
+  };
+  return withCaching ? cachingConditionResolver(queryGraph, resolver) : resolver;
+}

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -791,7 +791,8 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
       return ` (${this.props.edgeTriggers[idx]}) `;
     }).join('');
     const deferStr = this.deferOnTail ? ` <defer='${this.deferOnTail.label}'>` : '';
-    return `${isRoot ? '' : this.root}${pathStr}${deferStr} (types: [${this.props.runtimeTypesOfTail.join(', ')}])`;
+    const typeStr = this.props.runtimeTypesOfTail.length > 0 ? ` (types: [${this.props.runtimeTypesOfTail.join(', ')}])` : '';
+    return `${isRoot ? '' : this.root}${pathStr}${deferStr}${typeStr}`;
   }
 }
 
@@ -866,7 +867,7 @@ export function traversePath(
 
 // Note that ConditionResolver are guaranteed to be only called for edge with conditions.
 export type ConditionResolver =
-  (edge: Edge, context: PathContext, excludedEdges: ExcludedEdges, excludedConditions: ExcludedConditions) => ConditionResolution;
+  (edge: Edge, context: PathContext, excludedDestinations: ExcludedDestinations, excludedConditions: ExcludedConditions) => ConditionResolution;
 
 
 export type ConditionResolution = {
@@ -1169,30 +1170,28 @@ function createLazyTransitionOptions<V extends Vertex>(
   ));
 }
 
-// A set of excluded edges, that is a pair of a head vertex index and an edge index (since edge indexes are relative to their vertex).
-export type ExcludedEdges = readonly [number, number][];
+// A "set" of excluded destinations, that is subgraph name. Note that we use an array instead of set because this is used
+// in pretty hot paths (the whole path computation is CPU intensive) and will basically always be tiny (it's bounded
+// by the number of distinct key on a given type, so usually 2-3 max; even in completely unrealistic cases, it's hard bounded
+// by the number of subgraph), so array is going to perform a lot better than `Set` in practice.
+export type ExcludedDestinations = readonly string[];
 
-function isEdgeExcluded(edge: Edge, excluded: ExcludedEdges): boolean {
-  return excluded.some(([vIdx, eIdx]) => edge.head.index === vIdx && edge.index === eIdx);
+function isDestinationExcluded(destination: string, excluded: ExcludedDestinations): boolean {
+  return excluded.includes(destination);
 }
 
-export function sameExcludedEdges(ex1: ExcludedEdges, ex2: ExcludedEdges): boolean {
+export function sameExcludedDestinations(ex1: ExcludedDestinations, ex2: ExcludedDestinations): boolean {
   if (ex1 === ex2) {
     return true;
   }
   if (ex1.length !== ex2.length) {
     return false;
   }
-  for (let i = 0; i < ex1.length; ++i) {
-    if (ex1[i][0] !== ex2[i][0] || ex1[i][1] !== ex2[i][1]) {
-      return false;
-    }
-  }
-  return true;
+  return ex1.every((d) => ex2.includes(d));
 }
 
-function addEdgeExclusion(excluded: ExcludedEdges, newExclusion: Edge): ExcludedEdges {
-  return excluded.concat([[newExclusion.head.index, newExclusion.index]]);
+function addDestinationExclusion(excluded: ExcludedDestinations, destination: string): ExcludedDestinations {
+  return excluded.includes(destination) ? excluded : excluded.concat(destination);
 }
 
 export type ExcludedConditions = readonly SelectionSet[];
@@ -1233,7 +1232,7 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
   path: GraphPath<TTrigger, V, TNullEdge>,
   context: PathContext,
   conditionResolver: ConditionResolver,
-  excludedEdges: ExcludedEdges,
+  excludedDestinations: ExcludedDestinations,
   excludedConditions: ExcludedConditions,
   convertTransitionWithCondition: (transition: Transition, context: PathContext) => TTrigger,
   triggerToEdge: (graph: QueryGraph, vertex: Vertex, t: TTrigger) => Edge | null | undefined
@@ -1299,7 +1298,9 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
     debug.group(() => `From ${toAdvance}:`);
     for (const edge of nextEdges) {
       debug.group(() => `Testing edge ${edge}`);
-      if (isEdgeExcluded(edge, excludedEdges)) {
+      const target = edge.tail;
+
+      if (isDestinationExcluded(target.source, excludedDestinations)) {
         debug.groupEnd(`Ignored: edge is excluded`);
         continue;
       }
@@ -1308,7 +1309,6 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
       // (we've already checked for direct transition from that original subgraph). On exception though
       // is if we're just after a @defer, in which case re-entering the current subgraph is actually
       // a thing.
-      const target = edge.tail;
       if (target.source === originalSource && !toAdvance.deferOnTail) {
         debug.groupEnd('Ignored: edge get us back to our original source');
         continue;
@@ -1352,12 +1352,15 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
       }
 
       debug.group(() => `Validating conditions ${edge.conditions}`);
+      // As we validate the condition for this edge, it might be necessary to jump to another subgraph, but if for that
+      // we need to jump to the same subgraph we're trying to get to, then it means there is another, shorter way to
+      // go to our destination and we can return that shorter path, not the one with the edge we're trying.
       const conditionResolution = canSatisfyConditions(
         toAdvance,
         edge,
         conditionResolver,
         context,
-        addEdgeExclusion(excludedEdges, edge),
+        addDestinationExclusion(excludedDestinations, target.source),
         excludedConditions,
       );
       if (conditionResolution.satisfied) {
@@ -1715,7 +1718,7 @@ function canSatisfyConditions<TTrigger, V extends Vertex, TNullEdge extends null
   edge: Edge,
   conditionResolver: ConditionResolver,
   context: PathContext,
-  excludedEdges: ExcludedEdges,
+  excludedEdges: ExcludedDestinations,
   excludedConditions: ExcludedConditions
 ): ConditionResolution {
   const conditions = edge.conditions;
@@ -1779,7 +1782,7 @@ export class SimultaneousPathsWithLazyIndirectPaths<V extends Vertex = Vertex> {
     readonly paths: SimultaneousPaths<V>,
     readonly context: PathContext,
     readonly conditionResolver: ConditionResolver,
-    readonly excludedNonCollectingEdges: ExcludedEdges = [],
+    readonly excludedNonCollectingEdges: ExcludedDestinations = [],
     readonly excludedConditionsOnNonCollectingEdges: ExcludedConditions = [],
   ) {
     this.lazilyComputedIndirectPaths = new Array(paths.length);
@@ -2033,7 +2036,7 @@ export function createInitialOptions<V extends Vertex>(
   initialPath: OpGraphPath<V>,
   initialContext: PathContext,
   conditionResolver: ConditionResolver,
-  excludedEdges: ExcludedEdges,
+  excludedEdges: ExcludedDestinations,
   excludedConditions: ExcludedConditions,
 ): SimultaneousPathsWithLazyIndirectPaths<V>[] {
   const lazyInitialPath = new SimultaneousPathsWithLazyIndirectPaths(

--- a/query-graphs-js/src/index.ts
+++ b/query-graphs-js/src/index.ts
@@ -5,3 +5,4 @@ export * from './graphviz';
 export * from './transition';
 export * from './pathContext';
 export * from './conditionsCaching';
+export * from './conditionsValidation';

--- a/query-planner-js/src/__tests__/buildPlan.defer.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.defer.test.ts
@@ -3613,7 +3613,6 @@ test('@defer only the key of an entity', () => {
           Fetch(service: "Subgraph1") {
             {
               t {
-                __typename
                 v0
                 id
               }


### PR DESCRIPTION
This PR contains 2 relatively small (in patch size) performance improvement for query planning (performance in the sense of the time it takes to compute query plans):
1. the first commit memoize when possible the result of the `FetchGroup.isUseless`, which was showing near the top of profiling some slow planning. This optimisation is arguably a minor one in that this probably only help specific cases, but it consistently reduced query planning time by ~15% on at least one example, so probably worth the small additional complexity.
2. the 2nd commit is arguably more impactful: in some situation with multiple keys, the planner was not discarding some options that are trivially inefficient (see commit message and included test for details). Which while not incorrect per-se, was sometime multiplying the number of plans evaluated by a lot, leading to very inefficient query planning time. This change sometimes decrease query planning time by an order of magnitude (some plan that took close to 2s now takes less than 100ms).