### PR TITLE
docs: typo requiresScope -> requiresScopes

### DIFF
--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -367,9 +367,9 @@ directive @authenticated on
   | ENUM
 ```
 
-Indicates to composition that the target element is accessible only to the authenticated supergraph users. For more granular access control, see the [`@requiresScope`](#requiresScope) directive below. Refer to the [Apollo Router article](/router/configuration/authorization#authenticated) for additional details.
+Indicates to composition that the target element is accessible only to the authenticated supergraph users. For more granular access control, see the [`@requiresScopes`](#requiresScopes) directive below. Refer to the [Apollo Router article](/router/configuration/authorization#authenticated) for additional details.
 
-### `@requiresScope`
+### `@requiresScopes`
 
 > ⚠️ **This directive is available in Apollo Federation 2.5 and later.**
 > **Is is an [Enterprise feature](/router/enterprise-features) of the Apollo Router** and requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).<br/>

--- a/docs/source/federation-versions.mdx
+++ b/docs/source/federation-versions.mdx
@@ -92,7 +92,7 @@ directive @authenticated on
 <tr>
 <td>
 
-##### `@requiresScope`
+##### `@requiresScopes`
 
 </td>
 <td>
@@ -134,7 +134,7 @@ Scope
 </td>
 <td>
 
-- Custom scalar representing a JWT scope. Used by new `@requiresScope` directive.
+- Custom scalar representing a JWT scope. Used by new `@requiresScopes` directive.
 
 </td>
 </tr>


### PR DESCRIPTION
The existing naming of this directive was _incorrect_ in the documentation, so this fast-follows with the typos corrected.