### PR TITLE
docs: set min router version for 2.6

### DIFF
--- a/docs/source/federation-versions.mdx
+++ b/docs/source/federation-versions.mdx
@@ -39,7 +39,7 @@ First release
 
 Available in GraphOS?
 
-**No**
+**Yes**
 
 </div>
 
@@ -47,7 +47,7 @@ Available in GraphOS?
 
 Minimum router version
 
-**TBD**
+**1.35.0**
 
 </div>
 


### PR DESCRIPTION
Documents Federation 2.6's min router version as 1.35.0