### PR TITLE
Add ability to transform an existing GraphQLSchema to a federated schema

### DIFF
--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG for `@apollo/subgraph`
 
 ## 2.5.2
+### Minor Changes
+- Introduce the new `transformFederatedSchema` to transform and existing `GraphQLSchema` into a federated schema.
 ### Patch Changes
 
 - Updated dependencies [[`35179f08`](https://github.com/apollographql/federation/commit/35179f086ce973e9ae7bb455f7ea7d73cdc10f69)]:

--- a/subgraph-js/src/index.ts
+++ b/subgraph-js/src/index.ts
@@ -1,2 +1,3 @@
 export { buildSubgraphSchema } from './buildSubgraphSchema';
 export { printSubgraphSchema } from './printSubgraphSchema';
+export { transformFederatedSchema } from './transformFederatedSchema';

--- a/subgraph-js/src/transformFederatedSchema.ts
+++ b/subgraph-js/src/transformFederatedSchema.ts
@@ -1,0 +1,80 @@
+import {
+  GraphQLSchema,
+  isObjectType,
+  isUnionType,
+  GraphQLUnionType,
+  GraphQLObjectType,
+} from 'graphql';
+import {
+  transformSchema,
+  addResolversToSchema,
+  GraphQLResolverMap,
+} from './schema-helper';
+import { typeIncludesDirective } from './directives';
+import { serviceField, entitiesField, EntityType } from './types';
+import { printSubgraphSchema } from './printSubgraphSchema';
+
+export function transformFederatedSchema(
+  schema: GraphQLSchema,
+  resolvers: GraphQLResolverMap<any>[] = [],
+): GraphQLSchema {
+  // At this point in time, we have a schema to be printed into SDL which is
+  // representative of what the user defined for their schema. This is before
+  // we process any of the federation directives and add custom federation types
+  // so its the right place to create our service definition sdl.
+  //
+  // We have to use a modified printSchema from graphql-js which includes
+  // support for preserving the *uses* of federation directives while removing
+  // their *definitions* from the sdl.
+  const sdl = printSubgraphSchema(schema);
+
+  // Add an empty query root type if none has been defined
+  if (!schema.getQueryType()) {
+    schema = new GraphQLSchema({
+      ...schema.toConfig(),
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {},
+      }),
+    });
+  }
+
+  const entityTypes = Object.values(schema.getTypeMap()).filter(
+    type => isObjectType(type) && typeIncludesDirective(type, 'key'),
+  );
+  const hasEntities = entityTypes.length > 0;
+
+  schema = transformSchema(schema, type => {
+    // Add `_entities` and `_service` fields to query root type
+    if (isObjectType(type) && type === schema.getQueryType()) {
+      const config = type.toConfig();
+      return new GraphQLObjectType({
+        ...config,
+        fields: {
+          ...(hasEntities && { _entities: entitiesField }),
+          _service: {
+            ...serviceField,
+            resolve: () => ({ sdl }),
+          },
+          ...config.fields,
+        },
+      });
+    }
+
+    return undefined;
+  });
+
+  schema = transformSchema(schema, type => {
+    if (hasEntities && isUnionType(type) && type.name === EntityType.name) {
+      return new GraphQLUnionType({
+        ...EntityType.toConfig(),
+        types: entityTypes.filter(isObjectType),
+      });
+    }
+    return undefined;
+  });
+
+  resolvers.forEach(resolver => addResolversToSchema(schema, resolver));
+
+  return schema;
+}


### PR DESCRIPTION
This brings over the work from a previous [Apollo Server PR](https://github.com/apollographql/apollo-server/pull/4310)

There are current GraphQL servers that have patterns that create a `GraphQLSchema` from a pattern defined by the authors of that server. 

For example, RedwoodJS uses `makeMergedSchema` to create a `GraphQLSchema` from a set of `sdl` blobs and defined `services` in the projects structure. There is no way to introduce the Apollo Federation Subgraph Spec into the schema and these servers require someway to modify their existing `GraphQLSchema` to add the Apollo Federation pieces.