### PR TITLE
Reapply #2639 (with fix for #2680)

### DIFF
--- a/.changeset/wild-buses-poke.md
+++ b/.changeset/wild-buses-poke.md
@@ -1,0 +1,12 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+"@apollo/gateway": patch
+---
+
+Reapply #2639:
+
+Try reusing named fragments in subgraph fetches even if those fragment only apply partially to the subgraph. Before this change, only named fragments that were applying entirely to a subgraph were tried, leading to less reuse that expected. Concretely, this change can sometimes allow the generation of smaller subgraph fetches.
+
+Additionally, resolve a bug which surfaced in the fragment optimization logic which could result in invalid/incorrect optimizations / fragment reuse.
+  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - next
+      - version-2.4
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - next
-      - version-2.4
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/gateway-js/src/__tests__/buildQueryPlan.test.ts
+++ b/gateway-js/src/__tests__/buildQueryPlan.test.ts
@@ -744,18 +744,21 @@ describe('buildQueryPlan', () => {
 
     it(`should not get confused by a fragment spread multiple times`, () => {
       const operationString = `#graphql
-        fragment Price on Product {
+        fragment PriceAndCountry on Product {
           price
+          details {
+            country
+          }
         }
 
         query {
           topProducts {
             __typename
             ... on Book {
-              ...Price
+              ...PriceAndCountry
             }
             ... on Furniture {
-              ...Price
+              ...PriceAndCountry
             }
           }
         }
@@ -770,16 +773,20 @@ describe('buildQueryPlan', () => {
                       topProducts {
                         __typename
                         ... on Book {
-                          ...Price
+                          ...PriceAndCountry
                         }
                         ... on Furniture {
-                          ...Price
+                          ...PriceAndCountry
                         }
                       }
                     }
                     
-                    fragment Price on Product {
+                    fragment PriceAndCountry on Product {
                       price
+                      details {
+                        __typename
+                        country
+                      }
                     }
                   },
                 }

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -35,7 +35,7 @@ function astSSet(...selections: SelectionNode[]): SelectionSetNode {
 
 describe('fragments optimization', () => {
   // Takes a query with fragments as inputs, expand all those fragments, and ensures that all the
-  // fragments gets optimized back, and that we get back the exact same query. 
+  // fragments gets optimized back, and that we get back the exact same query.
   function testFragmentsRoundtrip({
     schema,
     query,
@@ -946,6 +946,89 @@ describe('fragments optimization', () => {
         }
       `,
     });
+  });
+
+  test('off by 1 error', () => {
+    const schema = buildSchema(`#graphql
+      type Query {
+        t: T
+      }
+      type T {
+        id: String!
+        a: A
+        v: V
+      }
+      type A {
+        id: String!
+      }
+      type V {
+        t: T!
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      {
+        t {
+          ...TFrag
+          v {
+            t {
+              id
+              a {
+                __typename
+                id
+              }
+            }
+          }
+        }
+      }
+
+      fragment TFrag on T {
+        __typename
+        id
+      }
+    `);
+
+    const withoutFragments = operation.expandAllFragments();
+    expect(withoutFragments.toString()).toMatchString(`
+      {
+        t {
+          __typename
+          id
+          v {
+            t {
+              id
+              a {
+                __typename
+                id
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const optimized = withoutFragments.optimize(operation.fragments!);
+    expect(optimized.toString()).toMatchString(`
+      fragment TFrag on T {
+        __typename
+        id
+      }
+
+      {
+        t {
+          ...TFrag
+          v {
+            t {
+              ...TFrag
+              a {
+                __typename
+                id
+              }
+            }
+          }
+        }
+      }
+    `);
   });
 
   describe('applied directives', () => {
@@ -2179,7 +2262,7 @@ describe('fragments optimization', () => {
         x
         y
       }
- 
+
       fragment TFields on T {
         a1
         a2
@@ -2754,6 +2837,408 @@ describe('named fragment selection set restrictions at type', () => {
         w: [
           T2.w
         ]
+      }
+    `);
+  });
+});
+
+describe('named fragment rebasing on subgraphs', () => {
+  test('it skips unknown fields', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        v0: Int
+        v1: Int
+        v2: Int
+        u1: U
+        u2: U
+      }
+
+      type U {
+        v3: Int
+        v4: Int
+        v5: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        t {
+          ...FragOnT
+        }
+      }
+
+      fragment FragOnT on T {
+        v0
+        v1
+        v2
+        u1 {
+          v3
+          v4
+          v5
+        }
+        u2 {
+          v4
+          v5
+        }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        _: Int
+      }
+
+      type T {
+        v1: Int
+        u1: U
+      }
+
+      type U {
+        v3: Int
+        v5: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment FragOnT on T {
+        v1
+        u1 {
+          v3
+          v5
+        }
+      }
+    `);
+  });
+
+  test('it skips unknown type (on condition)', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+        u: U
+      }
+
+      type T {
+        x: Int
+        y: Int
+      }
+
+      type U {
+        x: Int
+        y: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        t {
+          ...FragOnT
+        }
+        u {
+          ...FragOnU
+        }
+      }
+
+      fragment FragOnT on T {
+        x
+        y
+      }
+
+      fragment FragOnU on U {
+        x
+        y
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        x: Int
+        y: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment FragOnT on T {
+        x
+        y
+      }
+    `);
+  });
+
+  test('it skips unknown type (used inside fragment)', () => {
+    const schema = parseSchema(`
+      type Query {
+        i: I
+      }
+
+      interface I {
+        id: ID!
+        otherId: ID!
+      }
+
+      type T1 implements I {
+        id: ID!
+        otherId: ID!
+        x: Int
+      }
+
+      type T2 implements I {
+        id: ID!
+        otherId: ID!
+        y: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        i {
+          ...FragOnI
+        }
+      }
+
+      fragment FragOnI on I {
+         id
+         otherId
+         ... on T1 {
+           x
+         }
+         ... on T2 {
+           y
+         }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        i: I
+      }
+
+      interface I {
+        id: ID!
+      }
+
+      type T2 implements I {
+        id: ID!
+        y: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment FragOnI on I {
+        id
+        ... on T2 {
+          y
+        }
+      }
+    `);
+  });
+
+  test('it skips fragments with no selection or trivial ones applying', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        a: Int
+        b: Int
+        c: Int
+        d: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        t {
+          ...F1
+          ...F2
+          ...F3
+        }
+      }
+
+      fragment F1 on T {
+         a
+         b
+      }
+
+      fragment F2 on T {
+         __typename
+         a
+         b
+      }
+
+      fragment F3 on T {
+         __typename
+         a
+         b
+         c
+         d
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        c: Int
+        d: Int
+      }
+    `);
+
+    // F1 reduces to nothing, and F2 reduces to just __typename so we shouldn't keep them.
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment F3 on T {
+        __typename
+        c
+        d
+      }
+    `);
+  });
+
+  test('it handles skipped fragments used by other fragments', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        x: Int
+        u: U
+      }
+
+      type U {
+        y: Int
+        z: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        ...TheQuery
+      }
+
+      fragment TheQuery on Query {
+        t {
+          x
+          ...GetU
+        }
+      }
+
+      fragment GetU on T {
+         u {
+           y
+           z
+         }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+        x: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment TheQuery on Query {
+        t {
+          x
+        }
+      }
+    `);
+  });
+
+  test('it handles fields whose type is a subtype in the subgarph', () => {
+    const schema = parseSchema(`
+      type Query {
+        t: I
+      }
+
+      interface I {
+         x: Int
+         y: Int
+      }
+
+      type T implements I {
+         x: Int
+         y: Int
+         z: Int
+      }
+    `);
+
+    const operation = parseOperation(schema, `
+      query {
+        ...TQuery
+      }
+
+      fragment TQuery on Query {
+        t {
+          x
+          y
+          ... on T {
+            z
+          }
+        }
+      }
+    `);
+
+    const fragments = operation.fragments;
+    assert(fragments, 'Should have some fragments');
+
+    const subgraph = parseSchema(`
+      type Query {
+        t: T
+      }
+
+      type T {
+         x: Int
+         y: Int
+         z: Int
+      }
+    `);
+
+    const rebased = fragments.rebaseOn(subgraph);
+    expect(rebased?.toString('')).toMatchString(`
+      fragment TQuery on Query {
+        t {
+          x
+          y
+          ... on T {
+            z
+          }
+        }
       }
     `);
   });

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -85,7 +85,11 @@ abstract class AbstractOperationElement<T extends AbstractOperationElement<T>> e
 
   abstract asPathElement(): string | undefined;
 
-  abstract rebaseOn(parentType: CompositeType): T;
+  abstract rebaseOn(args: { parentType: CompositeType, errorIfCannotRebase: boolean }): T | undefined;
+
+  rebaseOnOrError(parentType: CompositeType): T {
+    return this.rebaseOn({ parentType, errorIfCannotRebase: true })!;
+  }
 
   abstract withUpdatedDirectives(newDirectives: readonly Directive<any>[]): T;
 
@@ -290,7 +294,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     }
   }
 
-  rebaseOn(parentType: CompositeType): Field<TArgs> {
+  rebaseOn({ parentType, errorIfCannotRebase }: { parentType: CompositeType, errorIfCannotRebase: boolean }): Field<TArgs> | undefined {
     const fieldParent = this.definition.parent;
     if (parentType === fieldParent) {
       return this;
@@ -300,12 +304,16 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
       return this.withUpdatedDefinition(parentType.typenameField()!);
     }
 
-    validate(
-      this.canRebaseOn(parentType),
-      () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${parentType}"`
-    );
     const fieldDef = parentType.field(this.name);
