### PR TITLE
Generalizes heurisitic to cut indirect paths to the root of paths

### DIFF
--- a/.changeset/tall-impalas-act.md
+++ b/.changeset/tall-impalas-act.md
@@ -1,0 +1,11 @@
+---
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+---
+
+More aggressive ignoring of indirect paths from root types when a more direct alternative exists. This optimisation
+slightly generalize an existing heuristic of the query planner, allowing it to ignore some known inefficient options
+earlier in its process. When this optimisation can be used, this yield faster query plan computation, but by reducing
+the number of plans to be consider, this can sometimes prevent the planner to degrade it's output when it consider
+there is too many plans to consider, which can result in more optimal query plans too.
+  

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -1677,7 +1677,6 @@ function withFieldAliased(selectionSet: SelectionSet, aliases: FieldToAlias[]): 
 }
 
 class DeferredInfo {
-
   private constructor(
     readonly label: string,
     readonly path: GroupPath,


### PR DESCRIPTION
The planner has a number of heuristics whose goal is to cut the number of concrete plans it has to fully generate and evaluate, which is important to its performance. One of them cut paths that take a "detour" in a subgraph when a more direct path exists, that is, if we have some path:
```
T(S1) --[x]--> U(S1) --[y]--> V(S1)
```
then we ignore a path that, from `T` in S1 goes to some S2 subgraph to get `x` to come back to S1, that is:
```
T(S1) --[key(id)] --> T(S2) --[x]--> U(S2) --[key(id)] --> U(S1) --[y]--> V(S1)
```
because the more direct option is always going to be better.

However, the code for this optimisation was not working for essentially the same case but at the root of the path. That is, if we have path:
```
Query(S1) --[x]--> U(S1) --[y]--> V(S1)
```
then we were not ignoring:
```
Query(S2) --[x]--> U(S2) --[key(id)] --> U(S1) --[y]--> V(S1)
```
even though it similarly never going to be better (even if we must get other fields after `x` in S2, it's still better to get 2 top-level parallel fetch to both S1 and S2, rather than only getting to S2 to get to S1 next, as it's the same number of fetches but there is more serialization).

Long story short, this commit slightly generalise the existing heuristic so it cut this root-level case too.

Note that when a lot of queried field follow that pattern, this can cut the number of plans considered drastically, so this optimisation can also result in better generated plans due to the planner not falling into its "panic" mode where it semi-arbitrarily cut options to avoid exponential explosion, yielding potentially non-optimal plans in doing so.

Fixes #2661.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
