### PR TITLE
Fix normalization of fragment spreads

### DIFF
--- a/.changeset/rotten-ants-clean.md
+++ b/.changeset/rotten-ants-clean.md
@@ -1,0 +1,10 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fix issue in the code to reuse fragments that, in some rare circumstances, could led to invalid queries where a named
+spread was use in an invalid position. If triggered, this resulted in an subgraph fetch whereby a named spread was
+used inside a sub-selection even though the spread condition did not intersect the parent type (the exact error message
+would depend on the client library used to handle subgraph fetches, but with GraphQL-js, the error message had the
+form "Fragment <F> cannot be spread here as objects of type <X> can never be of type <Y>").
+  


### PR DESCRIPTION
The code that "normalize" selection sets to remove unecessary fragments is also used to remove impossibe (and thus invalid) branches when some reused fragments gets expanded away due to only be used once.

However, while the code for inline fragments was correctly removing impossible branches, the similar code for named spreads was not, which in some rare cases could result in an invalid subgraph fetch.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