-    validate(fieldDef, () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${parentType}" (that does not declare that field)`);
+    const canRebase = this.canRebaseOn(parentType) && fieldDef;
+    if (!canRebase) {
+      validate(
+        !errorIfCannotRebase,
+        () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${parentType}"`
+      );
+      return undefined;
+    }
+
     return this.withUpdatedDefinition(fieldDef);
   }
 
@@ -466,7 +474,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     return newFragment;
   }
 
-  rebaseOn(parentType: CompositeType): FragmentElement {
+  rebaseOn({ parentType, errorIfCannotRebase }: { parentType: CompositeType, errorIfCannotRebase: boolean }): FragmentElement | undefined {
     const fragmentParent = this.parentType;
     const typeCondition = this.typeCondition;
     if (parentType === fragmentParent) {
@@ -477,10 +485,13 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     // to update the source type of the fragment, but also "rebase" the condition to the selection set
     // schema.
     const { canRebase, rebasedCondition } = this.canRebaseOn(parentType);
-    validate(
-      canRebase,
-      () => `Cannot add fragment of condition "${typeCondition}" (runtimes: [${possibleRuntimeTypes(typeCondition!)}]) to parent type "${parentType}" (runtimes: ${possibleRuntimeTypes(parentType)})`
-    );
+    if (!canRebase) {
+      validate(
+        !errorIfCannotRebase,
+        () => `Cannot add fragment of condition "${typeCondition}" (runtimes: [${possibleRuntimeTypes(typeCondition!)}]) to parent type "${parentType}" (runtimes: ${possibleRuntimeTypes(parentType)})`
+      );
+      return undefined;
+    }
     return this.withUpdatedTypes(parentType, rebasedCondition);
   }
 
@@ -1232,7 +1243,7 @@ export class NamedFragmentDefinition extends DirectiveTargetElement<NamedFragmen
   }
 
   toString(indent?: string): string {
-    return (indent ?? '') + `fragment ${this.name} on ${this.typeCondition}${this.appliedDirectivesToString()} ${this.selectionSet.toString(false, true, indent)}`;
+    return `fragment ${this.name} on ${this.typeCondition}${this.appliedDirectivesToString()} ${this.selectionSet.toString(false, true, indent)}`;
   }
 }
 
