### PR TITLE
Use `prettier@2` for jest snapshots

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -22,5 +22,6 @@ module.exports = {
         tsconfig: "<rootDir>/tsconfig.test.json",
         diagnostics: false
       }
-    }
+    },
+    prettierPath: require.resolve("prettier-2"),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "nock": "13.3.3",
         "node-fetch": "2.7.0",
         "prettier": "3.0.2",
+        "prettier-2": "npm:prettier@2.8.8",
         "semver": "7.5.4",
         "strip-indent": "3.0.0",
         "ts-jest": "29.1.1",
@@ -14312,6 +14313,22 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-2": {
+      "name": "prettier",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "nock": "13.3.3",
     "node-fetch": "2.7.0",
     "prettier": "3.0.2",
+    "prettier-2": "npm:prettier@2.8.8",
     "semver": "7.5.4",
     "strip-indent": "3.0.0",
     "ts-jest": "29.1.1",


### PR DESCRIPTION
Same PR, different repo. All necessary context in link below. Jest v29 doesn't support Prettier v3 for snapshots yet.
https://github.com/apollographql/apollo-utils/pull/349