### PR TITLE
Fix incorrect removal of dependencies between groups in some rare `@requires`

### DIFF
--- a/.changeset/strange-moons-prove.md
+++ b/.changeset/strange-moons-prove.md
@@ -1,0 +1,15 @@
+---
+"@apollo/query-planner": major
+"@apollo/gateway": major
+---
+
+Fix some potentially incorrect query plans with `@requires` when some dependencies are involved.
+
+In some rare case of `@requires`, an over-eager optimisation was incorrectly considering that
+a dependency between 2 subgraph fetches was unnecessary, leading to doing 2 subgraphs queries
+in parallel when those should be done sequentially (because the 2nd query rely on results
+from the 1st one). This effectively resulted in the required fields not being provided (the
+consequence of which depends a bit on the resolver detail, but if the resolver expected
+the required fields to be populated (as they should), then this could typically result
+in a message of the form `GraphQLError: Cannot read properties of null`).
+  

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -1109,6 +1109,15 @@ class FetchGroup {
       return true;
     }
 
+    // If we do have inputs, then we first look at the path to `maybeParent`, and it needs to be
+    // essentially empty, "essentially" is because path can sometimes have some leading fragment(s)
+    // and those are fine to ignore. But if the path has some field, then this imply that the inputs
+    // of `this` are based on something at a deeper level than those of `maybeParent`, and the "contains"
+    // comparison we do below would not make sense.
+    if (relation.path.some((elt) => elt.kind === 'Field')) {
+      return false;
+    }
+
     // In theory, the most general test we could have here is to check if `this.inputs` "intersects"
     // `maybeParent.selection. As if it doesn't, we know our inputs don't depend on anything the
     // parent fetches. However, selection set intersection is a bit tricky to implement (due to fragments,

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -1111,7 +1111,7 @@ class FetchGroup {
 
     // If we do have inputs, then we first look at the path to `maybeParent`, and it needs to be
     // essentially empty, "essentially" is because path can sometimes have some leading fragment(s)
-    // and those are fine to ignore. But if the path has some field, then this imply that the inputs
+    // and those are fine to ignore. But if the path has some field, then this implies that the inputs
     // of `this` are based on something at a deeper level than those of `maybeParent`, and the "contains"
     // comparison we do below would not make sense.
     if (relation.path.some((elt) => elt.kind === 'Field')) {


### PR DESCRIPTION
Fulfilling some `@requires` can necessitate querying group(s) (subgraphs) that are not the direct parent of the group with the `@requires`. To generate plan that are as optimal as possible, the code needs to figure out the proper parent of those new groups, that is what is the "earliest" group those new groups truly depend on. This is done by starting to look at the parent of the `@requires` group, see if the new groups genuinely depend on anything that parent fetches, and if not, iterate the same logic on the grand-parent (until we either find a parent the new groups depend on, or we reach the beginning of the plan.

But the code that checked if the new groups truly depend on a given parent was incomplete: it was sometimes responding that there were no dependency when that was not true.

The result is that for some specific configuration of a `@requires`, we could end up with a plan whereby some group/fetch A depended on the results of another group/fetch B, but A was performed in parallel of B instead of after it. Which ultimately resulted in not getting the proper data for the required fields, leading to incorrect executions (the exact detail of how this would show up depends a bit on the exact service implementation, but typically the resolver of the field on which there is a `@requires` would get `null` for its requirements, which might lead that resolver to throw an error as this is unexpected).

Fixes #2683

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
