### PR TITLE
Add link to federated architecture article

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -15,6 +15,7 @@
     "Changelog": "/federation-versions",
     "Interactive tutorial": "https://www.apollographql.com/tutorials/voyage-part1",
     "Demo app": "https://github.com/apollographql/supergraph-demo-fed2",
+    "Federated architecture": "https://graphql.com/learn/federated-architecture/",
     "Quickstart": {
       "1️⃣ Project setup": "/quickstart/setup",
       "2️⃣ Composition in Apollo Studio": "/quickstart/studio-composition",

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -32,9 +32,9 @@ With federation, you can responsibly share ownership of your supergraph across a
   </ButtonLink>
   <Button
     as="a"
-    href="https://graphql.com/learn/federated-architecture/"
-    >
-    Learn more about federated architecture
+    href="#how-it-works"
+  >
+    Learn more
   </Button>
 </div>
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -32,9 +32,9 @@ With federation, you can responsibly share ownership of your supergraph across a
   </ButtonLink>
   <Button
     as="a"
-    href="#how-it-works"
-  >
-    Learn more
+    href="https://graphql.com/learn/federated-architecture/"
+    >
+    Learn more about federated architecture
   </Button>
 </div>
 


### PR DESCRIPTION
This adds a link to the[ new federated arch article](https://graphql.com/learn/federated-architecture/).