### PR TITLE
Progressive `@override` (composition only)

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -71,14 +71,14 @@ describe('composition', () => {
     expect(result.supergraphSdl).toMatchString(`
       schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
-        @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+        @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
       {
         query: Query
       }
 
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -219,14 +219,14 @@ describe('composition', () => {
     expect(result.supergraphSdl).toMatchString(`
       schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
-        @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+        @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
       {
         query: Query
       }
 
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -502,7 +502,7 @@ describe("composition involving @override directive", () => {
 
     const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
     expect(result.errors).toBeDefined();
-    expect(result.errors?.map(e => e.message)).toMatchStringArray([
+    expect(result.errors?.map((e) => e.message)).toMatchStringArray([
       `
       The following supergraph API query:
       {
@@ -526,7 +526,7 @@ describe("composition involving @override directive", () => {
       - from subgraph "Subgraph2":
         - cannot find field "T.a".
         - cannot move to subgraph "Subgraph1" using @key(fields: "k") of "T", the key field(s) cannot be resolved from subgraph "Subgraph2" (note that some of those key fields are overridden in "Subgraph2").
-      `
+      `,
     ]);
   });
 
@@ -562,9 +562,9 @@ describe("composition involving @override directive", () => {
     expect(result.errors).toBeDefined();
     expect(errors(result)).toStrictEqual([
       [
-        'FIELD_TYPE_MISMATCH',
-        'Type of field "T.a" is incompatible across subgraphs: it has type "Int" in subgraph "Subgraph1" but type "String" in subgraph "Subgraph2"'
-      ]
+        "FIELD_TYPE_MISMATCH",
+        'Type of field "T.a" is incompatible across subgraphs: it has type "Int" in subgraph "Subgraph1" but type "String" in subgraph "Subgraph2"',
+      ],
     ]);
   });
 
@@ -810,7 +810,7 @@ describe("composition involving @override directive", () => {
   // At the moment, we've punted on @override support when interacting with @interfaceObject, so the
   // following tests mainly cover the various possible use and show that it currently correcly raise
   // some validation errors. We may lift some of those limitation in the future.
-  describe('@interfaceObject', () => {
+  describe("@interfaceObject", () => {
     it("does not allow @override on @interfaceObject fields", () => {
       // We currently rejects @override on fields of an @interfaceObject type. We could lift
       // that limitation in the future, and that would mean such override overrides the field
@@ -912,6 +912,65 @@ describe("composition involving @override directive", () => {
         "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
         'Invalid @override on field "A.a" of subgraph "Subgraph2": source subgraph "Subgraph1" does not have field "A.a" but abstract it in type "I" and overriding abstracted fields is not supported.',
       ]);
+    });
+  });
+
+  describe("progressive override", () => {
+    it("captures override labels in supergraph", () => {
+      const subgraph1 = {
+        name: "Subgraph1",
+        url: "https://Subgraph1",
+        typeDefs: gql`
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "k") {
+            k: ID
+            a: Int @override(from: "Subgraph2", label: "foo")
+          }
+        `,
+      };
+
+      const subgraph2 = {
+        name: "Subgraph2",
+        url: "https://Subgraph2",
+        typeDefs: gql`
+          type T @key(fields: "k") {
+            k: ID
+            a: Int
+            b: Int
+          }
+        `,
+      };
+
+      const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+      assertCompositionSuccess(result);
+
+      const typeT = result.schema.type("T");
+      expect(printType(typeT!)).toMatchInlineSnapshot(`
+        "type T
+          @join__type(graph: SUBGRAPH1, key: \\"k\\")
+          @join__type(graph: SUBGRAPH2, key: \\"k\\")
+        {
+          k: ID
+          a: Int @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\", overrideLabel: \\"foo\\")
+          b: Int @join__field(graph: SUBGRAPH2)
+        }"
+      `);
+
+      const [_, api] = schemas(result);
+      expect(printSchema(api)).toMatchString(`
+        type Query {
+          t: T
+        }
+
+        type T {
+          k: ID
+          a: Int
+          b: Int
+        }
+      `);
     });
   });
 });

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -985,11 +985,13 @@ describe("composition involving @override directive", () => {
         `,
       };
 
-      it.each(["abc123", "Z_1-2:3/4.5"])("allows valid labels starting with alpha and including alphanumerics + `_-:./`", (value) => {
-        const withValidLabel = {
-          name: "validLabel",
-          url: "https://validLabel",
-          typeDefs: gql`
+      it.each(["abc123", "Z_1-2:3/4.5"])(
+        "allows valid labels starting with alpha and including alphanumerics + `_-:./`",
+        (value) => {
+          const withValidLabel = {
+            name: "validLabel",
+            url: "https://validLabel",
+            typeDefs: gql`
             type Query {
               t: T
             }
@@ -1000,17 +1002,20 @@ describe("composition involving @override directive", () => {
                 @override(from: "overridden", label: "${value}")
             }
           `,
-        };
+          };
 
-        const result = composeAsFed2Subgraphs([withValidLabel, overridden]);
-        assertCompositionSuccess(result);
-      });
+          const result = composeAsFed2Subgraphs([withValidLabel, overridden]);
+          assertCompositionSuccess(result);
+        }
+      );
 
-      it.each(["1_starts-with-non-alpha", "includes!@_invalid_chars"])("disallows invalid labels", (value) => {
-        const withInvalidLabel = {
-          name: "invalidLabel",
-          url: "https://invalidLabel",
-          typeDefs: gql`
+      it.each(["1_starts-with-non-alpha", "includes!@_invalid_chars"])(
+        "disallows invalid labels",
+        (value) => {
+          const withInvalidLabel = {
+            name: "invalidLabel",
+            url: "https://invalidLabel",
+            typeDefs: gql`
             type Query {
               t: T
             }
@@ -1020,15 +1025,16 @@ describe("composition involving @override directive", () => {
               a: Int @override(from: "overridden", label: "${value}")
             }
           `,
-        };
+          };
 
-        const result = composeAsFed2Subgraphs([withInvalidLabel, overridden]);
-        expect(result.errors).toBeDefined();
-        expect(errors(result)).toContainEqual([
-          "OVERRIDE_LABEL_INVALID",
-          `Invalid @override label "${value}" on field "T.a" on subgraph "invalidLabel": labels must start with a letter and after that may contain alphanumerics, underscores, minuses, colons, periods, or slashes. Alternatively, labels may be of the form "percent(x)" where x is a float between 0-100 inclusive.`,
-        ]);
-      });
+          const result = composeAsFed2Subgraphs([withInvalidLabel, overridden]);
+          expect(result.errors).toBeDefined();
+          expect(errors(result)).toContainEqual([
+            "OVERRIDE_LABEL_INVALID",
+            `Invalid @override label "${value}" on field "T.a" on subgraph "invalidLabel": labels must start with a letter and after that may contain alphanumerics, underscores, minuses, colons, periods, or slashes. Alternatively, labels may be of the form "percent(x)" where x is a float between 0-100 inclusive.`,
+          ]);
+        }
+      );
 
       it.each(["0.5", "1", "1.0", "99.9"])(
         "allows valid percent-based labels",

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -121,7 +121,7 @@ class FieldMergeContext {
     return this._props[idx].overrideWithUnknownTarget;
   }
 
-  overrideLabelForIdx(idx: number) {
+  overrideLabel(idx: number) {
     return this._props[idx].overrideLabel;
   }
 
@@ -1614,7 +1614,7 @@ class Merger {
         type: allTypesEqual ? undefined : source.type?.toString(),
         external: external ? true : undefined,
         usedOverridden: usedOverridden ? true : undefined,
-        overrideLabel: mergeContext.overrideLabelForIdx(idx),
+        overrideLabel: mergeContext.overrideLabel(idx),
       });
     }
   }

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -65,6 +65,7 @@ The following errors might be raised during composition:
 | `ONLY_INACCESSIBLE_CHILDREN` | A type visible in the API schema has only @inaccessible children. | 2.0.0 |  |
 | `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
 | `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
+| `OVERRIDE_LABEL_INVALID` | The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_-:./]*$/ or /^percent(([0-9]|[1-9][0-9]|100))$/ | 2.7.0 |  |
 | `OVERRIDE_ON_INTERFACE` | The @override directive cannot be used on the fields of an interface type. | 2.3.0 |  |
 | `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
 | `PROVIDES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@provides` directive includes some directive applications. This is not supported | 2.1.0 |  |

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -65,7 +65,7 @@ The following errors might be raised during composition:
 | `ONLY_INACCESSIBLE_CHILDREN` | A type visible in the API schema has only @inaccessible children. | 2.0.0 |  |
 | `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
 | `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
-| `OVERRIDE_LABEL_INVALID` | The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_-:./]*$/ or /^percent(([0-9]|[1-9][0-9]|100))$/ | 2.7.0 |  |
+| `OVERRIDE_LABEL_INVALID` | The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_-:./]*$/ or /^percent((d{1,2}(.d{1,8})?|100))$/ | 2.7.0 |  |
 | `OVERRIDE_ON_INTERFACE` | The @override directive cannot be used on the fields of an interface type. | 2.3.0 |  |
 | `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
 | `PROVIDES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@provides` directive includes some directive applications. This is not supported | 2.1.0 |  |

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -148,8 +148,8 @@ describe('lifecycle hooks', () => {
     // Note that this assertion is a tad fragile in that every time we modify
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
-    expect(secondCall[0]!.compositionId).toEqual(
-      '4644102bb30ec7e254fac2577f78137bbab156cb965973ae481f309120738ff6',
+    expect(secondCall[0]!.compositionId).toMatchInlineSnapshot(
+      `"40b32cfc113afdd0dc81ccced57d0631ff892e8736ba4116a6841128905d4f7a"`,
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -513,6 +513,12 @@ const OVERRIDE_ON_INTERFACE = makeCodeDefinition(
   { addedIn: '2.3.0' },
 );
 
+const OVERRIDE_LABEL_INVALID = makeCodeDefinition(
+  'OVERRIDE_LABEL_INVALID',
+  'The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_\-:./]*$/ or /^percent\(([0-9]|[1-9][0-9]|100)\)$/',
+  { addedIn: '2.7.0' },
+);
+
 const UNSUPPORTED_FEATURE = makeCodeDefinition(
   'UNSUPPORTED_FEATURE',
   'Indicates an error due to feature currently unsupported by federation.',
@@ -633,6 +639,7 @@ export const ERRORS = {
   OVERRIDE_FROM_SELF_ERROR,
   OVERRIDE_SOURCE_HAS_OVERRIDE,
   OVERRIDE_ON_INTERFACE,
+  OVERRIDE_LABEL_INVALID,
   UNSUPPORTED_FEATURE,
   INVALID_FEDERATION_SUPERGRAPH,
   DOWNSTREAM_SERVICE_ERROR,

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -515,7 +515,7 @@ const OVERRIDE_ON_INTERFACE = makeCodeDefinition(
 
 const OVERRIDE_LABEL_INVALID = makeCodeDefinition(
   'OVERRIDE_LABEL_INVALID',
-  'The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_\-:./]*$/ or /^percent\(([0-9]|[1-9][0-9]|100)\)$/',
+  'The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_\-:./]*$/ or /^percent\((\d{1,2}(\.\d{1,8})?|100)\)$/',
   { addedIn: '2.7.0' },
 );
 

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -1191,9 +1191,9 @@ export function setSchemaAsFed2Subgraph(schema: Schema) {
 
 // This is the full @link declaration as added by `asFed2SubgraphDocument`. It's here primarily for uses by tests that print and match
 // subgraph schema to avoid having to update 20+ tests every time we use a new directive or the order of import changes ...
-export const FEDERATION2_LINK_WITH_FULL_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject", "@authenticated", "@requiresScopes", "@policy"])';
+export const FEDERATION2_LINK_WITH_FULL_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject", "@authenticated", "@requiresScopes", "@policy"])';
 // This is the full @link declaration that is added when upgrading fed v1 subgraphs to v2 version. It should only be used by tests.
-export const FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"])';
+export const FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS = '@link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"])';
 
 /**
  * Given a document that is assumed to _not_ be a fed2 schema (it does not have a `@link` to the federation spec),
@@ -1439,7 +1439,7 @@ function completeFed2SubgraphSchema(schema: Schema): GraphQLError[] {
   const spec = FEDERATION_VERSIONS.find(fedFeature.url.version);
   if (!spec) {
     return [ERRORS.UNKNOWN_FEDERATION_LINK_VERSION.err(
-      `Invalid version ${fedFeature.url.version} for the federation feature in @link direction on schema`,
+      `Invalid version ${fedFeature.url.version} for the federation feature in @link directive on schema`,
       { nodes: fedFeature.directive.sourceAST },
     )];
   }
@@ -1561,7 +1561,7 @@ export function collectTargetFields({
       validate,
     });
   } catch (e) {
-    // If we explicitely requested no validation, then we shouldn't throw a (graphQL) error, but if we do, we swallow it
+    // If we explicitly requested no validation, then we shouldn't throw a (graphQL) error, but if we do, we swallow it
     // (returning a partial result, but we assume it is fine).
     const isGraphQLError = errorCauses(e) !== undefined
     if (!isGraphQLError || validate) {

--- a/internals-js/src/specs/federationSpec.ts
+++ b/internals-js/src/specs/federationSpec.ts
@@ -124,11 +124,22 @@ export class FederationSpecDefinition extends FeatureDefinition {
 
     this.registerSubFeature(INACCESSIBLE_VERSIONS.getMinimumRequiredVersion(version));
 
-    this.registerDirective(createDirectiveSpecification({
-      name: FederationDirectiveName.OVERRIDE,
-      locations: [DirectiveLocation.FIELD_DEFINITION],
-      args: [{ name: 'from', type: (schema) => new NonNullType(schema.stringType()) }],
-    }));
+    if (version >= (new FeatureVersion(2, 7))) {
+      this.registerDirective(createDirectiveSpecification({
+        name: FederationDirectiveName.OVERRIDE,
+        locations: [DirectiveLocation.FIELD_DEFINITION],
+        args: [
+          { name: 'from', type: (schema) => new NonNullType(schema.stringType()) },
+          { name: 'label', type: (schema) => schema.stringType() },
+        ],
+      }));
+    } else {
+      this.registerDirective(createDirectiveSpecification({
+        name: FederationDirectiveName.OVERRIDE,
+        locations: [DirectiveLocation.FIELD_DEFINITION],
+        args: [{ name: 'from', type: (schema) => new NonNullType(schema.stringType()) }],
+      }));
+    }
 
     if (version.gte(new FeatureVersion(2, 1))) {
       this.registerDirective(createDirectiveSpecification({
@@ -165,6 +176,7 @@ export const FEDERATION_VERSIONS = new FeatureDefinitions<FederationSpecDefiniti
   .add(new FederationSpecDefinition(new FeatureVersion(2, 3)))
   .add(new FederationSpecDefinition(new FeatureVersion(2, 4)))
   .add(new FederationSpecDefinition(new FeatureVersion(2, 5)))
-  .add(new FederationSpecDefinition(new FeatureVersion(2, 6)));
+  .add(new FederationSpecDefinition(new FeatureVersion(2, 6)))
+  .add(new FederationSpecDefinition(new FeatureVersion(2, 7)));
 
 registerKnownFeature(FEDERATION_VERSIONS);

--- a/internals-js/src/specs/joinSpec.ts
+++ b/internals-js/src/specs/joinSpec.ts
@@ -46,6 +46,7 @@ export type JoinFieldDirectiveArguments = {
   type?: string,
   external?: boolean,
   usedOverridden?: boolean,
+  overrideLabel?: string,
 }
 
 export class JoinSpecDefinition extends FeatureDefinition {
@@ -124,6 +125,11 @@ export class JoinSpecDefinition extends FeatureDefinition {
       const joinEnumValue = this.addDirective(schema, 'enumValue').addLocations(DirectiveLocation.ENUM_VALUE);
       joinEnumValue.repeatable = true;
       joinEnumValue.addArgument('graph', new NonNullType(graphEnum));
+    }
+
+    // progressive override
+    if (this.version >= (new FeatureVersion(0, 4))) {
+      joinField.addArgument('overrideLabel', schema.stringType());
     }
 
     if (this.isV01()) {
@@ -227,9 +233,11 @@ export class JoinSpecDefinition extends FeatureDefinition {
 //    for federation 2 in general.
 //  - 0.2: this is the original version released with federation 2.
 //  - 0.3: adds the `isInterfaceObject` argument to `@join__type`, and make the `graph` in `@join__field` skippable.
+//  - 0.4: adds the optional `overrideLabel` argument to `@join_field` for progressive override.
 export const JOIN_VERSIONS = new FeatureDefinitions<JoinSpecDefinition>(joinIdentity)
   .add(new JoinSpecDefinition(new FeatureVersion(0, 1)))
   .add(new JoinSpecDefinition(new FeatureVersion(0, 2)))
-  .add(new JoinSpecDefinition(new FeatureVersion(0, 3), new FeatureVersion(2, 0)));
+  .add(new JoinSpecDefinition(new FeatureVersion(0, 3), new FeatureVersion(2, 0)))
+  .add(new JoinSpecDefinition(new FeatureVersion(0, 4), new FeatureVersion(2, 7)));
 
 registerKnownFeature(JOIN_VERSIONS);

--- a/internals-js/src/supergraphs.ts
+++ b/internals-js/src/supergraphs.ts
@@ -13,6 +13,7 @@ export const DEFAULT_SUPPORTED_SUPERGRAPH_FEATURES = new Set([
   'https://specs.apollo.dev/join/v0.1',
   'https://specs.apollo.dev/join/v0.2',
   'https://specs.apollo.dev/join/v0.3',
+  'https://specs.apollo.dev/join/v0.4',
   'https://specs.apollo.dev/tag/v0.1',
   'https://specs.apollo.dev/tag/v0.2',
   'https://specs.apollo.dev/tag/v0.3',

--- a/subgraph-js/src/directives.ts
+++ b/subgraph-js/src/directives.ts
@@ -135,6 +135,9 @@ export const OverrideDirective = new GraphQLDirective({
     from: {
       type: new GraphQLNonNull(GraphQLString),
     },
+    label: {
+      type: GraphQLString,
+    }
   },
 });
 


### PR DESCRIPTION
Bump fed spec to v2.7
Bump join spec to v0.4

Add new optional `label` arg to `@override` which is a `String`.
Capture label in the supergraph via the new `@join__field` arg `overrideLabel` so these values can be used during query graph creation and query planning.