### PR TITLE
Fix `fallbackPollIntervalInMs` behavior

### DIFF
--- a/.changeset/grumpy-hairs-sleep.md
+++ b/.changeset/grumpy-hairs-sleep.md
@@ -1,0 +1,12 @@
+---
+"@apollo/gateway": patch
+---
+
+Fix `fallbackPollIntervalInMs` behavior.
+
+The `fallbackPollIntervalInMs` serves 2 purposes:
+* it allows users to provide an Uplink poll interval if Uplink doesn't provide one
+* it allows users to use a longer poll interval that what's prescribed by Uplink
+
+The second bullet is how the configuration option is documented, but not how it was previously implemented. This change corrects the behavior to respect this configuration if it's provided AND is longer than the Uplink interval.
+  

--- a/.cspell/cspell-dict.txt
+++ b/.cspell/cspell-dict.txt
@@ -241,6 +241,7 @@ unaliased
 uncacheable
 uncesssary
 uncomposable
+unconfigured
 undici
 unecesasry
 unecessarally

--- a/gateway-js/src/supergraphManagers/UplinkSupergraphManager/__tests__/UplinkSupergraphManager.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkSupergraphManager/__tests__/UplinkSupergraphManager.test.ts
@@ -72,32 +72,8 @@ describe('UplinkSupergraphManager', () => {
   });
 
   describe('fallbackPollIntervalInMs', () => {
-    beforeEach(() => {
-      nockBeforeEach();
-      // This explicitly mocks only `setTimeout` and `clearTimeout`
-      jest.useFakeTimers({
-        doNotFake: [
-          'Date',
-          'hrtime',
-          'nextTick',
-          'performance',
-          'queueMicrotask',
-          'requestAnimationFrame',
-          'cancelAnimationFrame',
-          'requestIdleCallback',
-          'cancelIdleCallback',
-          'setImmediate',
-          'clearImmediate',
-          'setInterval',
-          'clearInterval',
-        ],
-      });
-    });
-
-    afterEach(() => {
-      nockAfterEach();
-      jest.useRealTimers();
-    });
+    beforeEach(nockBeforeEach);
+    afterEach(nockAfterEach);
 
     it('uses the provided fallback interval when Uplink provides a shorter interval', async () => {
       // These are the two interesting values for the test. We just want to make

--- a/gateway-js/src/supergraphManagers/UplinkSupergraphManager/__tests__/UplinkSupergraphManager.test.ts
+++ b/gateway-js/src/supergraphManagers/UplinkSupergraphManager/__tests__/UplinkSupergraphManager.test.ts
@@ -1,6 +1,12 @@
 import mockedEnv from 'mocked-env';
 
 import { UplinkSupergraphManager } from '@apollo/gateway';
+import nock from 'nock';
+import { SUPERGRAPH_SDL_QUERY } from '../loadSupergraphSdlFromStorage';
+import {
+  nockBeforeEach,
+  nockAfterEach,
+} from '../../../__tests__/nockAssertions';
 
 let cleanUp: (() => void) | undefined;
 
@@ -29,7 +35,9 @@ describe('UplinkSupergraphManager', () => {
     it('uses default uplink URLs', async () => {
       const manager = new UplinkSupergraphManager({ apiKey, graphRef, logger });
 
-      expect(manager.uplinkEndpoints).toEqual(UplinkSupergraphManager.DEFAULT_UPLINK_ENDPOINTS);
+      expect(manager.uplinkEndpoints).toEqual(
+        UplinkSupergraphManager.DEFAULT_UPLINK_ENDPOINTS,
+      );
     });
 
     it('can set uplink URLs via config', async () => {
@@ -62,4 +70,87 @@ describe('UplinkSupergraphManager', () => {
       expect(manager.uplinkEndpoints).toEqual([uplinkUrl]);
     });
   });
+
+  describe('fallbackPollIntervalInMs', () => {
+    beforeEach(() => {
+      nockBeforeEach();
+      // This explicitly mocks only `setTimeout` and `clearTimeout`
+      jest.useFakeTimers({
+        doNotFake: [
+          'Date',
+          'hrtime',
+          'nextTick',
+          'performance',
+          'queueMicrotask',
+          'requestAnimationFrame',
+          'cancelAnimationFrame',
+          'requestIdleCallback',
+          'cancelIdleCallback',
+          'setImmediate',
+          'clearImmediate',
+          'setInterval',
+          'clearInterval',
+        ],
+      });
+    });
+
+    afterEach(() => {
+      nockAfterEach();
+      jest.useRealTimers();
+    });
+
+    it('uses the provided fallback interval when Uplink provides a shorter interval', async () => {
+      // These are the two interesting values for the test. We just want to make
+      // sure that when the UplinkSupergraphManager receives 5s from Uplink that
+      // it opts for the fallbackInterval since it's longer.
+      const fallbackPollIntervalInMs = 15_000;
+      // This is used in the mock response from Uplink below
+      const minDelaySeconds = 5;
+
+      const manager = new UplinkSupergraphManager({
+        apiKey,
+        graphRef,
+        fallbackPollIntervalInMs,
+      });
+
+      mockUplinkResponse(minDelaySeconds);
+
+      const { supergraphSdl, cleanup } = await manager.initialize({
+        // These aren't really used for anything, just keeping TS happy
+        update: jest.fn(),
+        healthCheck: jest.fn(),
+        getDataSource: jest.fn(),
+      });
+      cleanUp = cleanup;
+
+      // validates we got a response from "Uplink" that we're happy with
+      expect(supergraphSdl).toEqual('supergraph sdl');
+
+      // validates that the fallback interval was used instead of the one from Uplink
+      expect(manager['pollIntervalMs']).toEqual(fallbackPollIntervalInMs);
+    });
+  });
 });
+
+function mockUplinkResponse(minDelaySeconds: number) {
+  nock('https://uplink.api.apollographql.com/')
+    .post('/', {
+      query: SUPERGRAPH_SDL_QUERY,
+      variables: {
+        ref: graphRef,
+        apiKey,
+        ifAfterId: null,
+      },
+    })
+    .reply(200, {
+      data: {
+        __typename: 'Query',
+        routerConfig: {
+          __typename: 'RouterConfigResult',
+          id: '123',
+          supergraphSdl: 'supergraph sdl',
+          minDelaySeconds,
+        },
+      },
+    });
+}

--- a/gateway-js/src/supergraphManagers/UplinkSupergraphManager/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkSupergraphManager/index.ts
@@ -64,7 +64,7 @@ export class UplinkSupergraphManager implements SupergraphManager {
     UplinkSupergraphManager.DEFAULT_REQUEST_TIMEOUT_MS;
   private initialMaxRetries: number;
   private pollIntervalMs: number = UplinkSupergraphManager.MIN_POLL_INTERVAL_MS;
-  // private fallbackPollIntervalInMs?: number;
+  private fallbackPollIntervalInMs?: number;
   private logger: Logger;
   private update?: SupergraphSdlUpdateFunction;
   private shouldRunSubgraphHealthcheck: boolean = false;
@@ -118,7 +118,7 @@ export class UplinkSupergraphManager implements SupergraphManager {
     this.initialMaxRetries = initialMaxRetries ?? this.maxRetries;
 
     this.pollIntervalMs = fallbackPollIntervalInMs ?? this.pollIntervalMs;
-    // this.fallbackPollIntervalInMs = fallbackPollIntervalInMs;
+    this.fallbackPollIntervalInMs = fallbackPollIntervalInMs;
     if (this.pollIntervalMs < UplinkSupergraphManager.MIN_POLL_INTERVAL_MS) {
       this.logger.warn(
         'Polling Apollo services at a frequency of less than once per 10 seconds (10000) is disallowed. Instead, the minimum allowed pollInterval of 10000 will be used. Please reconfigure your `fallbackPollIntervalInMs` accordingly. If this is problematic for your team, please contact support.',
@@ -236,12 +236,12 @@ export class UplinkSupergraphManager implements SupergraphManager {
         // configured. If we take the max above unconditionally, then a gateway
         // with an unconfigured fallback interval will only ever lengthen its
         // poll interval rather than adapt to changes coming from Uplink.
-        // if (this.fallbackPollIntervalInMs) {
-        //   this.pollIntervalMs = Math.max(
-        //     this.pollIntervalMs,
-        //     this.fallbackPollIntervalInMs,
-        //   );
-        // }
+        if (this.fallbackPollIntervalInMs) {
+          this.pollIntervalMs = Math.max(
+            this.pollIntervalMs,
+            this.fallbackPollIntervalInMs,
+          );
+        }
       }
     } catch (e) {
       this.logger.debug(

--- a/gateway-js/src/supergraphManagers/UplinkSupergraphManager/index.ts
+++ b/gateway-js/src/supergraphManagers/UplinkSupergraphManager/index.ts
@@ -64,6 +64,7 @@ export class UplinkSupergraphManager implements SupergraphManager {
     UplinkSupergraphManager.DEFAULT_REQUEST_TIMEOUT_MS;
   private initialMaxRetries: number;
   private pollIntervalMs: number = UplinkSupergraphManager.MIN_POLL_INTERVAL_MS;
+  // private fallbackPollIntervalInMs?: number;
   private logger: Logger;
   private update?: SupergraphSdlUpdateFunction;
   private shouldRunSubgraphHealthcheck: boolean = false;
@@ -117,6 +118,7 @@ export class UplinkSupergraphManager implements SupergraphManager {
     this.initialMaxRetries = initialMaxRetries ?? this.maxRetries;
 
     this.pollIntervalMs = fallbackPollIntervalInMs ?? this.pollIntervalMs;
+    // this.fallbackPollIntervalInMs = fallbackPollIntervalInMs;
     if (this.pollIntervalMs < UplinkSupergraphManager.MIN_POLL_INTERVAL_MS) {
       this.logger.warn(
         'Polling Apollo services at a frequency of less than once per 10 seconds (10000) is disallowed. Instead, the minimum allowed pollInterval of 10000 will be used. Please reconfigure your `fallbackPollIntervalInMs` accordingly. If this is problematic for your team, please contact support.',
@@ -229,6 +231,17 @@ export class UplinkSupergraphManager implements SupergraphManager {
       supergraphSdl = result.supergraphSdl;
       if (result?.minDelaySeconds) {
         this.pollIntervalMs = result.minDelaySeconds * 1000;
+
+        // We only want to take the max of the two _if_ a fallback interval is
+        // configured. If we take the max above unconditionally, then a gateway
+        // with an unconfigured fallback interval will only ever lengthen its
+        // poll interval rather than adapt to changes coming from Uplink.
+        // if (this.fallbackPollIntervalInMs) {
+        //   this.pollIntervalMs = Math.max(
+        //     this.pollIntervalMs,
+        //     this.fallbackPollIntervalInMs,
+        //   );
+        // }
       }
     } catch (e) {
       this.logger.debug(


### PR DESCRIPTION
Fixes #2707
Fixes #2705

Expected behavior [documented here](https://www.apollographql.com/docs/apollo-server/using-federation/api/apollo-gateway/#fallbackpollintervalinms-managed-mode-only). Gateway should be taking the max of Uplink's dictated poll interval and the fallback provided via config, which isn't currently happening.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
