### PR TITLE
Gateway OpenTelemetry improvements

### DIFF
--- a/.changeset/fair-snakes-accept.md
+++ b/.changeset/fair-snakes-accept.md
@@ -1,0 +1,36 @@
+---
+"@apollo/gateway": minor
+---
+
+Add more information to OpenTelemetry spans.
+
+Rename `operationName` to `graphql.operation.name` and add a
+`graphql.operation.type` attribute, in conformance with the OpenTelemetry
+Semantic Conventions for GraphQL. The `operationName` attribute is now
+deprecated, but it is still emitted alongside `graphql.operation.name`.
+
+Add a `graphql.document` span attribute to the `gateway.request` span,
+containing the entire GraphQL source sent in the request. This feature
+is disable by default.
+
+When one or more GraphQL or internal errors occur, report them in the
+OpenTelemetry span in which they took place, as an exception event. This
+feature is disabled by default.
+
+To enable the `graphql.document` span attribute and the exception event
+reporting, add the following entries to your `ApolloGateway` instance
+configuration:
+
+```ts
+const gateway = new ApolloGateway({
+  // ...
+  telemetry: {
+    // Set to `true` to include the `graphql.document` attribute
+    includeDocument: true,
+    // Set to `true` to report all exception events, or set to a number
+    // to report at most that number of exception events per span
+    reportExceptions: true,
+    // or: reportExceptions: 1
+  },
+});
+```

