### PR TITLE
feat: Extend support for content types that include JSON

### DIFF
--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -293,11 +293,10 @@ export class RemoteGraphQLDataSource<
     _fetchRequest?: NodeFetchRequest,
     _context?: TContext,
   ): Promise<object | string> {
-    const contentType = fetchResponse.headers.get('Content-Type');
+    const contentType = fetchResponse.headers.get('Content-Type') || '';
+    const [type, subtype] = contentType.split(';')[0].trim().split('/').map(s => s.trim());
     if (
-      contentType &&
-      (contentType.startsWith('application/json') ||
-        contentType.startsWith('application/graphql-response+json'))
+      type === 'application' && subtype && subtype.includes('json')
     ) {
       return fetchResponse.json();
     } else {

--- a/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/gateway-js/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -226,16 +226,16 @@ describe('constructing requests', () => {
   const contentTypeHandleTestCases = [
     {
       label: 'with application/graphql-response+json',
-      contentType: 'application/graphql-response+json'
+      contentType: 'application/graphql-response+json',
     },
     {
       label: 'with parameters',
-      contentType: 'application/something+json; charset=utf-8'
+      contentType: 'application/something+json; charset=utf-8',
     },
     {
       label: 'with application/graphql+json',
-      contentType: 'application/graphql+json'
-    }
+      contentType: 'application/graphql+json',
+    },
   ];
   contentTypeHandleTestCases.forEach(({ label, contentType }) => {
     it(`stringifies a request that supports the JSON subtype in its content type ${label}`, async () => {
@@ -246,11 +246,7 @@ describe('constructing requests', () => {
 
       nock('https://api.example.com')
         .post('/foo', { query: '{ me { name } }' })
-        .reply(
-          200,
-          { data: { me: 'james' } },
-          { 'content-type': contentType },
-        );
+        .reply(200, { data: { me: 'james' } }, { 'content-type': contentType });
 
       const { data: dataWithResponse } = await DataSource.process({
         ...defaultProcessOptions,


### PR DESCRIPTION
### Problem:
While federating a `smallrye-graphql` based API server using Apollo Gateway, I encountered an issue. The server responds with a `application/graphql+json` content type, which is currently not supported by the gateway.

### Proposed Solution:
This PR aims to broaden the supported content types in Apollo Gateway, specifically to include responses with `application/graphql+json` and other JSON subtypes. This change ensures that APIs like those built with `smallrye-graphql` can be seamlessly integrated without content type restrictions.

### Changes:
- Enhanced the content type detection logic to support types that include `json`.

