### PR TITLE
Include non apollo spec composed directives in api schema

### DIFF
--- a/internals-js/src/specs/__tests__/coreSpec.test.ts
+++ b/internals-js/src/specs/__tests__/coreSpec.test.ts
@@ -194,20 +194,20 @@ describe('removeAllCoreFeatures', () => {
     expect(schema.elementByCoordinate("@foobar__directive")).toBeDefined();
     expect(schema.elementByCoordinate("foo")).toBeDefined();
     expect(schema.elementByCoordinate("foo__Scalar")).toBeUndefined();
-    expect(schema.elementByCoordinate("@foo")).toBeUndefined();
-    expect(schema.elementByCoordinate("@foo__directive")).toBeUndefined();
+    expect(schema.elementByCoordinate("@foo")).toBeDefined();
+    expect(schema.elementByCoordinate("@foo__directive")).toBeDefined();
     expect(schema.elementByCoordinate("bar")).toBeUndefined();
     expect(schema.elementByCoordinate("foo__bar")).toBeUndefined();
-    expect(schema.elementByCoordinate("@baz")).toBeUndefined();
-    expect(schema.elementByCoordinate("@foo__baz")).toBeUndefined();
+    expect(schema.elementByCoordinate("@baz")).toBeDefined();
+    expect(schema.elementByCoordinate("@foo__baz")).toBeDefined();
     expect(schema.elementByCoordinate("qux")).toBeDefined();
     expect(schema.elementByCoordinate("@quz")).toBeDefined();
     expect(schema.elementByCoordinate("qax")).toBeUndefined();
     expect(schema.elementByCoordinate("foo__qax")).toBeUndefined();
     expect(schema.elementByCoordinate("foo__qux")).toBeUndefined();
-    expect(schema.elementByCoordinate("@qaz")).toBeUndefined();
-    expect(schema.elementByCoordinate("@foo__qaz")).toBeUndefined();
-    expect(schema.elementByCoordinate("@foo__quz")).toBeUndefined();
+    expect(schema.elementByCoordinate("@qaz")).toBeDefined();
+    expect(schema.elementByCoordinate("@foo__qaz")).toBeDefined();
+    expect(schema.elementByCoordinate("@foo__quz")).toBeDefined();
   });
 });
 

--- a/internals-js/src/specs/coreSpec.ts
+++ b/internals-js/src/specs/coreSpec.ts
@@ -836,6 +836,17 @@ export const LINK_VERSIONS = new FeatureDefinitions<CoreSpecDefinition>(linkIden
 registerKnownFeature(CORE_VERSIONS);
 registerKnownFeature(LINK_VERSIONS);
 
+const CORE_APOLLO_SPEC = [
+  'https://specs.apollo.dev/core',
+  'https://specs.apollo.dev/join',
+  'https://specs.apollo.dev/link',
+  'https://specs.apollo.dev/tag',
+  'https://specs.apollo.dev/inaccessible',
+  'https://specs.apollo.dev/federation',
+  'https://specs.apollo.dev/authenticated',
+  'https://specs.apollo.dev/requiresScopes',
+];
+
 export function removeAllCoreFeatures(schema: Schema) {
   // Gather a list of core features up front, since we can't fetch them during
   // removal. (Also note that core being a feature itself, this will remove core
@@ -852,7 +863,8 @@ export function removeAllCoreFeatures(schema: Schema) {
   for (const feature of coreFeatures) {
     // Remove feature directive definitions and their applications.
     const featureDirectiveDefs = schema.directives()
-      .filter(d => feature.isFeatureDefinition(d));
+      .filter(d => feature.isFeatureDefinition(d) && CORE_APOLLO_SPEC.includes(feature.url.identity));
+
     featureDirectiveDefs.forEach(def =>
       def.remove().forEach(application => application.remove())
     );


### PR DESCRIPTION
### Description

A wip example for what issue https://github.com/apollographql/federation/issues/2895 could look like. This implementation would include all composed directives in the api schema that are not in the core apollo specs.

