### PR TITLE
Reuse named fragment in subgraphs even if they only apply partially

### DIFF
--- a/.changeset/olive-bees-build.md
+++ b/.changeset/olive-bees-build.md
@@ -1,0 +1,8 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+"@apollo/gateway": patch
+---
+
+Try reusing named fragments in subgraph fetches even if those fragment only apply partially to the subgraph. Before this change, only named fragments that were applying entirely to a subgraph were tried, leading to less reuse that expected. Concretely, this change can sometimes allow the generation of smaller subgraph fetches.
+  

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -744,18 +744,21 @@ describe('buildQueryPlan', () => {
 
     it(`should not get confused by a fragment spread multiple times`, () => {
       const operationString = `#graphql
-        fragment Price on Product {
+        fragment PriceAndCountry on Product {
           price
+          details {
+            country
+          }
         }
 
         query {
           topProducts {
             __typename
             ... on Book {
-              ...Price
+              ...PriceAndCountry
             }
             ... on Furniture {
-              ...Price
+              ...PriceAndCountry
             }
           }
         }
@@ -770,16 +773,20 @@ describe('buildQueryPlan', () => {
                       topProducts {
                         __typename
                         ... on Book {
-                          ...Price
+                          ...PriceAndCountry
                         }
                         ... on Furniture {
-                          ...Price
+                          ...PriceAndCountry
                         }
                       }
                     }
                     
-                    fragment Price on Product {
+                    fragment PriceAndCountry on Product {
                       price
+                      details {
+                        __typename
+                        country
+                      }
                     }
                   },
                 }

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -2546,7 +2546,7 @@ describe('named fragment rebasing on subgraphs', () => {
       }
     `);
 
-    // F1 reduces to nothing, and F2 reduces to just __typename so we should keep them.
+    // F1 reduces to nothing, and F2 reduces to just __typename so we shouldn't keep them.
     const rebased = fragments.rebaseOn(subgraph);
     expect(rebased?.toString('')).toMatchString(`
       fragment F3 on T {
@@ -2607,7 +2607,6 @@ describe('named fragment rebasing on subgraphs', () => {
       }
     `);
 
-    // F1 reduces to nothing, and F2 reduces to just __typename so we should keep them.
     const rebased = fragments.rebaseOn(subgraph);
     expect(rebased?.toString('')).toMatchString(`
       fragment TheQuery on Query {

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -2278,3 +2278,406 @@ describe('named fragment selection set restrictions at type', () => {
     `);
   });
 });
