### PR TITLE
Fix incorrect removal of fragments only used by other fragments

### DIFF
--- a/.changeset/stale-birds-think.md
+++ b/.changeset/stale-birds-think.md
@@ -1,0 +1,7 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fix regression in named fragment reuse introduced by 2.4.8 that caused fragments that were only used by other fragments
+to not be reused, even if they are making the overall query smaller and thus should be reused.
+  

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -946,7 +946,9 @@ export class Operation {
       // refactor all this later to avoid this case without additional complexity.
       if (finalFragments) {
         const usages = new Map<string, number>();
+        // Collecting all usages, both in the selection and within other fragments.
         optimizedSelection.collectUsedFragmentNames(usages);
+        finalFragments.collectUsedFragmentNames(usages);
         finalFragments = finalFragments.filter((f) => (usages.get(f.name) ?? 0) > 0);
       }
     }
@@ -1282,6 +1284,15 @@ export class NamedFragments {
 
   definitions(): readonly NamedFragmentDefinition[] {
     return this.fragments.values();
+  }
+
+  /**
+   * Collect the usages of fragments that are used within the selection of other fragments.
+   */
+  collectUsedFragmentNames(collector: Map<string, number>) {
+    for (const fragment of this.definitions()) {
+      fragment.collectUsedFragmentNames(collector);
+    }
   }
 
   map(mapper: (def: NamedFragmentDefinition) => NamedFragmentDefinition): NamedFragments {


### PR DESCRIPTION
The patch from https://github.com/apollographql/federation/pull/2628, while it did fix the issue of leaving unused
fragments, mistakenly introduced a regression in that fragments
that are used by other fragments but are not used in the query
selection are now removed, which is obviously undesirable.

This was simply because the patch of https://github.com/apollographql/federation/pull/2628 only counted the usages
in the main selection, not the ones other fragments as it should
have. This commit fixes that.