### PR TITLE
Fix `__typename` rebasing for interface objects

### DIFF
--- a/.changeset/dry-seahorses-grin.md
+++ b/.changeset/dry-seahorses-grin.md
@@ -1,0 +1,5 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fix query planning bug where `__typename` on interface object types in named fragments can cause query plan execution to fail. ([#2886](https://github.com/apollographql/federation/issues/2886))

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -305,7 +305,15 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     }
 
     if (this.name === typenameFieldName) {
-      return this.withUpdatedDefinition(parentType.typenameField()!);
+      if (possibleRuntimeTypes(parentType).some((runtimeType) => isInterfaceObjectType(runtimeType))) {
+        validate(
+          !errorIfCannotRebase,
+          () => `Cannot add selection of field "${this.definition.coordinate}" to selection set of parent type "${parentType}" that is potentially an interface object type at runtime`
+        );
+        return undefined;
+      } else {
+        return this.withUpdatedDefinition(parentType.typenameField()!);
+      }
     }
 
     const fieldDef = parentType.field(this.name);


### PR DESCRIPTION
We should never query `__typename` from a subgraph for an object type marked `@interfaceObject`, as the value we get back will always be wrong. Normally, we prevent this by not having a `__typename` edge in the federated query graph.

However, during the optimization where we try to reuse existing named fragments, we rebase them from the API schema onto the subgraph schemas. We usually ignore selections where this leads to invalidity (e.g. fields or types that don't exist in the subgraph schema), but the code doesn't currently view the `__typename` field being rebased onto an interface object as invalid. This has led to bugs where named fragments containing `__typename` accidentally cause it to be queried on interface objects in subgraph queries.

This PR changes `Field.rebaseOn()` such that `__typename` being rebased onto a parent type that is an interface object is considered invalid. Additionally, if the parent type is an abstract type, and that abstract type could possibly be an interface object type at runtime, then this is additionally considered invalid.