### PR TITLE
Allow known `FeatureDefinition` subclasses to define custom subgraph schema validation rules

### DIFF
--- a/.changeset/popular-mirrors-move.md
+++ b/.changeset/popular-mirrors-move.md
@@ -1,0 +1,6 @@
+---
+"@apollo/federation-internals": minor
+"@apollo/composition": patch
+---
+
+Allow known `FeatureDefinition` subclasses to define custom subgraph schema validation rules

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -5046,7 +5046,7 @@ describe('@source* directives', () => {
       const messages = result.errors!.map(e => e.message);
 
       expect(messages).toContain(
-        '[bad] @sourceAPI(name: "A?!") must be valid GraphQL identifier'
+        '[bad] @sourceAPI(name: "A?!") must be valid GraphQL name'
       );
 
       expect(messages).toContain(
@@ -5100,7 +5100,7 @@ describe('@source* directives', () => {
       const messages = result.errors!.map(e => e.message);
 
       expect(messages).toContain(
-        '[renamed] @api(name: "not an identifier") must be valid GraphQL identifier'
+        '[renamed] @api(name: "not an identifier") must be valid GraphQL name'
       );
     });
   });

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4961,4 +4961,101 @@ describe('@source* directives', () => {
 }`
     )
   });
+
+  describe('validation errors', () => {
+    const goodSchema = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"])
+        @link(url: "https://specs.apollo.dev/source/v0.1", import: [
+          "@sourceAPI"
+          "@sourceType"
+          "@sourceField"
+        ])
+        @sourceAPI(
+          name: "A"
+          http: { baseURL: "https://api.a.com/v1" }
+        )
+      {
+        query: Query
+      }
+
+      type Query {
+        resources: [Resource!]! @sourceField(
+          api: "A"
+          http: { GET: "/resources" }
+        )
+      }
+
+      type Resource @key(fields: "id") @sourceType(
+        api: "A"
+        http: { GET: "/resources/{id}" }
+        selection: "id description"
+      ) {
+        id: ID!
+        description: String!
+      }
+    `;
+
+    const badSchema = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"])
+        @link(url: "https://specs.apollo.dev/source/v0.1", import: [
+          "@sourceAPI"
+          "@sourceType"
+          "@sourceField"
+        ])
+        @sourceAPI(
+          name: "A?!" # Should be valid GraphQL identifier
+          http: { baseURL: "https://api.a.com/v1" }
+        )
+      {
+        query: Query
+      }
+
+      type Query {
+        resources: [Resource!]! @sourceField(
+          api: "A"
+          http: { GET: "/resources" }
+        )
+      }
+
+      type Resource @key(fields: "id") @sourceType(
+        api: "A"
+        http: { GET: "/resources/{id}" }
+        selection: "id description"
+      ) {
+        id: ID!
+        description: String!
+      }
+    `;
+
+    it('good schema composes without validation errors', () => {
+      const result = composeServices([{
+        name: 'good',
+        typeDefs: goodSchema,
+      }]);
+      expect(result.errors ?? []).toEqual([]);
+    });
+
+    it('bad schema composes with validation errors', () => {
+      const result = composeServices([{
+        name: 'bad',
+        typeDefs: badSchema,
+      }]);
+
+      const messages = result.errors!.map(e => e.message);
+
+      expect(messages).toContain(
+        '[bad] @sourceAPI(name: "A?!") must be valid GraphQL identifier'
+      );
+
+      expect(messages).toContain(
+        '[bad] sourceType specifies unknown api A'
+      );
+
+      expect(messages).toContain(
+        '[bad] sourceField specifies unknown api A'
+      );
+    });
+  });
 });

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -5050,11 +5050,11 @@ describe('@source* directives', () => {
       );
 
       expect(messages).toContain(
-        '[bad] sourceType specifies unknown api A'
+        '[bad] @sourceType specifies unknown api A'
       );
 
       expect(messages).toContain(
-        '[bad] sourceField specifies unknown api A'
+        '[bad] @sourceField specifies unknown api A'
       );
     });
 

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -5046,7 +5046,7 @@ describe('@source* directives', () => {
       const messages = result.errors!.map(e => e.message);
 
       expect(messages).toContain(
-        '[bad] @sourceAPI(name: "A?!") must be valid GraphQL name'
+        '[bad] @sourceAPI(name: "A?!") must specify valid GraphQL name'
       );
 
       expect(messages).toContain(
@@ -5100,7 +5100,7 @@ describe('@source* directives', () => {
       const messages = result.errors!.map(e => e.message);
 
       expect(messages).toContain(
-        '[renamed] @api(name: "not an identifier") must be valid GraphQL name'
+        '[renamed] @api(name: "not an identifier") must specify valid GraphQL name'
       );
     });
   });

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -89,23 +89,23 @@ The following errors might be raised during composition:
 | `ROOT_SUBSCRIPTION_USED` | A subgraph's schema defines a type with the name `subscription`, while also specifying a _different_ type name as the root query object. This is not allowed. | 0.x |  |
 | `SATISFIABILITY_ERROR` | Subgraphs can be merged, but the resulting supergraph API would have queries that cannot be satisfied by those subgraphs. | 2.0.0 |  |
 | `SHAREABLE_HAS_MISMATCHED_RUNTIME_TYPES` | A shareable field return type has mismatched possible runtime types in the subgraphs in which the field is declared. As shared fields must resolve the same way in all subgraphs, this is almost surely a mistake. | 2.0.0 |  |
-| `SOURCE_API_HTTP_BASE_URL_INVALID` | The `@sourceAPI` directive must specify a valid http.baseURL | 2.6.0 |  |
-| `SOURCE_API_NAME_INVALID` | Each `@sourceAPI` directive must take a unique and valid name as an argument | 2.6.0 |  |
-| `SOURCE_API_PROTOCOL_INVALID` | Each `@sourceAPI` directive must specify exactly one of the known protocols | 2.6.0 |  |
-| `SOURCE_FIELD_API_ERROR` | The `api` argument of the `@sourceField` directive must match a valid `@sourceAPI` name | 2.6.0 |  |
-| `SOURCE_FIELD_HTTP_BODY_INVALID` | If `@sourceField` specifies http.body, it must be a valid `JSONSelection` matching available arguments and fields | 2.6.0 |  |
-| `SOURCE_FIELD_HTTP_METHOD_INVALID` | The `@sourceField` directive must specify at most one of `http.{GET,POST,PUT,PATCH,DELETE}` | 2.6.0 |  |
-| `SOURCE_FIELD_HTTP_PATH_INVALID` | The `@sourceField` directive must specify a valid URL template for `http.{GET,POST,PUT,PATCH,DELETE}` | 2.6.0 |  |
-| `SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD` | The `@sourceField` directive must be applied to a field of the `Query` or `Mutation` types, or of an entity type | 2.6.0 |  |
-| `SOURCE_FIELD_PROTOCOL_INVALID` | If `@sourceField` specifies a protocol, it must match the corresponding `@sourceAPI` protocol | 2.6.0 |  |
-| `SOURCE_FIELD_SELECTION_INVALID` | The `selection` argument of the `@sourceField` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type | 2.6.0 |  |
-| `SOURCE_HTTP_HEADERS_INVALID` | The `http.headers` argument of `@source*` directives must specify valid HTTP headers | 2.6.0 |  |
-| `SOURCE_TYPE_API_ERROR` | The `api` argument of the `@sourceType` directive must match a valid `@sourceAPI` name | 2.6.0 |  |
-| `SOURCE_TYPE_HTTP_BODY_INVALID` | If the `@sourceType` specifies `http.body`, it must be a valid `JSONSelection` | 2.6.0 |  |
-| `SOURCE_TYPE_HTTP_METHOD_INVALID` | The `@sourceType` directive must specify exactly one of `http.GET` or `http.POST` | 2.6.0 |  |
-| `SOURCE_TYPE_HTTP_PATH_INVALID` | The `@sourceType` directive must specify a valid URL template for `http.GET` or `http.POST` | 2.6.0 |  |
-| `SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY` | The `@sourceType` directive must be applied to an object or interface type that also has `@key` | 2.6.0 |  |
-| `SOURCE_TYPE_PROTOCOL_INVALID` | The `@sourceType` directive must specify the same protocol as its corresponding `@sourceAPI` | 2.6.0 |  |
+| `SOURCE_API_HTTP_BASE_URL_INVALID` | The `@sourceAPI` directive must specify a valid http.baseURL | 2.7.0 |  |
+| `SOURCE_API_NAME_INVALID` | Each `@sourceAPI` directive must take a unique and valid name as an argument | 2.7.0 |  |
+| `SOURCE_API_PROTOCOL_INVALID` | Each `@sourceAPI` directive must specify exactly one of the known protocols | 2.7.0 |  |
+| `SOURCE_FIELD_API_ERROR` | The `api` argument of the `@sourceField` directive must match a valid `@sourceAPI` name | 2.7.0 |  |
+| `SOURCE_FIELD_HTTP_BODY_INVALID` | If `@sourceField` specifies http.body, it must be a valid `JSONSelection` matching available arguments and fields | 2.7.0 |  |
+| `SOURCE_FIELD_HTTP_METHOD_INVALID` | The `@sourceField` directive must specify at most one of `http.{GET,POST,PUT,PATCH,DELETE}` | 2.7.0 |  |
+| `SOURCE_FIELD_HTTP_PATH_INVALID` | The `@sourceField` directive must specify a valid URL template for `http.{GET,POST,PUT,PATCH,DELETE}` | 2.7.0 |  |
+| `SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD` | The `@sourceField` directive must be applied to a field of the `Query` or `Mutation` types, or of an entity type | 2.7.0 |  |
+| `SOURCE_FIELD_PROTOCOL_INVALID` | If `@sourceField` specifies a protocol, it must match the corresponding `@sourceAPI` protocol | 2.7.0 |  |
+| `SOURCE_FIELD_SELECTION_INVALID` | The `selection` argument of the `@sourceField` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type | 2.7.0 |  |
+| `SOURCE_HTTP_HEADERS_INVALID` | The `http.headers` argument of `@source*` directives must specify valid HTTP headers | 2.7.0 |  |
+| `SOURCE_TYPE_API_ERROR` | The `api` argument of the `@sourceType` directive must match a valid `@sourceAPI` name | 2.7.0 |  |
+| `SOURCE_TYPE_HTTP_BODY_INVALID` | If the `@sourceType` specifies `http.body`, it must be a valid `JSONSelection` | 2.7.0 |  |
+| `SOURCE_TYPE_HTTP_METHOD_INVALID` | The `@sourceType` directive must specify exactly one of `http.GET` or `http.POST` | 2.7.0 |  |
+| `SOURCE_TYPE_HTTP_PATH_INVALID` | The `@sourceType` directive must specify a valid URL template for `http.GET` or `http.POST` | 2.7.0 |  |
+| `SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY` | The `@sourceType` directive must be applied to an object or interface type that also has `@key` | 2.7.0 |  |
+| `SOURCE_TYPE_PROTOCOL_INVALID` | The `@sourceType` directive must specify the same protocol as its corresponding `@sourceAPI` | 2.7.0 |  |
 | `SOURCE_TYPE_SELECTION_INVALID` | The `selection` argument of the `@sourceType` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type | 2.0.0 |  |
 | `TYPE_DEFINITION_INVALID` | A built-in or federation type has an invalid definition in the schema. | 2.0.0 |  |
 | `TYPE_KIND_MISMATCH` | A type has the same name in different subgraphs, but a different kind. For instance, one definition is an object type but another is an interface. | 2.0.0 | Replaces: `VALUE_TYPE_KIND_MISMATCH`, `EXTENSION_OF_WRONG_KIND`, `ENUM_MISMATCH_TYPE` |

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -89,6 +89,24 @@ The following errors might be raised during composition:
 | `ROOT_SUBSCRIPTION_USED` | A subgraph's schema defines a type with the name `subscription`, while also specifying a _different_ type name as the root query object. This is not allowed. | 0.x |  |
 | `SATISFIABILITY_ERROR` | Subgraphs can be merged, but the resulting supergraph API would have queries that cannot be satisfied by those subgraphs. | 2.0.0 |  |
 | `SHAREABLE_HAS_MISMATCHED_RUNTIME_TYPES` | A shareable field return type has mismatched possible runtime types in the subgraphs in which the field is declared. As shared fields must resolve the same way in all subgraphs, this is almost surely a mistake. | 2.0.0 |  |
+| `SOURCE_API_HTTP_BASE_URL_INVALID` | The `@sourceAPI` directive must specify a valid http.baseURL | 2.6.0 |  |
+| `SOURCE_API_NAME_INVALID` | Each `@sourceAPI` directive must take a unique and valid name as an argument | 2.6.0 |  |
+| `SOURCE_API_PROTOCOL_INVALID` | Each `@sourceAPI` directive must specify exactly one of the known protocols | 2.6.0 |  |
+| `SOURCE_FIELD_API_ERROR` | The api argument of the @sourceField directive must match a valid @sourceAPI name | 2.6.0 |  |
+| `SOURCE_FIELD_HTTP_BODY_INVALID` | If @sourceField specifies http.body, it must be a valid JSONSelection matching available arguments and fields | 2.6.0 |  |
+| `SOURCE_FIELD_HTTP_METHOD_INVALID` | The @sourceField directive must specify at most one of http.{GET,POST,PUT,PATCH,DELETE} | 2.6.0 |  |
+| `SOURCE_FIELD_HTTP_PATH_INVALID` | The @sourceField directive must specify a valid URL template for http.{GET,POST,PUT,PATCH,DELETE} | 2.6.0 |  |
+| `SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD` | The @sourceField directive must be applied to a field of the Query or Mutation types, or of an entity type | 2.6.0 |  |
+| `SOURCE_FIELD_PROTOCOL_INVALID` | If @sourceField specifies a protocol, it must match the corresponding @sourceAPI protocol | 2.6.0 |  |
+| `SOURCE_FIELD_SELECTION_INVALID` | The selection argument of the @sourceField directive must be a valid JSONSelection that outputs fields of the GraphQL type | 2.6.0 |  |
+| `SOURCE_HTTP_HEADERS_INVALID` | The http.headers argument of `@source*` directives must specify valid HTTP headers | 2.6.0 |  |
+| `SOURCE_TYPE_API_ERROR` | The api argument of the @sourceType directive must match a valid @sourceAPI name | 2.6.0 |  |
+| `SOURCE_TYPE_HTTP_BODY_INVALID` | If the @sourceType specifies http.body, it must be a valid JSONSelection | 2.6.0 |  |
+| `SOURCE_TYPE_HTTP_METHOD_INVALID` | The @sourceType directive must specify exactly one of http.GET or http.POST | 2.6.0 |  |
+| `SOURCE_TYPE_HTTP_PATH_INVALID` | The @sourceType directive must specify a valid URL template for http.GET or http.POST | 2.6.0 |  |
+| `SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY` | The @sourceType directive must be applied to an object or interface type that also has @key | 2.6.0 |  |
+| `SOURCE_TYPE_PROTOCOL_INVALID` | The @sourceType directive must specify the same protocol as its corresponding @sourceAPI | 2.6.0 |  |
+| `SOURCE_TYPE_SELECTION_INVALID` | The selection argument of the @sourceType directive must be a valid JSONSelection that outputs fields of the GraphQL type | 2.0.0 |  |
 | `TYPE_DEFINITION_INVALID` | A built-in or federation type has an invalid definition in the schema. | 2.0.0 |  |
 | `TYPE_KIND_MISMATCH` | A type has the same name in different subgraphs, but a different kind. For instance, one definition is an object type but another is an interface. | 2.0.0 | Replaces: `VALUE_TYPE_KIND_MISMATCH`, `EXTENSION_OF_WRONG_KIND`, `ENUM_MISMATCH_TYPE` |
 | `TYPE_WITH_ONLY_UNUSED_EXTERNAL` | A federation 1 schema has a composite type comprised only of unused external fields. Note that this error can _only_ be raised for federation 1 schema as federation 2 schema do not allow unused external fields (and errors with code EXTERNAL_UNUSED will be raised in that case). But when federation 1 schema are automatically migrated to federation 2 ones, unused external fields are automatically removed, and in rare case this can leave a type empty. If that happens, an error with this code will be raised | 2.0.0 |  |

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -92,21 +92,21 @@ The following errors might be raised during composition:
 | `SOURCE_API_HTTP_BASE_URL_INVALID` | The `@sourceAPI` directive must specify a valid http.baseURL | 2.6.0 |  |
 | `SOURCE_API_NAME_INVALID` | Each `@sourceAPI` directive must take a unique and valid name as an argument | 2.6.0 |  |
 | `SOURCE_API_PROTOCOL_INVALID` | Each `@sourceAPI` directive must specify exactly one of the known protocols | 2.6.0 |  |
-| `SOURCE_FIELD_API_ERROR` | The api argument of the @sourceField directive must match a valid @sourceAPI name | 2.6.0 |  |
-| `SOURCE_FIELD_HTTP_BODY_INVALID` | If @sourceField specifies http.body, it must be a valid JSONSelection matching available arguments and fields | 2.6.0 |  |
-| `SOURCE_FIELD_HTTP_METHOD_INVALID` | The @sourceField directive must specify at most one of http.{GET,POST,PUT,PATCH,DELETE} | 2.6.0 |  |
-| `SOURCE_FIELD_HTTP_PATH_INVALID` | The @sourceField directive must specify a valid URL template for http.{GET,POST,PUT,PATCH,DELETE} | 2.6.0 |  |
-| `SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD` | The @sourceField directive must be applied to a field of the Query or Mutation types, or of an entity type | 2.6.0 |  |
-| `SOURCE_FIELD_PROTOCOL_INVALID` | If @sourceField specifies a protocol, it must match the corresponding @sourceAPI protocol | 2.6.0 |  |
-| `SOURCE_FIELD_SELECTION_INVALID` | The selection argument of the @sourceField directive must be a valid JSONSelection that outputs fields of the GraphQL type | 2.6.0 |  |
-| `SOURCE_HTTP_HEADERS_INVALID` | The http.headers argument of `@source*` directives must specify valid HTTP headers | 2.6.0 |  |
-| `SOURCE_TYPE_API_ERROR` | The api argument of the @sourceType directive must match a valid @sourceAPI name | 2.6.0 |  |
-| `SOURCE_TYPE_HTTP_BODY_INVALID` | If the @sourceType specifies http.body, it must be a valid JSONSelection | 2.6.0 |  |
-| `SOURCE_TYPE_HTTP_METHOD_INVALID` | The @sourceType directive must specify exactly one of http.GET or http.POST | 2.6.0 |  |
-| `SOURCE_TYPE_HTTP_PATH_INVALID` | The @sourceType directive must specify a valid URL template for http.GET or http.POST | 2.6.0 |  |
-| `SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY` | The @sourceType directive must be applied to an object or interface type that also has @key | 2.6.0 |  |
-| `SOURCE_TYPE_PROTOCOL_INVALID` | The @sourceType directive must specify the same protocol as its corresponding @sourceAPI | 2.6.0 |  |
-| `SOURCE_TYPE_SELECTION_INVALID` | The selection argument of the @sourceType directive must be a valid JSONSelection that outputs fields of the GraphQL type | 2.0.0 |  |
+| `SOURCE_FIELD_API_ERROR` | The `api` argument of the `@sourceField` directive must match a valid `@sourceAPI` name | 2.6.0 |  |
+| `SOURCE_FIELD_HTTP_BODY_INVALID` | If `@sourceField` specifies http.body, it must be a valid `JSONSelection` matching available arguments and fields | 2.6.0 |  |
+| `SOURCE_FIELD_HTTP_METHOD_INVALID` | The `@sourceField` directive must specify at most one of `http.{GET,POST,PUT,PATCH,DELETE}` | 2.6.0 |  |
+| `SOURCE_FIELD_HTTP_PATH_INVALID` | The `@sourceField` directive must specify a valid URL template for `http.{GET,POST,PUT,PATCH,DELETE}` | 2.6.0 |  |
+| `SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD` | The `@sourceField` directive must be applied to a field of the `Query` or `Mutation` types, or of an entity type | 2.6.0 |  |
+| `SOURCE_FIELD_PROTOCOL_INVALID` | If `@sourceField` specifies a protocol, it must match the corresponding `@sourceAPI` protocol | 2.6.0 |  |
+| `SOURCE_FIELD_SELECTION_INVALID` | The `selection` argument of the `@sourceField` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type | 2.6.0 |  |
+| `SOURCE_HTTP_HEADERS_INVALID` | The `http.headers` argument of `@source*` directives must specify valid HTTP headers | 2.6.0 |  |
+| `SOURCE_TYPE_API_ERROR` | The `api` argument of the `@sourceType` directive must match a valid `@sourceAPI` name | 2.6.0 |  |
+| `SOURCE_TYPE_HTTP_BODY_INVALID` | If the `@sourceType` specifies `http.body`, it must be a valid `JSONSelection` | 2.6.0 |  |
+| `SOURCE_TYPE_HTTP_METHOD_INVALID` | The `@sourceType` directive must specify exactly one of `http.GET` or `http.POST` | 2.6.0 |  |
+| `SOURCE_TYPE_HTTP_PATH_INVALID` | The `@sourceType` directive must specify a valid URL template for `http.GET` or `http.POST` | 2.6.0 |  |
+| `SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY` | The `@sourceType` directive must be applied to an object or interface type that also has `@key` | 2.6.0 |  |
+| `SOURCE_TYPE_PROTOCOL_INVALID` | The `@sourceType` directive must specify the same protocol as its corresponding `@sourceAPI` | 2.6.0 |  |
+| `SOURCE_TYPE_SELECTION_INVALID` | The `selection` argument of the `@sourceType` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type | 2.0.0 |  |
 | `TYPE_DEFINITION_INVALID` | A built-in or federation type has an invalid definition in the schema. | 2.0.0 |  |
 | `TYPE_KIND_MISMATCH` | A type has the same name in different subgraphs, but a different kind. For instance, one definition is an object type but another is an interface. | 2.0.0 | Replaces: `VALUE_TYPE_KIND_MISMATCH`, `EXTENSION_OF_WRONG_KIND`, `ENUM_MISMATCH_TYPE` |
 | `TYPE_WITH_ONLY_UNUSED_EXTERNAL` | A federation 1 schema has a composite type comprised only of unused external fields. Note that this error can _only_ be raised for federation 1 schema as federation 2 schema do not allow unused external fields (and errors with code EXTERNAL_UNUSED will be raised in that case). But when federation 1 schema are automatically migrated to federation 2 ones, unused external fields are automatically removed, and in rare case this can leave a type empty. If that happens, an error with this code will be raised | 2.0.0 |  |

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -575,90 +575,90 @@ const SOURCE_API_HTTP_BASE_URL_INVALID = makeCodeDefinition(
 
 const SOURCE_HTTP_HEADERS_INVALID = makeCodeDefinition(
   'SOURCE_HTTP_HEADERS_INVALID',
-  'The http.headers argument of `@source*` directives must specify valid HTTP headers',
+  'The `http.headers` argument of `@source*` directives must specify valid HTTP headers',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_API_ERROR = makeCodeDefinition(
   'SOURCE_TYPE_API_ERROR',
-  'The api argument of the @sourceType directive must match a valid @sourceAPI name',
+  'The `api` argument of the `@sourceType` directive must match a valid `@sourceAPI` name',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_PROTOCOL_INVALID',
-  'The @sourceType directive must specify the same protocol as its corresponding @sourceAPI',
+  'The `@sourceType` directive must specify the same protocol as its corresponding `@sourceAPI`',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_HTTP_METHOD_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_METHOD_INVALID',
-  'The @sourceType directive must specify exactly one of http.GET or http.POST',
+  'The `@sourceType` directive must specify exactly one of `http.GET` or `http.POST`',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_HTTP_PATH_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_PATH_INVALID',
-  'The @sourceType directive must specify a valid URL template for http.GET or http.POST',
+  'The `@sourceType` directive must specify a valid URL template for `http.GET` or `http.POST`',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_HTTP_BODY_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_BODY_INVALID',
-  'If the @sourceType specifies http.body, it must be a valid JSONSelection',
+  'If the `@sourceType` specifies `http.body`, it must be a valid `JSONSelection`',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY = makeCodeDefinition(
   'SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY',
-  'The @sourceType directive must be applied to an object or interface type that also has @key',
+  'The `@sourceType` directive must be applied to an object or interface type that also has `@key`',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_SELECTION_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_SELECTION_INVALID',
-  'The selection argument of the @sourceType directive must be a valid JSONSelection that outputs fields of the GraphQL type',
+  'The `selection` argument of the `@sourceType` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type',
 );
 
 const SOURCE_FIELD_API_ERROR = makeCodeDefinition(
   'SOURCE_FIELD_API_ERROR',
-  'The api argument of the @sourceField directive must match a valid @sourceAPI name',
+  'The `api` argument of the `@sourceField` directive must match a valid `@sourceAPI` name',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_PROTOCOL_INVALID',
-  'If @sourceField specifies a protocol, it must match the corresponding @sourceAPI protocol',
+  'If `@sourceField` specifies a protocol, it must match the corresponding `@sourceAPI` protocol',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_HTTP_METHOD_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_METHOD_INVALID',
-  'The @sourceField directive must specify at most one of http.{GET,POST,PUT,PATCH,DELETE}',
+  'The `@sourceField` directive must specify at most one of `http.{GET,POST,PUT,PATCH,DELETE}`',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_HTTP_PATH_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_PATH_INVALID',
-  'The @sourceField directive must specify a valid URL template for http.{GET,POST,PUT,PATCH,DELETE}',
+  'The `@sourceField` directive must specify a valid URL template for `http.{GET,POST,PUT,PATCH,DELETE}`',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_HTTP_BODY_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_BODY_INVALID',
-  'If @sourceField specifies http.body, it must be a valid JSONSelection matching available arguments and fields',
+  'If `@sourceField` specifies http.body, it must be a valid `JSONSelection` matching available arguments and fields',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_SELECTION_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_SELECTION_INVALID',
-  'The selection argument of the @sourceField directive must be a valid JSONSelection that outputs fields of the GraphQL type',
+  'The `selection` argument of the `@sourceField` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type',
   { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD = makeCodeDefinition(
   'SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD',
-  'The @sourceField directive must be applied to a field of the Query or Mutation types, or of an entity type',
+  'The `@sourceField` directive must be applied to a field of the `Query` or `Mutation` types, or of an entity type',
   { addedIn: '2.6.0' },
 );
 

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -555,6 +555,95 @@ const INTERFACE_KEY_MISSING_IMPLEMENTATION_TYPE = makeCodeDefinition(
   { addedIn: '2.3.0' },
 )
 
+const SOURCE_API_NAME_INVALID = makeCodeDefinition(
+  'SOURCE_API_NAME_INVALID',
+  'Each `@sourceAPI` directive must take a unique and valid name as an argument',
+);
+
+const SOURCE_API_PROTOCOL_INVALID = makeCodeDefinition(
+  'SOURCE_API_PROTOCOL_INVALID',
+  'Each `@sourceAPI` directive must specify exactly one of the known protocols',
+);
+
+const SOURCE_API_HTTP_BASE_URL_INVALID = makeCodeDefinition(
+  'SOURCE_API_HTTP_BASE_URL_INVALID',
+  'The `@sourceAPI` directive must specify a valid http.baseURL',
+);
+
+const SOURCE_HTTP_HEADERS_INVALID = makeCodeDefinition(
+  'SOURCE_HTTP_HEADERS_INVALID',
+  'The http.headers argument of `@source*` directives must specify valid HTTP headers',
+);
+
+const SOURCE_TYPE_API_ERROR = makeCodeDefinition(
+  'SOURCE_TYPE_API_ERROR',
+  'The api argument of the @sourceType directive must match a valid @sourceAPI name',
+);
+
+const SOURCE_TYPE_PROTOCOL_INVALID = makeCodeDefinition(
+  'SOURCE_TYPE_PROTOCOL_INVALID',
+  'The @sourceType directive must specify the same protocol as its corresponding @sourceAPI',
+);
+
+const SOURCE_TYPE_HTTP_METHOD_INVALID = makeCodeDefinition(
+  'SOURCE_TYPE_HTTP_METHOD_INVALID',
+  'The @sourceType directive must specify exactly one of http.GET or http.POST',
+);
+
+const SOURCE_TYPE_HTTP_PATH_INVALID = makeCodeDefinition(
+  'SOURCE_TYPE_HTTP_PATH_INVALID',
+  'The @sourceType directive must specify a valid URL template for http.GET or http.POST',
+);
+
+const SOURCE_TYPE_HTTP_BODY_INVALID = makeCodeDefinition(
+  'SOURCE_TYPE_HTTP_BODY_INVALID',
+  'If the @sourceType specifies http.body, it must be a valid JSONSelection',
+);
+
+const SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY = makeCodeDefinition(
+  'SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY',
+  'The @sourceType directive must be applied to an object or interface type that also has @key',
+);
+
+const SOURCE_TYPE_SELECTION_INVALID = makeCodeDefinition(
+  'SOURCE_TYPE_SELECTION_INVALID',
+  'The selection argument of the @sourceType directive must be a valid JSONSelection that outputs fields of the GraphQL type',
+);
+
+const SOURCE_FIELD_API_ERROR = makeCodeDefinition(
+  'SOURCE_FIELD_API_ERROR',
+  'The api argument of the @sourceField directive must match a valid @sourceAPI name',
+);
+
+const SOURCE_FIELD_PROTOCOL_INVALID = makeCodeDefinition(
+  'SOURCE_FIELD_PROTOCOL_INVALID',
+  'If @sourceField specifies a protocol, it must match the corresponding @sourceAPI protocol',
+);
+
+const SOURCE_FIELD_HTTP_METHOD_INVALID = makeCodeDefinition(
+  'SOURCE_FIELD_HTTP_METHOD_INVALID',
+  'The @sourceField directive must specify at most one of http.{GET,POST,PUT,PATCH,DELETE}',
+);
+
+const SOURCE_FIELD_HTTP_PATH_INVALID = makeCodeDefinition(
+  'SOURCE_FIELD_HTTP_PATH_INVALID',
+  'The @sourceField directive must specify a valid URL template for http.{GET,POST,PUT,PATCH,DELETE}',
+);
+
+const SOURCE_FIELD_HTTP_BODY_INVALID = makeCodeDefinition(
+  'SOURCE_FIELD_HTTP_BODY_INVALID',
+  'If @sourceField specifies http.body, it must be a valid JSONSelection matching available arguments and fields',
+);
+
+const SOURCE_FIELD_SELECTION_INVALID = makeCodeDefinition(
+  'SOURCE_FIELD_SELECTION_INVALID',
+  'The selection argument of the @sourceField directive must be a valid JSONSelection that outputs fields of the GraphQL type',
+);
+
+const SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD = makeCodeDefinition(
+  'SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD',
+  'The @sourceField directive must be applied to a field of the Query or Mutation types, or of an entity type'
+);
 
 export const ERROR_CATEGORIES = {
   DIRECTIVE_FIELDS_MISSING_EXTERNAL,
@@ -643,6 +732,25 @@ export const ERRORS = {
   INTERFACE_OBJECT_USAGE_ERROR,
   INTERFACE_KEY_NOT_ON_IMPLEMENTATION,
   INTERFACE_KEY_MISSING_IMPLEMENTATION_TYPE,
+  // Errors related to @sourceAPI, @sourceType, and/or @sourceField
+  SOURCE_API_NAME_INVALID,
+  SOURCE_API_PROTOCOL_INVALID,
+  SOURCE_API_HTTP_BASE_URL_INVALID,
+  SOURCE_HTTP_HEADERS_INVALID,
+  SOURCE_TYPE_API_ERROR,
+  SOURCE_TYPE_PROTOCOL_INVALID,
+  SOURCE_TYPE_HTTP_METHOD_INVALID,
+  SOURCE_TYPE_HTTP_PATH_INVALID,
+  SOURCE_TYPE_HTTP_BODY_INVALID,
+  SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY,
+  SOURCE_TYPE_SELECTION_INVALID,
+  SOURCE_FIELD_API_ERROR,
+  SOURCE_FIELD_PROTOCOL_INVALID,
+  SOURCE_FIELD_HTTP_METHOD_INVALID,
+  SOURCE_FIELD_HTTP_PATH_INVALID,
+  SOURCE_FIELD_HTTP_BODY_INVALID,
+  SOURCE_FIELD_SELECTION_INVALID,
+  SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD,
 };
 
 const codeDefByCode = Object.values(ERRORS).reduce((obj: {[code: string]: ErrorCodeDefinition}, codeDef: ErrorCodeDefinition) => { obj[codeDef.code] = codeDef; return obj; }, {});

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -558,51 +558,61 @@ const INTERFACE_KEY_MISSING_IMPLEMENTATION_TYPE = makeCodeDefinition(
 const SOURCE_API_NAME_INVALID = makeCodeDefinition(
   'SOURCE_API_NAME_INVALID',
   'Each `@sourceAPI` directive must take a unique and valid name as an argument',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_API_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_API_PROTOCOL_INVALID',
   'Each `@sourceAPI` directive must specify exactly one of the known protocols',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_API_HTTP_BASE_URL_INVALID = makeCodeDefinition(
   'SOURCE_API_HTTP_BASE_URL_INVALID',
   'The `@sourceAPI` directive must specify a valid http.baseURL',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_HTTP_HEADERS_INVALID = makeCodeDefinition(
   'SOURCE_HTTP_HEADERS_INVALID',
   'The http.headers argument of `@source*` directives must specify valid HTTP headers',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_API_ERROR = makeCodeDefinition(
   'SOURCE_TYPE_API_ERROR',
   'The api argument of the @sourceType directive must match a valid @sourceAPI name',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_PROTOCOL_INVALID',
   'The @sourceType directive must specify the same protocol as its corresponding @sourceAPI',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_HTTP_METHOD_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_METHOD_INVALID',
   'The @sourceType directive must specify exactly one of http.GET or http.POST',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_HTTP_PATH_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_PATH_INVALID',
   'The @sourceType directive must specify a valid URL template for http.GET or http.POST',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_HTTP_BODY_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_BODY_INVALID',
   'If the @sourceType specifies http.body, it must be a valid JSONSelection',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY = makeCodeDefinition(
   'SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY',
   'The @sourceType directive must be applied to an object or interface type that also has @key',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_TYPE_SELECTION_INVALID = makeCodeDefinition(
@@ -613,36 +623,43 @@ const SOURCE_TYPE_SELECTION_INVALID = makeCodeDefinition(
 const SOURCE_FIELD_API_ERROR = makeCodeDefinition(
   'SOURCE_FIELD_API_ERROR',
   'The api argument of the @sourceField directive must match a valid @sourceAPI name',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_PROTOCOL_INVALID',
   'If @sourceField specifies a protocol, it must match the corresponding @sourceAPI protocol',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_HTTP_METHOD_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_METHOD_INVALID',
   'The @sourceField directive must specify at most one of http.{GET,POST,PUT,PATCH,DELETE}',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_HTTP_PATH_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_PATH_INVALID',
   'The @sourceField directive must specify a valid URL template for http.{GET,POST,PUT,PATCH,DELETE}',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_HTTP_BODY_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_BODY_INVALID',
   'If @sourceField specifies http.body, it must be a valid JSONSelection matching available arguments and fields',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_SELECTION_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_SELECTION_INVALID',
   'The selection argument of the @sourceField directive must be a valid JSONSelection that outputs fields of the GraphQL type',
+  { addedIn: '2.6.0' },
 );
 
 const SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD = makeCodeDefinition(
   'SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD',
-  'The @sourceField directive must be applied to a field of the Query or Mutation types, or of an entity type'
+  'The @sourceField directive must be applied to a field of the Query or Mutation types, or of an entity type',
+  { addedIn: '2.6.0' },
 );
 
 export const ERROR_CATEGORIES = {

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -558,61 +558,61 @@ const INTERFACE_KEY_MISSING_IMPLEMENTATION_TYPE = makeCodeDefinition(
 const SOURCE_API_NAME_INVALID = makeCodeDefinition(
   'SOURCE_API_NAME_INVALID',
   'Each `@sourceAPI` directive must take a unique and valid name as an argument',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_API_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_API_PROTOCOL_INVALID',
   'Each `@sourceAPI` directive must specify exactly one of the known protocols',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_API_HTTP_BASE_URL_INVALID = makeCodeDefinition(
   'SOURCE_API_HTTP_BASE_URL_INVALID',
   'The `@sourceAPI` directive must specify a valid http.baseURL',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_HTTP_HEADERS_INVALID = makeCodeDefinition(
   'SOURCE_HTTP_HEADERS_INVALID',
   'The `http.headers` argument of `@source*` directives must specify valid HTTP headers',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_TYPE_API_ERROR = makeCodeDefinition(
   'SOURCE_TYPE_API_ERROR',
   'The `api` argument of the `@sourceType` directive must match a valid `@sourceAPI` name',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_TYPE_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_PROTOCOL_INVALID',
   'The `@sourceType` directive must specify the same protocol as its corresponding `@sourceAPI`',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_TYPE_HTTP_METHOD_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_METHOD_INVALID',
   'The `@sourceType` directive must specify exactly one of `http.GET` or `http.POST`',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_TYPE_HTTP_PATH_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_PATH_INVALID',
   'The `@sourceType` directive must specify a valid URL template for `http.GET` or `http.POST`',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_TYPE_HTTP_BODY_INVALID = makeCodeDefinition(
   'SOURCE_TYPE_HTTP_BODY_INVALID',
   'If the `@sourceType` specifies `http.body`, it must be a valid `JSONSelection`',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY = makeCodeDefinition(
   'SOURCE_TYPE_ON_NON_OBJECT_OR_NON_ENTITY',
   'The `@sourceType` directive must be applied to an object or interface type that also has `@key`',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_TYPE_SELECTION_INVALID = makeCodeDefinition(
@@ -623,43 +623,43 @@ const SOURCE_TYPE_SELECTION_INVALID = makeCodeDefinition(
 const SOURCE_FIELD_API_ERROR = makeCodeDefinition(
   'SOURCE_FIELD_API_ERROR',
   'The `api` argument of the `@sourceField` directive must match a valid `@sourceAPI` name',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_FIELD_PROTOCOL_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_PROTOCOL_INVALID',
   'If `@sourceField` specifies a protocol, it must match the corresponding `@sourceAPI` protocol',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_FIELD_HTTP_METHOD_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_METHOD_INVALID',
   'The `@sourceField` directive must specify at most one of `http.{GET,POST,PUT,PATCH,DELETE}`',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_FIELD_HTTP_PATH_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_PATH_INVALID',
   'The `@sourceField` directive must specify a valid URL template for `http.{GET,POST,PUT,PATCH,DELETE}`',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_FIELD_HTTP_BODY_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_HTTP_BODY_INVALID',
   'If `@sourceField` specifies http.body, it must be a valid `JSONSelection` matching available arguments and fields',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_FIELD_SELECTION_INVALID = makeCodeDefinition(
   'SOURCE_FIELD_SELECTION_INVALID',
   'The `selection` argument of the `@sourceField` directive must be a valid `JSONSelection` that outputs fields of the GraphQL type',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 const SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD = makeCodeDefinition(
   'SOURCE_FIELD_NOT_ON_ROOT_OR_ENTITY_FIELD',
   'The `@sourceField` directive must be applied to a field of the `Query` or `Mutation` types, or of an entity type',
-  { addedIn: '2.6.0' },
+  { addedIn: '2.7.0' },
 );
 
 export const ERROR_CATEGORIES = {

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -80,11 +80,10 @@ import {
   FEDERATION1_TYPES,
   FEDERATION1_DIRECTIVES,
 } from "./specs/federationSpec";
-import { validateSourceAPIDirective, validateSourceFieldDirective, validateSourceTypeDirective } from './specs/sourceSpec';
 import { defaultPrintOptions, PrintOptions as PrintOptions, printSchema } from "./print";
 import { createObjectTypeSpecification, createScalarTypeSpecification, createUnionTypeSpecification } from "./directiveAndTypeSpecification";
 import { didYouMean, suggestionList } from "./suggestions";
-import { coreFeatureDefinitionIfKnown } from "./knownCoreFeatures";
+import { coreFeatureDefinitionIfKnown, validateKnownFeatures } from "./knownCoreFeatures";
 import { joinIdentity } from "./specs/joinSpec";
 import {
   SourceAPIDirectiveArgs,
@@ -583,15 +582,8 @@ export class FederationMetadata {
   private _sharingPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
   private _fieldUsedPredicate?: (field: FieldDefinition<CompositeType>) => boolean;
   private _isFed2Schema?: boolean;
-  private preMergeValidationDirectiveMap: { [key: string]: (schema: Schema, directive: Directive, errorCollector: GraphQLError[]) => void };
 
-  constructor(readonly schema: Schema) {
-    this.preMergeValidationDirectiveMap = {
-      [this.sourceAPIDirective().name]: validateSourceAPIDirective,
-      [this.sourceTypeDirective().name]: validateSourceTypeDirective,
-      [this.sourceFieldDirective().name]: validateSourceFieldDirective,
-    }
-  }
+  constructor(readonly schema: Schema) {}
 
   private onInvalidate() {
     this._externalTester = undefined;
@@ -610,10 +602,6 @@ export class FederationMetadata {
 
   federationFeature(): CoreFeature | undefined {
     return this.schema.coreFeatures?.getByIdentity(federationSpec.identity);
-  }
-
-  getPreMergeValidationDirectiveMap(): { [key: string]: (schema: Schema, directive: Directive, errorCollector: GraphQLError[]) => void } {
-    return this.preMergeValidationDirectiveMap;
   }
 
   private externalTester(): ExternalTester {
@@ -1092,17 +1080,10 @@ export class FederationBlueprint extends SchemaBlueprint {
     validateKeyOnInterfacesAreAlsoOnAllImplementations(metadata, errorCollector);
     validateInterfaceObjectsAreOnEntities(metadata, errorCollector);
 
-    // for any individual directives that have their own validation, go ahead and perform that
-    const validationDirectiveMap = metadata.getPreMergeValidationDirectiveMap();
-    for (const [directive, validator] of Object.entries(validationDirectiveMap)) {
-      const directiveDefinition = schema.directive(directive);
-      if (directiveDefinition) {
-        const usages = directiveDefinition.applications();
-        for (const usage of usages) {
-          validator(schema, usage, errorCollector);
-        }
-      }
-    }
+    // FeatureDefinition objects passed to registerKnownFeature can register
+    // validation functions for subgraph schemas by overriding the
+    // validateSubgraphSchema method.
+    validateKnownFeatures(schema, errorCollector);
 
     // If tag is redefined by the user, make sure the definition is compatible with what we expect
     const tagDirective = metadata.tagDirective();

--- a/internals-js/src/specs/coreSpec.ts
+++ b/internals-js/src/specs/coreSpec.ts
@@ -117,6 +117,11 @@ export abstract class FeatureDefinition {
       .concat(this.typeSpecs().map((spec) => spec.name));
   }
 
+  // No-op implementation that can be overridden by subclasses.
+  validateSubgraphSchema(_schema: Schema): GraphQLError[] {
+    return [];
+  }
+
   protected nameInSchema(schema: Schema): string | undefined {
     const feature = this.featureInSchema(schema);
     return feature?.nameInSchema;

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -102,6 +102,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
     sourceField.repeatable = true;
     sourceField.addArgument('api', new NonNullType(schema.stringType()));
     sourceField.addArgument('selection', JSONSelection);
+    sourceField.addArgument('keyTypeMap', KeyTypeMap);
 
     const HTTPSourceField = schema.addType(new InputObjectType('HTTPSourceField'));
     HTTPSourceField.addField(new InputFieldDefinition('GET')).type = URLPathTemplate;
@@ -540,6 +541,7 @@ export type SourceFieldDirectiveArgs = {
   api: string;
   http?: HTTPSourceField;
   selection?: JSONSelection;
+  keyTypeMap?: KeyTypeMap;
 };
 
 export type HTTPSourceField = {

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -284,6 +284,12 @@ export class SourceSpecDefinition extends FeatureDefinition {
             validateHTTPHeaders(headers, errors, sourceType.name);
 
             if (body) {
+              if (GET) {
+                errors.push(new GraphQLError(
+                  `${sourceType} http.GET cannot specify http.body`,
+                ));
+              }
+
               try {
                 parseJSONSelection(body);
                 // TODO Validate body selection matches the available fields.
@@ -351,6 +357,16 @@ export class SourceSpecDefinition extends FeatureDefinition {
             validateHTTPHeaders(headers, errors, sourceField.name);
 
             if (body) {
+              if (GET) {
+                errors.push(new GraphQLError(
+                  `${sourceType} http.GET cannot specify http.body`,
+                ));
+              } else if (DELETE) {
+                errors.push(new GraphQLError(
+                  `${sourceType} http.DELETE cannot specify http.body`,
+                ));
+              }
+
               try {
                 parseJSONSelection(body);
                 // TODO Validate body string matches the available fields of the

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -222,7 +222,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
           apiNameToProtocol.set(name, protocol);
 
           const protocolValue = rest[protocol];
-          if (protocolValue && protocol === "http") {
+          if (protocolValue && protocol === HTTP_PROTOCOL) {
             const { baseURL, headers } = protocolValue as HTTPSourceAPI;
 
             try {
@@ -261,7 +261,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
             ));
           }
 
-          if (protocolValue && expectedProtocol === "http") {
+          if (protocolValue && expectedProtocol === HTTP_PROTOCOL) {
             const { GET, POST, headers, body } = protocolValue as HTTPSourceType;
 
             if ([GET, POST].filter(Boolean).length !== 1) {
@@ -325,7 +325,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
         } else {
           const expectedProtocol = apiNameToProtocol.get(api);
           const protocolValue = expectedProtocol && rest[expectedProtocol];
-          if (protocolValue && expectedProtocol === "http") {
+          if (protocolValue && expectedProtocol === HTTP_PROTOCOL) {
             const {
               GET, POST, PUT, PATCH, DELETE,
               headers,
@@ -438,7 +438,10 @@ function validateHTTPHeaders(
   }
 }
 
-const KNOWN_SOURCE_PROTOCOLS = ["http"] as const;
+const HTTP_PROTOCOL = "http";
+const KNOWN_SOURCE_PROTOCOLS = [
+  HTTP_PROTOCOL,
+] as const;
 type ProtocolName = (typeof KNOWN_SOURCE_PROTOCOLS)[number];
 
 export type SourceAPIDirectiveArgs = {

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -6,6 +6,7 @@ import {
   InputObjectType,
   InputFieldDefinition,
   ListType,
+  Directive,
 } from '../definitions';
 import { registerKnownFeature } from '../knownCoreFeatures';
 import { createDirectiveSpecification } from '../directiveAndTypeSpecification';
@@ -140,6 +141,18 @@ export class SourceSpecDefinition extends FeatureDefinition {
   sourceFieldDirective(schema: Schema) {
     return this.directive<SourceFieldDirectiveArgs>(schema, 'sourceField')!;
   }
+}
+
+export function validateSourceAPIDirective(_schema: Schema, _directive: Directive<any>, _errorCollector: GraphQLError[]) {
+  // TODO
+}
+
+export function validateSourceTypeDirective(_schema: Schema, _directive: Directive<any>, _errorCollector: GraphQLError[]) {
+  // TODO
+}
+
+export function validateSourceFieldDirective(_schema: Schema, _directive: Directive<any>, _errorCollector: GraphQLError[]) {
+  // TODO
 }
 
 export type SourceAPIDirectiveArgs = {

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -196,12 +196,12 @@ export class SourceSpecDefinition extends FeatureDefinition {
         const { name, ...rest } = application.arguments();
 
         if (apiNameToProtocol.has(name)) {
-          errors.push(new GraphQLError(`${sourceAPI.name} must specify unique name`));
+          errors.push(new GraphQLError(`${sourceAPI} must specify unique name`));
         }
 
         // Ensure name is a valid GraphQL identifier.
         if (!/^[a-zA-Z_][0-9a-zA-Z_]*$/.test(name)) {
-          errors.push(new GraphQLError(`${sourceAPI.name}(name: ${
+          errors.push(new GraphQLError(`${sourceAPI}(name: ${
             JSON.stringify(name)
           }) must be valid GraphQL identifier`));
         }
@@ -211,7 +211,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
           if (rest[knownProtocol]) {
             if (protocol) {
               errors.push(new GraphQLError(
-                `${sourceAPI.name} must specify only one of ${KNOWN_SOURCE_PROTOCOLS.join(', ')}`,
+                `${sourceAPI} must specify only one of ${KNOWN_SOURCE_PROTOCOLS.join(', ')}`,
               ));
             }
             protocol = knownProtocol;
@@ -228,7 +228,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
             try {
               new URL(baseURL);
             } catch (e) {
-              errors.push(new GraphQLError(`${sourceAPI.name} http.baseURL ${
+              errors.push(new GraphQLError(`${sourceAPI} http.baseURL ${
                 JSON.stringify(baseURL)
               } must be valid URL`));
             }
@@ -237,7 +237,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
           }
         } else {
           errors.push(new GraphQLError(
-            `${sourceAPI.name} must specify one of ${KNOWN_SOURCE_PROTOCOLS.join(', ')}`,
+            `${sourceAPI} must specify one of ${KNOWN_SOURCE_PROTOCOLS.join(', ')}`,
           ));
         }
       });
@@ -247,16 +247,16 @@ export class SourceSpecDefinition extends FeatureDefinition {
       sourceType.applications().forEach(application => {
         const { api, ...rest } = application.arguments();
         if (!api || !apiNameToProtocol.has(api)) {
-          errors.push(new GraphQLError(`${sourceType.name} specifies unknown api ${api}`));
+          errors.push(new GraphQLError(`${sourceType} specifies unknown api ${api}`));
         } else {
           const expectedProtocol = apiNameToProtocol.get(api);
           const protocolValue = expectedProtocol && rest[expectedProtocol];
           if (expectedProtocol && !protocolValue) {
             errors.push(new GraphQLError(
-              `${sourceType.name} must specify same ${
+              `${sourceType} must specify same ${
                 expectedProtocol
               } argument as corresponding ${
-                sourceAPI!.name
+                sourceAPI
               } for api ${api}`,
             ));
           }
@@ -266,7 +266,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
 
             if ([GET, POST].filter(Boolean).length !== 1) {
               errors.push(new GraphQLError(
-                `${sourceType.name} must specify exactly one of http.GET or http.POST`,
+                `${sourceType} must specify exactly one of http.GET or http.POST`,
               ));
             } else {
               const urlPathTemplate = (GET || POST)!;
@@ -276,7 +276,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
                 parseURLPathTemplate(urlPathTemplate);
               } catch (e) {
                 errors.push(new GraphQLError(
-                  `${sourceType.name} http.GET or http.POST must be valid URL path template`,
+                  `${sourceType} http.GET or http.POST must be valid URL path template`,
                 ));
               }
             }
@@ -289,9 +289,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
                 // TODO Validate body selection matches the available fields.
               } catch (e) {
                 errors.push(new GraphQLError(
-                  `${sourceType.name} http.body not valid JSONSelection: ${
-                    e.message
-                  }`,
+                  `${sourceType} http.body not valid JSONSelection: ${e.message}`,
                 ));
               }
             }
@@ -304,14 +302,14 @@ export class SourceSpecDefinition extends FeatureDefinition {
           case "InterfaceTypeDefinition":
             if (!ast.directives?.some(directive => directive.name.value === "key")) {
               errors.push(new GraphQLError(
-                `${sourceType.name} must be applied to an entity type that also has a @key directive`,
+                `${sourceType} must be applied to an entity type that also has a @key directive`,
               ));
             }
             // TODO Validate selection is valid JSONSelection for type.
             break;
           default:
             errors.push(new GraphQLError(
-              `${sourceType.name} must be applied to object or interface type`,
+              `${sourceType} must be applied to object or interface type`,
             ));
         }
       });
