### PR TITLE
remove pruneClosedBranches

### DIFF
--- a/.changeset/nasty-trees-smell.md
+++ b/.changeset/nasty-trees-smell.md
@@ -1,0 +1,6 @@
+---
+"@apollo/query-planner": patch
+---
+
+pruneClosedBranches() was more computationally intensive than just running sort on all the branches. This can lead to an order of magnitude speedup on type exploded query plans.
+  


### PR DESCRIPTION
pruneClosedBranches() code is inefficient and causes query planning to take longer than just letting the computeBestPlan run over all options
