### PR TITLE
fix: directive name collisions

### DIFF
--- a/composition-js/src/__tests__/compose.composeDirective.test.ts
+++ b/composition-js/src/__tests__/compose.composeDirective.test.ts
@@ -998,37 +998,4 @@ describe('composing custom core directives', () => {
     const appliedDirectives = schema.elementByCoordinate('Query.shared')?.appliedDirectives;
     expect(appliedDirectives?.map(d => [d.name, d.arguments()])).toMatchObject([['auth', { scope: 'VIEWER'}], ['auth', {}]]);
   });
-
-  it('existing @authenticated directive with fed 1', () => {
-    const subgraphA = {
-      typeDefs: gql`
-        directive @authenticated(scope: [String!]) repeatable on FIELD_DEFINITION
-
-        extend type Foo @key(fields: "id") {
-          id: ID!
-          protected: String @authenticated(scope: ["foo"])
-        }
-      `,
-      name: 'subgraphA',
-    };
-
-    const subgraphB = {
-      typeDefs: gql`
-        type Query {
-          foo: Foo
-        }
-
-        type Foo @key(fields: "id") {
-          id: ID!
-          name: String!
-        }
-        `,
-      name: 'subgraphB',
-    };
-
-    const result = composeServices([subgraphA, subgraphB]);
-    const schema = expectNoErrors(result);
-    const authenticatedDirectiveExists = schema.directives().find(d => d.name === 'authenticated');
-    expect(authenticatedDirectiveExists).toBeUndefined();
-  });
 });

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4,7 +4,7 @@ import {
   AuthenticatedSpecDefinition,
   buildSubgraph,
   defaultPrintOptions,
-  FEDERATION2_LINK_WITH_FULL_IMPORTS,
+  FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS,
   inaccessibleIdentity,
   InputObjectType,
   isObjectType,
@@ -485,7 +485,7 @@ describe('composition', () => {
 
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -502,7 +502,7 @@ describe('composition', () => {
 
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -557,7 +557,7 @@ describe('composition', () => {
     // Of course, the federation directives should be rebuilt in the extracted subgraphs.
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -576,7 +576,7 @@ describe('composition', () => {
 
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4590,4 +4590,40 @@ describe('composition', () => {
       });
     });
   });
+
+  it('existing @authenticated directive with fed 1', () => {
+    const subgraphA = {
+      typeDefs: gql`
+        directive @authenticated(scope: [String!]) repeatable on FIELD_DEFINITION
+
+        extend type Foo @key(fields: "id") {
+          id: ID!
+          protected: String @authenticated(scope: ["foo"])
+        }
+      `,
+      name: 'subgraphA',
+    };
+
+    const subgraphB = {
+      typeDefs: gql`
+        type Query {
+          foo: Foo
+        }
+
+        type Foo @key(fields: "id") {
+          id: ID!
+          name: String!
+        }
+        `,
+      name: 'subgraphB',
+    };
+
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(errors(result)).toStrictEqual([]);
+    const { schema } = result;
+    expect(schema).toBeDefined();
+    assert(schema, 'schema does not exist');
+    const authenticatedDirectiveExists = schema.directives().find(d => d.name === 'authenticated');
+    expect(authenticatedDirectiveExists).toBeUndefined();
+  });
 });

--- a/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
+++ b/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
@@ -1,4 +1,4 @@
-import { FEDERATION2_LINK_WITH_FULL_IMPORTS, ObjectType, printSchema, Schema, SubgraphASTNode, Subgraphs, Supergraph } from '@apollo/federation-internals';
+import { FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS, ObjectType, printSchema, Schema, SubgraphASTNode, Subgraphs, Supergraph } from '@apollo/federation-internals';
 import { CompositionResult, composeServices, CompositionSuccess } from '../compose';
 import gql from 'graphql-tag';
 import './matchers';
@@ -68,7 +68,7 @@ describe('basic type extensions', () => {
     // it's easier to do so and harmless otherwise.
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -90,7 +90,7 @@ describe('basic type extensions', () => {
     // an extension.
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -150,7 +150,7 @@ describe('basic type extensions', () => {
     // Same remark than in prevoius test
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -165,7 +165,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -237,7 +237,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphA')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -252,7 +252,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphB')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }
@@ -269,7 +269,7 @@ describe('basic type extensions', () => {
 
     expect(subgraphs.get('subgraphC')!.toString()).toMatchString(`
       schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
       {
         query: Query
       }

--- a/composition-js/src/__tests__/testHelper.ts
+++ b/composition-js/src/__tests__/testHelper.ts
@@ -34,6 +34,6 @@ export function composeAsFed2Subgraphs(services: ServiceDefinition[], options: C
 export function asFed2Service(service: ServiceDefinition): ServiceDefinition {
   return {
     ...service,
-    typeDefs: asFed2SubgraphDocument(service.typeDefs)
+    typeDefs: asFed2SubgraphDocument(service.typeDefs, { includeAllImports: true })
   };
 }

--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -1,4 +1,4 @@
-import { FEDERATION2_LINK_WITH_FULL_IMPORTS } from '..';
+import { FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS } from '..';
 import { ObjectType } from '../definitions';
 import { buildSubgraph, Subgraphs } from '../federation';
 import { UpgradeChangeID, UpgradeResult, upgradeSubgraphsIfNecessary } from '../schemaUpgrader';
@@ -92,7 +92,7 @@ test('upgrade complex schema', () => {
 
   expect(res.subgraphs?.get('s1')?.toString()).toMatchString(`
     schema
-      ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+      ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
     {
       query: Query
     }
@@ -148,7 +148,7 @@ test('update federation directive non-string arguments', () => {
 
   expect(res.subgraphs?.get('s')?.toString()).toMatchString(`
     schema
-      ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+      ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
     {
       query: Query
     }

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -89,6 +89,9 @@ import { joinIdentity } from "./joinSpec";
 const linkSpec = LINK_VERSIONS.latest();
 const tagSpec = TAG_VERSIONS.latest();
 const federationSpec = FEDERATION_VERSIONS.latest();
+// Some users rely on auto-expanding fed v1 graphs with fed v2 directives. While technically we should only expand @tag
+// directive from v2 definitions, we will continue expanding other directives (up to v2.4) to ensure backwards compatibility.
+const autoExpandedFederationSpec = FEDERATION_VERSIONS.find(new FeatureVersion(2, 4))!;
 
 // We don't let user use this as a subgraph name. That allows us to use it in `query graphs` to name the source of roots
 // in the "federated query graph" without worrying about conflict (see `FEDERATED_GRAPH_ROOT_SOURCE` in `querygraph.ts`).
@@ -1168,7 +1171,7 @@ export function setSchemaAsFed2Subgraph(schema: Schema) {
     core.coreItself.nameInSchema,
     {
       url: federationSpec.url.toString(),
-      import: federationSpec.directiveSpecs().map((spec) => `@${spec.name}`),
+      import: autoExpandedFederationSpec.directiveSpecs().map((spec) => `@${spec.name}`),
     }
   );
   const errors = completeSubgraphSchema(schema);
@@ -1180,6 +1183,8 @@ export function setSchemaAsFed2Subgraph(schema: Schema) {
 // This is the full @link declaration as added by `asFed2SubgraphDocument`. It's here primarily for uses by tests that print and match
 // subgraph schema to avoid having to update 20+ tests every time we use a new directive or the order of import changes ...
 export const FEDERATION2_LINK_WITH_FULL_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject", "@authenticated", "@requiresScopes"])';
+// This is the full @link declaration that is added when upgrading fed v1 subgraphs to v2 version. It should only be used by tests.
+export const FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"])';
 
 /**
  * Given a document that is assumed to _not_ be a fed2 schema (it does not have a `@link` to the federation spec),
@@ -1202,7 +1207,7 @@ export function asFed2SubgraphDocument(document: DocumentNode, options?: { addAs
       {
         kind: Kind.ARGUMENT,
         name: { kind: Kind.NAME, value: 'import' },
-        value: { kind: Kind.LIST, values: federationSpec.directiveSpecs().map((spec) => ({ kind: Kind.STRING, value: `@${spec.name}` })) }
+        value: { kind: Kind.LIST, values: autoExpandedFederationSpec.directiveSpecs().map((spec) => ({ kind: Kind.STRING, value: `@${spec.name}` })) }
       }
     ]
   });

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -1193,8 +1193,11 @@ export const FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS = '@link(url: "https://
  * @param document - the document to "augment".
  * @param options.addAsSchemaExtension - defines whethere the added `@link` is added as a schema extension (`extend schema`) or
  *   added to the schema definition. Defaults to `true` (added as an extension), as this mimics what we tends to write manually.
+ * @param options.includeAllImports - defines whether we should auto import ALL latest federation v2 directive definitions or include
+ *   only limited set of directives (i.e. federation v2.4 definitions)
  */
-export function asFed2SubgraphDocument(document: DocumentNode, options?: { addAsSchemaExtension: boolean }): DocumentNode {
+export function asFed2SubgraphDocument(document: DocumentNode, options?: { addAsSchemaExtension?: boolean, includeAllImports?: boolean }): DocumentNode {
+  const importedDirectives = options?.includeAllImports ? federationSpec.directiveSpecs() : autoExpandedFederationSpec.directiveSpecs();
   const directiveToAdd: ConstDirectiveNode = ({
     kind: Kind.DIRECTIVE,
     name: { kind: Kind.NAME, value: linkDirectiveDefaultName },
@@ -1207,7 +1210,7 @@ export function asFed2SubgraphDocument(document: DocumentNode, options?: { addAs
       {
         kind: Kind.ARGUMENT,
         name: { kind: Kind.NAME, value: 'import' },
-        value: { kind: Kind.LIST, values: autoExpandedFederationSpec.directiveSpecs().map((spec) => ({ kind: Kind.STRING, value: `@${spec.name}` })) }
+        value: { kind: Kind.LIST, values: importedDirectives.map((spec) => ({ kind: Kind.STRING, value: `@${spec.name}` })) }
       }
     ]
   });

--- a/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/printSubgraphSchema.test.ts
@@ -3,7 +3,7 @@ import { buildSubgraphSchema } from '../buildSubgraphSchema';
 import { printSubgraphSchema } from '../printSubgraphSchema';
 import gql from 'graphql-tag';
 import './matchers';
-import { FEDERATION2_LINK_WITH_FULL_IMPORTS } from '@apollo/federation-internals';
+import { FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS } from '@apollo/federation-internals';
 
 describe('printSubgraphSchema', () => {
   it('prints a subgraph correctly', () => {
@@ -15,7 +15,7 @@ describe('printSubgraphSchema', () => {
       }
 
       extend schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
 
       directive @stream on FIELD
 
@@ -110,7 +110,7 @@ describe('printSubgraphSchema', () => {
     const schema = buildSubgraphSchema(fixtures[5].typeDefs);
     expect(printSubgraphSchema(schema)).toMatchString(`
       extend schema
-        ${FEDERATION2_LINK_WITH_FULL_IMPORTS}
+        ${FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS}
 
       directive @stream on FIELD
 


### PR DESCRIPTION
We are currently auto-expanding Fed v1 subgraphs with ALL Fed v2 definitions which causes an issue if users already defined directive with the same name. For convenience we also rely on this behavior in our tests... Since newly introduced `@authenticated` directive is already used by some customers in their v1 schemas, composition fails in those scenarios. In order to preserve backwards compatibility, we will continue auto-expanding directive definitions up to Fed v2.4.

Fixes: https://github.com/apollographql/federation/issues/2673
