### PR TITLE
[docs] add info about mismatched keys

### DIFF
--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -104,30 +104,6 @@ type Product @key(fields: "upc") {
 
 </CodeColumns>
 
-If subgraphs share any fields that act as unique identifiers, you can use these shared field(s) as `@keys` for optimal [query planner](./entities#the-query-plan) performance.
-
-<p style="margin-bottom: 0">✅</p>
-
-<CodeColumns>
-
-```graphql title="Products subgraph"
-type Product @key(fields: "upc") {
-  sku: ID!
-  upc: String!
-  name: String!
-  price: Int
-}
-```
-
-```graphql title="Inventory subgraph"
-type Product @key(fields: "upc") {
-  upc: String!
-  inStock: Boolean!
-}
-```
-
-</CodeColumns>
-
 ## Migrating entities and fields
 
 As your supergraph grows, you might want to move parts of an entity to a different subgraph. This section describes how to perform these migrations safely.

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -81,7 +81,7 @@ type Product @key(fields: "upc") {
 
 </CodeColumns>
 
-To merge entities between subgraphs, the entity must have at least one shared field between subgraphs. For example, you can't merge the `Product` entity defined in the following subgraphs because they don't share any fields:
+To merge entities between subgraphs, the entity must have at least one shared field between subgraphs. For example, you can't merge the `Product` entity defined in the following subgraphs because they don't share any fields specified in `@key` selection set:
 
 <p style="margin-bottom: 0">❌</p>
 

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -107,7 +107,7 @@ type Product @key(fields: "upc") {
 
 #### Operations with mismatched `@key`s
 
-Mismatched keys also affect which fields can be resolved. Requests can resolve an entity's fields _if there is a traversable path from the root query to the fields_.
+Mismatched keys affect which fields from an entity can be resolved. Requests can resolve an entity's fields _if there is a traversable path from the root query to the fields_.
 
 Take these subgraph schemas as an example:
 
@@ -138,7 +138,7 @@ type Product @key(fields: "upc") {
 
 The queries defined in the products subgraph can always resolve all product fields because the product entity can be joined via the `upc` field present in both schemas.
 
-On the other hand, queries added to the inventory subgraph can't resolve fields from the products subgraph.
+On the other hand, queries added to the inventory subgraph can't resolve fields from the products subgraph:
 
 <CodeColumns>
 

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -59,29 +59,96 @@ type Organization {
 
 ### Differing `@key`s across subgraphs
 
-An entity often has the same @key fields across subgraphs, but this isn't required. For example, you can define a `Product` entity shared between products and inventory subgraphs, one with `id` as the `@key` field and one with `sku` as the `@key` field:
+An entity often has the exact same `@key` field(s) across subgraphs, but this isn't required. For example, you can define a `Product` entity shared between subgraphs, one with `sku` and `upc` as the `@key`s and one with only `upc` as the `@key` field:
 
 <CodeColumns>
 
 ```graphql title="Products subgraph"
-type Product @key(fields: "id") {
-  id: ID!
+type Product @key(fields: "sku") @key(fields: "upc") {
+  sku: ID!
+  upc: String!
   name: String!
   price: Int
 }
 ```
 
 ```graphql title="Inventory subgraph"
-type Product @key(fields: "sku") {
-  sku: ID!
+type Product @key(fields: "upc") {
+  upc: String!
   inStock: Boolean!
 }
 ```
 
 </CodeColumns>
 
-As long as `id` is a unique identifier within the products subgraph and `sku` is a unique identifier for the same product in the inventory subgraph, the subgraphs can each resolve the `Product` type.
-In other words, **each key declaration is specific to the subgraph it belongs to**, and you don't need to match `@key` fields between graphs.
+To merge entities between subgraphs, the entity must have at least one shared field between subgraphs. For example, you can't merge the `Product` entity defined in the following subgraphs because they don't share any fields:
+
+<p style="margin-bottom: 0">❌</p>
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "sku") {
+  sku: ID!
+  name: String!
+  price: Int
+}
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "upc") {
+  upc: String!
+  inStock: Boolean!
+}
+```
+
+</CodeColumns>
+
+The following would allow you to merge the `Product` entity since both subgraph schemas include the `upc` field, even if it's only the `@key` for one of them:
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "sku") {
+  sku: ID!
+  upc: String!
+  name: String!
+  price: Int
+}
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "upc") {
+  upc: String!
+  inStock: Boolean!
+}
+```
+
+</CodeColumns>
+
+If subgraphs share any fields—for example `upc` in the preceding example—it's best to use these shared field(s) as `@keys` for optimal [query planner](./entities#the-query-plan) performance.
+
+<p style="margin-bottom: 0">✅</p>
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "upc") {
+  sku: ID!
+  upc: String!
+  name: String!
+  price: Int
+}
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "upc") {
+  upc: String!
+  inStock: Boolean!
+}
+```
+
+</CodeColumns>
 
 ## Migrating entities and fields
 

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -81,7 +81,8 @@ type Product @key(fields: "upc") {
 
 </CodeColumns>
 
-To merge entities between subgraphs, the entity must have at least one shared field between subgraphs. For example, queries can't merge the `Product` entity defined in the following subgraphs because they don't share any fields specified in `@key` selection set:
+
+To merge entities between subgraphs, the entity must have at least one shared field between subgraphs. For example, operations can't merge the `Product` entity defined in the following subgraphs because they don't share any fields specified in the `@key` selection set:
 
 <p style="margin-bottom: 0">❌</p>
 
@@ -99,6 +100,93 @@ type Product @key(fields: "sku") {
 type Product @key(fields: "upc") {
   upc: String!
   inStock: Boolean!
+}
+```
+
+</CodeColumns>
+
+#### Operations with mismatched `@key`s
+
+Mismatched keys also affect which fields can be resolved. Requests can resolve an entity's fields _if there is a traversable path from the root query to the fields_.
+
+Take these subgraph schemas as an example:
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "sku") {
+  sku: ID!
+  upc: String!
+  name: String!
+  price: Int
+}
+
+type Query {
+  product(sku: ID!): Product
+  products: [Product!]!
+}
+
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "upc") {
+  upc: String!
+  inStock: Boolean!
+}
+```
+</CodeColumns>
+
+The queries defined in the products subgraph can always resolve all product fields because the product entity can be joined via the `upc` field present in both schemas.
+
+On the other hand, queries added to the inventory subgraph can't resolve fields from the products subgraph.
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "sku") {
+  sku: ID!
+  upc: String!
+  name: String!
+  price: Int
+}
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "upc") {
+  upc: String!
+  inStock: Boolean!
+}
+
+type Query {
+  productsInStock: [Product!]!
+}
+```
+
+</CodeColumns>
+
+The `productsInStock` query can't resolve fields from the product subgraph since its `Product` type definition doesn't have `@key(fields: "upc")`, and the `sku` field isn't present in the inventory subgraph.
+
+If the product subgraph includes `@key(fields: "upc")`, all queries from the inventory subgraph can resolve all product fields:
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "sku") @key(fields: "upc") {
+  sku: ID!
+  upc: String!
+  name: String!
+  price: Int
+}
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "upc") {
+  upc: String!
+  inStock: Boolean!
+}
+
+type Query {
+  productsInStock: [Product!]!
 }
 ```
 

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -57,6 +57,34 @@ type Organization {
 }
 ```
 