--- a/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
+++ b/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
@@ -186,7 +186,33 @@ exports[`opentelemetry with local data receives spans on validation failure 1`] 
     "attributes": {
       "operationName": "InvalidVariables",
       "graphql.operation.name": "InvalidVariables",
-      "graphql.document": "#graphql\\n      query InvalidVariables($first: Int!) {\\n        topReviews(first: $first) {\\n          body\\n        }\\n      }\\n    ",
+      "graphql.document": "#graphql\\n      query InvalidVariables($first: Int!, $second: Int!) {\\n        topReviews(first: $first) {\\n          body\\n        }\\n      }",
+      "graphql.operation.type": "query"
+    },
+    "children": [
+      {
+        "name": "gateway.validate",
+        "attributes": {},
+        "children": [],
+        "status": {
+          "code": 2
+        }
+      }
+    ],
+    "status": {
+      "code": 2
+    }
+  }
+]
+`;
+
+exports[`opentelemetry with local data with includeDocument set to false does not include the source document 1`] = `
+[
+  {
+    "name": "gateway.request",
+    "attributes": {
+      "operationName": "InvalidVariables",
+      "graphql.operation.name": "InvalidVariables",
       "graphql.operation.type": "query"
     },
     "children": [

--- a/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
+++ b/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
@@ -5,7 +5,8 @@ exports[`opentelemetry receives spans on fetch failure 1`] = `
   {
     "name": "gateway.request",
     "attributes": {
-      "operationName": "GetProduct"
+      "operationName": "GetProduct",
+      "graphql.document": "#graphql\\n    query GetProduct($upc: String!) {\\n      product(upc: $upc) {\\n        name\\n      }\\n    }\\n    "
     },
     "children": [
       {
@@ -64,7 +65,8 @@ exports[`opentelemetry with local data receives spans on plan failure 1`] = `
   {
     "name": "gateway.request",
     "attributes": {
-      "operationName": "GetProduct"
+      "operationName": "GetProduct",
+      "graphql.document": "#graphql\\n      subscription GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    "
     },
     "children": [
       {
@@ -96,7 +98,8 @@ exports[`opentelemetry with local data receives spans on success 1`] = `
   {
     "name": "gateway.request",
     "attributes": {
-      "operationName": "GetProduct"
+      "operationName": "GetProduct",
+      "graphql.document": "#graphql\\n      query GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    "
     },
     "children": [
       {
@@ -175,7 +178,8 @@ exports[`opentelemetry with local data receives spans on validation failure 1`] 
   {
     "name": "gateway.request",
     "attributes": {
-      "operationName": "InvalidVariables"
+      "operationName": "InvalidVariables",
+      "graphql.document": "#graphql\\n      query InvalidVariables($first: Int!) {\\n        topReviews(first: $first) {\\n          body\\n        }\\n      }\\n    "
     },
     "children": [
       {

--- a/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
+++ b/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
@@ -7,7 +7,8 @@ exports[`opentelemetry receives spans on fetch failure 1`] = `
     "attributes": {
       "operationName": "GetProduct",
       "graphql.operation.name": "GetProduct",
-      "graphql.document": "#graphql\\n    query GetProduct($upc: String!) {\\n      product(upc: $upc) {\\n        name\\n      }\\n    }\\n    "
+      "graphql.document": "#graphql\\n    query GetProduct($upc: String!) {\\n      product(upc: $upc) {\\n        name\\n      }\\n    }\\n    ",
+      "graphql.operation.type": "query"
     },
     "children": [
       {
@@ -68,7 +69,8 @@ exports[`opentelemetry with local data receives spans on plan failure 1`] = `
     "attributes": {
       "operationName": "GetProduct",
       "graphql.operation.name": "GetProduct",
-      "graphql.document": "#graphql\\n      subscription GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    "
+      "graphql.document": "#graphql\\n      subscription GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    ",
+      "graphql.operation.type": "subscription"
     },
     "children": [
       {
@@ -102,7 +104,8 @@ exports[`opentelemetry with local data receives spans on success 1`] = `
     "attributes": {
       "operationName": "GetProduct",
       "graphql.operation.name": "GetProduct",
-      "graphql.document": "#graphql\\n      query GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    "
+      "graphql.document": "#graphql\\n      query GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    ",
+      "graphql.operation.type": "query"
     },
     "children": [
       {
@@ -183,7 +186,8 @@ exports[`opentelemetry with local data receives spans on validation failure 1`] 
     "attributes": {
       "operationName": "InvalidVariables",
       "graphql.operation.name": "InvalidVariables",
-      "graphql.document": "#graphql\\n      query InvalidVariables($first: Int!) {\\n        topReviews(first: $first) {\\n          body\\n        }\\n      }\\n    "
+      "graphql.document": "#graphql\\n      query InvalidVariables($first: Int!) {\\n        topReviews(first: $first) {\\n          body\\n        }\\n      }\\n    ",
+      "graphql.operation.type": "query"
     },
     "children": [
       {

--- a/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
+++ b/gateway-js/src/__tests__/gateway/__snapshots__/opentelemetry.test.ts.snap
@@ -6,6 +6,7 @@ exports[`opentelemetry receives spans on fetch failure 1`] = `
     "name": "gateway.request",
     "attributes": {
       "operationName": "GetProduct",
+      "graphql.operation.name": "GetProduct",
       "graphql.document": "#graphql\\n    query GetProduct($upc: String!) {\\n      product(upc: $upc) {\\n        name\\n      }\\n    }\\n    "
     },
     "children": [
@@ -66,6 +67,7 @@ exports[`opentelemetry with local data receives spans on plan failure 1`] = `
     "name": "gateway.request",
     "attributes": {
       "operationName": "GetProduct",
+      "graphql.operation.name": "GetProduct",
       "graphql.document": "#graphql\\n      subscription GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    "
     },
     "children": [
@@ -99,6 +101,7 @@ exports[`opentelemetry with local data receives spans on success 1`] = `
     "name": "gateway.request",
     "attributes": {
       "operationName": "GetProduct",
+      "graphql.operation.name": "GetProduct",
       "graphql.document": "#graphql\\n      query GetProduct($upc: String!) {\\n        product(upc: $upc) {\\n          name\\n        }\\n      }\\n    "
     },
     "children": [
@@ -179,6 +182,7 @@ exports[`opentelemetry with local data receives spans on validation failure 1`] 
     "name": "gateway.request",
     "attributes": {
       "operationName": "InvalidVariables",
+      "graphql.operation.name": "InvalidVariables",
       "graphql.document": "#graphql\\n      query InvalidVariables($first: Int!) {\\n        topReviews(first: $first) {\\n          body\\n        }\\n      }\\n    "
     },
     "children": [

--- a/gateway-js/src/__tests__/gateway/opentelemetry.test.ts
+++ b/gateway-js/src/__tests__/gateway/opentelemetry.test.ts
@@ -63,7 +63,11 @@ describe('opentelemetry', () => {
     `;
 
       await execute(executor, source, {upc: '1'}, 'GetProduct');
-      expect(inMemorySpans.getFinishedSpans()).toMatchSnapshot();
+      const spans = inMemorySpans.getFinishedSpans()
+      expect(spans).toMatchSnapshot();
+      spans.forEach((span) => {
+        expect(span.events).toStrictEqual([])
+      })
     });
 
     it('receives spans on validation failure', async () => {
@@ -77,7 +81,12 @@ describe('opentelemetry', () => {
     `;
 
       await execute(executor, source, { upc: '1' }, 'InvalidVariables');
-      expect(inMemorySpans.getFinishedSpans()).toMatchSnapshot();
+      const spans = inMemorySpans.getFinishedSpans()
+      expect(spans).toMatchSnapshot();
+      const validationSpan = spans.find((span) =>
+        span.name === 'gateway.validate');
+
+      expect(validationSpan?.events.length).toBeGreaterThan(0)
     });
 
     it('receives spans on plan failure', async () => {
@@ -94,7 +103,12 @@ describe('opentelemetry', () => {
         await execute(executor, source, {upc: '1'}, 'GetProduct');
       }
       catch(err) {}
-      expect(inMemorySpans.getFinishedSpans()).toMatchSnapshot();
+      const spans = inMemorySpans.getFinishedSpans()
+      expect(spans).toMatchSnapshot();
+      const planSpan = spans.find((span) =>
+        span.name === 'gateway.plan');
+
+      expect(planSpan?.events.length).toBeGreaterThan(0)
     });
   });
 
@@ -118,6 +132,11 @@ describe('opentelemetry', () => {
     `;
 
     await execute(executor, source, {upc: '1'}, 'GetProduct');
-    expect(inMemorySpans.getFinishedSpans()).toMatchSnapshot();
+    const spans = inMemorySpans.getFinishedSpans()
+    expect(spans).toMatchSnapshot();
+    const fetchSpan = spans.find((span) =>
+      span.name === 'gateway.fetch');
+
+    expect(fetchSpan?.events.length).toBeGreaterThan(0)
   });
 });

--- a/gateway-js/src/__tests__/gateway/opentelemetry.test.ts
+++ b/gateway-js/src/__tests__/gateway/opentelemetry.test.ts
@@ -33,7 +33,12 @@ describe('opentelemetry', () => {
 
   describe('with local data', () =>
   {
-    async function gateway() {
+    async function gateway(
+      telemetryConfig?: {
+        includeDocument?: boolean,
+        recordExceptions?: boolean | number
+      }
+    ) {
       const localDataSources = Object.fromEntries(
         fixtures.map((f) => [
           f.name,
@@ -45,10 +50,32 @@ describe('opentelemetry', () => {
         buildService(service) {
           return localDataSources[service.name];
         },
+        telemetry: telemetryConfig || {
+          includeDocument: true,
+          recordExceptions: true
+        }
       });
 
       const {executor} = await gateway.load();
       return executor;
+    }
+
+    const executeValidationFailure = async (
+      telemetryConfig?: {
+        includeDocument?: boolean,
+        recordExceptions?: boolean | number
+      }
+    ) => {
+      const executor = await gateway(telemetryConfig);
+
+      const source = `#graphql
+      query InvalidVariables($first: Int!, $second: Int!) {
+        topReviews(first: $first) {
+          body
+        }
+      }`;
+
+      await execute(executor, source, { upc: '1' }, 'InvalidVariables');
     }
 
     it('receives spans on success', async () => {
@@ -71,22 +98,14 @@ describe('opentelemetry', () => {
     });
 
     it('receives spans on validation failure', async () => {
-      const executor = await gateway();
-      const source = `#graphql
-      query InvalidVariables($first: Int!) {
-        topReviews(first: $first) {
-          body
-        }
-      }
-    `;
+      await executeValidationFailure();
 
-      await execute(executor, source, { upc: '1' }, 'InvalidVariables');
       const spans = inMemorySpans.getFinishedSpans()
       expect(spans).toMatchSnapshot();
       const validationSpan = spans.find((span) =>
         span.name === 'gateway.validate');
 
-      expect(validationSpan?.events.length).toBeGreaterThan(0)
+      expect(validationSpan?.events.length).toEqual(2)
     });
 
     it('receives spans on plan failure', async () => {
@@ -108,8 +127,38 @@ describe('opentelemetry', () => {
       const planSpan = spans.find((span) =>
         span.name === 'gateway.plan');
 
-      expect(planSpan?.events.length).toBeGreaterThan(0)
+      expect(planSpan?.events.length).toEqual(1)
     });
+
+    describe('with recordExceptions set to a number', () => {
+      it('receives at most that number of exception events', async () => {
+        await executeValidationFailure({recordExceptions: 1})
+        const spans = inMemorySpans.getFinishedSpans()
+        const validationSpan = spans.find((span) =>
+          span.name === 'gateway.validate');
+
+        expect(validationSpan?.events.length).toEqual(1)
+      })
+    })
+
+    describe('with recordExceptions set to false', () => {
+      it('receives no exception events', async () => {
+        await executeValidationFailure({recordExceptions: false})
+        const spans = inMemorySpans.getFinishedSpans()
+        const validationSpan = spans.find((span) =>
+          span.name === 'gateway.validate');
+
+        expect(validationSpan?.events.length).toEqual(0)
+      })
+    })
+
+    describe('with includeDocument set to false', () => {
+      it('does not include the source document', async () => {
+        await executeValidationFailure({recordExceptions: false})
+        const spans = inMemorySpans.getFinishedSpans()
+        expect(spans).toMatchSnapshot();
+      })
+    })
   });
 
 
@@ -119,6 +168,10 @@ describe('opentelemetry', () => {
       fetcher: () => {
         throw Error('Nooo');
       },
+      telemetry: {
+        includeDocument: true,
+        recordExceptions: true
+      }
     });
 
     const { executor } = await gateway.load();
@@ -137,6 +190,6 @@ describe('opentelemetry', () => {
     const fetchSpan = spans.find((span) =>
       span.name === 'gateway.fetch');
 
-    expect(fetchSpan?.events.length).toBeGreaterThan(0)
+    expect(fetchSpan?.events.length).toEqual(1)
   });
 });

--- a/gateway-js/src/config.ts
+++ b/gateway-js/src/config.ts
@@ -9,6 +9,7 @@ import { ServiceMap } from './executeQueryPlan';
 import { ServiceDefinition } from "@apollo/federation-internals";
 import { Fetcher } from '@apollo/utils.fetcher';
 import { UplinkSupergraphManager } from './supergraphManagers';
+import { OpenTelemetryConfig } from './utilities/opentelemetry';
 
 export type ServiceEndpointDefinition = Pick<ServiceDefinition, 'name' | 'url'>;
 
@@ -129,6 +130,7 @@ interface GatewayConfigBase {
   serviceHealthCheck?: boolean;
 
   queryPlannerConfig?: QueryPlannerConfig;
+  telemetry?: OpenTelemetryConfig;
 
   /**
    * Whether to validate the supergraphs received from either the static configuration or the

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -239,7 +239,7 @@ export async function executeQueryPlan(
           // Note that this behavior is also what the router does (and in fact, the exact name of the `extensions` we use,
           // "valueCompletion", comes from the router and we use it for alignment.
           if (errors.length === 0 && postProcessingErrors.length > 0) {
-            span.recordException(postProcessingErrors[0]);
+            postProcessingErrors.forEach(error => span.recordException(error));
             span.setStatus({ code:SpanStatusCode.ERROR });
             return { extensions: { "valueCompletion":  postProcessingErrors }, data };
           }
@@ -282,7 +282,7 @@ export async function executeQueryPlan(
       });
 
       if(result.errors) {
-        span.recordException(result.errors[0]);
+        result.errors.forEach(error => span.recordException(error));
         span.setStatus({ code:SpanStatusCode.ERROR });
       }
       return result;

--- a/gateway-js/src/executeQueryPlan.ts
+++ b/gateway-js/src/executeQueryPlan.ts
@@ -239,10 +239,12 @@ export async function executeQueryPlan(
           // Note that this behavior is also what the router does (and in fact, the exact name of the `extensions` we use,
           // "valueCompletion", comes from the router and we use it for alignment.
           if (errors.length === 0 && postProcessingErrors.length > 0) {
+            span.recordException(postProcessingErrors[0]);
             span.setStatus({ code:SpanStatusCode.ERROR });
             return { extensions: { "valueCompletion":  postProcessingErrors }, data };
           }
         } catch (error) {
+          span.recordException(error);
           span.setStatus({ code:SpanStatusCode.ERROR });
           if (error instanceof GraphQLError) {
             return { errors: [error] };
@@ -280,11 +282,13 @@ export async function executeQueryPlan(
       });
 
       if(result.errors) {
+        span.recordException(result.errors[0]);
         span.setStatus({ code:SpanStatusCode.ERROR });
       }
       return result;
     }
     catch (err) {
+      span.recordException(err)
       span.setStatus({ code:SpanStatusCode.ERROR });
       throw err;
     }
@@ -517,6 +521,7 @@ async function executeFetch(
       }
     }
     catch (err) {
+      span.recordException(err);
       span.setStatus({ code:SpanStatusCode.ERROR });
       throw err;
     }

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -772,6 +772,7 @@ export class ApolloGateway implements GatewayInterface {
           );
 
           if (validationErrors.length > 0) {
+            span.recordException(validationErrors[0]);
             span.setStatus({ code: SpanStatusCode.ERROR });
             return { errors: validationErrors };
           }
@@ -790,6 +791,7 @@ export class ApolloGateway implements GatewayInterface {
                   // TODO(#631): Can we be sure the query planner has been initialized here?
                   return this.queryPlanner!.buildQueryPlan(operation);
                 } catch (err) {
+                  span.recordException(err);
                   span.setStatus({ code: SpanStatusCode.ERROR });
                   throw err;
                 } finally {
@@ -870,10 +872,12 @@ export class ApolloGateway implements GatewayInterface {
             };
           }
           if (response.errors) {
+            span.recordException(response.errors[0]);
             span.setStatus({ code: SpanStatusCode.ERROR });
           }
           return response;
         } catch (err) {
+          span.recordException(err);
           span.setStatus({ code: SpanStatusCode.ERROR });
           throw err;
         } finally {
@@ -902,10 +906,12 @@ export class ApolloGateway implements GatewayInterface {
         );
 
         if (errors) {
+          span.recordException(errors[0]);
           span.setStatus({ code: SpanStatusCode.ERROR });
         }
         return errors || [];
       } catch (err) {
+        span.recordException(err);
         span.setStatus({ code: SpanStatusCode.ERROR });
         throw err;
       } finally {

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -41,7 +41,7 @@ import {
   SupergraphManager,
 } from './config';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { OpenTelemetrySpanNames, tracer } from './utilities/opentelemetry';
+import { OpenTelemetrySpanNames, tracer, requestContextSpanAttributes } from './utilities/opentelemetry';
 import { addExtensions } from './schema-helper/addExtensions';
 import {
   IntrospectAndCompose,
@@ -745,13 +745,9 @@ export class ApolloGateway implements GatewayInterface {
   public executor = async (
     requestContext: GatewayGraphQLRequestContext,
   ): Promise<GatewayExecutionResult> => {
-    const spanAttributes = requestContext.operationName
-      ? { operationName: requestContext.operationName }
-      : {};
-
     return tracer.startActiveSpan(
       OpenTelemetrySpanNames.REQUEST,
-      { attributes: spanAttributes },
+      { attributes: requestContextSpanAttributes(requestContext) },
       async (span) => {
         try {
           const { request, document, queryHash } = requestContext;

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -768,7 +768,7 @@ export class ApolloGateway implements GatewayInterface {
           );
 
           if (validationErrors.length > 0) {
-            span.recordException(validationErrors[0]);
+            validationErrors.forEach(error => span.recordException(error));
             span.setStatus({ code: SpanStatusCode.ERROR });
             return { errors: validationErrors };
           }
@@ -868,7 +868,7 @@ export class ApolloGateway implements GatewayInterface {
             };
           }
           if (response.errors) {
-            span.recordException(response.errors[0]);
+            response.errors.forEach(error => span.recordException(error));
             span.setStatus({ code: SpanStatusCode.ERROR });
           }
           return response;
@@ -902,7 +902,7 @@ export class ApolloGateway implements GatewayInterface {
         );
 
         if (errors) {
-          span.recordException(errors[0]);
+          errors.forEach(error => span.recordException(error));
           span.setStatus({ code: SpanStatusCode.ERROR });
         }
         return errors || [];

--- a/gateway-js/src/index.ts
+++ b/gateway-js/src/index.ts
@@ -41,7 +41,7 @@ import {
   SupergraphManager,
 } from './config';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { OpenTelemetrySpanNames, tracer, requestContextSpanAttributes } from './utilities/opentelemetry';
+import { OpenTelemetrySpanNames, tracer, requestContextSpanAttributes, operationContextSpanAttributes } from './utilities/opentelemetry';
 import { addExtensions } from './schema-helper/addExtensions';
 import {
   IntrospectAndCompose,
@@ -759,6 +759,8 @@ export class ApolloGateway implements GatewayInterface {
             operationDocument: document,
             operationName: request.operationName,
           });
+
+          span.setAttributes(operationContextSpanAttributes(operationContext));
 
           // No need to build a query plan if we know the request is invalid beforehand
           // In the future, this should be controlled by the requestPipeline

--- a/gateway-js/src/utilities/opentelemetry.ts
+++ b/gateway-js/src/utilities/opentelemetry.ts
@@ -1,4 +1,5 @@
 import opentelemetry from '@opentelemetry/api';
+import type { GatewayGraphQLRequestContext } from '@apollo/server-gateway-interface';
 
 export enum OpenTelemetrySpanNames {
   REQUEST = 'gateway.request',
@@ -11,3 +12,16 @@ export enum OpenTelemetrySpanNames {
 
 const { name, version } = require('../../package.json');
 export const tracer = opentelemetry.trace.getTracer(`${name}/${version}`);
+
+export function requestContextSpanAttributes(requestContext: GatewayGraphQLRequestContext): {[key: string]: any} {
+  const spanAttributes: {[key: string]: any} = {};
+
+  if (requestContext.operationName) {
+    spanAttributes["operationName"] = requestContext.operationName;
+  }
+  if (requestContext.source) {
+    spanAttributes["graphql.document"] = requestContext.source;
+  }
+
+  return spanAttributes;
+}

--- a/gateway-js/src/utilities/opentelemetry.ts
+++ b/gateway-js/src/utilities/opentelemetry.ts
@@ -1,7 +1,34 @@
 import opentelemetry from '@opentelemetry/api';
-import type { Attributes } from '@opentelemetry/api';
+import type { Attributes, Exception, Span } from '@opentelemetry/api';
 import type { GatewayGraphQLRequestContext } from '@apollo/server-gateway-interface';
 import { OperationContext } from '../operationContext';
+
+export type OpenTelemetryConfig = {
+  /**
+   * Whether or not to include the `graphql.document` attribute in the
+   * `gateway.request` OpenTelemetry span. When set to `true`, the attribute
+   * will contain the entire GraphQL document for the current request.
+   *
+   * Defaults to `false`, meaning that the GraphQL document will not be added
+   * as a span attribute.
+   */
+  includeDocument?: boolean;
+  /**
+   * Whether or not to record the GraphQL and internal errors that take place
+   * while processing a request as exception events in the OpenTelemetry spans
+   * in which they occur.
+   *
+   * When a number is given as a value, it represents the maximum number of
+   * exceptions that will be reported in each OpenTelemetry span.
+   *
+   * Regardless of the value of this setting, the span status code will be set
+   * to `ERROR` when a GraphQL or internal error occurs.
+   *
+   * Defaults to `false`, meaning that no exceptions will be reported in any
+   * spans.
+   */
+  recordExceptions?: boolean | number;
+}
 
 export enum OpenTelemetrySpanNames {
   REQUEST = 'gateway.request',
@@ -26,7 +53,8 @@ export interface SpanAttributes extends Attributes {
 }
 
 export function requestContextSpanAttributes(
-  requestContext: GatewayGraphQLRequestContext
+  requestContext: GatewayGraphQLRequestContext,
+  config: OpenTelemetryConfig | undefined
 ): SpanAttributes {
   const spanAttributes: SpanAttributes = {};
 
@@ -34,7 +62,7 @@ export function requestContextSpanAttributes(
     spanAttributes["operationName"] = requestContext.operationName;
     spanAttributes["graphql.operation.name"] = requestContext.operationName;
   }
-  if (requestContext.source) {
+  if (config?.includeDocument && requestContext.source) {
     spanAttributes["graphql.document"] = requestContext.source;
   }
 
@@ -51,4 +79,30 @@ export function operationContextSpanAttributes(
   }
 
   return spanAttributes;
+}
+
+export function recordExceptions(
+  span: Span,
+  exceptions: readonly Exception[],
+  config: OpenTelemetryConfig | undefined
+) {
+  const recordExceptions = config?.recordExceptions;
+
+  if (recordExceptions === undefined || recordExceptions === false) {
+    return;
+  }
+
+  let exceptionsToRecord;
+
+  if (recordExceptions === true) {
+    exceptionsToRecord = exceptions;
+  } else if (recordExceptions <= 0) {
+    return;
+  } else {
+    exceptionsToRecord = exceptions.slice(0, recordExceptions)
+  }
+
+  for (const exception of exceptionsToRecord) {
+    span.recordException(exception);
+  }
 }

--- a/gateway-js/src/utilities/opentelemetry.ts
+++ b/gateway-js/src/utilities/opentelemetry.ts
@@ -1,4 +1,5 @@
 import opentelemetry from '@opentelemetry/api';
+import type { Attributes } from '@opentelemetry/api';
 import type { GatewayGraphQLRequestContext } from '@apollo/server-gateway-interface';
 
 export enum OpenTelemetrySpanNames {
@@ -13,11 +14,23 @@ export enum OpenTelemetrySpanNames {
 const { name, version } = require('../../package.json');
 export const tracer = opentelemetry.trace.getTracer(`${name}/${version}`);
 
-export function requestContextSpanAttributes(requestContext: GatewayGraphQLRequestContext): {[key: string]: any} {
-  const spanAttributes: {[key: string]: any} = {};
+export interface SpanAttributes extends Attributes {
+  /**
+   * @deprecated in favor of `graphql.operation.name`
+   */
+  operationName?: string;
+  'graphql.operation.name'?: string;
+  'graphql.document'?: string;
+}
+
+export function requestContextSpanAttributes(
+  requestContext: GatewayGraphQLRequestContext
+): SpanAttributes {
+  const spanAttributes: SpanAttributes = {};
 
   if (requestContext.operationName) {
     spanAttributes["operationName"] = requestContext.operationName;
+    spanAttributes["graphql.operation.name"] = requestContext.operationName;
   }
   if (requestContext.source) {
     spanAttributes["graphql.document"] = requestContext.source;

--- a/gateway-js/src/utilities/opentelemetry.ts
+++ b/gateway-js/src/utilities/opentelemetry.ts
@@ -1,6 +1,7 @@
 import opentelemetry from '@opentelemetry/api';
 import type { Attributes } from '@opentelemetry/api';
 import type { GatewayGraphQLRequestContext } from '@apollo/server-gateway-interface';
+import { OperationContext } from '../operationContext';
 
 export enum OpenTelemetrySpanNames {
   REQUEST = 'gateway.request',
@@ -20,6 +21,7 @@ export interface SpanAttributes extends Attributes {
    */
   operationName?: string;
   'graphql.operation.name'?: string;
+  'graphql.operation.type'?: string;
   'graphql.document'?: string;
 }
 
@@ -34,6 +36,18 @@ export function requestContextSpanAttributes(
   }
   if (requestContext.source) {
     spanAttributes["graphql.document"] = requestContext.source;
+  }
+
+  return spanAttributes;
+}
+
+export function operationContextSpanAttributes(
+  operationContext: OperationContext
+): SpanAttributes {
+  const spanAttributes: SpanAttributes = {};
+
+  if (operationContext.operation.operation) {
+    spanAttributes["graphql.operation.type"] = operationContext.operation.operation;
   }
 
   return spanAttributes;


### PR DESCRIPTION
This PR adds the GraphQL document as a span attribute on the gateway's request span, and makes it so that errors are recorded as exception events in the spans in which they occur.

## Commits

### [Record errors as OTel exception events](https://github.com/apollographql/federation/commit/d8a36a8c0e4a45553435e62a68d4d139c53cfa72)

When an error is received or thrown, in addition to setting the
span status to error, report the error as an OpenTelemetry
exception event.

If more than one error is received in a GraphQL error array, report
only the first one.

### [Report the GraphQL document as a span attribute](https://github.com/apollographql/federation/commit/f92f200ddd48ced4b6250ced0a8a8faa86d6c569)

On the request OpenTelemetry span, add the GraphQL document as an
OpenTelemetry span attribute, using the name for this
property recommended by the OpenTelemetry Semantic Conventions.

## Notes

- I made it so that only the first error in a GraphQL error array is added, erring on the side of caution, as I'm unsure just how many errors could be reported. If you'd rather it reports all errors in the array, let me know.
- The exception events are not tested through the snapshots, but separately, checking only for their presence in the desired spans. This is convenient, as the details of the error (backtrace, timing) are not interesting to check against.
- I could not figure out how to add the sub-query that is sent on fetch operations as a span attribute on the fetch spans. I believe this would also be useful. I am quite unfamiliar with the codebase, any pointers would be appreciated.
- I did not rename the existing `operationName` attribute to the recommended `graphql.operation.name` in the OpenTelemetry Semantic Conventions. Let me know if you want me to do that.