### PR TITLE
Fix fetch group processing handling of dependencies

### DIFF
--- a/.changeset/gentle-plums-relax.md
+++ b/.changeset/gentle-plums-relax.md
@@ -1,0 +1,7 @@
+---
+"@apollo/query-planner": patch
+---
+
+Fix bug in the handling of dependencies of subgraph fetches. This bug was manifesting itself as an assertion error
+thrown during query planning with a message of the form `Root groups X should have no remaining groups unhandled (...)`.
+  

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -6386,7 +6386,7 @@ test('does not error on some complex fetch group dependencies', () => {
         v2: V
 
         # Note: this field is not queried, but matters to the reproduction this test exists
-        # for because it prevents some optimisations that would happen without it (namely,
+        # for because it prevents some optimizations that would happen without it (namely,
         # without it, the planner would notice that everything after type T is guaranteed
         # to be local to the subgraph).
         user: User


### PR DESCRIPTION
The code that process `FetchGroup` in dependency order has a bug that, for some types of dependencies, can finish with some group not handled, even though they could and should have been.

In practice, this shows itself by failing the post-processing assertion that double-check that no groups are left unhandled.

The error message when this triggered looks like `Root groups X should have no remaining groups unhandled (...)` (where `X` is a dump of the fetch groups involved and so this can be large and hard to parse, but basically the assertion error starts with "Root groups").