### PR TITLE
remove unused types from both fed1 and fed2 extractSubgraphs

### DIFF
--- a/internals-js/src/__tests__/extractSubgraphsFromSupergraph.test.ts
+++ b/internals-js/src/__tests__/extractSubgraphsFromSupergraph.test.ts
@@ -738,3 +738,80 @@ test('throw meaningful error for type erased from supergraph due to extending an
     + 'Error: Cannot find type "T" in subgraph "serviceB"'
   );
 })
+
+test('types that are empty because of overridden fields are erased', () => {
+  const supergraph = `
+    schema
+      @link(url: "https://specs.apollo.dev/link/v1.0")
+      @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+      @link(url: "https://specs.apollo.dev/tag/v0.3")
+    {
+      query: Query
+    }
+
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+    directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+    directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+    input Input
+      @join__type(graph: B)
+    {
+      a: Int! = 1234
+    }
+
+    scalar join__FieldSet
+
+    enum join__Graph {
+      A @join__graph(name: "a", url: "")
+      B @join__graph(name: "b", url: "")
+    }
+
+    scalar link__Import
+
+    enum link__Purpose {
+      """
+      \`SECURITY\` features provide metadata necessary to securely resolve fields.
+      """
+      SECURITY
+
+      """
+      \`EXECUTION\` features provide metadata necessary for operation execution.
+      """
+      EXECUTION
+    }
+
+    type Query
+      @join__type(graph: A)
+    {
+      field: String
+    }
+
+    type User
+    @join__type(graph: A)
+    @join__type(graph: B)
+    {
+      foo: String @join__field(graph: A, override: "b")
+
+      bar: String @join__field(graph: A)
+
+      baz: String @join__field(graph: A)
+    }
+  `;
+
+  const subgraphs = Supergraph.build(supergraph).subgraphs();
+
+  const subgraph = subgraphs.get('b');
+  const inputType = subgraph?.schema.type('User') as InputObjectType | undefined;
+  expect(inputType).toBeUndefined();
+});

--- a/internals-js/src/__tests__/extractSubgraphsFromSupergraph.test.ts
+++ b/internals-js/src/__tests__/extractSubgraphsFromSupergraph.test.ts
@@ -1,4 +1,4 @@
-import { Supergraph, InputObjectType } from "..";
+import { Supergraph, InputObjectType, ObjectType } from "..";
 
 
 test('handles types having no fields referenced by other objects in a subgraph correctly', () => {
@@ -812,6 +812,6 @@ test('types that are empty because of overridden fields are erased', () => {
   const subgraphs = Supergraph.build(supergraph).subgraphs();
 
   const subgraph = subgraphs.get('b');
-  const inputType = subgraph?.schema.type('User') as InputObjectType | undefined;
-  expect(inputType).toBeUndefined();
+  const userType = subgraph?.schema.type('User') as ObjectType | undefined;
+  expect(userType).toBeUndefined();
 });


### PR DESCRIPTION
This can potentially happen because use of the `@override` directive can result in a type being empty.

