### PR TITLE
Fix nested fragments on interfaces (when a directive is present)

### DIFF
--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -2239,7 +2239,7 @@ function makeSelection(parentType: CompositeType, updates: SelectionUpdate[], fr
   const element = updateElement(first).rebaseOnOrError(parentType);
   const subSelectionParentType = element.kind === 'Field' ? element.baseType() : element.castedType();
   if (!isCompositeType(subSelectionParentType)) {
-    // This is a leaf, so all updates should correspond ot the same field and we just use the first.
+    // This is a leaf, so all updates should correspond to the same field and we just use the first.
     return selectionOfElement(element);
   }
 


### PR DESCRIPTION
The following query:

```gql
query {
  i {
    _id
    ... on I2 {
      ... on I2 @test {
        id
      }
    }
  }
}
```
Blows up with the following error:
>Cannot add fragment of condition "I2" (runtimes: [T1,T2]) to parent type "T1" (runtimes: T1)

When the `@test` directive is removed, we collapse the inline fragments and this error doesn't occur, but we can't do that when a directive application is present.

This _seems_ to be due to the way that the query planner handles interface conditions, by expanding them into their runtime types. My understanding right now is roughly this:

Expanding the above query in theory looks something like:
```gql
query {
  i {
    _id
    ... on T1 {
      ... on I2 @test {
        id
      }
    }
    ... on T2 {
      ... on I2 @test {
        id
      }
    }
  }
}
```
...but this T2 as parent type of an I2 is triggering the error since `canRebaseOn` is returning false.

Minimal reproduction of https://github.com/apollographql/federation/issues/2862