+
+describe('named fragment rebasing on subgraphs', () => {
+  test('it skips unknown fields', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        v0: Int
+        v1: Int
+        v2: Int
+        u1: U
+        u2: U
+      }
+
+      type U {
+        v3: Int
+        v4: Int
+        v5: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        t {
+          ...FragOnT
+        }
+      }
+
+      fragment FragOnT on T {
+        v0
+        v1
+        v2
+        u1 {
+          v3
+          v4
+          v5
+        }
+        u2 {
+          v4
+          v5
+        }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        _: Int
+      }
+
+      type T {
+        v1: Int
+        u1: U
+      }
+
+      type U {
+        v3: Int
+        v5: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment FragOnT on T {
+        v1
+        u1 {
+          v3
+          v5
+        }
+      }
+    `);
+  });
+
+  test('it skips unknown type (on condition)', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+        u: U
+      }
+
+      type T {
+        x: Int
+        y: Int
+      }
+
+      type U {
+        x: Int
+        y: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        t {
+          ...FragOnT
+        }
+        u {
+          ...FragOnU
+        }
+      }
+
+      fragment FragOnT on T {
+        x
+        y
+      }
+
+      fragment FragOnU on U {
+        x
+        y
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        x: Int
+        y: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment FragOnT on T {
+        x
+        y
+      }
+    `);
+  });
+
+  test('it skips unknown type (used inside fragment)', () => {
+    const schema = parseSchema(`
+      type Query {
+        i: I
+      }
+
+      interface I {
+        id: ID!
+        otherId: ID!
+      }
+
+      type T1 implements I {
+        id: ID!
+        otherId: ID!
+        x: Int
+      }
+
+      type T2 implements I {
+        id: ID!
+        otherId: ID!
+        y: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        i {
+          ...FragOnI
+        }
+      }
+
+      fragment FragOnI on I {
+         id
+         otherId
+         ... on T1 {
+           x
+         }
+         ... on T2 {
+           y
+         }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        i: I
+      }
+
+      interface I {
+        id: ID!
+      }
+
+      type T2 implements I {
+        id: ID!
+        y: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment FragOnI on I {
+        id
+        ... on T2 {
+          y
+        }
+      }
+    `);
+  });
+
+  test('it skips fragments with no selection or trivial ones applying', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        a: Int
+        b: Int
+        c: Int
+        d: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        t {
+          ...F1
+          ...F2
+          ...F3
+        }
+      }
+
+      fragment F1 on T {
+         a
+         b
+      }
+
+      fragment F2 on T {
+         __typename
+         a
+         b
+      }
+
+      fragment F3 on T {
+         __typename
+         a
+         b
+         c
+         d
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        c: Int
+        d: Int
+      }
+    `);
+
+    // F1 reduces to nothing, and F2 reduces to just __typename so we should keep them.
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment F3 on T {
+        __typename
+        c
+        d
+      }
+    `);
+  });
+
+  test('it handles skipped fragments used by other fragments', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        x: Int
+        u: U
+      }
+
+      type U {
+        y: Int
+        z: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        ...TheQuery
+      }
+
+      fragment TheQuery on Query {
+        t {
+          x
+          ...GetU
+        }
+      }
+
+      fragment GetU on T {
+         u {
+           y
+           z
+         }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        x: Int
+      }
+    `);
+
+    // F1 reduces to nothing, and F2 reduces to just __typename so we should keep them.
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment TheQuery on Query {
+        t {
+          x
+        }
+      }
+    `);
+  });
+
+  test('it handles fields whose type is a subtype in the subgarph', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: I
+      }
+
+      interface I {
+         x: Int
+         y: Int
+      }
+
+      type T implements I {
+         x: Int
+         y: Int
+         z: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        ...TQuery
+      }
+
+      fragment TQuery on Query {
+        t {
+          x
+          y
+          ... on T {
+            z
+          }
+        }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+         x: Int
+         y: Int
+         z: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment TQuery on Query {
+        t {
+          x
+          y
+          ... on T {
+            z
+          }
+        }
+      }
+    `);
+  });
+});

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1359,7 +1359,7 @@ export class NamedFragments {
   }
 
   // When we rebase named fragments on a subgraph schema, only a subset of what the fragment handles may belong
-  // to that particular subgraph. And there is a few sub-cases where that subset is such that we basically need or
+  // to that particular subgraph. And there are a few sub-cases where that subset is such that we basically need or
   // want to consider to ignore the fragment for that subgraph, and that is when:
   // 1. the subset that apply is actually empty. The fragment wouldn't be valid in this case anyway.
   // 2. the subset is a single leaf field: in that case, using the one field directly is just shorter than using
@@ -2541,13 +2541,13 @@ abstract class AbstractSelection<TElement extends OperationElement, TIsLeaf exte
       }
 
       // As we check inclusion, we ignore the case where the fragment queries __typename but the subSelection does not.
-      // The rational is that querying `__typename` unecessarily is mostly harmess (it always works and it's super cheap)
-      // so we don't want to not use a fragment just to save querying a `__typename` in a few case. But the underlying
-      // context of why this matter is that the query planner always request __typename for abstract type, and will do
+      // The rational is that querying `__typename` unecessarily is mostly harmless (it always works and it's super cheap)
+      // so we don't want to not use a fragment just to save querying a `__typename` in a few cases. But the underlying
+      // context of why this matters is that the query planner always requests __typename for abstract type, and will do
       // so in fragments too, but we can have a field that _does_ return an abstract type within a fragment, but that
-      // _do not_ end up returning an abstract type when applied in a "more specific" context (think a fragment on
+      // _does not_ end up returning an abstract type when applied in a "more specific" context (think a fragment on
       // an interface I1 where a inside field returns another interface I2, but applied in the context of a implementation
-      // type of I1 where that particular field returns an implentation of I2 rather than I2 directly; we would have
+      // type of I1 where that particular field returns an implementation of I2 rather than I2 directly; we would have
       // added __typename to the fragment (because it's all interfaces), but the selection itself, which only deals
       // with object type, may not have __typename requested; using the fragment might still be a good idea, and
       // querying __typename needlessly is a very small price to pay for that).

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -4541,7 +4541,7 @@ function inputsForRequire(
       assert(supergraphItfType && isInterfaceType(supergraphItfType), () => `Type ${entityType} should be an interface in the supergraph`);
       // Note: we are rebasing on another schema below, but we also known that we're working on a full expanded
       // selection set (no spread), so passing undefined is actually correct.
-      keyConditionAsInput = keyConditionAsInput.rebaseOn(supergraphItfType, undefined);
+      keyConditionAsInput = keyConditionAsInput.rebaseOn({ parentType: supergraphItfType, fragments: undefined, errorIfCannotRebase: true });
     }
     fullSelectionSet.updates().add(keyConditionAsInput);
 


### PR DESCRIPTION
The focus of the code reusing fragment has been thus far on making that if a given named fragment can be used in a given selection set, then the code finds it. But in practice, the named fragments we try to reuse are those of the input query, so defined against the supergraph API schema, while we're trying to reuse them on subgraph fetches, so the fragment may be defined on a type that a subgraph does know, or request fields the subgraph does not define.

Currently, when asking if a given named fragment can be used against a given subgraph, we only keep fragment that _fully_ apply to that subgraph (that is, only if everything the fragment queries exists in the subgraph).

This does limit the usefulness of named fragment reuse however, as one of the point of federation is that each subgraph defines a subset of the full supergraph API.

This commit improves this by instead computing the subset of each named fragment that do apply to a given subgraph, and define the fragment as only that fragment for the subgraph.

Note that it does so, this commit do not try reusing a named fragment against a subgraph if the subset of the fragment on the subgraph comes to only a single leaf field. This avoids spending time trying to reuse a fragment that ends up being just:
```graphql
fragment MySuperFragment on X {
  __typename
}
```
or even:
```graphql
fragment MySuperFragment on X {
 id
}
```
as those aren't productive (the goal of fragment reuse is to try to make the subgraph fetches smaller, but it is small to just request `id`, even 10 times, than to request 10 times `...MySuperFragment`).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
