### PR TITLE
Prevent over-eager merging of fields which have differing directive applications

### DIFF
--- a/.changeset/curvy-rockets-bow.md
+++ b/.changeset/curvy-rockets-bow.md
@@ -1,0 +1,21 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+---
+
+Fix over-eager merging of fields with different directive applications
+
+Previously, the following query would incorrectly combine the selection set of `hello`, with both fields ending up under the @skip condition:
+```graphql
+query Test($skipField: Boolean!) {
+  hello @skip(if: $skipField) {
+    world
+  }
+  hello {
+    goodbye
+  }
+}
+```
+
+This change identifies those two selections on `hello` as unique while constructing our operation representation so they aren't merged at all, leaving it to the subgraph to handle the operation as-is.
+  

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -2533,7 +2533,7 @@ describe('basic operations', () => {
       }
     `);
 
-    expect(operation.toString()).toMatch(`
+    expect(operation.toString()).toMatchString(`
       query Test($skipIf: Boolean!) {
         t {
           v1

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -9,6 +9,7 @@ import { FragmentRestrictionAtType, MutableSelectionSet, NamedFragmentDefinition
 import './matchers';
 import { DocumentNode, FieldNode, GraphQLError, Kind, OperationDefinitionNode, OperationTypeNode, parse, SelectionNode, SelectionSetNode, validate } from 'graphql';
 import { assert } from '../utils';
+import gql from 'graphql-tag';
 
 function parseSchema(schema: string): Schema {
   try {
@@ -2518,6 +2519,30 @@ describe('basic operations', () => {
       ['B', 'b2'],
       ['T', 'v2'],
     ]);
+  })
+
+  test('fields are keyed on both name and directive applications', () => {
+    const operation = operationFromDocument(schema, gql`
+      query Test($skipIf: Boolean!) {
+        t {
+          v1
+        }
+        t @skip(if: $skipIf) {
+          v2
+        }
+      }
+    `);
+
+    expect(operation.toString()).toMatch(`
+      query Test($skipIf: Boolean!) {
+        t {
+          v1
+        }
+        t @skip(if: $skipIf) {
+          v2
+        }
+      }
+    `);
   })
 });
 

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -146,8 +146,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
   }
 
   key(): string {
-    const appliedDirectives = this.appliedDirectivesToString();
-    return this.responseName() + appliedDirectives;
+    return this.responseName() + this.appliedDirectivesToString();
   }
 
   asPathElement(): string {

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -146,7 +146,8 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
   }
 
   key(): string {
-    return this.responseName();
+    const appliedDirectives = this.appliedDirectivesToString();
+    return this.responseName() + appliedDirectives;
   }
 
   asPathElement(): string {
@@ -3787,16 +3788,19 @@ function operationFromAST({
   const rootType = schema.schemaDefinition.root(operation.operation);
   validate(rootType, () => `The schema has no "${operation.operation}" root type defined`);
   const fragmentsIfAny = fragments.isEmpty() ? undefined : fragments;
+
+  const parsed = parseSelectionSet({
+    parentType: rootType.type,
+    source: operation.selectionSet,
+    variableDefinitions,
+    fragments: fragmentsIfAny,
+    validate: validateInput,
+  });
+
   return new Operation(
     schema,
     operation.operation,
-    parseSelectionSet({
-      parentType: rootType.type,
-      source: operation.selectionSet,
-      variableDefinitions,
-      fragments: fragmentsIfAny,
-      validate: validateInput,
-    }),
+    parsed,
     variableDefinitions,
     fragmentsIfAny,
     operation.name?.value

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -3787,19 +3787,16 @@ function operationFromAST({
   const rootType = schema.schemaDefinition.root(operation.operation);
   validate(rootType, () => `The schema has no "${operation.operation}" root type defined`);
   const fragmentsIfAny = fragments.isEmpty() ? undefined : fragments;
-
-  const parsed = parseSelectionSet({
-    parentType: rootType.type,
-    source: operation.selectionSet,
-    variableDefinitions,
-    fragments: fragmentsIfAny,
-    validate: validateInput,
-  });
-
   return new Operation(
     schema,
     operation.operation,
-    parsed,
+    parseSelectionSet({
+      parentType: rootType.type,
+      source: operation.selectionSet,
+      variableDefinitions,
+      fragments: fragmentsIfAny,
+      validate: validateInput,
+    }),
     variableDefinitions,
     fragmentsIfAny,
     operation.name?.value

--- a/query-planner-js/src/__tests__/buildPlan.directiveMerging.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.directiveMerging.test.ts
@@ -1,0 +1,90 @@
+import { operationFromDocument } from '@apollo/federation-internals';
+import gql from 'graphql-tag';
+import { composeAndCreatePlanner } from './testHelper';
+
+describe('merging @skip / @include directives', () => {
+  const subgraph1 = {
+    name: 'S1',
+    typeDefs: gql`
+      type Query {
+        hello: Hello!
+        extraFieldPreventSkipNode: String!
+      }
+
+      type Hello {
+        world: String!
+        goodbye: String!
+      }
+    `,
+  };
+
+  const [api, queryPlanner] = composeAndCreatePlanner(subgraph1);
+
+  it('with fragment', () => {
+    const operation = operationFromDocument(
+      api,
+      gql`
+        query Test($skipField: Boolean!) {
+          ...ConditionalSkipFragment
+          hello {
+            world
+          }
+          extraFieldPreventSkipNode
+        }
+
+        fragment ConditionalSkipFragment on Query {
+          hello @skip(if: $skipField) {
+            goodbye
+          }
+        }
+      `,
+    );
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "S1") {
+          {
+            hello @skip(if: $skipField) {
+              goodbye
+              world
+            }
+            extraFieldPreventSkipNode
+          }
+        },
+      }
+    `);
+  });
+
+  it('without fragment', () => {
+    const operation = operationFromDocument(
+      api,
+      gql`
+        query Test($skipField: Boolean!) {
+          hello @skip(if: $skipField) {
+            world
+          }
+          hello {
+            goodbye
+          }
+          extraFieldPreventSkipNode
+        }
+      `,
+    );
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "S1") {
+          {
+            hello @skip(if: $skipField) {
+              world
+              goodbye
+            }
+            extraFieldPreventSkipNode
+          }
+        },
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Fixes #2712

Directive applications are an interesting case where multiple usages of an unaliased field within the same selection set is permitted. See test cases for examples. I've confirmed that the resulting subgraph fetches after this change are still valid graphql operations (via a small test Apollo Server), so it makes sense to me that we "preserve" rather than merge in these cases and forward along a more complete version of the request to the subgraph.

The fix here is to have fields id themselves using a more complex key which includes their applied directives when we parse the operation, that way their selections aren't grouped into the same entry if the directive applications differ.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