@@ -321,7 +319,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
       sourceField.applications().forEach(application => {
         const { api, selection, ...rest } = application.arguments();
         if (!api || !apiNameToProtocol.has(api)) {
-          errors.push(new GraphQLError(`${sourceField.name} specifies unknown api ${api}`));
+          errors.push(new GraphQLError(`${sourceField} specifies unknown api ${api}`));
         } else {
           const expectedProtocol = apiNameToProtocol.get(api);
           const protocolValue = expectedProtocol && rest[expectedProtocol];
@@ -335,7 +333,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
             const usedMethods = [GET, POST, PUT, PATCH, DELETE].filter(Boolean);
             if (usedMethods.length > 1) {
               errors.push(new GraphQLError(`${
-                sourceField.name
+                sourceField
               } allows at most one of http.GET, http.POST, http.PUT, http.PATCH, and http.DELETE`));
             } else if (usedMethods.length === 1) {
               const urlPathTemplate = usedMethods[0]!;
@@ -345,7 +343,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
                 parseURLPathTemplate(urlPathTemplate);
               } catch (e) {
                 errors.push(new GraphQLError(
-                  `${sourceField.name} http.GET, http.POST, http.PUT, http.PATCH, or http.DELETE must be valid URL path template`,
+                  `${sourceField} http.GET, http.POST, http.PUT, http.PATCH, or http.DELETE must be valid URL path template`,
                 ));
               }
             }
@@ -359,9 +357,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
                 // parent type and/or argument names of the field.
               } catch (e) {
                 errors.push(new GraphQLError(
-                  `${sourceField.name} http.body not valid JSONSelection: ${
-                    e.message
-                  }`,
+                  `${sourceField} http.body not valid JSONSelection: ${e.message}`,
                 ));
               }
             }
