### PR TITLE
Fix issues with named fragment handling code

### DIFF
--- a/.changeset/nice-cheetahs-yell.md
+++ b/.changeset/nice-cheetahs-yell.md
@@ -1,0 +1,10 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+---
+
+Fix issues in code to reuse named fragments. One of the fixed issue would manifest as an assertion error with a message
+looking like `Cannot add fragment of condition X (...) to parent type Y (...)`. Another would manifest itself by
+generating an invalid subgraph fetch where a field conflicts with another version of that field that is in a reused
+named fragment.
+  

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -1770,7 +1770,7 @@ describe('named fragment selection set restrictions at type', () => {
     assert(type && isCompositeType(type), `Invalid type ${typeName}`)
     // `expandedSelectionSetAtType` assumes it's argument passes `canApplyAtType`, so let's make sure we're
     // not typo-ing something in our tests.
-    assert(frag.canApplyAtType(type), `${frag.name} cannot be applied at type ${typeName}`);
+    assert(frag.canApplyDirectlyAtType(type), `${frag.name} cannot be applied at type ${typeName}`);
     return frag.expandedSelectionSetAtType(type);
   }
 
@@ -1832,19 +1832,6 @@ describe('named fragment selection set restrictions at type', () => {
     const frag = operation.fragments?.get('FonI1')!;
 
     let { selectionSet, trimmed } = expandAtType(frag, schema, 'I1');
-    expect(selectionSet.toString()).toBe('{ x ... on T1 { x } ... on T2 { x } ... on I2 { x } ... on I3 { x } }');
-    expect(trimmed?.toString()).toBeUndefined();
-
-    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'I2'));
-    expect(selectionSet.toString()).toBe('{ x ... on T1 { x } ... on I2 { x } }');
-    expect(trimmed?.toString()).toBe('{ ... on T2 { x } ... on I3 { x } }');
-
-    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'I3'));
-    expect(selectionSet.toString()).toBe('{ x ... on T2 { x } ... on I3 { x } }');
-    expect(trimmed?.toString()).toBe('{ ... on T1 { x } ... on I2 { x } }');
-
-    // Note: I4 has the same runtimes than I1, so it's result should be basically the same than for `I1` itself
-    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'I4'));
     expect(selectionSet.toString()).toBe('{ x ... on T1 { x } ... on T2 { x } ... on I2 { x } ... on I3 { x } }');
     expect(trimmed?.toString()).toBeUndefined();
 

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -1,12 +1,14 @@
 import {
   defaultRootName,
+  isCompositeType,
   Schema,
   SchemaRootKind,
 } from '../../dist/definitions';
 import { buildSchema } from '../../dist/buildSchema';
-import { MutableSelectionSet, Operation, operationFromDocument, parseOperation } from '../../dist/operations';
+import { MutableSelectionSet, NamedFragmentDefinition, Operation, operationFromDocument, parseOperation, SelectionSetAtType } from '../../dist/operations';
 import './matchers';
 import { DocumentNode, FieldNode, GraphQLError, Kind, OperationDefinitionNode, OperationTypeNode, parse, SelectionNode, SelectionSetNode, validate } from 'graphql';
+import { assert } from '../utils';
 
 function parseSchema(schema: string): Schema {
   try {
@@ -1060,113 +1062,344 @@ describe('fragments optimization', () => {
     });
   });
 