@@ -1363,21 +1374,39 @@ export class NamedFragments {
     });
   }
 
+  // When we rebase named fragments on a subgraph schema, only a subset of what the fragment handles may belong
+  // to that particular subgraph. And there are a few sub-cases where that subset is such that we basically need or
+  // want to consider to ignore the fragment for that subgraph, and that is when:
+  // 1. the subset that apply is actually empty. The fragment wouldn't be valid in this case anyway.
+  // 2. the subset is a single leaf field: in that case, using the one field directly is just shorter than using
+  //   the fragment, so we consider the fragment don't really apply to that subgraph. Technically, using the
+  //   fragment could still be of value if the fragment name is a lot smaller than the one field name, but it's
+  //   enough of a niche case that we ignore it. Note in particular that one sub-case of this rule that is likely
+  //   to be common is when the subset ends up being just `__typename`: this would basically mean the fragment
+  //   don't really apply to the subgraph, and that this will ensure this is the case.
+  private selectionSetIsWorthUsing(selectionSet: SelectionSet): boolean {
+    const selections = selectionSet.selections();
+    if (selections.length === 0) {
+      return false;
+    }
+    if (selections.length === 1) {
+      const s = selections[0];
+      return !(s.kind === 'FieldSelection' && s.element.isLeafField());
+    }
+    return true;
+  }
+
   rebaseOn(schema: Schema): NamedFragments | undefined {
     return this.mapInDependencyOrder((fragment, newFragments) => {
       const rebasedType = schema.type(fragment.selectionSet.parentType.name);
-      try {
-        if (!rebasedType || !isCompositeType(rebasedType)) {
-          return undefined;
-        }
-
-        const rebasedSelection = fragment.selectionSet.rebaseOn(rebasedType, newFragments);
-        return new NamedFragmentDefinition(schema, fragment.name, rebasedType).setSelectionSet(rebasedSelection);
-      } catch (e) {
-        // This means we cannot rebase this selection on the schema and thus cannot reuse that fragment on that
-        // particular schema.
+      if (!rebasedType || !isCompositeType(rebasedType)) {
         return undefined;
       }
+
+      const rebasedSelection = fragment.selectionSet.rebaseOn({ parentType: rebasedType, fragments: newFragments, errorIfCannotRebase: false });
+      return this.selectionSetIsWorthUsing(rebasedSelection)
+        ? new NamedFragmentDefinition(schema, fragment.name, rebasedType).setSelectionSet(rebasedSelection)
+        : undefined;
     });
   }
 
@@ -1513,6 +1542,20 @@ export class SelectionSet {
   // Returns whether the selection contains a _non-aliased_ selection of __typename.
   hasTopLevelTypenameField(): boolean {
     return this._keyedSelections.has(typenameFieldName);
+  }
+
+  withoutTopLevelTypenameField(): SelectionSet {
+    if (!this.hasTopLevelTypenameField) {
+      return this;
+    }
+
+    const newKeyedSelections = new Map<string, Selection>();
+    for (const [key, selection] of this._keyedSelections) {
+      if (key !== typenameFieldName) {
+        newKeyedSelections.set(key, selection);
+      }
+    }
+    return new SelectionSet(this.parentType, newKeyedSelections);
   }
 
   fieldsInSet(): CollectedFieldsInSet {
@@ -1759,14 +1802,25 @@ export class SelectionSet {
     return updated.isEmpty() ? undefined : updated;
   }
 
-  rebaseOn(parentType: CompositeType, fragments: NamedFragments | undefined): SelectionSet {
+  rebaseOn({
+    parentType,
+    fragments,
+    errorIfCannotRebase,
+  }: {
+    parentType: CompositeType,
+    fragments: NamedFragments | undefined
+    errorIfCannotRebase: boolean,
+  }): SelectionSet {
     if (this.parentType === parentType) {
       return this;
     }
 
     const newSelections = new Map<string, Selection>();
     for (const selection of this.selections()) {
-      newSelections.set(selection.key(), selection.rebaseOn(parentType, fragments));
+      const rebasedSelection = selection.rebaseOn({ parentType, fragments, errorIfCannotRebase });
+      if (rebasedSelection) {
+        newSelections.set(selection.key(), rebasedSelection);
+      }
     }
 
     return new SelectionSet(parentType, newSelections);
@@ -1790,22 +1844,36 @@ export class SelectionSet {
     return true;
   }
 
-  contains(that: SelectionSet): ContainsResult {
+  contains(that: SelectionSet, options?: { ignoreMissingTypename?: boolean }): ContainsResult {
+    const ignoreMissingTypename = options?.ignoreMissingTypename ?? false;
     if (that._selections.length > this._selections.length) {
-      return ContainsResult.NOT_CONTAINED;
+      // If `that` has more selections but we're ignoring missing __typename, then in the case where
+      // `that` has a __typename but `this` does not, then we need the length of `that` to be at
+      // least 2 more than that of `this` to be able to conclude there is no contains.
+      if (!ignoreMissingTypename || that._selections.length > this._selections.length + 1 || this.hasTopLevelTypenameField() || !that.hasTopLevelTypenameField()) {
+        return ContainsResult.NOT_CONTAINED;
+      }
     }
 
     let isEqual = true;
+    let didIgnoreTypename = false;
     for (const [key, thatSelection] of that._keyedSelections) {
+      if (key === typenameFieldName && ignoreMissingTypename) {
+        if (!this._keyedSelections.has(typenameFieldName)) {
+          didIgnoreTypename = true;
+        }
+        continue;
+      }
+
       const thisSelection = this._keyedSelections.get(key);
-      const selectionResult = thisSelection?.contains(thatSelection);
+      const selectionResult = thisSelection?.contains(thatSelection, options);
       if (selectionResult === undefined || selectionResult === ContainsResult.NOT_CONTAINED) {
         return ContainsResult.NOT_CONTAINED;
       }
       isEqual &&= selectionResult === ContainsResult.EQUAL;
     }
 
-    return isEqual && that._selections.length === this._selections.length
+    return isEqual && that._selections.length === (this._selections.length + (didIgnoreTypename ? 1 : 0))
       ? ContainsResult.EQUAL
       : ContainsResult.STRICTLY_CONTAINED;
   }
@@ -2164,10 +2232,10 @@ function makeSelection(parentType: CompositeType, updates: SelectionUpdate[], fr
 
   // Optimize for the simple case of a single selection, as we don't have to do anything complex to merge the sub-selections.
   if (updates.length === 1 && first instanceof AbstractSelection) {
-    return first.rebaseOn(parentType, fragments);
+    return first.rebaseOnOrError({ parentType, fragments });
   }
 
-  const element = updateElement(first).rebaseOn(parentType);
+  const element = updateElement(first).rebaseOnOrError(parentType);
   const subSelectionParentType = element.kind === 'Field' ? element.baseType() : element.castedType();
   if (!isCompositeType(subSelectionParentType)) {
     // This is a leaf, so all updates should correspond ot the same field and we just use the first.
@@ -2356,7 +2424,11 @@ abstract class AbstractSelection<TElement extends OperationElement, TIsLeaf exte
 
   abstract validate(variableDefinitions: VariableDefinitions): void;
 
-  abstract rebaseOn(parentType: CompositeType, fragments: NamedFragments | undefined): TOwnType;
+  abstract rebaseOn(args: { parentType: CompositeType, fragments: NamedFragments | undefined, errorIfCannotRebase: boolean}): TOwnType | undefined;
+
+  rebaseOnOrError({ parentType, fragments }: { parentType: CompositeType, fragments: NamedFragments | undefined }): TOwnType {
+    return this.rebaseOn({ parentType, fragments, errorIfCannotRebase: true})!;
+  }
 
   get parentType(): CompositeType {
     return this.element.parentType;
@@ -2468,7 +2540,6 @@ abstract class AbstractSelection<TElement extends OperationElement, TIsLeaf exte
     const applyingFragments: { fragment: NamedFragmentDefinition, atType: FragmentRestrictionAtType }[] = [];
     for (const candidate of candidates) {
       const atType = candidate.expandedSelectionSetAtType(parentType);
-      const selectionSetAtType = atType.selectionSet;
       // It's possible that while the fragment technically applies at `parentType`, it's "rebasing" on
       // `parentType` is empty, or contains only `__typename`. For instance, suppose we have
       // a union `U = A | B | C`, and then a fragment:
@@ -2487,11 +2558,22 @@ abstract class AbstractSelection<TElement extends OperationElement, TIsLeaf exte
       //
       // Using `F` in those cases is, while not 100% incorrect, at least not productive, and so we
       // skip it that case. This is essentially an optimisation.
-      if (selectionSetAtType.isEmpty() || (selectionSetAtType.selections().length === 1 && selectionSetAtType.selections()[0].isTypenameField())) {
+      if (atType.selectionSet.isEmpty() || (atType.selectionSet.selections().length === 1 && atType.selectionSet.selections()[0].isTypenameField())) {
         continue;
       }
 
-      const res = subSelection.contains(selectionSetAtType);
+      // As we check inclusion, we ignore the case where the fragment queries __typename but the subSelection does not.
+      // The rational is that querying `__typename` unecessarily is mostly harmless (it always works and it's super cheap)
+      // so we don't want to not use a fragment just to save querying a `__typename` in a few cases. But the underlying
+      // context of why this matters is that the query planner always requests __typename for abstract type, and will do
+      // so in fragments too, but we can have a field that _does_ return an abstract type within a fragment, but that
+      // _does not_ end up returning an abstract type when applied in a "more specific" context (think a fragment on
+      // an interface I1 where a inside field returns another interface I2, but applied in the context of a implementation
+      // type of I1 where that particular field returns an implementation of I2 rather than I2 directly; we would have
+      // added __typename to the fragment (because it's all interfaces), but the selection itself, which only deals
+      // with object type, may not have __typename requested; using the fragment might still be a good idea, and
+      // querying __typename needlessly is a very small price to pay for that).
+      const res = subSelection.contains(atType.selectionSet, { ignoreMissingTypename: true });
 
       if (res === ContainsResult.EQUAL) {
         if (canUseFullMatchingFragment(candidate)) {
@@ -2568,7 +2650,7 @@ abstract class AbstractSelection<TElement extends OperationElement, TIsLeaf exte
 
     let notCoveredByFragments = subSelection;
     const optimized = new SelectionSetUpdates();
-    for (const { fragment, atType} of filteredApplyingFragments) {
+    for (const { fragment, atType } of filteredApplyingFragments) {
       if (!validator.checkCanReuseFragmentAndTrackIt(atType)) {
         continue;
       }
@@ -2874,12 +2956,24 @@ export class FieldSelection extends AbstractSelection<Field<any>, undefined, Fie
    * Obviously, this operation will only succeed if this selection (both the field itself and its subselections)
    * make sense from the provided parent type. If this is not the case, this method will throw.
    */
-  rebaseOn(parentType: CompositeType, fragments: NamedFragments | undefined): FieldSelection {
+  rebaseOn({
+    parentType,
+    fragments,
+    errorIfCannotRebase,
+  }: {
+    parentType: CompositeType,
+    fragments: NamedFragments | undefined,
+    errorIfCannotRebase: boolean,
+  }): FieldSelection | undefined {
     if (this.element.parentType === parentType) {
       return this;
     }
 
-    const rebasedElement = this.element.rebaseOn(parentType);
+    const rebasedElement = this.element.rebaseOn({ parentType, errorIfCannotRebase });
+    if (!rebasedElement) {
+      return undefined;
+    }
+
     if (!this.selectionSet) {
       return this.withUpdatedElement(rebasedElement);
     }
@@ -2890,7 +2984,8 @@ export class FieldSelection extends AbstractSelection<Field<any>, undefined, Fie
     }
 
     validate(isCompositeType(rebasedBase), () => `Cannot rebase field selection ${this} on ${parentType}: rebased field base return type ${rebasedBase} is not composite`);
-    return this.withUpdatedComponents(rebasedElement, this.selectionSet.rebaseOn(rebasedBase, fragments));
+    const rebasedSelectionSet = this.selectionSet.rebaseOn({ parentType: rebasedBase, fragments, errorIfCannotRebase });
+    return rebasedSelectionSet.isEmpty() ? undefined : this.withUpdatedComponents(rebasedElement, rebasedSelectionSet);
   }
 
   /**
@@ -2997,7 +3092,7 @@ export class FieldSelection extends AbstractSelection<Field<any>, undefined, Fie
     return !!that.selectionSet && this.selectionSet.equals(that.selectionSet);
   }
 
-  contains(that: Selection): ContainsResult {
+  contains(that: Selection, options?: { ignoreMissingTypename?: boolean }): ContainsResult {
     if (!(that instanceof FieldSelection) || !this.element.equals(that.element)) {
       return ContainsResult.NOT_CONTAINED;
     }
@@ -3007,7 +3102,7 @@ export class FieldSelection extends AbstractSelection<Field<any>, undefined, Fie
       return ContainsResult.EQUAL;
     }
     assert(that.selectionSet, '`this` and `that` have the same element, so if one has sub-selection, the other one should too')
-    return this.selectionSet.contains(that.selectionSet);
+    return this.selectionSet.contains(that.selectionSet, options);
   }
 
   toString(expandFragments: boolean = true, indent?: string): string {
@@ -3051,7 +3146,7 @@ export abstract class FragmentSelection extends AbstractSelection<FragmentElemen
 
   abstract equals(that: Selection): boolean;
 
-  abstract contains(that: Selection): ContainsResult;
+  abstract contains(that: Selection, options?: { ignoreMissingTypename?: boolean }): ContainsResult;
 
   normalize({ parentType, recursive }: { parentType: CompositeType, recursive? : boolean }): FragmentSelection | SelectionSet | undefined {
     const thisCondition = this.element.typeCondition;
@@ -3108,18 +3203,31 @@ class InlineFragmentSelection extends FragmentSelection {
     this.selectionSet.validate(variableDefinitions);
   }
 
-  rebaseOn(parentType: CompositeType, fragments: NamedFragments | undefined): FragmentSelection {
+  rebaseOn({
+    parentType,
+    fragments,
+    errorIfCannotRebase,
+  }: {
+    parentType: CompositeType,
+    fragments: NamedFragments | undefined,
+    errorIfCannotRebase: boolean,
+  }): FragmentSelection | undefined {
     if (this.parentType === parentType) {
       return this;
     }
 
-    const rebasedFragment = this.element.rebaseOn(parentType);
+    const rebasedFragment = this.element.rebaseOn({ parentType, errorIfCannotRebase });
+    if (!rebasedFragment) {
+      return undefined;
+    }
+
     const rebasedCastedType = rebasedFragment.castedType();
     if (rebasedCastedType === this.selectionSet.parentType) {
       return this.withUpdatedElement(rebasedFragment);
     }
 
-    return this.withUpdatedComponents(rebasedFragment, this.selectionSet.rebaseOn(rebasedCastedType, fragments));
+    const rebasedSelectionSet = this.selectionSet.rebaseOn({ parentType: rebasedCastedType, fragments, errorIfCannotRebase });
+    return rebasedSelectionSet.isEmpty() ? undefined : this.withUpdatedComponents(rebasedFragment, rebasedSelectionSet);
   }
 
   canAddTo(parentType: CompositeType): boolean {
@@ -3268,7 +3376,8 @@ class InlineFragmentSelection extends FragmentSelection {
           return undefined;
         } else {
           return this.withUpdatedComponents(
-            this.element.rebaseOn(parentType),
+            // We should be able to rebase, or there is a bug, so error if that is the case.
+            this.element.rebaseOnOrError(parentType),
             selectionSetOfElement(
               new Field(
                 (this.element.typeCondition ?? parentType).typenameField()!,
@@ -3320,7 +3429,7 @@ class InlineFragmentSelection extends FragmentSelection {
 
     return this.parentType === parentType && this.selectionSet === normalizedSelectionSet
       ? this
-      : this.withUpdatedComponents(this.element.rebaseOn(parentType), normalizedSelectionSet);
+      : this.withUpdatedComponents(this.element.rebaseOnOrError(parentType), normalizedSelectionSet);
   }
 
   expandFragments(updatedFragments: NamedFragments | undefined): FragmentSelection {
@@ -3337,12 +3446,12 @@ class InlineFragmentSelection extends FragmentSelection {
       && this.selectionSet.equals(that.selectionSet);
   }
 
-  contains(that: Selection): ContainsResult {
+  contains(that: Selection, options?: { ignoreMissingTypename?: boolean }): ContainsResult {
     if (!(that instanceof FragmentSelection) || !this.element.equals(that.element)) {
       return ContainsResult.NOT_CONTAINED;
     }
 
-    return this.selectionSet.contains(that.selectionSet);
+    return this.selectionSet.contains(that.selectionSet, options);
   }
 
   toString(expandFragments: boolean = true, indent?: string): string {
@@ -3385,7 +3494,7 @@ class FragmentSpreadSelection extends FragmentSelection {
     // We must update the spread parent type if necessary since we're not going deeper,
     // or we'll be fundamentally losing context.
     assert(parentType.schema() === this.parentType.schema(), 'Should not try to normalize using a type from another schema');
-    return this.rebaseOn(parentType, this.fragments);
+    return this.rebaseOnOrError({ parentType, fragments: this.fragments });
   }
 
   validate(): void {
@@ -3421,7 +3530,15 @@ class FragmentSpreadSelection extends FragmentSelection {
     return this;
   }
 
-  rebaseOn(parentType: CompositeType, fragments: NamedFragments | undefined): FragmentSelection {
+  rebaseOn({
+    parentType,
+    fragments,
+    errorIfCannotRebase,
+  }: {
+    parentType: CompositeType,
+    fragments: NamedFragments | undefined,
+    errorIfCannotRebase: boolean,
+  }): FragmentSelection | undefined {
     // We preserve the parent type here, to make sure we don't lose context, but we actually don't
     // want to expand the spread  as that would compromise the code that optimize subgraph fetches to re-use named
     // fragments.
@@ -3441,7 +3558,14 @@ class FragmentSpreadSelection extends FragmentSelection {
     assert(fragments || this.parentType.schema() === parentType.schema(), `Must provide fragments is rebasing on other schema`);
     const newFragments = fragments ?? this.fragments;
     const namedFragment = newFragments.get(this.namedFragment.name);
-    assert(namedFragment, () => `Cannot rebase ${this} if it isn't part of the provided fragments`);
+    // If we're rebasing on another schema (think a subgraph), then named fragments will have been rebased on that, and some
+    // of them may not contain anything that is on that subgraph, in which case they will not have been included at all.
+    // If so, then as long as we're not ask to error if we cannot rebase, then we're happy to skip that spread (since again,
+    // it expands to nothing that apply on the schema).
+    if (!namedFragment) {
+      validate(!errorIfCannotRebase, () => `Cannot rebase ${this.toString(false)} if it isn't part of the provided fragments`);
+      return undefined;
+    }
     return new FragmentSpreadSelection(
       parentType,
       newFragments,
@@ -3497,7 +3621,7 @@ class FragmentSpreadSelection extends FragmentSelection {
       && sameDirectiveApplications(this.spreadDirectives, that.spreadDirectives);
   }
 
-  contains(that: Selection): ContainsResult {
+  contains(that: Selection, options?: { ignoreMissingTypename?: boolean }): ContainsResult {
     if (this.equals(that)) {
       return ContainsResult.EQUAL;
     }
@@ -3506,7 +3630,7 @@ class FragmentSpreadSelection extends FragmentSelection {
       return ContainsResult.NOT_CONTAINED;
     }
 
-    return  this.selectionSet.contains(that.selectionSet);
+    return this.selectionSet.contains(that.selectionSet, options);
   }
 
   toString(expandFragments: boolean = true, indent?: string): string {

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -4542,7 +4542,7 @@ function inputsForRequire(
       assert(supergraphItfType && isInterfaceType(supergraphItfType), () => `Type ${entityType} should be an interface in the supergraph`);
       // Note: we are rebasing on another schema below, but we also known that we're working on a full expanded
       // selection set (no spread), so passing undefined is actually correct.
-      keyConditionAsInput = keyConditionAsInput.rebaseOn(supergraphItfType, undefined);
+      keyConditionAsInput = keyConditionAsInput.rebaseOn({ parentType: supergraphItfType, fragments: undefined, errorIfCannotRebase: true });
     }
     fullSelectionSet.updates().add(keyConditionAsInput);
 


### PR DESCRIPTION
This PR ports #2684 to the `2.5.x` release line.

This commit reapplies #2639 with an additional fix related to reproducing and resolving #2680.

The bug existed in the `SelectionSet.contains` logic in the final check to provide a `ContainsResult`. Here the lengths of the compared selection sets are used to determine subset or strictly equal. In the case that the `__typename` field was ignored up above, the comparison becomes invalid unless we offset the comparison by 1 to account for the non-existent field.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
