### PR TITLE
fix: handle directive conditions on fragments when building query graphs

### DIFF
--- a/.changeset/shiny-forks-happen.md
+++ b/.changeset/shiny-forks-happen.md
@@ -1,0 +1,9 @@
+---
+"@apollo/query-graphs": patch
+---
+
+fix: handle directive conditions on fragments when building query graphs
+
+This fix addresses issues with handling fragments when they specify directive conditions:
+* when exploding the types we were not propagating directive conditions
+* when processing fragment that specifies super type of an existing type and also specifies directive condition, we were incorrectly preserving the unnecessary type condition. This type condition was problematic as it could be referecing types from supergraph that were not available in the local schema. Instead, we now drop the redundant type condition and only preserve the directives (if specified).  

--- a/.changeset/shiny-forks-happen.md
+++ b/.changeset/shiny-forks-happen.md
@@ -6,4 +6,4 @@ fix: handle directive conditions on fragments when building query graphs
 
 This fix addresses issues with handling fragments when they specify directive conditions:
 * when exploding the types we were not propagating directive conditions
-* when processing fragment that specifies super type of an existing type and also specifies directive condition, we were incorrectly preserving the unnecessary type condition. This type condition was problematic as it could be referecing types from supergraph that were not available in the local schema. Instead, we now drop the redundant type condition and only preserve the directives (if specified).  
+* when processing fragment that specifies super type of an existing type and also specifies directive condition, we were incorrectly preserving the unnecessary type condition. This type condition was problematic as it could be referencing types from supergraph that were not available in the local schema. Instead, we now drop the redundant type condition and only preserve the directives (if specified).  

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -7975,7 +7975,7 @@ describe('@requires references external field indirectly', () => {
 });
 
 describe('handles fragments with directive conditions', () => {
-  test('fragment with interseting parent type and directive condition', () => {
+  test('fragment with intersecting parent type and directive condition', () => {
     const subgraphA = {
       typeDefs: gql`
         directive @test on FRAGMENT_SPREAD

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -8035,16 +8035,6 @@ describe('handles fragments with directive conditions', () => {
       `,
     );
 
-    expect(operation.expandAllFragments().toString()).toMatchInlineSnapshot(`
-      "{
-        i {
-          _id
-          ... on I2 @test {
-            id
-          }
-        }
-      }"
-    `);
     const queryPlan = queryPlanner.buildQueryPlan(operation);
     expect(queryPlan).toMatchInlineSnapshot(`
       QueryPlan {

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -8022,8 +8022,8 @@ describe('handles fragments with directive conditions', () => {
     const [api, queryPlanner] = composeAndCreatePlanner(subgraphA, subgraphB);
 
     const operation = operationFromDocument(
-        api,
-        gql`
+      api,
+      gql`
         query {
           i {
             _id
@@ -8113,8 +8113,8 @@ describe('handles fragments with directive conditions', () => {
     const [api, queryPlanner] = composeAndCreatePlanner(subgraphA, subgraphB);
 
     const operation = operationFromDocument(
-        api,
-        gql`
+      api,
+      gql`
         query {
           i {
             _id

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -7973,3 +7973,195 @@ describe('@requires references external field indirectly', () => {
     `);
   });
 });
+
+describe('handles fragments with directive conditions', () => {
+  test('fragment with interseting parent type and directive condition', () => {
+    const subgraphA = {
+      typeDefs: gql`
+        directive @test on FRAGMENT_SPREAD
+        type Query {
+          i: I
+        }
+        interface I {
+          _id: ID
+        }
+        type T1 implements I @key(fields: "id") {
+          _id: ID
+          id: ID
+        }
+        type T2 implements I @key(fields: "id") {
+          _id: ID
+          id: ID
+        }
+      `,
+      name: 'A',
+    };
+
+    const subgraphB = {
+      typeDefs: gql`
+        directive @test on FRAGMENT_SPREAD
+        type Query {
+          i2s: [I2]
+        }
+        interface I2 {
+          id: ID
+          title: String
+        }
+        type T1 implements I2 @key(fields: "id") {
+          id: ID
+          title: String
+        }
+        type T2 implements I2 @key(fields: "id") {
+          id: ID
+          title: String
+        }
+      `,
+      name: 'B',
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlanner(subgraphA, subgraphB);
+
+    const operation = operationFromDocument(
+        api,
+        gql`
+        query {
+          i {
+            _id
+            ... on I2 @test {
+              id
+            }
+          }
+        }
+      `,
+    );
+
+    expect(operation.expandAllFragments().toString()).toMatchInlineSnapshot(`
+      "{
+        i {
+          _id
+          ... on I2 @test {
+            id
+          }
+        }
+      }"
+    `);
+    const queryPlan = queryPlanner.buildQueryPlan(operation);
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "A") {
+          {
+            i {
+              __typename
+              _id
+              ... on T1 @test {
+                id
+              }
+              ... on T2 @test {
+                id
+              }
+            }
+          }
+        },
+      }
+    `);
+  });
+
+  test('nested fragment with interseting parent type and directive condition', () => {
+    const subgraphA = {
+      typeDefs: gql`
+        directive @test on FRAGMENT_SPREAD
+        type Query {
+          i: I
+        }
+        interface I {
+          _id: ID
+        }
+        type T1 implements I @key(fields: "id") {
+          _id: ID
+          id: ID
+        }
+        type T2 implements I @key(fields: "id") {
+          _id: ID
+          id: ID
+        }
+      `,
+      name: 'A',
+    };
+
+    const subgraphB = {
+      typeDefs: gql`
+        directive @test on FRAGMENT_SPREAD
+        type Query {
+          i2s: [I2]
+        }
+        interface I2 {
+          id: ID
+          title: String
+        }
+        type T1 implements I2 @key(fields: "id") {
+          id: ID
+          title: String
+        }
+        type T2 implements I2 @key(fields: "id") {
+          id: ID
+          title: String
+        }
+      `,
+      name: 'B',
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlanner(subgraphA, subgraphB);
+
+    const operation = operationFromDocument(
+        api,
+        gql`
+        query {
+          i {
+            _id
+            ... on I2 {
+              ... on I2 @test {
+                id
+              }
+            }
+          }
+        }
+      `,
+    );
+
+    expect(operation.expandAllFragments().toString()).toMatchInlineSnapshot(`
+      "{
+        i {
+          _id
+          ... on I2 {
+            ... on I2 @test {
+              id
+            }
+          }
+        }
+      }"
+    `);
+    const queryPlan = queryPlanner.buildQueryPlan(operation);
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "A") {
+          {
+            i {
+              __typename
+              _id
+              ... on T1 {
+                ... @test {
+                  id
+                }
+              }
+              ... on T2 {
+                ... @test {
+                  id
+                }
+              }
+            }
+          }
+        },
+      }
+    `);
+  });
+});


### PR DESCRIPTION
This PR addresses issues with handling fragments when they specify directive conditions:
* when exploding the types we were not propagating directive conditions
* when processing fragment that specifies super type of an existing type and also specifies directive condition, we were incorrectly preserving the unnecessary type condition. This type condition was problematic as it could be referencing types from supergraph that were not available in the local schema. Instead, we now drop the redundant type condition and only preserve the directives (if specified).

Related:
* fixes #2862
* supersedes #2864