### PR TITLE
Use SPDX identifiers in `package.json` `license` fields

### DIFF
--- a/.changeset/hungry-ducks-remember.md
+++ b/.changeset/hungry-ducks-remember.md
@@ -1,0 +1,11 @@
+---
+"apollo-federation-integration-testsuite": minor
+"@apollo/query-planner": minor
+"@apollo/query-graphs": minor
+"@apollo/composition": minor
+"@apollo/federation-internals": minor
+"@apollo/gateway": minor
+---
+
+Update `license` field in `package.json` to use `Elastic-2.0` SPDX identifier
+  

--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -19,7 +19,7 @@
     "composition"
   ],
   "author": "Apollo <packages@apollographql.com>",
-  "license": "SEE LICENSE IN ./LICENSE",
+  "license": "Elastic-2.0",
   "engines": {
     "node": ">=14.15.0"
   },

--- a/federation-integration-testsuite-js/package.json
+++ b/federation-integration-testsuite-js/package.json
@@ -12,7 +12,7 @@
   },
   "keywords": [],
   "author": "Apollo <packages@apollographql.com>",
-  "license": "SEE LICENSE IN ./LICENSE",
+  "license": "Elastic-2.0",
   "bugs": {
     "url": "https://github.com/apollographql/federation/issues"
   },

--- a/gateway-js/package.json
+++ b/gateway-js/package.json
@@ -20,7 +20,7 @@
   "engines": {
     "node": ">=14.15.0"
   },
-  "license": "SEE LICENSE IN ./LICENSE",
+  "license": "Elastic-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -18,7 +18,7 @@
     "apollo"
   ],
   "author": "Apollo <packages@apollographql.com>",
-  "license": "SEE LICENSE IN ./LICENSE",
+  "license": "Elastic-2.0",
   "engines": {
     "node": ">=14.15.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "apollo-federation-monorepo",
   "private": true,
-  "license": "SEE LICENSE IN ./LICENSE",
   "repository": "github:apollographql/federation",
   "scripts": {
     "clean": "git clean -dfqX -- ./target ./node_modules **/{dist,node_modules}/ ./*/tsconfig*tsbuildinfo",

--- a/query-graphs-js/package.json
+++ b/query-graphs-js/package.json
@@ -18,7 +18,7 @@
     "apollo"
   ],
   "author": "Apollo <packages@apollographql.com>",
-  "license": "SEE LICENSE IN ./LICENSE",
+  "license": "Elastic-2.0",
   "engines": {
     "node": ">=14.15.0"
   },

--- a/query-planner-js/package.json
+++ b/query-planner-js/package.json
@@ -20,7 +20,7 @@
   "engines": {
     "node": ">=14.15.0"
   },
-  "license": "SEE LICENSE IN ./LICENSE",
+  "license": "Elastic-2.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Fixes #2736

The `license` field in `package.json` is used by various tools. NPM [recommends the use of SPDX identifiers for this field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license), so this change is just a better use of that field.

It's plausible this change results in some reactions from current users' tooling, so landing this to `next` to target the next minor.