@@ -375,7 +371,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
             // the parent type and/or argument names of the field.
           } catch (e) {
             errors.push(new GraphQLError(
-              `${sourceField.name} selection not valid JSONSelection: ${
+              `${sourceField} selection not valid JSONSelection: ${
                 e.message
               }`,
             ));
@@ -387,13 +383,13 @@ export class SourceSpecDefinition extends FeatureDefinition {
         const fieldParent = application.parent;
         if (fieldParent.sourceAST?.kind !== "FieldDefinition") {
           errors.push(new GraphQLError(
-            `${sourceField.name} must be applied to field`,
+            `${sourceField} must be applied to field`,
           ));
         } else {
           const typeGrandparent = fieldParent.parent as SchemaElement<any, any>;
           if (typeGrandparent.sourceAST?.kind !== "ObjectTypeDefinition") {
             errors.push(new GraphQLError(
-              `${sourceField.name} must be applied to field of object type`,
+              `${sourceField} must be applied to field of object type`,
             ));
           } else {
             const typeGrandparentName = typeGrandparent.sourceAST?.name.value;
@@ -403,7 +399,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
               typeGrandparent.appliedDirectivesOf("key").length === 0
             ) {
               errors.push(new GraphQLError(
-                `${sourceField.name} must be applied to root Query or Mutation field or field of entity type`,
+                `${sourceField} must be applied to root Query or Mutation field or field of entity type`,
               ));
             }
           }
@@ -420,6 +416,9 @@ function validateHTTPHeaders(
   errors: GraphQLError[],
   directiveName: string,
 ) {
+  if (!directiveName.startsWith('@')) {
+    directiveName = '@' + directiveName;
+  }
   if (headers) {
     headers.forEach(({ name, as, value }, i) => {
       // Ensure name is a valid HTTP header name.

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -157,7 +157,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
     schema.schemaDefinition.appliedDirectivesOf<LinkDirectiveArgs>('link')
       .forEach(linkDirective => {
         const { url, import: imports } = linkDirective.arguments();
-        if (imports && FeatureUrl.parse(url).identity === sourceIdentity) {
+        if (imports && FeatureUrl.maybeParse(url)?.identity === sourceIdentity) {
           imports.forEach(nameOrRename => {
             const originalName = typeof nameOrRename === 'string' ? nameOrRename : nameOrRename.name;
             const importedName = typeof nameOrRename === 'string' ? nameOrRename : nameOrRename.as || originalName;


### PR DESCRIPTION
There are a number of `// TODO` comments left in this implementation, but this PR demonstrates a basic framework for allowing known `FeatureDefinition` subclasses, like `SourceSpecDefinition`, to define their own subgraph validation rules, by overriding the `validateSubgraphSchema(schema: Schema): GraphQLError[]` method.

It's the responsibility of `validateSubgraphSchema` to determine if its validation rules are applicable to a given schema, ideally returning an empty array quickly if the feature in question is not used in the schema.

In order for `validateKnownFeatures` to work, a given `FeatureDefinition` subclass needs to have been registered with `registerKnownFeature`.

I'll keep working on the `TODO`s and the tests.