### PR TITLE
Expands over-eager merging of field fix to handle `@defer` consistently

### DIFF
--- a/.changeset/sixty-walls-chew.md
+++ b/.changeset/sixty-walls-chew.md
@@ -1,0 +1,41 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Expands over-eager merging of field fix to handle `@defer` consistently
+
+The previously committed [#2713](https://github.com/apollographql/federation/pull/2713) fixed an issue introduced by
+[#2387](https://github.com/apollographql/federation/pull/2387), ensuring that querying the same field with different
+directives applications was not merged, similar to what was/is done for fragments. But the exact behaviour slightly
+differs between fields and fragments when it comes to `@defer` in that for fragments, we never merge 2 similar fragments
+where both have `@defer`, which we do merge for fields. Or to put it more concretely, in the following query:
+```graphq
+query Test($skipField: Boolean!) {
+  x {
+    ... on X @defer {
+      a
+    }
+    ... on X @defer {
+      b
+    }
+  }
+}
+```
+the 2 `... on X @defer` are not merged, resulting in 2 deferred sections that can run in parallel. But following
+[#2713](https://github.com/apollographql/federation/pull/2713), query:
+```graphq
+query Test($skipField: Boolean!) {
+  x @defer {
+    a
+  }
+  x @defer {
+    b
+  }
+}
+```
+_will_ merge both `x @defer`, resulting in a single deferred section.
+
+This fix changes that later behaviour so that the 2 `x @defer` are not merged and result in 2 deferred sections,
+consistently with both 1) the case of fragments and 2) the behaviour prior to
+[#2387](https://github.com/apollographql/federation/pull/2387).
+  

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -113,6 +113,10 @@ abstract class AbstractOperationElement<T extends AbstractOperationElement<T>> e
       }
     }
   }
+
+  protected keyForDirectives(): string {
+    return this.appliedDirectives.map((d) => keyForDirective(d)).join(' ');
+  }
 }
 
 export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> extends AbstractOperationElement<Field<TArgs>> {
@@ -146,7 +150,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
   }
 
   key(): string {
-    return this.responseName() + this.appliedDirectivesToString();
+    return this.responseName() + this.keyForDirectives();
   }
 
   asPathElement(): string {
@@ -394,7 +398,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
  * 2. we sort the argument (by their name) before converting them to string, since argument order does not matter in graphQL.
  */
 function keyForDirective(
-  directive: Directive<OperationElement>,
+  directive: Directive<AbstractOperationElement<any>>,
   directivesNeverEqualToThemselves: string[] = [ 'defer' ],
 ): string {
   if (directivesNeverEqualToThemselves.includes(directive.name)) {
@@ -436,8 +440,7 @@ export class FragmentElement extends AbstractOperationElement<FragmentElement> {
     if (!this.computedKey) {
       // The key is such that 2 fragments with the same key within a selection set gets merged together. So the type-condition
       // is include, but so are the directives.
-      const keyForDirectives = this.appliedDirectives.map((d) => keyForDirective(d)).join(' ');
-      this.computedKey = '...' + (this.typeCondition ? ' on ' + this.typeCondition.name : '') + keyForDirectives;
+      this.computedKey = '...' + (this.typeCondition ? ' on ' + this.typeCondition.name : '') + this.keyForDirectives();
     }
     return this.computedKey;
   }


### PR DESCRIPTION
The previously committed [#2713](https://github.com/apollographql/federation/pull/2713) fixed an issue introduced by [#2387](https://github.com/apollographql/federation/pull/2387), ensuring that querying the same field with different directives applications was not merged, similar to what was/is done for fragments. But the exact behaviour slightly differs between fields and fragments when it comes to `@defer` in that for fragments, we never merge 2 similar fragments where both have `@defer`, which we do merge for fields. Or to put it more concretely, in the following query:
```graphq
query Test($skipField: Boolean!) {
  x {
    ... on X @defer {
      a
    }
    ... on X @defer {
      b
    }
  }
}
```
the 2 `... on X @defer` are not merged, resulting in 2 deferred sections that can run in parallel. But following [#2713](https://github.com/apollographql/federation/pull/2713), query:
```graphq
query Test($skipField: Boolean!) {
  x @defer {
    a
  }
  x @defer {
    b
  }
}
```
_will_ merge both `x @defer`, resulting in a single deferred section.

This fix changes that later behaviour so that the 2 `x @defer` are not merged and result in 2 deferred sections, consistently with both 1) the case of fragments and 2) the behaviour prior to [#2387](https://github.com/apollographql/federation/pull/2387).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
