### PR TITLE
Remove invalid advice about omitting fields from `@shareable` types

### DIFF
--- a/docs/source/federated-types/sharing-types.mdx
+++ b/docs/source/federated-types/sharing-types.mdx
@@ -137,7 +137,8 @@ To make `Position.z` shareable, you can do one of the following:
 
 ## Differing shared fields
 
-The type of a shared field can vary in nullability (`String` / `String!`), but _can't_ vary in its core type (`Int` vs. `String`) or in whether it returns a list (`Int` vs. `[Int]`). Shareable value types must also have the same fields in _every_ subgraph that defines them.
+Shared fields can only differ in their [return types](#return-types) and [arguments](#arguments) in specific ways.
+If fields you want to share between subgraphs differ more than is permitted, use  [entities](../entities) instead of shareable value types.
 
 > To contribute different fields from different subgraphs, you can use [entity types](../entities) instead of shareable value types.
 

--- a/docs/source/federated-types/sharing-types.mdx
+++ b/docs/source/federated-types/sharing-types.mdx
@@ -137,35 +137,9 @@ To make `Position.z` shareable, you can do one of the following:
 
 ## Differing shared fields
 
-Shared fields can differ between subgraphs in specific ways:
-* The return type of a shared field can vary in nullability (`String` / `String!`).
-  * A shared field's return type _can't_ vary in its core type (`Int` vs. `String`) or in whether it returns a list (`Int` vs. `[Int]`).
-* A field can be omitted from a subgraph, _if_ that field is always [resolvable](../federated-types/composition/#rules-of-composition).
+The type of a shared field can vary in nullability (`String` / `String!`), but _can't_ vary in its core type (`Int` vs. `String`) or in whether it returns a list (`Int` vs. `[Int]`). Shareable value types must also have the same fields in _every_ subgraph that defines them.
 
-For example, take a look at the shared `Food` type below:
-
-<CodeColumns>
-
-```graphql {3} title="Subgraph A"
-type Food @shareable {
-  name: String!
-  price: Int!
-}
-```
-
-```graphql {3-4} title="Subgraph B"
-type Food @shareable {
-  name: String!
-  price: Int # Nullable
-  inStock: Boolean! # Not in A
-}
-```
-
-<></>
-
-</CodeColumns>
-
-The above `Food` types differ in the nullability of their fields _and_ the fields included in each type.
+> To contribute different fields from different subgraphs, you can use [entity types](../entities) instead of shareable value types.
 
 ### Return types
 

--- a/docs/source/federated-types/sharing-types.mdx
+++ b/docs/source/federated-types/sharing-types.mdx
@@ -140,7 +140,6 @@ To make `Position.z` shareable, you can do one of the following:
 Shared fields can only differ in their [return types](#return-types) and [arguments](#arguments) in specific ways.
 If fields you want to share between subgraphs differ more than is permitted, use  [entities](../entities) instead of shareable value types.
 
-> To contribute different fields from different subgraphs, you can use [entity types](../entities) instead of shareable value types.
 
 ### Return types
 


### PR DESCRIPTION
I'm pretty sure the example that was present was never valid, because I don't think the field can be omitted _and_ resolvable unless it's an entity.

This article probably needs a larger pass to separate it more clearly from entities, but the immediate goal here is to remove the example that caused some confusion for a Discord user.