### PR TITLE
Fix case where reusing fragments can still lead to invalid selection …

### DIFF
--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -1988,6 +1988,142 @@ describe('fragments optimization', () => {
         }
       `);
     });
+
+    test('due to the trimmed selection of nested fragments', () => {
+      const schema = parseSchema(`
+        type Query {
+          u1: U
+          u2: U
+          u3: U
+        }
+
+        union U = S | T
+
+        type T  {
+          id: ID!
+          vt: Int
+        }
+
+        interface I {
+          vs: Int
+        }
+
+        type S implements I {
+          vs: Int!
+        }
+      `);
+      const gqlSchema = schema.toGraphQLJSSchema();
+
+      const operation = parseOperation(schema, `
+        {
+          u1 {
+            ...F1
+          }
+          u2 {
+            ...F3
+          }
+          u3 {
+            ...F3
+          }
+        }
+
+        fragment F1 on U {
+           ... on S {
+             __typename
+             vs
+           }
+           ... on T {
+             __typename
+             vt
+           }
+        }
+
+        fragment F2 on T {
+           __typename
+           vt
+        }
+
+        fragment F3 on U {
+           ... on I {
+             vs
+           }
+           ...F2
+        }
+      `);
+      expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+
+      const withoutFragments = operation.expandAllFragments();
+      expect(withoutFragments.toString()).toMatchString(`
+        {
+          u1 {
+            ... on S {
+              __typename
+              vs
+            }
+            ... on T {
+              __typename
+              vt
+            }
+          }
+          u2 {
+            ... on I {
+              vs
+            }
+            ... on T {
+              __typename
+              vt
+            }
+          }
+          u3 {
+            ... on I {
+              vs
+            }
+            ... on T {
+              __typename
+              vt
+            }
+          }
+        }
+      `);
+
+      // We use `mapToExpandedSelectionSets` with a no-op mapper because this will still expand the selections
+      // and re-optimize them, which 1) happens to match what happens in the query planner and 2) is necessary
+      // for reproducing a bug that this test was initially added to cover.
+      const newFragments = operation.fragments!.mapToExpandedSelectionSets((s) => s);
+      const optimized = withoutFragments.optimize(newFragments, 2);
+      expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+
+      expect(optimized.toString()).toMatchString(`
+        fragment F3 on U {
+          ... on I {
+            vs
+          }
+          ... on T {
+            __typename
+            vt
+          }
+        }
+
+        {
+          u1 {
+            ... on S {
+              __typename
+              vs
+            }
+            ... on T {
+              __typename
+              vt
+            }
+          }
+          u2 {
+            ...F3
+          }
+          u3 {
+            ...F3
+          }
+        }
+      `);
+    });
   });
 
   test('does not leave unused fragments', () => {
@@ -3094,12 +3230,25 @@ describe('named fragment selection set restrictions at type', () => {
 
     const frag = operation.fragments?.get('FonU1')!;
 
-    // Note that with unions, the fragments inside the unions can be "lifted" and so they everyting normalize to just the
+    // Note that with unions, the fragments inside the unions can be "lifted" and so that everything normalizes to just the
     // possible runtimes.
 
     let { selectionSet, validator } = expandAtType(frag, schema, 'U1');
     expect(selectionSet.toString()).toBe('{ ... on T1 { x y } ... on T2 { z w } }');
-    expect(validator?.toString()).toBeUndefined();
+    // Similar remarks than on interfaces (the validator is strictly speaking not necessary, but
+    // this happens due to the "lifting" of selection mentioned above, is a bit hard to avoid,
+    // and is essentially harmess (it may result in a bit more cpu cycles in some cases but
+    // that is likely negligible).
+    expect(validator?.toString()).toMatchString(`
+      {
+        y: [
+          T1.y
+        ]
+        w: [
+          T2.w
+        ]
+      }
+    `);
 
     ({ selectionSet, validator } = expandAtType(frag, schema, 'U2'));
     expect(selectionSet.toString()).toBe('{ ... on T1 { x y } }');
@@ -3107,6 +3256,9 @@ describe('named fragment selection set restrictions at type', () => {
       {
         z: [
           T2.z
+        ]
+        y: [
+          T1.y
         ]
         w: [
           T2.w
@@ -3124,6 +3276,9 @@ describe('named fragment selection set restrictions at type', () => {
         y: [
           T1.y
         ]
+        w: [
+          T2.w
+        ]
       }
     `);
 
@@ -3135,11 +3290,11 @@ describe('named fragment selection set restrictions at type', () => {
         x: [
           T1.x
         ]
-        y: [
-          T1.y
-        ]
         z: [
           T2.z
+        ]
+        y: [
+          T1.y
         ]
         w: [
           T2.w

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -6570,6 +6570,7 @@ describe("named fragments", () => {
           {
             t1 {
               other {
+                __typename
                 id
               }
             }


### PR DESCRIPTION
…with conflicting fields

Trying to reuse fragments, if done without specific case, can in some context result in invalid selections due to fields conflicting. It is to avoid that problem that #2619 introduced the `FieldsConflictValidator` mechanism (later improved by #2635).

Unfortunately, in some fairly specific setups with nested fragments, the code was missing some data in the validation mentioned above, which led to still having case where a subgraph fetch may be invalid due to some fields (within reusing fragments) conflicting at some point of the query.

This commit fix that issue by ensuring we take everything we should into account when doing the aforementioned validation.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