+### Mismatched `@key`s
+
+Conventionally, `@key` fields for an entity are the same between subgraphs, but this isn't required.
+
+For example, you could define a `Product` entity shared between products and inventory subgraphs, one with the `id` field as the `@key` field, and one with `sku` as the `@key` field:
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  price: Int
+}
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "sku") {
+  sku: ID!
+  inStock: Boolean!
+}
+```
+
+</CodeColumns>
+
+As long as `id` is a unique identifier within the products subgraph, and `sku` is a unique identifier for the same product in the inventory subgraph, the subgraphs can resolve the `Product` type.
+In other words, **each key declaration is specific to the subgraph it belongs to** and you don't need to match `@key` fields between graphs.
+
 ## Migrating entities and fields
 
 As your supergraph grows, you might want to move parts of an entity to a different subgraph. This section describes how to perform these migrations safely.

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -81,7 +81,7 @@ type Product @key(fields: "upc") {
 
 </CodeColumns>
 
-To merge entities between subgraphs, the entity must have at least one shared field between subgraphs. For example, you can't merge the `Product` entity defined in the following subgraphs because they don't share any fields specified in `@key` selection set:
+To merge entities between subgraphs, the entity must have at least one shared field between subgraphs. For example, queries can't merge the `Product` entity defined in the following subgraphs because they don't share any fields specified in `@key` selection set:
 
 <p style="margin-bottom: 0">❌</p>
 

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -104,29 +104,7 @@ type Product @key(fields: "upc") {
 
 </CodeColumns>
 
-The following would allow you to merge the `Product` entity since both subgraph schemas include the `upc` field, even if it's only the `@key` for one of them:
-
-<CodeColumns>
-
-```graphql title="Products subgraph"
-type Product @key(fields: "sku") {
-  sku: ID!
-  upc: String!
-  name: String!
-  price: Int
-}
-```
-
-```graphql title="Inventory subgraph"
-type Product @key(fields: "upc") {
-  upc: String!
-  inStock: Boolean!
-}
-```
-
-</CodeColumns>
-
-If subgraphs share any fields—for example `upc` in the preceding example—it's best to use these shared field(s) as `@keys` for optimal [query planner](./entities#the-query-plan) performance.
+If subgraphs share any fields that act as unique identifiers, you can use these shared field(s) as `@keys` for optimal [query planner](./entities#the-query-plan) performance.
 
 <p style="margin-bottom: 0">✅</p>
 

--- a/docs/source/entities-advanced.mdx
+++ b/docs/source/entities-advanced.mdx
@@ -57,11 +57,9 @@ type Organization {
 }
 ```
 