-  test('does not generate invalid operations', () => {
-    const schema = parseSchema(`
-      type Query {
-        t1: T1
-        i: I
-      }
-
-      interface I {
-        id: ID!
-      }
-
-      interface WithF {
-        f(arg: Int): Int
-      }
-
-      type T1 implements I {
-        id: ID!
-        f(arg: Int): Int
-      }
-
-      type T2 implements I & WithF {
-        id: ID!
-        f(arg: Int): Int
-      }
-    `);
-    const gqlSchema = schema.toGraphQLJSSchema();
-
-    const operation = parseOperation(schema, `
-      query {
-        t1 {
-          id
-          f(arg: 0)
+  describe('does not generate invalid operations', () => {
+    test('due to conflict between selection and reused fragment', () => {
+      const schema = parseSchema(`
+        type Query {
+          t1: T1
+          i: I
         }
-        i {
-          ...F1
-        }
-      }
 
-      fragment F1 on I {
-        id
-        ... on WithF {
-          f(arg: 1)
+        interface I {
+          id: ID!
         }
-      }
-    `);
-    expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
 
-    const withoutFragments = operation.expandAllFragments();
-    expect(withoutFragments.toString()).toMatchString(`
-      {
-        t1 {
-          id
-          f(arg: 0)
+        interface WithF {
+          f(arg: Int): Int
         }
-        i {
+
+        type T1 implements I {
+          id: ID!
+          f(arg: Int): Int
+        }
+
+        type T2 implements I & WithF {
+          id: ID!
+          f(arg: Int): Int
+        }
+      `);
+      const gqlSchema = schema.toGraphQLJSSchema();
+
+      const operation = parseOperation(schema, `
+        query {
+          t1 {
+            id
+            f(arg: 0)
+          }
+          i {
+            ...F1
+          }
+        }
+
+        fragment F1 on I {
           id
           ... on WithF {
             f(arg: 1)
           }
         }
-      }
-    `);
+      `);
+      expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
 
-    // Note that technically, `t1` has parent type `T1` which is a `I`, so `F1` can be spread
-    // withing `t1`, and `t1 { ...F1 }` is just `t1 { id }` (because `T` does not implement `WithF`),
-    // so that it would appear that it could be valid to optimize this query into:
-    //   {
-    //     t1 {
-    //       ...F1       // Notice the use of F1 here, which does expand to `id` in this context
-    //       f(arg: 0)
-    //     }
-    //     i {
-    //       ...F1
-    //     }
-    //   }
-    // And while doing this may look "dumb" in that toy example (we're replacing `id` with `...F1`
-    // which is longer so less optimal really), it's easy to expand this to example where re-using
-    // `F1` this way _does_ make things smaller.
-    //
-    // But the query above is actually invalid. And it is invalid because the validation of graphQL
-    // does not take into account the fact that the `... on WithF` part of `F1` is basically dead
-    // code within `t1`. And so it finds a conflict between `f(arg: 0)` and the `f(arg: 1)` in `F1`
-    // (even though, again, the later is statically known to never apply, but graphQL does not
-    // include such static analysis in its validation).
-    //
-    // And so this test does make sure we do not generate the query above (do not use `F1` in `t1`).
-    const optimized = withoutFragments.optimize(operation.fragments!, 1);
-    expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
-
-    expect(optimized.toString()).toMatchString(`
-      fragment F1 on I {
-        id
-        ... on WithF {
-          f(arg: 1)
+      const withoutFragments = operation.expandAllFragments();
+      expect(withoutFragments.toString()).toMatchString(`
+        {
+          t1 {
+            id
+            f(arg: 0)
+          }
+          i {
+            id
+            ... on WithF {
+              f(arg: 1)
+            }
+          }
         }
-      }
+      `);
 
-      {
-        t1 {
+      // Note that technically, `t1` has return type `T1` which is a `I`, so `F1` can be spread
+      // within `t1`, and `t1 { ...F1 }` is just `t1 { id }` (because `T!` does not implement `WithF`),
+      // so that it would appear that it could be valid to optimize this query into:
+      //   {
+      //     t1 {
+      //       ...F1       // Notice the use of F1 here, which does expand to `id` in this context
+      //       f(arg: 0)
+      //     }
+      //     i {
+      //       ...F1
+      //     }
+      //   }
+      // And while doing this may look "dumb" in that toy example (we're replacing `id` with `...F1`
+      // which is longer so less optimal really), it's easy to expand this to example where re-using
+      // `F1` this way _does_ make things smaller.
+      //
+      // But the query above is actually invalid. And it is invalid because the validation of graphQL
+      // does not take into account the fact that the `... on WithF` part of `F1` is basically dead
+      // code within `t1`. And so it finds a conflict between `f(arg: 0)` and the `f(arg: 1)` in `F1`
+      // (even though, again, the later is statically known to never apply, but graphQL does not
+      // include such static analysis in its validation).
+      //
+      // And so this test does make sure we do not generate the query above (do not use `F1` in `t1`).
+      const optimized = withoutFragments.optimize(operation.fragments!, 1);
+      expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+
+      expect(optimized.toString()).toMatchString(`
+        fragment F1 on I {
           id
+          ... on WithF {
+            f(arg: 1)
+          }
+        }
+
+        {
+          t1 {
+            id
+            f(arg: 0)
+          }
+          i {
+            ...F1
+          }
+        }
+      `);
+    });
+
+    test('due to conflict between the active selection of a reused fragment and the trimmed part of another fragments', () => {
+      const schema = parseSchema(`
+        type Query {
+          t1: T1
+          i: I
+        }
+
+        interface I {
+          id: ID!
+        }
+
+        interface WithF {
+          f(arg: Int): Int
+        }
+
+        type T1 implements I {
+          id: ID!
+          f(arg: Int): Int
+        }
+
+        type T2 implements I & WithF {
+          id: ID!
+          f(arg: Int): Int
+        }
+      `);
+      const gqlSchema = schema.toGraphQLJSSchema();
+
+      const operation = parseOperation(schema, `
+        query {
+          t1 {
+            id
+            ...F1
+          }
+          i {
+            ...F2
+          }
+        }
+
+        fragment F1 on T1 {
           f(arg: 0)
         }
-        i {
-          ...F1
+
+        fragment F2 on I {
+          id
+          ... on WithF {
+            f(arg: 1)
+          }
         }
-      }
-    `);
+
+      `);
+      expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+
+      const withoutFragments = operation.expandAllFragments();
+      expect(withoutFragments.toString()).toMatchString(`
+        {
+          t1 {
+            id
+            f(arg: 0)
+          }
+          i {
+            id
+            ... on WithF {
+              f(arg: 1)
+            }
+          }
+        }
+      `);
+
+      // See the comments on the previous test. The only different here is that `F1` is applied
+      // first, and then we need to make sure we do not apply `F2` even though it's restriction
+      // inside `t1` matches its selection set.
+      const optimized = withoutFragments.optimize(operation.fragments!, 1);
+      expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+
+      expect(optimized.toString()).toMatchString(`
+        fragment F1 on T1 {
+          f(arg: 0)
+        }
+
+        fragment F2 on I {
+          id
+          ... on WithF {
+            f(arg: 1)
+          }
+        }
+
+        {
+          t1 {
+            ...F1
+            id
+          }
+          i {
+            ...F2
+          }
+        }
+      `);
+    });
+
+    test('due to conflict between the trimmed parts of 2 fragments', () => {
+      const schema = parseSchema(`
+        type Query {
+          t1: T1
+          i1: I
+          i2: I
+        }
+
+        interface I {
+          id: ID!
+          a: Int
+          b: Int
+        }
+
+        interface WithF {
+          f(arg: Int): Int
+        }
+
+        type T1 implements I {
+          id: ID!
+          a: Int
+          b: Int
+          f(arg: Int): Int
+        }
+
+        type T2 implements I & WithF {
+          id: ID!
+          a: Int
+          b: Int
+          f(arg: Int): Int
+        }
+      `);
+      const gqlSchema = schema.toGraphQLJSSchema();
+
+      const operation = parseOperation(schema, `
+        query {
+          t1 {
+            id
+            a
+            b
+          }
+          i1 {
+            ...F1
+          }
+          i2 {
+            ...F2
+          }
+        }
+
+        fragment F1 on I {
+          id
+          a
+          ... on WithF {
+            f(arg: 0)
+          }
+        }
+
+        fragment F2 on I {
+          id
+          b
+          ... on WithF {
+            f(arg: 1)
+          }
+        }
+
+      `);
+      expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+
+      const withoutFragments = operation.expandAllFragments();
+      expect(withoutFragments.toString()).toMatchString(`
+        {
+          t1 {
+            id
+            a
+            b
+          }
+          i1 {
+            id
+            a
+            ... on WithF {
+              f(arg: 0)
+            }
+          }
+          i2 {
+            id
+            b
+            ... on WithF {
+              f(arg: 1)
+            }
+          }
+        }
+      `);
+
+      // Here, `F1` in `T1` reduces to `{ id a }` and F2 reduces to `{ id b }`, so theoretically both could be used
+      // within the first `T1` branch. But they can't both be used because their `... on WithF` part conflict,
+      // and even though that part is dead in `T1`, this would still be illegal graphQL.
+      const optimized = withoutFragments.optimize(operation.fragments!, 1);
+      expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+
+      expect(optimized.toString()).toMatchString(`
+        fragment F1 on I {
+          id
+          a
+          ... on WithF {
+            f(arg: 0)
+          }
+        }
+
+        fragment F2 on I {
+          id
+          b
+          ... on WithF {
+            f(arg: 1)
+          }
+        }
+
+        {
+          t1 {
+            ...F1
+            b
+          }
+          i1 {
+            ...F1
+          }
+          i2 {
+            ...F2
+          }
+        }
+      `);
+    });
   });
 });
 
