### PR TITLE
Support `@join__directive(graphs, name, args)` directives

### DIFF
--- a/.changeset/real-comics-stare.md
+++ b/.changeset/real-comics-stare.md
@@ -1,0 +1,6 @@
+---
+"@apollo/composition": minor
+"@apollo/federation-internals": minor
+---
+
+Support `@join__directive(graphs, name, args)` directives

--- a/.cspell/cspell-dict.txt
+++ b/.cspell/cspell-dict.txt
@@ -220,6 +220,7 @@ subgpraph
 subgrahs
 SUBGRAPHA
 SUBGRAPHB
+SUBGRAPHC
 subraph
 subraphs
 Substrat

--- a/composition-js/src/__tests__/__snapshots__/compose.composeDirective.test.ts.snap
+++ b/composition-js/src/__tests__/__snapshots__/compose.composeDirective.test.ts.snap
@@ -24,6 +24,8 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
 directive @mytag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
 directive @tag(name: String!, prop: String!) on FIELD_DEFINITION | OBJECT
@@ -48,6 +50,8 @@ enum join__Graph {
 }
 
 scalar join__FieldSet
+
+scalar join__DirectiveArguments
 
 type Query
   @join__type(graph: SUBGRAPHA)

--- a/composition-js/src/__tests__/__snapshots__/compose.composeDirective.test.ts.snap
+++ b/composition-js/src/__tests__/__snapshots__/compose.composeDirective.test.ts.snap
@@ -24,7 +24,7 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
 
 directive @mytag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4645,38 +4645,38 @@ describe('composition', () => {
 
   it('@source{API,Type,Field} directives', () => {
     const subgraphA = {
-      typeDefs: gql`
-extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.1", import: [
-    "@key"
-  ])
-  @link(url: "https://specs.apollo.dev/source/v0.1", import: [
-    "@sourceAPI"
-    "@sourceType"
-    "@sourceField"
-  ])
-  @sourceAPI(
-    name: "A"
-    http: { baseURL: "https://api.a.com/v1" }
-  )
-
-type Query {
-  resources: [Resource!]! @sourceField(
-    api: "A"
-    http: { GET: "/resources" }
-  )
-}
-
-type Resource @key(fields: "id") @sourceType(
-  api: "A"
-  http: { GET: "/resources/{id}" }
-  selection: "id description"
-) {
-  id: ID!
-  description: String!
-}
-      `,
       name: 'subgraphA',
+      typeDefs: gql`
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.1", import: [
+            "@key"
+          ])
+          @link(url: "https://specs.apollo.dev/source/v0.1", import: [
+            "@sourceAPI"
+            "@sourceType"
+            "@sourceField"
+          ])
+          @sourceAPI(
+            name: "A"
+            http: { baseURL: "https://api.a.com/v1" }
+          )
+
+        type Query {
+          resources: [Resource!]! @sourceField(
+            api: "A"
+            http: { GET: "/resources" }
+          )
+        }
+
+        type Resource @key(fields: "id") @sourceType(
+          api: "A"
+          http: { GET: "/resources/{id}" }
+          selection: "id description"
+        ) {
+          id: ID!
+          description: String!
+        }
+      `,
     };
     const result = composeServices([subgraphA]);
     expect(result.errors ?? []).toEqual([]);

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -76,6 +76,8 @@ describe('composition', () => {
         query: Query
       }
 
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
       directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
@@ -96,6 +98,8 @@ describe('composition', () => {
         V1 @join__enumValue(graph: SUBGRAPH2)
         V2 @join__enumValue(graph: SUBGRAPH2)
       }
+
+      scalar join__DirectiveArguments
 
       scalar join__FieldSet
 
@@ -224,6 +228,8 @@ describe('composition', () => {
         query: Query
       }
 
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
       directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
@@ -244,6 +250,8 @@ describe('composition', () => {
         V1 @join__enumValue(graph: SUBGRAPH2)
         V2 @join__enumValue(graph: SUBGRAPH2)
       }
+
+      scalar join__DirectiveArguments
 
       scalar join__FieldSet
 
@@ -2489,6 +2497,8 @@ describe('composition', () => {
         query: Query
       }
 
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
       directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
@@ -2502,6 +2512,8 @@ describe('composition', () => {
       directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
       directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+      scalar join__DirectiveArguments
 
       scalar join__FieldSet
 
@@ -4629,5 +4641,76 @@ describe('composition', () => {
     assert(schema, 'schema does not exist');
     const authenticatedDirectiveExists = schema.directives().find(d => d.name === 'authenticated');
     expect(authenticatedDirectiveExists).toBeUndefined();
+  });
+
+  it('@source{API,Type,Field} directives', () => {
+    const subgraphA = {
+      typeDefs: gql`
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.1", import: [
+    "@key"
+  ])
+  @link(url: "https://specs.apollo.dev/source/v0.1", import: [
+    "@sourceAPI"
+    "@sourceType"
+    "@sourceField"
+  ])
+  @sourceAPI(
+    name: "A"
+    http: { baseURL: "https://api.a.com/v1" }
+  )
+
+type Query {
+  resources: [Resource!]! @sourceField(
+    api: "A"
+    http: { GET: "/resources" }
+  )
+}
+
+type Resource @key(fields: "id") @sourceType(
+  api: "A"
+  http: { GET: "/resources/{id}" }
+  selection: "id description"
+) {
+  id: ID!
+  description: String!
+}
+      `,
+      name: 'subgraphA',
+    };
+    const result = composeServices([subgraphA]);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toContain(
+`schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @join__directive(graphs: [SUBGRAPHA], name: "link", args: {url: "https://specs.apollo.dev/source/v0.1", import: ["@sourceAPI", "@sourceType", "@sourceField"]})
+  @join__directive(graphs: [SUBGRAPHA], name: "sourceAPI", args: {name: "A", http: {baseURL: "https://api.a.com/v1"}})
+{
+  query: Query
+}`);
+
+    expect(printed).toContain(
+      `directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION`
+    );
+
+    expect(printed).toContain(
+`type Query
+  @join__type(graph: SUBGRAPHA)
+{
+  resources: [Resource!]! @join__directive(graphs: [SUBGRAPHA], name: "sourceField", args: {api: "A", http: {GET: "/resources"}})
+}`
+    );
+
+    expect(printed).toContain(
+`type Resource
+  @join__type(graph: SUBGRAPHA, key: "id")
+  @join__directive(graphs: [SUBGRAPHA], name: "sourceType", args: {api: "A", http: {GET: "/resources/{id}"}, selection: "id description"})
+{
+  id: ID!
+  description: String!
+}`
+    );
   });
 });

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4642,41 +4642,100 @@ describe('composition', () => {
     const authenticatedDirectiveExists = schema.directives().find(d => d.name === 'authenticated');
     expect(authenticatedDirectiveExists).toBeUndefined();
   });
+});
 
-  it('@source{API,Type,Field} directives', () => {
+describe('@source* directives', () => {
+  const schemaA = gql`
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.1", import: [
+        "@key"
+        "@shareable"
+      ])
+      @link(url: "https://specs.apollo.dev/source/v0.1", import: [
+        "@sourceAPI"
+        "@sourceType"
+        "@sourceField"
+      ])
+      @sourceAPI(
+        name: "A"
+        http: { baseURL: "https://api.a.com/v1" }
+      )
+
+    type Query {
+      resources: [Resource!]! @sourceField(
+        api: "A"
+        http: { GET: "/resources" }
+      ) @shareable
+    }
+
+    type Resource @key(fields: "id") @sourceType(
+      api: "A"
+      http: { GET: "/resources/{id}" }
+      selection: "id description"
+    ) {
+      id: ID!
+      description: String!
+    }
+  `;
+
+  const schemaB = gql`
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.1", import: [
+        "@key"
+        "@shareable"
+      ])
+      @link(url: "https://specs.apollo.dev/source/v0.1", import: [
+        "@sourceAPI"
+        "@sourceType"
+        "@sourceField"
+      ])
+      @sourceAPI(
+        name: "A"
+        http: { baseURL: "https://api.a.com/v1" }
+      )
+
+    type Query {
+      resources: [Resource!]! @sourceField(
+        api: "A"
+        http: { GET: "/resources" }
+      ) @shareable
+    }
+
+    type Resource @key(fields: "id") {
+      id: ID!
+    }
+  `;
+
+  const schemaC = gql`
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.1", import: [
+        "@key"
+        "@shareable"
+      ])
+      @link(url: "https://specs.apollo.dev/source/v0.1", import: [
+        "@sourceAPI"
+        "@sourceType"
+        "@sourceField"
+      ])
+      @sourceAPI(
+        name: "A"
+        http: { baseURL: "https://api.a.com/v1" }
+      )
+
+    type Resource @key(fields: "id") @sourceType(
+      api: "A"
+      http: { GET: "/resources/{id}" }
+      selection: "id creationDate"
+    ) {
+      id: ID!
+      creationDate: String!
+    }
+  `;
+
+  it('single subgraph composition', () => {
     const subgraphA = {
       name: 'subgraphA',
-      typeDefs: gql`
-        extend schema
-          @link(url: "https://specs.apollo.dev/federation/v2.1", import: [
-            "@key"
-          ])
-          @link(url: "https://specs.apollo.dev/source/v0.1", import: [
-            "@sourceAPI"
-            "@sourceType"
-            "@sourceField"
-          ])
-          @sourceAPI(
-            name: "A"
-            http: { baseURL: "https://api.a.com/v1" }
-          )
-
-        type Query {
-          resources: [Resource!]! @sourceField(
-            api: "A"
-            http: { GET: "/resources" }
-          )
-        }
-
-        type Resource @key(fields: "id") @sourceType(
-          api: "A"
-          http: { GET: "/resources/{id}" }
-          selection: "id description"
-        ) {
-          id: ID!
-          description: String!
-        }
-      `,
+      typeDefs: schemaA,
     };
     const result = composeServices([subgraphA]);
     expect(result.errors ?? []).toEqual([]);
@@ -4712,5 +4771,198 @@ describe('composition', () => {
   description: String!
 }`
     );
+  });
+
+  it('subgraphA and subgraphB composition', () => {
+    const result = composeServices([
+      {
+        name: 'subgraphA',
+        typeDefs: schemaA,
+      },
+      {
+        name: 'subgraphB',
+        typeDefs: schemaB,
+      },
+    ]);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+
+    expect(printed).toContain(
+`schema
+  @link(url: \"https://specs.apollo.dev/link/v1.0\")
+  @link(url: \"https://specs.apollo.dev/join/v0.3\", for: EXECUTION)
+  @join__directive(graphs: [SUBGRAPHA, SUBGRAPHB], name: \"link\", args: {url: \"https://specs.apollo.dev/source/v0.1\", import: [\"@sourceAPI\", \"@sourceType\", \"@sourceField\"]})
+  @join__directive(graphs: [SUBGRAPHA, SUBGRAPHB], name: \"sourceAPI\", args: {name: \"A\", http: {baseURL: \"https://api.a.com/v1\"}})
+{
+  query: Query
+}`
+    );
+
+    expect(printed).toContain(
+`type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+{
+  resources: [Resource!]! @join__directive(graphs: [SUBGRAPHA, SUBGRAPHB], name: \"sourceField\", args: {api: \"A\", http: {GET: \"/resources\"}})
+}`
+    );
+
+    expect(printed).toContain(
+`type Resource
+  @join__type(graph: SUBGRAPHA, key: \"id\")
+  @join__type(graph: SUBGRAPHB, key: \"id\")
+  @join__directive(graphs: [SUBGRAPHA], name: \"sourceType\", args: {api: \"A\", http: {GET: \"/resources/{id}\"}, selection: \"id description\"})
+{
+  id: ID!
+  description: String! @join__field(graph: SUBGRAPHA)
+}`
+    );
+  });
+
+  it('subgraphA and subgraphC composition', () => {
+    const result = composeServices([
+      {
+        name: 'subgraphA',
+        typeDefs: schemaA,
+      },
+      {
+        name: 'subgraphC',
+        typeDefs: schemaC,
+      },
+    ]);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+
+    expect(printed).toContain(
+`schema
+  @link(url: \"https://specs.apollo.dev/link/v1.0\")
+  @link(url: \"https://specs.apollo.dev/join/v0.3\", for: EXECUTION)
+  @join__directive(graphs: [SUBGRAPHA, SUBGRAPHC], name: \"link\", args: {url: \"https://specs.apollo.dev/source/v0.1\", import: [\"@sourceAPI\", \"@sourceType\", \"@sourceField\"]})
+  @join__directive(graphs: [SUBGRAPHA, SUBGRAPHC], name: \"sourceAPI\", args: {name: \"A\", http: {baseURL: \"https://api.a.com/v1\"}})
+{
+  query: Query
+}`
+    );
+
+    expect(printed).toContain(
+`type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHC)
+{
+  resources: [Resource!]! @join__field(graph: SUBGRAPHA) @join__directive(graphs: [SUBGRAPHA], name: \"sourceField\", args: {api: \"A\", http: {GET: \"/resources\"}})
+}`
+    );
+
+    expect(printed).toContain(
+`type Resource
+  @join__type(graph: SUBGRAPHA, key: \"id\")
+  @join__type(graph: SUBGRAPHC, key: \"id\")
+  @join__directive(graphs: [SUBGRAPHA], name: \"sourceType\", args: {api: \"A\", http: {GET: \"/resources/{id}\"}, selection: \"id description\"})
+  @join__directive(graphs: [SUBGRAPHC], name: \"sourceType\", args: {api: \"A\", http: {GET: \"/resources/{id}\"}, selection: \"id creationDate\"})
+{
+  id: ID!
+  description: String! @join__field(graph: SUBGRAPHA)
+  creationDate: String! @join__field(graph: SUBGRAPHC)
+}`
+    );
+  });
+
+  it('subgraphB and subgraphC composition', () => {
+    const result = composeServices([
+      {
+        name: 'subgraphB',
+        typeDefs: schemaB,
+      },
+      {
+        name: 'subgraphC',
+        typeDefs: schemaC,
+      },
+    ]);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+
+    expect(printed).toContain(
+`schema
+  @link(url: \"https://specs.apollo.dev/link/v1.0\")
+  @link(url: \"https://specs.apollo.dev/join/v0.3\", for: EXECUTION)
+  @join__directive(graphs: [SUBGRAPHB, SUBGRAPHC], name: \"link\", args: {url: \"https://specs.apollo.dev/source/v0.1\", import: [\"@sourceAPI\", \"@sourceType\", \"@sourceField\"]})
+  @join__directive(graphs: [SUBGRAPHB, SUBGRAPHC], name: \"sourceAPI\", args: {name: \"A\", http: {baseURL: \"https://api.a.com/v1\"}})
+{
+  query: Query
+}`);
+
+    expect(printed).toContain(
+`type Query
+  @join__type(graph: SUBGRAPHB)
+  @join__type(graph: SUBGRAPHC)
+{
+  resources: [Resource!]! @join__field(graph: SUBGRAPHB) @join__directive(graphs: [SUBGRAPHB], name: \"sourceField\", args: {api: \"A\", http: {GET: \"/resources\"}})
+}`
+    );
+
+    expect(printed).toContain(
+`type Resource
+  @join__type(graph: SUBGRAPHB, key: \"id\")
+  @join__type(graph: SUBGRAPHC, key: \"id\")
+  @join__directive(graphs: [SUBGRAPHC], name: \"sourceType\", args: {api: \"A\", http: {GET: \"/resources/{id}\"}, selection: \"id creationDate\"})
+{
+  id: ID!
+  creationDate: String! @join__field(graph: SUBGRAPHC)
+}`
+    );
+  });
+
+  it('subgraphA, subgraphB, and subgraphC composition', () => {
+    const result = composeServices([
+      {
+        name: 'subgraphA',
+        typeDefs: schemaA,
+      },
+      {
+        name: 'subgraphB',
+        typeDefs: schemaB,
+      },
+      {
+        name: 'subgraphC',
+        typeDefs: schemaC,
+      },
+    ]);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+
+    expect(printed).toContain(
+`schema
+  @link(url: \"https://specs.apollo.dev/link/v1.0\")
+  @link(url: \"https://specs.apollo.dev/join/v0.3\", for: EXECUTION)
+  @join__directive(graphs: [SUBGRAPHA, SUBGRAPHB, SUBGRAPHC], name: \"link\", args: {url: \"https://specs.apollo.dev/source/v0.1\", import: [\"@sourceAPI\", \"@sourceType\", \"@sourceField\"]})
+  @join__directive(graphs: [SUBGRAPHA, SUBGRAPHB, SUBGRAPHC], name: \"sourceAPI\", args: {name: \"A\", http: {baseURL: \"https://api.a.com/v1\"}})
+{
+  query: Query
+}`
+    );
+
+    expect(printed).toContain(
+`type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+  @join__type(graph: SUBGRAPHC)
+{
+  resources: [Resource!]! @join__field(graph: SUBGRAPHA) @join__field(graph: SUBGRAPHB) @join__directive(graphs: [SUBGRAPHA, SUBGRAPHB], name: \"sourceField\", args: {api: \"A\", http: {GET: \"/resources\"}})
+}`
+    );
+
+    expect(printed).toContain(
+`type Resource
+  @join__type(graph: SUBGRAPHA, key: \"id\")
+  @join__type(graph: SUBGRAPHB, key: \"id\")
+  @join__type(graph: SUBGRAPHC, key: \"id\")
+  @join__directive(graphs: [SUBGRAPHA], name: \"sourceType\", args: {api: \"A\", http: {GET: \"/resources/{id}\"}, selection: \"id description\"})
+  @join__directive(graphs: [SUBGRAPHC], name: \"sourceType\", args: {api: \"A\", http: {GET: \"/resources/{id}\"}, selection: \"id creationDate\"})
+{
+  id: ID!
+  description: String! @join__field(graph: SUBGRAPHA)
+  creationDate: String! @join__field(graph: SUBGRAPHC)
+}`
+    )
   });
 });

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -76,7 +76,7 @@ describe('composition', () => {
         query: Query
       }
 
-      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
 
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
@@ -228,7 +228,7 @@ describe('composition', () => {
         query: Query
       }
 
-      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
 
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
@@ -2497,7 +2497,7 @@ describe('composition', () => {
         query: Query
       }
 
-      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
 
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
@@ -4692,7 +4692,7 @@ describe('composition', () => {
 }`);
 
     expect(printed).toContain(
-      `directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION`
+      `directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION`
     );
 
     expect(printed).toContain(

--- a/composition-js/src/composeDirectiveManager.ts
+++ b/composition-js/src/composeDirectiveManager.ts
@@ -64,6 +64,7 @@ const DISALLOWED_IDENTITIES = [
   'https://specs.apollo.dev/federation',
   'https://specs.apollo.dev/authenticated',
   'https://specs.apollo.dev/requiresScopes',
+  'https://specs.apollo.dev/source',
 ];
 
 export class ComposeDirectiveManager {

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -149,7 +149,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
-      '9fe0d6cbe27c0273ba219c791d35f2368681b7d535300c46435ec2dc39b4c192',
+      '4657c2b2d643e1269c49c3f661f5c1e174cef413065c7ab79b28e16ea5f64479',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -149,7 +149,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toEqual(
-      '4644102bb30ec7e254fac2577f78137bbab156cb965973ae481f309120738ff6',
+      '9fe0d6cbe27c0273ba219c791d35f2368681b7d535300c46435ec2dc39b4c192',
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -85,6 +85,11 @@ import { createObjectTypeSpecification, createScalarTypeSpecification, createUni
 import { didYouMean, suggestionList } from "./suggestions";
 import { coreFeatureDefinitionIfKnown } from "./knownCoreFeatures";
 import { joinIdentity } from "./specs/joinSpec";
+import {
+  SourceAPIDirectiveArgs,
+  SourceFieldDirectiveArgs,
+  SourceTypeDirectiveArgs,
+} from "./specs/sourceSpec";
 
 const linkSpec = LINK_VERSIONS.latest();
 const tagSpec = TAG_VERSIONS.latest();
@@ -774,6 +779,18 @@ export class FederationMetadata {
     return this.getPost20FederationDirective(FederationDirectiveName.POLICY);
   }
 
+  sourceAPIDirective(): Post20FederationDirectiveDefinition<SourceAPIDirectiveArgs> {
+    return this.getPost20FederationDirective(FederationDirectiveName.SOURCE_API);
+  }
+
+  sourceTypeDirective(): Post20FederationDirectiveDefinition<SourceTypeDirectiveArgs> {
+    return this.getPost20FederationDirective(FederationDirectiveName.SOURCE_TYPE);
+  }
+
+  sourceFieldDirective(): Post20FederationDirectiveDefinition<SourceFieldDirectiveArgs> {
+    return this.getPost20FederationDirective(FederationDirectiveName.SOURCE_FIELD);
+  }
+
   allFederationDirectives(): DirectiveDefinition[] {
     const baseDirectives: DirectiveDefinition[] = [
       this.keyDirective(),
@@ -812,6 +829,19 @@ export class FederationMetadata {
     const policyDirective = this.policyDirective();
     if (isFederationDirectiveDefinedInSchema(policyDirective)) {
       baseDirectives.push(policyDirective);
+    }
+
+    const sourceAPIDirective = this.sourceAPIDirective();
+    if (isFederationDirectiveDefinedInSchema(sourceAPIDirective)) {
+      baseDirectives.push(sourceAPIDirective);
+    }
+    const sourceTypeDirective = this.sourceTypeDirective();
+    if (isFederationDirectiveDefinedInSchema(sourceTypeDirective)) {
+      baseDirectives.push(sourceTypeDirective);
+    }
+    const sourceFieldDirective = this.sourceFieldDirective();
+    if (isFederationDirectiveDefinedInSchema(sourceFieldDirective)) {
+      baseDirectives.push(sourceFieldDirective);
     }
 
     return baseDirectives;

--- a/internals-js/src/index.ts
+++ b/internals-js/src/index.ts
@@ -23,3 +23,4 @@ export * from './argumentCompositionStrategies';
 export * from './specs/authenticatedSpec';
 export * from './specs/requiresScopesSpec';
 export * from './specs/policySpec';
+export * from './specs/sourceSpec';

--- a/internals-js/src/specs/federationSpec.ts
+++ b/internals-js/src/specs/federationSpec.ts
@@ -40,6 +40,9 @@ export enum FederationDirectiveName {
   AUTHENTICATED = 'authenticated',
   REQUIRES_SCOPES = 'requiresScopes',
   POLICY = 'policy',
+  SOURCE_API = 'sourceAPI',
+  SOURCE_TYPE = 'sourceType',
+  SOURCE_FIELD = 'sourceField',
 }
 
 const fieldSetTypeSpec = createScalarTypeSpecification({ name: FederationTypeName.FIELD_SET });

--- a/internals-js/src/specs/joinSpec.ts
+++ b/internals-js/src/specs/joinSpec.ts
@@ -134,13 +134,10 @@ export class JoinSpecDefinition extends FeatureDefinition {
     }
 
     const joinDirective = this.addDirective(schema, 'directive').addLocations(
-      // Allow @join__directive at any location where @joinType or @joinField
-      // can appear, as well as on the schema element.
-      ...new Set([
-        DirectiveLocation.SCHEMA,
-        ...joinType.locations,
-        ...joinField.locations,
-      ]),
+      DirectiveLocation.SCHEMA,
+      DirectiveLocation.OBJECT,
+      DirectiveLocation.INTERFACE,
+      DirectiveLocation.FIELD_DEFINITION,
     );
     joinDirective.repeatable = true;
     // Note this 'graphs' argument is plural, since the same directive

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -143,6 +143,10 @@ export class SourceSpecDefinition extends FeatureDefinition {
 }
 
 export const SOURCE_VERSIONS = new FeatureDefinitions<SourceSpecDefinition>(sourceIdentity)
-  .add(new SourceSpecDefinition(new FeatureVersion(0, 1)));
+  .add(new SourceSpecDefinition(
+    new FeatureVersion(0, 1),
+    // TODO Expecting this to be bumped to 2.7, but there's no 2.7 version yet.
+    new FeatureVersion(2, 6),
+  ));
 
 registerKnownFeature(SOURCE_VERSIONS);

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -1,0 +1,146 @@
+import { DirectiveLocation, GraphQLError } from 'graphql';
+import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from "./coreSpec";
+import {
+  Schema,
+  NonNullType,
+  InputObjectType,
+  InputFieldDefinition,
+  ListType,
+} from "../definitions";
+import { registerKnownFeature } from '../knownCoreFeatures';
+import { createDirectiveSpecification } from '../directiveAndTypeSpecification';
+
+export const sourceIdentity = 'https://specs.apollo.dev/source';
+
+export class SourceSpecDefinition extends FeatureDefinition {
+  constructor(version: FeatureVersion, minimumFederationVersion?: FeatureVersion) {
+    super(new FeatureUrl(sourceIdentity, 'source', version), minimumFederationVersion);
+
+    this.registerDirective(createDirectiveSpecification({
+      name: 'sourceAPI',
+      locations: [DirectiveLocation.SCHEMA],
+      repeatable: true,
+      // We "compose" these `@source{API,Type,Field}` directives using the
+      // `@join__directive` mechanism, so they do not need to be composed in the
+      // way passing `composes: true` here implies.
+      composes: false,
+    }));
+
+    this.registerDirective(createDirectiveSpecification({
+      name: 'sourceType',
+      locations: [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE],
+      repeatable: true,
+      composes: false,
+    }));
+
+    this.registerDirective(createDirectiveSpecification({
+      name: 'sourceField',
+      locations: [DirectiveLocation.FIELD_DEFINITION],
+      repeatable: true,
+      composes: false,
+    }));
+  }
+
+  addElementsToSchema(schema: Schema): GraphQLError[] {
+    const sourceAPI = this.addDirective(schema, 'sourceAPI').addLocations(DirectiveLocation.SCHEMA);
+    sourceAPI.repeatable = true;
+
+    sourceAPI.addArgument('name', new NonNullType(schema.stringType()));
+
+    const HTTPHeaderMapping = schema.addType(new InputObjectType('HTTPHeaderMapping'));
+    HTTPHeaderMapping.addField(new InputFieldDefinition('name')).type =
+      new NonNullType(schema.stringType());
+    HTTPHeaderMapping.addField(new InputFieldDefinition('as')).type =
+      schema.stringType();
+    HTTPHeaderMapping.addField(new InputFieldDefinition('value')).type =
+      schema.stringType();
+
+    const HTTPSourceAPI = schema.addType(new InputObjectType('HTTPSourceAPI'));
+    HTTPSourceAPI.addField(new InputFieldDefinition('baseURL')).type =
+      new NonNullType(schema.stringType());
+    HTTPSourceAPI.addField(new InputFieldDefinition('headers')).type =
+      new ListType(new NonNullType(HTTPHeaderMapping));
+    sourceAPI.addArgument('http', HTTPSourceAPI);
+
+    const sourceType = this.addDirective(schema, 'sourceType').addLocations(
+      DirectiveLocation.OBJECT,
+      DirectiveLocation.INTERFACE,
+      // TODO Allow @sourceType on unions, similar to interfaces?
+      // DirectiveLocation.UNION,
+    );
+    sourceType.repeatable = true;
+    sourceType.addArgument('api', new NonNullType(schema.stringType()));
+
+    const URLPathTemplate = this.addScalarType(schema, 'URLPathTemplate');
+    const JSONSelection = this.addScalarType(schema, 'JSONSelection');
+    const JSON = this.addScalarType(schema, 'JSON');
+
+    const HTTPSourceType = schema.addType(new InputObjectType('HTTPSourceType'));
+    HTTPSourceType.addField(new InputFieldDefinition('GET')).type = URLPathTemplate;
+    HTTPSourceType.addField(new InputFieldDefinition('POST')).type = URLPathTemplate;
+    HTTPSourceType.addField(new InputFieldDefinition('headers')).type =
+      new ListType(new NonNullType(HTTPHeaderMapping));
+    HTTPSourceType.addField(new InputFieldDefinition('body')).type = JSONSelection;
+    sourceType.addArgument('http', HTTPSourceType);
+
+    sourceType.addArgument('selection', new NonNullType(JSONSelection));
+
+    const KeyTypeMap = schema.addType(new InputObjectType('KeyTypeMap'));
+    KeyTypeMap.addField(new InputFieldDefinition('key')).type = new NonNullType(schema.stringType());
+    KeyTypeMap.addField(new InputFieldDefinition('typeMap')).type = JSON;
+    sourceType.addArgument('keyTypeMap', KeyTypeMap);
+
+    const sourceField = this.addDirective(schema, 'sourceField').addLocations(
+      DirectiveLocation.FIELD_DEFINITION,
+    );
+    sourceField.repeatable = true;
+    sourceField.addArgument('api', new NonNullType(schema.stringType()));
+    sourceField.addArgument('selection', JSONSelection);
+
+    const HTTPSourceField = schema.addType(new InputObjectType('HTTPSourceField'));
+    HTTPSourceField.addField(new InputFieldDefinition('GET')).type = URLPathTemplate;
+    HTTPSourceField.addField(new InputFieldDefinition('POST')).type = URLPathTemplate;
+    HTTPSourceField.addField(new InputFieldDefinition('PUT')).type = URLPathTemplate;
+    HTTPSourceField.addField(new InputFieldDefinition('PATCH')).type = URLPathTemplate;
+    HTTPSourceField.addField(new InputFieldDefinition('DELETE')).type = URLPathTemplate;
+    HTTPSourceField.addField(new InputFieldDefinition('body')).type = JSONSelection;
+    HTTPSourceField.addField(new InputFieldDefinition('headers')).type =
+      new ListType(new NonNullType(HTTPHeaderMapping));
+    sourceField.addArgument('http', HTTPSourceField);
+
+    return [];
+  }
+
+  allElementNames(): string[] {
+    return [
+      '@sourceAPI',
+      '@sourceType',
+      '@sourceField',
+      // 'JSONSelection',
+      // 'URLPathTemplate',
+      // 'JSON',
+      // 'HTTPHeaderMapping',
+      // 'HTTPSourceAPI',
+      // 'HTTPSourceType',
+      // 'HTTPSourceField',
+      // 'KeyTypeMap',
+    ];
+  }
+
+  sourceAPIDirective(schema: Schema) {
+    return this.directive(schema, 'sourceAPI')!;
+  }
+
+  sourceTypeDirective(schema: Schema) {
+    return this.directive(schema, 'sourceType')!;
+  }
+
+  sourceFieldDirective(schema: Schema) {
+    return this.directive(schema, 'sourceField')!;
+  }
+}
+
+export const SOURCE_VERSIONS = new FeatureDefinitions<SourceSpecDefinition>(sourceIdentity)
+  .add(new SourceSpecDefinition(new FeatureVersion(0, 1)));
+
+registerKnownFeature(SOURCE_VERSIONS);

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -130,17 +130,73 @@ export class SourceSpecDefinition extends FeatureDefinition {
   }
 
   sourceAPIDirective(schema: Schema) {
-    return this.directive(schema, 'sourceAPI')!;
+    return this.directive<SourceAPIDirectiveArgs>(schema, 'sourceAPI')!;
   }
 
   sourceTypeDirective(schema: Schema) {
-    return this.directive(schema, 'sourceType')!;
+    return this.directive<SourceTypeDirectiveArgs>(schema, 'sourceType')!;
   }
 
   sourceFieldDirective(schema: Schema) {
-    return this.directive(schema, 'sourceField')!;
+    return this.directive<SourceFieldDirectiveArgs>(schema, 'sourceField')!;
   }
 }
+
+export type SourceAPIDirectiveArgs = {
+  name: string;
+  http?: HTTPSourceAPI;
+};
+
+export type HTTPSourceAPI = {
+  baseURL: string;
+  headers?: HTTPHeaderMapping[];
+};
+
+export type HTTPHeaderMapping = {
+  name: string;
+  as?: string;
+  value?: string;
+};
+
+export type SourceTypeDirectiveArgs = {
+  api: string;
+  http?: HTTPSourceType;
+  selection: JSONSelection;
+  keyTypeMap?: KeyTypeMap;
+};
+
+export type HTTPSourceType = {
+  GET?: URLPathTemplate;
+  POST?: URLPathTemplate;
+  headers?: HTTPHeaderMapping[];
+  body?: JSONSelection;
+};
+
+type URLPathTemplate = string;
+type JSONSelection = string;
+
+type KeyTypeMap = {
+  key: string;
+  typeMap: {
+    [__typename: string]: string;
+  };
+};
+
+export type SourceFieldDirectiveArgs = {
+  api: string;
+  http?: HTTPSourceField;
+  selection?: JSONSelection;
+};
+
+export type HTTPSourceField = {
+  GET?: URLPathTemplate;
+  POST?: URLPathTemplate;
+  PUT?: URLPathTemplate;
+  PATCH?: URLPathTemplate;
+  DELETE?: URLPathTemplate;
+  body?: JSONSelection;
+  headers?: HTTPHeaderMapping[];
+};
 
 export const SOURCE_VERSIONS = new FeatureDefinitions<SourceSpecDefinition>(sourceIdentity)
   .add(new SourceSpecDefinition(

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -6,7 +6,7 @@ import {
   InputObjectType,
   InputFieldDefinition,
   ListType,
-} from "../definitions";
+} from '../definitions';
 import { registerKnownFeature } from '../knownCoreFeatures';
 import { createDirectiveSpecification } from '../directiveAndTypeSpecification';
 

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -73,7 +73,6 @@ export class SourceSpecDefinition extends FeatureDefinition {
 
     const URLPathTemplate = this.addScalarType(schema, 'URLPathTemplate');
     const JSONSelection = this.addScalarType(schema, 'JSONSelection');
-    const JSON = this.addScalarType(schema, 'JSON');
 
     const HTTPSourceType = schema.addType(new InputObjectType('HTTPSourceType'));
     HTTPSourceType.addField(new InputFieldDefinition('GET')).type = URLPathTemplate;
@@ -87,7 +86,10 @@ export class SourceSpecDefinition extends FeatureDefinition {
 
     const KeyTypeMap = schema.addType(new InputObjectType('KeyTypeMap'));
     KeyTypeMap.addField(new InputFieldDefinition('key')).type = new NonNullType(schema.stringType());
-    KeyTypeMap.addField(new InputFieldDefinition('typeMap')).type = JSON;
+    KeyTypeMap.addField(new InputFieldDefinition('typeMap')).type =
+      // TypenameKeyMap is a scalar type similar to a JSON dictionary, where the
+      // keys are __typename strings and the values are values of the key field.
+      this.addScalarType(schema, 'TypenameKeyMap');
     sourceType.addArgument('keyTypeMap', KeyTypeMap);
 
     const sourceField = this.addDirective(schema, 'sourceField').addLocations(


### PR DESCRIPTION
This new `@join__directive` directive, like other `@join__` directives, is a mechanism for linking supergraph schema elements back to their originating subgraph elements.

In the case of `@join__directive`, the specific kind of subgraph schema elements to be linked are _directive applications_. In addition to its `graphs: [join__Graph!]!` argument, `@join__directive` represents the `name` and `args` of directive applications found in subgraphs, without literally reapplying the directives in the supergraph, as `@composeDirective` would do.

Since directive applications can appear on a variety of schema elements in subgraphs, `@join__directive` is allowed on a similar variety of locations in the supergraph schema (anywhere `@join__type` or `@join__field` can appear, plus on `schema` definitions).

In principle, this new `@join__directive` behavior can be enabled at the granularity of any `@link` specification URL, and is initially enabled for directives imported from the hypothetical `https://specs.apollo.dev/source` URL, as well as for any `@link` directives involved in those imports. This limited initial usage of `@join__directive` allows preserving/recovering accurate per-subgraph information about the original directive applications.

We can extend this behavior to other specification URLs in the future if it works and proves useful, and we might consider opening the behavior up to subgraph authors by allowing, say, `@composeDirective` to generate `@join__directive` applications instead of reapplying subgraph directives verbatim (as it does by default), perhaps with an optional `@composeDirective(name: "someDirective", strategy: "@join__directive")` argument.

One way `@join__directive` deviates from the rest of the `@join__` directives is in taking a plural `graphs: [join__Graph!]!` argument, rather than a single `graph: join__Graph!` argument. This API allows directives that are repeated exactly in different subgraphs (same name, deep-equal arguments) to be represented with a single `@join__directive` directive in the supergraph (with multiple graph names in the `graphs` list), which tends to save a bunch of repetition of `@join__directive` in the supergraph.