### PR TITLE
Remove extraneous `span.setStatus()` following `span.end()`

### DIFF
--- a/.changeset/dull-gorillas-drive.md
+++ b/.changeset/dull-gorillas-drive.md
@@ -1,0 +1,10 @@
+---
+"@apollo/gateway": patch
+---
+
+Remove extraneous call to `span.setStatus()` on a span which has already ended.
+
+In cases where a subgraph responded with an error, we would sometimes try to set
+the status of a span which had already ended. This resulted in a warning log to
+the console (but no effect otherwise). This warning should no longer happen.
+  

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -273,6 +273,9 @@ export async function executeQueryPlan(
         finally {
           span.end()
         }
+        if(errors.length > 0) {
+          span.setStatus({ code:SpanStatusCode.ERROR });
+        }
         return errors.length === 0 ? { data } : { errors, data };
       });
 

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -273,9 +273,6 @@ export async function executeQueryPlan(
         finally {
           span.end()
         }
-        if(errors.length > 0) {
-          span.setStatus({ code:SpanStatusCode.ERROR });
-        }
         return errors.length === 0 ? { data } : { errors, data };
       });
 

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -88,7 +88,7 @@ function makeIntrospectionQueryDocument(
   const usedVariables = collectUsedVariables(introspectionSelection);
   const usedVariableDefinitions = variableDefinitions?.filter((def) => usedVariables.has(def.variable.name.value));
   assert(
-    usedVariables.size === (usedVariableDefinitions?.length ?? 0), 
+    usedVariables.size === (usedVariableDefinitions?.length ?? 0),
     () => `Should have found all used variables ${[...usedVariables]} in definitions ${JSON.stringify(variableDefinitions)}`,
   );
   return {
@@ -273,9 +273,6 @@ export async function executeQueryPlan(
         finally {
           span.end()
         }
-        if(errors.length > 0) {
-          span.setStatus({ code:SpanStatusCode.ERROR });
-        }
         return errors.length === 0 ? { data } : { errors, data };
       });
 
@@ -381,7 +378,7 @@ async function executeNode(
       return new Trace.QueryPlanNode({ fetch: traceNode });
     }
     case 'Condition': {
-      const condition = evaluateCondition(node, context.operation.variableDefinitions, context.requestContext.request.variables); 
+      const condition = evaluateCondition(node, context.operation.variableDefinitions, context.requestContext.request.variables);
       const pickedBranch = condition ? node.ifClause : node.elseClause;
       let branchTraceNode: Trace.QueryPlanNode | undefined = undefined;
       if (pickedBranch) {


### PR DESCRIPTION
Fixes #2652

The call to `span.setStatus()` here does nothing since the span has already ended in the `finally` immediately above. This ends up being a noop but does trigger a warning log to the console as noted in the issue.

I hoped to capture this log in a test by mocking `console.warn` but otel blows up when I do that for some reason.

Anyway, the lack of changes in any tests at least confirms that we already didn't expect this code was doing anything.