@@ -1528,5 +1761,172 @@ describe('unsatisfiable branches removal', () => {
     { input: '{ i { ... on T2 { ... on I { a ... on J { b } } } } }', output: '{ i { ... on T2 { a } } }' },
   ])('removes unsatisfiable branches', ({input, output}) => {
     expect(normalized(input)).toBe(output);
+  });
+});
+
+describe('named fragment selection set restrictions at type', () => {
+  const expandAtType = (frag: NamedFragmentDefinition, schema: Schema, typeName: string): SelectionSetAtType => {
+    const type = schema.type(typeName);
+    assert(type && isCompositeType(type), `Invalid type ${typeName}`)
+    // `expandedSelectionSetAtType` assumes it's argument passes `canApplyAtType`, so let's make sure we're
+    // not typo-ing something in our tests.
+    assert(frag.canApplyAtType(type), `${frag.name} cannot be applied at type ${typeName}`);
+    return frag.expandedSelectionSetAtType(type);
+  }
+
+  test('for fragment on interfaces', () => {
+    const schema = parseSchema(`
+      type Query {
+        t1: I1
+      }
+
+      interface I1 {
+        x: Int
+      }
+
+      interface I2 {
+        x: Int
+      }
+
+      interface I3 {
+        x: Int
+      }
+
+      interface I4 {
+        x: Int
+      }
+
+      type T1 implements I1 & I2 & I4 {
+        x: Int
+      }
+
+      type T2 implements I1 & I3 & I4 {
+        x: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      {
+        t1 {
+          ...FonI1
+        }
+      }
+
+      fragment FonI1 on I1 {
+        x
+        ... on T1 {
+          x
+        }
+        ... on T2 {
+          x
+        }
+        ... on I2 {
+          x
+        }
+        ... on I3 {
+          x
+        }
+      }
+    `);
+
+    const frag = operation.fragments?.get('FonI1')!;
+
+    let { selectionSet, trimmed } = expandAtType(frag, schema, 'I1');
+    expect(selectionSet.toString()).toBe('{ x ... on T1 { x } ... on T2 { x } ... on I2 { x } ... on I3 { x } }');
+    expect(trimmed?.toString()).toBeUndefined();
+
+    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'I2'));
+    expect(selectionSet.toString()).toBe('{ x ... on T1 { x } ... on I2 { x } }');
+    expect(trimmed?.toString()).toBe('{ ... on T2 { x } ... on I3 { x } }');
+
+    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'I3'));
+    expect(selectionSet.toString()).toBe('{ x ... on T2 { x } ... on I3 { x } }');
+    expect(trimmed?.toString()).toBe('{ ... on T1 { x } ... on I2 { x } }');
+
+    // Note: I4 has the same runtimes than I1, so it's result should be basically the same than for `I1` itself
+    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'I4'));
+    expect(selectionSet.toString()).toBe('{ x ... on T1 { x } ... on T2 { x } ... on I2 { x } ... on I3 { x } }');
+    expect(trimmed?.toString()).toBeUndefined();
+
+    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'T1'));
+    expect(selectionSet.toString()).toBe('{ x }');
+    // Note: one could remark that having `... on T1 { x }` in `trimmed` below is a tad weird: this is
+    // because in this case `normalized` removed that fragment and so when we do `normalized.mins(original)`,
+    // then it shows up. It a tad difficult to avoid this however and it's ok for what we do (`trimmed`
+    // is used to check for field conflict and and the only reason we use `trimmed` is to make things faster
+    // but we could use the `original` instead).
+    expect(trimmed?.toString()).toBe('{ ... on T1 { x } ... on T2 { x } ... on I2 { x } ... on I3 { x } }');
+  });
+
+  test('for fragment on unions', () => {
+    const schema = parseSchema(`
+      type Query {
+        t1: U1
+      }
+
+      union U1 = T1 | T2
+      union U2 = T1
+      union U3 = T2
+      union U4 = T1 | T2
+
+      type T1 {
+        x: Int
+        y: Int
+      }
+
+      type T2 {
+        z: Int
+        w: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      {
+        t1 {
+          ...FonU1
+        }
+      }
+
+      fragment FonU1 on U1 {
+        ... on T1 {
+          x
+        }
+        ... on T2 {
+          z
+        }
+        ... on U2 {
+          ... on T1 {
+            y
+          }
+        }
+        ... on U3 {
+          ... on T2 {
+            w
+          }
+        }
+      }
+    `);
+
+    const frag = operation.fragments?.get('FonU1')!;
+
+    // Note that with unions, the fragments inside the unions can be "lifted" and so they everyting normalize to just the
+    // possible runtimes.
+
+    let { selectionSet, trimmed } = expandAtType(frag, schema, 'U1');
+    expect(selectionSet.toString()).toBe('{ ... on T1 { x y } ... on T2 { z w } }');
+    expect(trimmed?.toString()).toBeUndefined();
+
+    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'U2'));
+    expect(selectionSet.toString()).toBe('{ ... on T1 { x y } }');
+    expect(trimmed?.toString()).toBe('{ ... on T2 { z w } }');
+
+    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'U3'));
+    expect(selectionSet.toString()).toBe('{ ... on T2 { z w } }');
+    expect(trimmed?.toString()).toBe('{ ... on T1 { x y } }');
+
+    ({ selectionSet, trimmed } = expandAtType(frag, schema, 'T1'));
+    expect(selectionSet.toString()).toBe('{ x y }');
+    // Similar remarks that on interfaces
+    expect(trimmed?.toString()).toBe('{ ... on T1 { x y } ... on T2 { z w } }');
   });
 });

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -240,6 +240,10 @@ export function possibleRuntimeTypes(type: CompositeType): readonly ObjectType[]
 }
 
 export function runtimeTypesIntersects(t1: CompositeType, t2: CompositeType): boolean {
+  if (t1 === t2) {
+    return true;
+  }
+
   const rt1 = possibleRuntimeTypes(t1);
   const rt2 = possibleRuntimeTypes(t2);
   for (const obj1 of rt1) {

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -3136,7 +3136,10 @@ class FragmentSpreadSelection extends FragmentSelection {
   validate(): void {
     this.validateDeferAndStream();
 
-    // We don't do anything else because fragment definition are validated when created.
+    validate(
+      runtimeTypesIntersects(this.parentType, this.namedFragment.typeCondition),
+      () => `Fragment "${this.namedFragment.name}" cannot be spread inside type ${this.parentType} as the runtime types do not intersect ${this.namedFragment.typeCondition}`
+    );
   }
 
   toSelectionNode(): FragmentSpreadNode {

--- a/internals-js/src/types.ts
+++ b/internals-js/src/types.ts
@@ -3,8 +3,9 @@
  */
 
 import {
-    AbstractType,
+  AbstractType,
   InterfaceType,
+  isCompositeType,
   isInterfaceType,
   isListType,
   isNamedType,
@@ -144,3 +145,23 @@ export function isStrictSubtype(
         && isSubtype(type.ofType, maybeSubType, allowedRules, unionMembershipTester, implementsInterfaceTester);
   }
 }
+
+/**
+ * This essentially follows the beginning of https://spec.graphql.org/draft/#SameResponseShape().
+ * That is, the types cannot be merged unless:
+ * - they have the same nullability and "list-ability", potentially recursively.
+ * - their base type is either both composite, or are the same type.
+ */
+export function typesCanBeMerged(t1: Type, t2: Type): boolean {
+  if (isNonNullType(t1)) {
+    return isNonNullType(t2) ? typesCanBeMerged(t1.ofType, t2.ofType) : false;
+  }
+  if (isListType(t1)) {
+    return isListType(t2) ? typesCanBeMerged(t1.ofType, t2.ofType) : false;
+  }
+  if (isCompositeType(t1)) {
+    return isCompositeType(t2);
+  }
+  return sameType(t1, t2);
+}
+

--- a/query-planner-js/src/__tests__/allFeatures.test.ts
+++ b/query-planner-js/src/__tests__/allFeatures.test.ts
@@ -10,6 +10,7 @@ import {
   buildSchema,
   parseOperation,
 } from '@apollo/federation-internals';
+import { parse, validate } from 'graphql';
 
 
 // This test looks over all directories under tests/features and finds "supergraphSdl.graphql" in
@@ -52,6 +53,7 @@ for (const directory of directories) {
           const givenQuery = () => {
             given(/^query$/im, (operationString: string) => {
               operation = parseOperation(schema, operationString);
+              expect(validate(schema.toGraphQLJSSchema(), parse(operationString))).toStrictEqual([]);
             });
           };
 

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5760,7 +5760,7 @@ test('does not error out handling fragments when interface subtyping is involved
   `);
 });
 
-describe("named fragments reuse", () => {
+describe("named fragments", () => {
   test('handles mix of fragments indirection and unions', () => {
     const subgraph1 = {
       name: 'Subgraph1',
@@ -5998,6 +5998,69 @@ describe("named fragments reuse", () => {
           
           fragment Fragment4 on I {
             id
+          }
+        },
+      }
+    `);
+  });
+
+  test('handles fragments with interface field subtyping', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          t1: T1!
+        }
+
+        interface I {
+          id: ID!
+          other: I!
+        }
+
+        type T1 implements I {
+          id: ID!
+          other: T1!
+        }
+
+
+        type T2 implements I
+        {
+          id: ID!
+          other: T2!
+        }
+      `
+    }
+
+    const [api, queryPlanner] = composeAndCreatePlanner(subgraph1);
+    const operation = operationFromDocument(api, gql`
+      {
+        t1 {
+          ...Fragment1
+        }
+      }
+
+      fragment Fragment1 on I {
+        other {
+          ... on T1 {
+            id
+          }
+          ... on T2 {
+            id
+          }
+        }
+      }
+    `);
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            t1 {
+              other {
+                id
+              }
+            }
           }
         },
       }

--- a/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
+++ b/query-planner-js/src/__tests__/features/basic/build-query-plan.feature
@@ -914,13 +914,6 @@ Scenario: deduplicates fields / selections regardless of adjacency and type cond
     """
     query {
       body {
-        ... on Image {
-          ... on Text {
-            attributes {
-              bold
-            }
-          }
-        }
         ... on Body {
           ... on Text {
             attributes {
@@ -964,9 +957,6 @@ Scenario: deduplicates fields / selections regardless of adjacency and type cond
 
     query {
       body {
-        ... on Image {
-          ...TextFragment
-        }
         ... on Body {
           ...TextFragment
         }

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -2806,7 +2806,6 @@ export class QueryPlanner {
     // going to expand everything during the algorithm anyway. We'll re-optimize subgraph fetches with fragments
     // later if possible (which is why we saved them above before expansion).
     operation = operation.expandAllFragments();
-    operation = operation.trimUnsatisfiableBranches();
     operation = withoutIntrospection(operation);
     operation = this.withSiblingTypenameOptimizedAway(operation);
 

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -31,7 +31,6 @@ import {
   NamedFragments,
   operationToDocument,
   MapWithCachedArrays,
-  sameType,
   FederationMetadata,
   federationMetadata,
   entitiesFieldName,
@@ -51,7 +50,6 @@ import {
   mapValues,
   isInterfaceObjectType,
   isInterfaceType,
-  isNonNullType,
   Type,
   MutableSelectionSet,
   SelectionSetUpdates,
@@ -60,6 +58,7 @@ import {
   InterfaceType,
   FragmentSelection,
   possibleRuntimeTypes,
+  typesCanBeMerged,
 } from "@apollo/federation-internals";
 import {
   advanceSimultaneousPathsWithOperation,
@@ -1416,23 +1415,6 @@ function genAliasName(baseName: string, unavailableNames: Map<string, any>): str
     candidate = `${baseName}__alias_${++counter}`;
   }
   return candidate;
-}
-
-function typesCanBeMerged(t1: Type, t2: Type): boolean {
-  // This essentially follows the beginning of https://spec.graphql.org/draft/#SameResponseShape().
-  // That is, the types cannot be merged unless:
-  // - they have the same nullability and "list-ability", potentially recursively.
-  // - their base type is either both composite, or are the same type.
-  if (isNonNullType(t1)) {
-    return isNonNullType(t2) ? typesCanBeMerged(t1.ofType, t2.ofType) : false;
-  }
-  if (isListType(t1)) {
-    return isListType(t2) ? typesCanBeMerged(t1.ofType, t2.ofType) : false;
-  }
-  if (isCompositeType(t1)) {
-    return isCompositeType(t2);
-  }
-  return sameType(t1, t2);
 }
 
 type SelectionSetAtPath = {


### PR DESCRIPTION
This PR attempts to fix a number of remaining issues around the code to handle named fragments, namely at least:
1. the assertion failure reported in https://github.com/apollographql/router/issues/3227.
2. the assertion failure reported in https://github.com/apollographql/router/issues/3217 (which is the same assertion failing than in the previous point, but on a slightly different code path and due to a different issue).
3. an issue whereby named fragments are reused in a rare situation where this is invalid, resulting in an invalid (in the sense of graphQL validations) subgraph fetch.

The 2 first point have repro on the linked tickets, but for the last point, the problem is that the graphQL validation for conflicting fields specified by [FieldsInSetCanMerge](https://spec.graphql.org/draft/#FieldsInSetCanMerge()) traverses all fragments to look for conflicts, even "branches" that can be statically proven to be dead branches, but because the named fragment reuse code was taking those dead branch into account, it was sometimes using a named fragment that created a validation issue (in such a dead branch). See https://github.com/apollographql/federation/commit/e1d104484b466e5eafde306820543a08131e8419 for an example of the problem with some explanations.