-### Mismatched `@key`s
+### Differing `@key`s across subgraphs
 
-Conventionally, `@key` fields for an entity are the same between subgraphs, but this isn't required.
-
-For example, you could define a `Product` entity shared between products and inventory subgraphs, one with the `id` field as the `@key` field, and one with `sku` as the `@key` field:
+An entity often has the same @key fields across subgraphs, but this isn't required. For example, you can define a `Product` entity shared between products and inventory subgraphs, one with `id` as the `@key` field and one with `sku` as the `@key` field:
 
 <CodeColumns>
 
@@ -82,8 +80,8 @@ type Product @key(fields: "sku") {
 
 </CodeColumns>
 
-As long as `id` is a unique identifier within the products subgraph, and `sku` is a unique identifier for the same product in the inventory subgraph, the subgraphs can resolve the `Product` type.
-In other words, **each key declaration is specific to the subgraph it belongs to** and you don't need to match `@key` fields between graphs.
+As long as `id` is a unique identifier within the products subgraph and `sku` is a unique identifier for the same product in the inventory subgraph, the subgraphs can each resolve the `Product` type.
+In other words, **each key declaration is specific to the subgraph it belongs to**, and you don't need to match `@key` fields between graphs.
 
 ## Migrating entities and fields
 

--- a/docs/source/entities.mdx
+++ b/docs/source/entities.mdx
@@ -55,12 +55,14 @@ type Product @key(fields: "id") {
 
 The `@key` directive defines the entity's **primary key**, which consists of one or more of the type's `fields`. In the example above, the `Product` entity's primary key is its `id` field.
 
-**Every instance of an entity must be uniquely identifiable by its `@key` fields within its own subgraph.** [See advanced options for `@key`s](./entities-advanced/#advanced-keys) for more information.
+**Every instance of an entity must be uniquely identifiable by its `@key` fields within its own subgraph.**
 
 > **An entity's `@key` _cannot_ include:**
 >
 > * Fields that return a union or interface
 > * Fields that take arguments
+
+[See advanced options for `@key`s](./entities-advanced/#advanced-keys) for more information.
 
 ### 2. Define a reference resolver
 

--- a/docs/source/entities.mdx
+++ b/docs/source/entities.mdx
@@ -55,14 +55,12 @@ type Product @key(fields: "id") {
 
 The `@key` directive defines the entity's **primary key**, which consists of one or more of the type's `fields`. In the example above, the `Product` entity's primary key is its `id` field.
 
-**Every instance of an entity must be uniquely identifiable by its `@key` fields.** This is what enables your router to associate field data from _different_ subgraphs with the _same_ entity instance.
+**Every instance of an entity must be uniquely identifiable by its `@key` fields within its own subgraph.** [See advanced options for `@key`s](./entities-advanced/#advanced-keys) for more information.
 
 > **An entity's `@key` _cannot_ include:**
 >
 > * Fields that return a union or interface
 > * Fields that take arguments
->
-> [See advanced options for `@key`s.](./entities-advanced/#advanced-keys)
 
 ### 2. Define a reference resolver
 

--- a/docs/source/entities.mdx
+++ b/docs/source/entities.mdx
@@ -53,16 +53,35 @@ type Product @key(fields: "id") {
 }
 ```
 
-The `@key` directive defines the entity's **primary key**, which consists of one or more of the type's `fields`. In the example above, the `Product` entity's primary key is its `id` field.
+The `@key` directive defines the entity's **primary key**, which consists of one or more of the type's `fields`. In the example above, the `Product` entity's primary key is its `id` field. **Every instance of an entity must be uniquely identifiable by its `@key` fields.** This is what enables your router to associate field data from _different_ subgraphs with the _same_ entity instance.
 
-**Every instance of an entity must be uniquely identifiable by its `@key` fields within its own subgraph.** This is what enables your router to associate field data from _different_ subgraphs with the _same_ entity instance.
+In most cases, the `@key` field(s) for the same entity will be the same across subgraphs. For example, if one subgraph uses `id` as the `@key` field for the `Product` entity, other subgraphs should do the same. However, this [isn't strictly required](./entities-advanced#differing-keys-across-subgraphs).
+
+<CodeColumns>
+
+```graphql title="Products subgraph"
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  price: Int
+}
+```
+
+```graphql title="Inventory subgraph"
+type Product @key(fields: "id") {
+  id: ID!
+  inStock: Boolean!
+}
+```
+
+</CodeColumns>
 
 > **An entity's `@key` _cannot_ include:**
 >
 > * Fields that return a union or interface
 > * Fields that take arguments
 
-[See advanced options for `@key`s](./entities-advanced/#advanced-keys) for more information.
+For more information on advanced key options, like how to define [multiple keys](./entities-advanced#multiple-keys) or [compound keys](/entities-advanced#compound-keys), see [Advanced topics for federation entities](./entities-advanced).
 
 ### 2. Define a reference resolver
 

--- a/docs/source/entities.mdx
+++ b/docs/source/entities.mdx
@@ -55,7 +55,7 @@ type Product @key(fields: "id") {
 
 The `@key` directive defines the entity's **primary key**, which consists of one or more of the type's `fields`. In the example above, the `Product` entity's primary key is its `id` field.
 
-**Every instance of an entity must be uniquely identifiable by its `@key` fields within its own subgraph.**
+**Every instance of an entity must be uniquely identifiable by its `@key` fields within its own subgraph.** This is what enables your router to associate field data from _different_ subgraphs with the _same_ entity instance.
 
 > **An entity's `@key` _cannot_ include:**
 >


### PR DESCRIPTION
This PR adds information about "mismatched" `@keys` across subgraphs.

Refer to https://apollograph.slack.com/archives/C03RH11Q6S1/p1685024491858819 for more info.