### PR TITLE
Modify type of argument of `@requiresScope`

### DIFF
--- a/.changeset/great-lions-work.md
+++ b/.changeset/great-lions-work.md
@@ -1,0 +1,13 @@
+---
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
+---
+
+Modifies the type for the argument of the `@requiresScopes` from `[federation__Scope!]!` to `[[federation__Scope!]!]!`.
+
+The `@requiresScopes` directives has been pre-emptively introduced in 2.5.0 to support an upcoming Apollo Router
+feature around scoped accesses. The argument for `@requiresScopes` in that upcoming feature is changed to accommodate a
+new semantic. Note that this technically a breaking change to the `@requiresScopes` directive definition, but as the
+full feature using that directive has been released yet, this directive cannot effectively be used and this should have
+no concrete impact.
+  

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4493,7 +4493,7 @@ describe('composition', () => {
         "https://specs.apollo.dev/requiresScopes/v0.1"
       );
       expect(printDirectiveDefinition(result.schema.directive('requiresScopes')!)).toMatchString(`
-        directive @requiresScopes(scopes: [requiresScopes__Scope!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+        directive @requiresScopes(scopes: [[requiresScopes__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
       `);
     });
 
@@ -4527,7 +4527,7 @@ describe('composition', () => {
         const invalidDefinition = {
           typeDefs: gql`
             scalar federation__Scope
-            directive @requiresScopes(scopes: [federation__Scope!]!) on ENUM_VALUE
+            directive @requiresScopes(scopes: [[federation__Scope!]!]!) on ENUM_VALUE
 
             type Query {
               a: Int
@@ -4565,7 +4565,7 @@ describe('composition', () => {
         const result = composeAsFed2Subgraphs([invalidDefinition]);
         expect(errors(result)[0]).toEqual([
           "DIRECTIVE_DEFINITION_INVALID",
-          "[invalidDefinition] Invalid definition for directive \"@requiresScopes\": argument \"scopes\" should have type \"[federation__Scope!]!\" but found type \"[federation__Scope]!\"",
+          "[invalidDefinition] Invalid definition for directive \"@requiresScopes\": argument \"scopes\" should have type \"[[federation__Scope!]!]!\" but found type \"[federation__Scope]!\"",
         ]);
       });
 

--- a/internals-js/src/requiresScopesSpec.ts
+++ b/internals-js/src/requiresScopesSpec.ts
@@ -41,7 +41,7 @@ export class RequiresScopesSpecDefinition extends FeatureDefinition {
           const scopeName = feature.typeNameInSchema(RequiresScopesTypeName.SCOPE);
           const scopeType = schema.type(scopeName);
           assert(scopeType, () => `Expected "${scopeName}" to be defined`);
-          return new NonNullType(new ListType(new NonNullType(scopeType)));
+          return new NonNullType(new ListType(new NonNullType(new ListType(new NonNullType(scopeType)))));
         },
         compositionStrategy: ARGUMENT_COMPOSITION_STRATEGIES.UNION,
       }],


### PR DESCRIPTION
This modifies the type for the argument of the `@requiresScopes` from `[federation__Scope!]!` to `[[federation__Scope!]!]!` in order to support "OR" semantic within subgraphs.

Note that this PR does not bump any spec versions, even if technically `@requiresScopes` has already been part of 2.5.0+ because:
- the overarching feature it exists for has not be released yet so the directive is not really effectively usable yet.
- bumping the federation spec to 2.6, which this would require if we wanted to bump versions, would be disruption and confusing, so this feel unecessary given the previous.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
