### PR TITLE
Implement progressive `@override`

### DIFF
--- a/.changeset/empty-dodos-turn.md
+++ b/.changeset/empty-dodos-turn.md
@@ -1,0 +1,22 @@
+---
+"@apollo/query-planner": minor
+"@apollo/query-graphs": minor
+"@apollo/composition": minor
+"@apollo/federation-internals": minor
+"@apollo/subgraph": minor
+"@apollo/gateway": minor
+---
+
+Implement progressive `@override` functionality
+
+The progressive `@override` feature brings a new argument to the `@override` directive: `label: String`. When a label is added to an `@override` application, the override becomes conditional, depending on parameters provided to the query planner (a set of which labels should be overridden). Note that this feature will be supported in router for enterprise users only.
+
+Out-of-the-box, the router will support a percentage-based use case for progressive `@override`. For example:
+```graphql
+type Query {
+  hello: String @override(from: "original", label: "percent(5)")
+}
+```
+The above example will override the root `hello` field from the "original" subgraph 5% of the time.
+
+More complex use cases will be supported by the router via the use of coprocessors/rhai to resolve arbitrary labels to true/false values (i.e. via a feature flag service).

--- a/.cspell/cspell-dict.txt
+++ b/.cspell/cspell-dict.txt
@@ -190,6 +190,7 @@ Reviwed
 Rhai
 righ
 rulesof
+runtimes
 samee
 Sant
 SATISFIABILITY

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -80,7 +80,7 @@ describe('composition', () => {
 
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -232,7 +232,7 @@ describe('composition', () => {
 
       directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -502,7 +502,7 @@ describe("composition involving @override directive", () => {
 
     const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
     expect(result.errors).toBeDefined();
-    expect(result.errors?.map(e => e.message)).toMatchStringArray([
+    expect(result.errors?.map((e) => e.message)).toMatchStringArray([
       `
       The following supergraph API query:
       {
@@ -526,7 +526,7 @@ describe("composition involving @override directive", () => {
       - from subgraph "Subgraph2":
         - cannot find field "T.a".
         - cannot move to subgraph "Subgraph1" using @key(fields: "k") of "T", the key field(s) cannot be resolved from subgraph "Subgraph2" (note that some of those key fields are overridden in "Subgraph2").
-      `
+      `,
     ]);
   });
 
@@ -562,9 +562,9 @@ describe("composition involving @override directive", () => {
     expect(result.errors).toBeDefined();
     expect(errors(result)).toStrictEqual([
       [
-        'FIELD_TYPE_MISMATCH',
-        'Type of field "T.a" is incompatible across subgraphs: it has type "Int" in subgraph "Subgraph1" but type "String" in subgraph "Subgraph2"'
-      ]
+        "FIELD_TYPE_MISMATCH",
+        'Type of field "T.a" is incompatible across subgraphs: it has type "Int" in subgraph "Subgraph1" but type "String" in subgraph "Subgraph2"',
+      ],
     ]);
   });
 
@@ -810,7 +810,7 @@ describe("composition involving @override directive", () => {
   // At the moment, we've punted on @override support when interacting with @interfaceObject, so the
   // following tests mainly cover the various possible use and show that it currently correcly raise
   // some validation errors. We may lift some of those limitation in the future.
-  describe('@interfaceObject', () => {
+  describe("@interfaceObject", () => {
     it("does not allow @override on @interfaceObject fields", () => {
       // We currently rejects @override on fields of an @interfaceObject type. We could lift
       // that limitation in the future, and that would mean such override overrides the field
@@ -912,6 +912,181 @@ describe("composition involving @override directive", () => {
         "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
         'Invalid @override on field "A.a" of subgraph "Subgraph2": source subgraph "Subgraph1" does not have field "A.a" but abstract it in type "I" and overriding abstracted fields is not supported.',
       ]);
+    });
+  });
+
+  describe("progressive override", () => {
+    it("captures override labels in supergraph", () => {
+      const subgraph1 = {
+        name: "Subgraph1",
+        url: "https://Subgraph1",
+        typeDefs: gql`
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "k") {
+            k: ID
+            a: Int @override(from: "Subgraph2", label: "foo")
+          }
+        `,
+      };
+
+      const subgraph2 = {
+        name: "Subgraph2",
+        url: "https://Subgraph2",
+        typeDefs: gql`
+          type T @key(fields: "k") {
+            k: ID
+            a: Int
+            b: Int
+          }
+        `,
+      };
+
+      const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+      assertCompositionSuccess(result);
+
+      const typeT = result.schema.type("T");
+      expect(printType(typeT!)).toMatchInlineSnapshot(`
+        "type T
+          @join__type(graph: SUBGRAPH1, key: \\"k\\")
+          @join__type(graph: SUBGRAPH2, key: \\"k\\")
+        {
+          k: ID
+          a: Int @join__field(graph: SUBGRAPH1, override: \\"Subgraph2\\", overrideLabel: \\"foo\\")
+          b: Int @join__field(graph: SUBGRAPH2)
+        }"
+      `);
+
+      const [_, api] = schemas(result);
+      expect(printSchema(api)).toMatchString(`
+        type Query {
+          t: T
+        }
+
+        type T {
+          k: ID
+          a: Int
+          b: Int
+        }
+      `);
+    });
+
+    describe("label validation", () => {
+      const overridden = {
+        name: "overridden",
+        url: "https://overridden",
+        typeDefs: gql`
+          type T @key(fields: "k") {
+            k: ID
+            a: Int
+          }
+        `,
+      };
+
+      it.each(["abc123", "Z_1-2:3/4.5"])(
+        "allows valid labels starting with alpha and including alphanumerics + `_-:./`",
+        (value) => {
+          const withValidLabel = {
+            name: "validLabel",
+            url: "https://validLabel",
+            typeDefs: gql`
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "k") {
+              k: ID
+              a: Int
+                @override(from: "overridden", label: "${value}")
+            }
+          `,
+          };
+
+          const result = composeAsFed2Subgraphs([withValidLabel, overridden]);
+          assertCompositionSuccess(result);
+        }
+      );
+
+      it.each(["1_starts-with-non-alpha", "includes!@_invalid_chars"])(
+        "disallows invalid labels",
+        (value) => {
+          const withInvalidLabel = {
+            name: "invalidLabel",
+            url: "https://invalidLabel",
+            typeDefs: gql`
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "k") {
+              k: ID
+              a: Int @override(from: "overridden", label: "${value}")
+            }
+          `,
+          };
+
+          const result = composeAsFed2Subgraphs([withInvalidLabel, overridden]);
+          expect(result.errors).toBeDefined();
+          expect(errors(result)).toContainEqual([
+            "OVERRIDE_LABEL_INVALID",
+            `Invalid @override label "${value}" on field "T.a" on subgraph "invalidLabel": labels must start with a letter and after that may contain alphanumerics, underscores, minuses, colons, periods, or slashes. Alternatively, labels may be of the form "percent(x)" where x is a float between 0-100 inclusive.`,
+          ]);
+        }
+      );
+
+      it.each(["0.5", "1", "1.0", "99.9"])(
+        "allows valid percent-based labels",
+        (value) => {
+          const withPercentLabel = {
+            name: "percentLabel",
+            url: "https://percentLabel",
+            typeDefs: gql`
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "k") {
+              k: ID
+              a: Int @override(from: "overridden", label: "percent(${value})")
+            }
+          `,
+          };
+
+          const result = composeAsFed2Subgraphs([withPercentLabel, overridden]);
+          assertCompositionSuccess(result);
+        }
+      );
+
+      it.each([".1", "101", "1.1234567879"])(
+        "disallows invalid percent-based labels",
+        (value) => {
+          const withInvalidPercentLabel = {
+            name: "invalidPercentLabel",
+            url: "https://invalidPercentLabel",
+            typeDefs: gql`
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "k") {
+              k: ID
+              a: Int @override(from: "overridden", label: "percent(${value})")
+            }
+          `,
+          };
+
+          const result = composeAsFed2Subgraphs([
+            withInvalidPercentLabel,
+            overridden,
+          ]);
+          expect(errors(result)).toContainEqual([
+            "OVERRIDE_LABEL_INVALID",
+            `Invalid @override label "percent(${value})" on field "T.a" on subgraph "invalidPercentLabel": labels must start with a letter and after that may contain alphanumerics, underscores, minuses, colons, periods, or slashes. Alternatively, labels may be of the form "percent(x)" where x is a float between 0-100 inclusive.`,
+          ]);
+        }
+      );
     });
   });
 });

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -95,6 +95,7 @@ type FieldMergeContextProperties = {
   usedOverridden: boolean,
   unusedOverridden: boolean,
   overrideWithUnknownTarget: boolean,
+  overrideLabel: string | undefined,
 }
 
 // for each source, specify additional properties that validate functions can set
@@ -102,7 +103,13 @@ class FieldMergeContext {
   _props: FieldMergeContextProperties[];
 
   constructor(sources: unknown[]) {
-    this._props = (new Array(sources.length)).fill(true).map(_ => ({ usedOverridden: false, unusedOverridden: false, overrideWithUnknownTarget: false}));
+    this._props = (
+      new Array(sources.length)).fill(true).map(_ => ({
+        usedOverridden: false,
+        unusedOverridden: false,
+        overrideWithUnknownTarget: false,
+        overrideLabel: undefined,
+      }));
   }
 
   isUsedOverridden(idx: number) {
@@ -117,6 +124,10 @@ class FieldMergeContext {
     return this._props[idx].overrideWithUnknownTarget;
   }
 
+  overrideLabel(idx: number) {
+    return this._props[idx].overrideLabel;
+  }
+
   setUsedOverridden(idx: number) {
     this._props[idx].usedOverridden = true;
   }
@@ -127,6 +138,10 @@ class FieldMergeContext {
 
   setOverrideWithUnknownTarget(idx: number) {
     this._props[idx].overrideWithUnknownTarget = true;
+  }
+
+  setOverrideLabel(idx: number, label: string) {
+    this._props[idx].overrideLabel = label;
   }
 
   some(predicate: (props: FieldMergeContextProperties) => boolean): boolean {
@@ -259,6 +274,11 @@ type EnumTypeUsage = {
     Input?: {coordinate: string, sourceAST?: SubgraphASTNode},
     Output?: {coordinate: string, sourceAST?: SubgraphASTNode},
   },
+}
+
+interface OverrideArgs {
+  from: string;
+  label?: string;
 }
 
 class Merger {
@@ -1064,7 +1084,7 @@ class Merger {
     return this.metadata(sourceIdx).isFieldShareable(field);
   }
 
-  private getOverrideDirective(sourceIdx: number, field: FieldDefinition<any>): Directive<any> | undefined {
+  private getOverrideDirective(sourceIdx: number, field: FieldDefinition<any>): Directive<any, OverrideArgs> | undefined {
     // Check the directive on the field, then on the enclosing type.
     const metadata = this.metadata(sourceIdx);
     const overrideDirective = metadata.isFed2Schema() ? metadata.overrideDirective() : undefined;
@@ -1119,7 +1139,7 @@ class Merger {
       isInterfaceField?: boolean,
       isInterfaceObject?: boolean,
       interfaceObjectAbstractingFields?: FieldDefinition<any>[],
-      overrideDirective?: Directive<FieldDefinition<any>>,
+      overrideDirective?: Directive<FieldDefinition<any>, OverrideArgs>,
     };
 
     type ReduceResultType = {
@@ -1164,7 +1184,9 @@ class Merger {
     // for each subgraph that has an @override directive, check to see if any errors or hints should be surfaced
     subgraphsWithOverride.forEach((subgraphName) => {
       const { overrideDirective, idx, isInterfaceObject, isInterfaceField } = subgraphMap[subgraphName];
-      const overridingSubgraphASTNode = overrideDirective?.sourceAST ? addSubgraphToASTNode(overrideDirective.sourceAST, subgraphName) : undefined;
+      if (!overrideDirective) return;
+
+      const overridingSubgraphASTNode = overrideDirective.sourceAST ? addSubgraphToASTNode(overrideDirective.sourceAST, subgraphName) : undefined;
       if (isInterfaceField) {
         this.errors.push(ERRORS.OVERRIDE_ON_INTERFACE.err(
           `@override cannot be used on field "${dest.coordinate}" on subgraph "${subgraphName}": @override is not supported on interface type fields.`,
@@ -1181,7 +1203,7 @@ class Merger {
         return;
       }
 
-      const sourceSubgraphName = overrideDirective?.arguments()?.from;
+      const sourceSubgraphName = overrideDirective.arguments().from;
       if (!this.names.includes(sourceSubgraphName)) {
         result.setOverrideWithUnknownTarget(idx);
         const suggestions = suggestionList(sourceSubgraphName, this.names);
@@ -1195,7 +1217,7 @@ class Merger {
       } else if (sourceSubgraphName === subgraphName) {
         this.errors.push(ERRORS.OVERRIDE_FROM_SELF_ERROR.err(
           `Source and destination subgraphs "${sourceSubgraphName}" are the same for overridden field "${dest.coordinate}"`,
-          { nodes: overrideDirective?.sourceAST },
+          { nodes: overrideDirective.sourceAST },
         ));
       } else if (subgraphsWithOverride.includes(sourceSubgraphName)) {
         this.errors.push(ERRORS.OVERRIDE_SOURCE_HAS_OVERRIDE.err(
@@ -1268,6 +1290,33 @@ class Merger {
               dest,
               overriddenSubgraphASTNode,
             ));
+          }
+
+          // capture an override label if it exists
+          const overrideLabel = overrideDirective.arguments().label;
+          if (overrideLabel) {
+            const labelRegex = /^[a-zA-Z][a-zA-Z0-9_\-:./]*$/;
+            // Enforce that the label matches the following pattern: percent(x)
+            // where x is a float between 0 and 100 with no more than 8 decimal places
+            const percentRegex = /^percent\((\d{1,2}(\.\d{1,8})?|100)\)$/;
+            if (labelRegex.test(overrideLabel)) {
+              result.setOverrideLabel(idx, overrideLabel);
+            } else if (percentRegex.test(overrideLabel)) {
+              const parts = percentRegex.exec(overrideLabel);
+              if (parts) {
+                const percent = parseFloat(parts[1]);
+                if (percent >= 0 && percent <= 100) {
+                  result.setOverrideLabel(idx, overrideLabel);
+                }
+              }
+            }
+
+            if (!result.overrideLabel(idx)) {
+              this.errors.push(ERRORS.OVERRIDE_LABEL_INVALID.err(
+                `Invalid @override label "${overrideLabel}" on field "${dest.coordinate}" on subgraph "${subgraphName}": labels must start with a letter and after that may contain alphanumerics, underscores, minuses, colons, periods, or slashes. Alternatively, labels may be of the form "percent(x)" where x is a float between 0-100 inclusive.`,
+                { nodes: overridingSubgraphASTNode }
+              ));
+            }
           }
         }
       }
@@ -1608,6 +1657,7 @@ class Merger {
         type: allTypesEqual ? undefined : source.type?.toString(),
         external: external ? true : undefined,
         usedOverridden: usedOverridden ? true : undefined,
+        overrideLabel: mergeContext.overrideLabel(idx),
       });
     }
   }

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1301,12 +1301,14 @@ class Merger {
             const percentRegex = /^percent\((\d{1,2}(\.\d{1,8})?|100)\)$/;
             if (labelRegex.test(overrideLabel)) {
               result.setOverrideLabel(idx, overrideLabel);
+              result.setOverrideLabel(fromIdx, overrideLabel);
             } else if (percentRegex.test(overrideLabel)) {
               const parts = percentRegex.exec(overrideLabel);
               if (parts) {
                 const percent = parseFloat(parts[1]);
                 if (percent >= 0 && percent <= 100) {
                   result.setOverrideLabel(idx, overrideLabel);
+                  result.setOverrideLabel(fromIdx, overrideLabel);
                 }
               }
             }
@@ -1589,7 +1591,7 @@ class Merger {
     if (!allTypesEqual) {
       return true;
     }
-    if (mergeContext.some(({ usedOverridden }) => usedOverridden)) {
+    if (mergeContext.some(({ usedOverridden, overrideLabel }) => usedOverridden || !!overrideLabel)) {
       return true;
     }
 
@@ -1642,7 +1644,8 @@ class Merger {
     for (const [idx, source] of sources.entries()) {
       const usedOverridden = mergeContext.isUsedOverridden(idx);
       const unusedOverridden = mergeContext.isUnusedOverridden(idx);
-      if (!source || unusedOverridden) {
+      const overrideLabel = mergeContext.overrideLabel(idx);
+      if (!source || (unusedOverridden && !overrideLabel)) {
         continue;
       }
 

--- a/composition-js/src/validate.ts
+++ b/composition-js/src/validate.ts
@@ -32,7 +32,8 @@ import {
   typenameFieldName,
   validateSupergraph,
   VariableDefinitions,
-  isOutputType
+  isOutputType,
+  JoinFieldDirectiveArguments,
 } from "@apollo/federation-internals";
 import {
   Edge,
@@ -289,31 +290,33 @@ function generateWitnessValue(type: InputType): any {
 }
 
 /**
- * Validates that all the queries expressable on the API schema resulting of the composition of the provided subgraphs can be executed
+ * Validates that all the queries expressible on the API schema resulting of the composition of the provided subgraphs can be executed
  * on those subgraphs.
  *
  * @param supergraphSchema the schema of the supergraph that composing `subgraphs` generated. Note this *must* be the full supergraph, not
  *   just it's API schema (because it may be used to find the definition of elements that are marked `@inaccessible`). Note that this _not_
  *   the same schema that the one reference inside `supergraphAPI` in particular.
  * @param supergraphAPI the `QueryGraph` corresponding to the `supergraphSchema` API schema.
- * @param subgraphs the (federated) `QueryGraph` corresponding the subgraphs having been composed to obtain `supergraphSchema`.
+ * @param federatedQueryGraph the (federated) `QueryGraph` corresponding the subgraphs having been composed to obtain `supergraphSchema`.
  */
 export function validateGraphComposition(
   supergraphSchema: Schema,
   supergraphAPI: QueryGraph,
-  subgraphs: QueryGraph
+  federatedQueryGraph: QueryGraph,
 ): {
   errors? : GraphQLError[],
   hints? : CompositionHint[],
 } {
-  const { errors, hints } = new ValidationTraversal(supergraphSchema, supergraphAPI, subgraphs).validate();
+  const { errors, hints } = new ValidationTraversal(supergraphSchema, supergraphAPI, federatedQueryGraph).validate();
   return errors.length > 0 ? { errors, hints } : { hints };
 }
 
+// TODO: we don't use this anywhere, can we just remove it?
 export function computeSubgraphPaths(
   supergraphSchema: Schema,
   supergraphPath: RootPath<Transition>,
-  subgraphs: QueryGraph
+  federatedQueryGraph: QueryGraph,
+  overrideConditions: Map<string, boolean>,
 ): {
   traversal?: ValidationState,
   isComplete?: boolean,
@@ -321,8 +324,8 @@ export function computeSubgraphPaths(
 } {
   try {
     assert(!supergraphPath.hasAnyEdgeConditions(), () => `A supergraph path should not have edge condition paths (as supergraph edges should not have conditions): ${supergraphPath}`);
-    const conditionResolver = simpleValidationConditionResolver({ supergraph: supergraphSchema, queryGraph: subgraphs, withCaching: true });
-    const initialState = ValidationState.initial({supergraphAPI: supergraphPath.graph, kind: supergraphPath.root.rootKind, subgraphs, conditionResolver});
+    const conditionResolver = simpleValidationConditionResolver({ supergraph: supergraphSchema, queryGraph: federatedQueryGraph, withCaching: true });
+    const initialState = ValidationState.initial({ supergraphAPI: supergraphPath.graph, kind: supergraphPath.root.rootKind, federatedQueryGraph, conditionResolver, overrideConditions });
     const context = new ValidationContext(supergraphSchema);
     let state = initialState;
     let isIncomplete = false;
@@ -371,7 +374,7 @@ export function extractValidationError(error: any): ValidationError | undefined 
 
 export class ValidationContext {
   private readonly joinTypeDirective: DirectiveDefinition;
-  private readonly joinFieldDirective: DirectiveDefinition<{ external?: boolean, usedOverridden?: boolean }>;
+  private readonly joinFieldDirective: DirectiveDefinition<JoinFieldDirectiveArguments>;
 
   constructor(
     readonly supergraphSchema: Schema,
@@ -401,7 +404,6 @@ export class ValidationContext {
         return !args.external && !args.usedOverridden;
       }).length > 1);
   }
-
 }
 
 export class ValidationState {
@@ -409,24 +411,37 @@ export class ValidationState {
     // Path in the supergraph corresponding to the current state.
     public readonly supergraphPath: RootPath<Transition>,
     // All the possible paths we could be in the subgraph.
-    public readonly subgraphPaths: TransitionPathWithLazyIndirectPaths<RootVertex>[]
+    public readonly subgraphPaths: TransitionPathWithLazyIndirectPaths<RootVertex>[],
+    // When we encounter an `@override`n field with a label condition, we record
+    // its value (T/F) as we traverse the graph. This allows us to ignore paths
+    // that can never be taken by the query planner (i.e. a path where the
+    // condition is T in one case and F in another).
+    public selectedOverrideConditions: Map<string, boolean> = new Map(),
   ) {
   }
 
   static initial({
     supergraphAPI,
     kind,
-    subgraphs,
+    federatedQueryGraph,
     conditionResolver,
+    overrideConditions,
   }: {
     supergraphAPI: QueryGraph,
     kind: SchemaRootKind,
-    subgraphs: QueryGraph,
+    federatedQueryGraph: QueryGraph,
     conditionResolver: ConditionResolver,
+    overrideConditions: Map<string, boolean>,
   }) {
     return new ValidationState(
       GraphPath.fromGraphRoot(supergraphAPI, kind)!,
-      initialSubgraphPaths(kind, subgraphs).map((p) => TransitionPathWithLazyIndirectPaths.initial(p, conditionResolver)),
+      initialSubgraphPaths(kind, federatedQueryGraph).map((p) =>
+        TransitionPathWithLazyIndirectPaths.initial(
+          p,
+          conditionResolver,
+          overrideConditions,
+        ),
+      ),
     );
   }
 
@@ -452,11 +467,22 @@ export class ValidationState {
     const targetType = supergraphEdge.tail.type;
     const newSubgraphPaths: TransitionPathWithLazyIndirectPaths<RootVertex>[] = [];
     const deadEnds: Unadvanceables[] = [];
+    // If the edge has an override condition, we should capture it in the state so
+    // that we can ignore later edges that don't satisfy the condition.
+    const newOverrideConditions = new Map([...this.selectedOverrideConditions]);
+    if (supergraphEdge.overrideCondition) {
+      newOverrideConditions.set(
+        supergraphEdge.overrideCondition.label,
+        supergraphEdge.overrideCondition.condition
+      );
+    }
+
     for (const path of this.subgraphPaths) {
       const options = advancePathWithTransition(
         path,
         transition,
         targetType,
+        newOverrideConditions,
       );
       if (isUnadvanceable(options)) {
         deadEnds.push(options);
@@ -474,7 +500,11 @@ export class ValidationState {
       return { error: satisfiabilityError(newPath, this.subgraphPaths.map((p) => p.path), deadEnds) };
     }
 
-    const updatedState = new ValidationState(newPath, newSubgraphPaths);
+    const updatedState = new ValidationState(
+      newPath,
+      newSubgraphPaths,
+      newOverrideConditions,
+    );
 
     // When handling a @shareable field, we also compare the set of runtime types for each subgraphs involved.
     // If there is no common intersection between those sets, then we record an error: a @shareable field should resolve
@@ -571,9 +601,20 @@ export class ValidationState {
   }
 }
 
-function isSupersetOrEqual(maybeSuperset: string[], other: string[]): boolean {
-  // `maybeSuperset` is a superset (or equal) if it contains all of `other`
-  return other.every(v => maybeSuperset.includes(v));
+// `maybeSuperset` is a superset (or equal) if it contains all of `other`'s
+// subgraphs and all of `other`'s labels (with matching conditions).
+function isSupersetOrEqual(maybeSuperset: VertexVisit, other: VertexVisit): boolean {
+  const includesAllSubgraphs = other.subgraphs.every((s) => maybeSuperset.subgraphs.includes(s));
+  const includesAllOverrideConditions = [...other.overrideConditions.entries()].every(([label, value]) =>
+    maybeSuperset.overrideConditions.get(label) === value
+  );
+
+  return includesAllSubgraphs && includesAllOverrideConditions;
+}
+
+interface VertexVisit {
+  subgraphs: string[];
+  overrideConditions: Map<string, boolean>;
 }
 
 class ValidationTraversal {
@@ -583,7 +624,7 @@ class ValidationTraversal {
 
   // For each vertex in the supergraph, records if we've already visited that vertex and in which subgraphs we were.
   // For a vertex, we may have multiple "sets of subgraphs", hence the double-array.
-  private readonly previousVisits: QueryGraphState<string[][]>;
+  private readonly previousVisits: QueryGraphState<VertexVisit[]>;
 
   private readonly validationErrors: GraphQLError[] = [];
   private readonly validationHints: CompositionHint[] = [];
@@ -593,18 +634,19 @@ class ValidationTraversal {
   constructor(
     supergraphSchema: Schema,
     supergraphAPI: QueryGraph,
-    subgraphs: QueryGraph
+    federatedQueryGraph: QueryGraph,
   ) {
     this.conditionResolver = simpleValidationConditionResolver({
       supergraph: supergraphSchema,
-      queryGraph: subgraphs,
+      queryGraph: federatedQueryGraph,
       withCaching: true,
     });
     supergraphAPI.rootKinds().forEach((kind) => this.stack.push(ValidationState.initial({
       supergraphAPI,
       kind,
-      subgraphs,
-      conditionResolver: this.conditionResolver
+      federatedQueryGraph,
+      conditionResolver: this.conditionResolver,
+      overrideConditions: new Map(),
     })));
     this.previousVisits = new QueryGraphState(supergraphAPI);
     this.context = new ValidationContext(supergraphSchema);
@@ -623,11 +665,15 @@ class ValidationTraversal {
   private handleState(state: ValidationState) {
     debug.group(() => `Validation: ${this.stack.length + 1} open states. Validating ${state}`);
     const vertex = state.supergraphPath.tail;
-    const currentSources = state.currentSubgraphNames();
-    const previousSeenSources = this.previousVisits.getVertexState(vertex);
-    if (previousSeenSources) {
-      for (const previousSources of previousSeenSources) {
-        if (isSupersetOrEqual(currentSources, previousSources)) {
+
+    const currentVertexVisit: VertexVisit = {
+      subgraphs: state.currentSubgraphNames(),
+      overrideConditions: state.selectedOverrideConditions
+    };
+    const previousVisitsForVertex = this.previousVisits.getVertexState(vertex);
+    if (previousVisitsForVertex) {
+      for (const previousVisit of previousVisitsForVertex) {
+        if (isSupersetOrEqual(currentVertexVisit, previousVisit)) {
           // This means that we've already seen the type we're currently on in the supergraph, and when saw it we could be in
           // one of `previousSources`, and we validated that we could reach anything from there. We're now on the same
           // type, and have strictly more options regarding subgraphs. So whatever comes next, we can handle in the exact
@@ -637,10 +683,10 @@ class ValidationTraversal {
         }
       }
       // We're gonna have to validate, but we can save the new set of sources here to hopefully save work later.
-      previousSeenSources.push(currentSources);
+      previousVisitsForVertex.push(currentVertexVisit);
     } else {
       // We save the current sources but do validate.
-      this.previousVisits.setVertexState(vertex, [currentSources]);
+      this.previousVisits.setVertexState(vertex, [currentVertexVisit]);
     }
 
     // Note that if supergraphPath is terminal, this method is a no-op, which is expected/desired as
@@ -650,6 +696,21 @@ class ValidationTraversal {
         // There is no point in validating __typename edges: we know we can always get those.
         continue;
       }
+
+      // `state.selectedOverrideConditions` indicates the labels (and their
+      // respective conditions) that we've selected so far in our traversal
+      // (i.e. "foo" -> true). There's no need to validate edges that share the
+      // same label with the opposite condition since they're unreachable during
+      // query planning.
+      if (
+        edge.overrideCondition
+        && state.selectedOverrideConditions.has(edge.overrideCondition.label)
+        && !edge.satisfiesOverrideConditions(state.selectedOverrideConditions)
+      ) {
+        debug.groupEnd(`Edge ${edge} doesn't satisfy label condition: ${edge.overrideCondition?.label}(${state.selectedOverrideConditions.get(edge.overrideCondition?.label ?? "")}), no need to validate further`);
+        continue;
+      }
+
 
       debug.group(() => `Validating supergraph edge ${edge}`);
       const { state: newState, error, hint } = state.validateTransition(this.context, edge);

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -65,6 +65,7 @@ The following errors might be raised during composition:
 | `ONLY_INACCESSIBLE_CHILDREN` | A type visible in the API schema has only @inaccessible children. | 2.0.0 |  |
 | `OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE` | The @override directive cannot be used on external fields, nor to override fields with either @external, @provides, or @requires. | 2.0.0 |  |
 | `OVERRIDE_FROM_SELF_ERROR` | Field with `@override` directive has "from" location that references its own subgraph. | 2.0.0 |  |
+| `OVERRIDE_LABEL_INVALID` | The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_-:./]*$/ or /^percent((d{1,2}(.d{1,8})?|100))$/ | 2.7.0 |  |
 | `OVERRIDE_ON_INTERFACE` | The @override directive cannot be used on the fields of an interface type. | 2.3.0 |  |
 | `OVERRIDE_SOURCE_HAS_OVERRIDE` | Field which is overridden to another subgraph is also marked @override. | 2.0.0 |  |
 | `PROVIDES_DIRECTIVE_IN_FIELDS_ARG` | The `fields` argument of a `@provides` directive includes some directive applications. This is not supported | 2.1.0 |  |

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -148,8 +148,8 @@ describe('lifecycle hooks', () => {
     // Note that this assertion is a tad fragile in that every time we modify
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
-    expect(secondCall[0]!.compositionId).toEqual(
-      '2d8ebbf41ff207deab8b6ac5f30f70cb398d5b61d2494f6f28e1c88beddeb49f',
+    expect(secondCall[0]!.compositionId).toMatchInlineSnapshot(
+      `"208492fefbbc8f62458b3f698b047a7c119f5169d4ccaef4c24b81a1ba82f87c"`,
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/error.ts
+++ b/internals-js/src/error.ts
@@ -513,6 +513,12 @@ const OVERRIDE_ON_INTERFACE = makeCodeDefinition(
   { addedIn: '2.3.0' },
 );
 
+const OVERRIDE_LABEL_INVALID = makeCodeDefinition(
+  'OVERRIDE_LABEL_INVALID',
+  'The @override directive `label` argument must match the pattern /^[a-zA-Z][a-zA-Z0-9_\-:./]*$/ or /^percent\((\d{1,2}(\.\d{1,8})?|100)\)$/',
+  { addedIn: '2.7.0' },
+);
+
 const UNSUPPORTED_FEATURE = makeCodeDefinition(
   'UNSUPPORTED_FEATURE',
   'Indicates an error due to feature currently unsupported by federation.',
@@ -739,6 +745,7 @@ export const ERRORS = {
   OVERRIDE_FROM_SELF_ERROR,
   OVERRIDE_SOURCE_HAS_OVERRIDE,
   OVERRIDE_ON_INTERFACE,
+  OVERRIDE_LABEL_INVALID,
   UNSUPPORTED_FEATURE,
   INVALID_FEDERATION_SUPERGRAPH,
   DOWNSTREAM_SERVICE_ERROR,

--- a/internals-js/src/extractSubgraphsFromSupergraph.ts
+++ b/internals-js/src/extractSubgraphsFromSupergraph.ts
@@ -418,15 +418,15 @@ function extractObjOrItfContent(args: ExtractArguments, info: TypeInfo<ObjectTyp
           }).length > 1;
 
         for (const application of fieldApplications) {
-          const args = application.arguments();
+          const joinFieldArgs = application.arguments();
           // We use a @join__field with no graph to indicates when a field in the supergraph does not come
           // directly from any subgraph and there is thus nothing to do to "extract" it.
-          if (!args.graph) {
+          if (!joinFieldArgs.graph) {
             continue;
           }
 
-          const { type: subgraphType, subgraph } = subgraphsInfo.get(args.graph)!;
-          addSubgraphField({ field, type: subgraphType, subgraph, isShareable, joinFieldArgs: args});
+          const { type: subgraphType, subgraph } = subgraphsInfo.get(joinFieldArgs.graph)!;
+          addSubgraphField({ field, type: subgraphType, subgraph, isShareable, joinFieldArgs });
         }
       }
     }
@@ -615,11 +615,14 @@ function addSubgraphField({
     subgraphField.applyDirective(subgraph.metadata().externalDirective());
   }
   const usedOverridden = !!joinFieldArgs?.usedOverridden;
-  if (usedOverridden) {
+  if (usedOverridden && !joinFieldArgs?.overrideLabel) {
     subgraphField.applyDirective(subgraph.metadata().externalDirective(), {'reason': '[overridden]'});
   }
   if (joinFieldArgs?.override) {
-    subgraphField.applyDirective(subgraph.metadata().overrideDirective(), {'from': joinFieldArgs.override});
+    subgraphField.applyDirective(subgraph.metadata().overrideDirective(), {
+      from: joinFieldArgs.override,
+      ...(joinFieldArgs.overrideLabel ? { label: joinFieldArgs.overrideLabel } : {})
+    });
   }
   if (isShareable && !external && !usedOverridden) {
     subgraphField.applyDirective(subgraph.metadata().shareableDirective());

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -726,7 +726,7 @@ export class FederationMetadata {
     return this.getLegacyFederationDirective(FederationDirectiveName.KEY);
   }
 
-  overrideDirective(): DirectiveDefinition<{from: string}> {
+  overrideDirective(): DirectiveDefinition<{from: string, label?: string}> {
     return this.getLegacyFederationDirective(FederationDirectiveName.OVERRIDE);
   }
 

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -1473,7 +1473,7 @@ function completeFed2SubgraphSchema(schema: Schema): GraphQLError[] {
   const spec = FEDERATION_VERSIONS.find(fedFeature.url.version);
   if (!spec) {
     return [ERRORS.UNKNOWN_FEDERATION_LINK_VERSION.err(
-      `Invalid version ${fedFeature.url.version} for the federation feature in @link direction on schema`,
+      `Invalid version ${fedFeature.url.version} for the federation feature in @link directive on schema`,
       { nodes: fedFeature.directive.sourceAST },
     )];
   }
@@ -1595,7 +1595,7 @@ export function collectTargetFields({
       validate,
     });
   } catch (e) {
-    // If we explicitely requested no validation, then we shouldn't throw a (graphQL) error, but if we do, we swallow it
+    // If we explicitly requested no validation, then we shouldn't throw a (graphQL) error, but if we do, we swallow it
     // (returning a partial result, but we assume it is fine).
     const isGraphQLError = errorCauses(e) !== undefined
     if (!isGraphQLError || validate) {

--- a/internals-js/src/specs/federationSpec.ts
+++ b/internals-js/src/specs/federationSpec.ts
@@ -128,11 +128,22 @@ export class FederationSpecDefinition extends FeatureDefinition {
 
     this.registerSubFeature(INACCESSIBLE_VERSIONS.getMinimumRequiredVersion(version));
 
-    this.registerDirective(createDirectiveSpecification({
-      name: FederationDirectiveName.OVERRIDE,
-      locations: [DirectiveLocation.FIELD_DEFINITION],
-      args: [{ name: 'from', type: (schema) => new NonNullType(schema.stringType()) }],
-    }));
+    if (version >= (new FeatureVersion(2, 7))) {
+      this.registerDirective(createDirectiveSpecification({
+        name: FederationDirectiveName.OVERRIDE,
+        locations: [DirectiveLocation.FIELD_DEFINITION],
+        args: [
+          { name: 'from', type: (schema) => new NonNullType(schema.stringType()) },
+          { name: 'label', type: (schema) => schema.stringType() },
+        ],
+      }));
+    } else {
+      this.registerDirective(createDirectiveSpecification({
+        name: FederationDirectiveName.OVERRIDE,
+        locations: [DirectiveLocation.FIELD_DEFINITION],
+        args: [{ name: 'from', type: (schema) => new NonNullType(schema.stringType()) }],
+      }));
+    }
 
     if (version.gte(new FeatureVersion(2, 1))) {
       this.registerDirective(createDirectiveSpecification({

--- a/internals-js/src/specs/joinSpec.ts
+++ b/internals-js/src/specs/joinSpec.ts
@@ -47,6 +47,7 @@ export type JoinFieldDirectiveArguments = {
   type?: string,
   external?: boolean,
   usedOverridden?: boolean,
+  overrideLabel?: string,
 }
 
 export type JoinDirectiveArguments = {
@@ -149,6 +150,9 @@ export class JoinSpecDefinition extends FeatureDefinition {
       joinDirective.addArgument('graphs', new ListType(new NonNullType(graphEnum)));
       joinDirective.addArgument('name', new NonNullType(schema.stringType()));
       joinDirective.addArgument('args', this.addScalarType(schema, 'DirectiveArguments'));
+
+      //progressive override
+      joinField.addArgument('overrideLabel', schema.stringType());
     }
 
     if (this.isV01()) {
@@ -256,6 +260,7 @@ export class JoinSpecDefinition extends FeatureDefinition {
 //    for federation 2 in general.
 //  - 0.2: this is the original version released with federation 2.
 //  - 0.3: adds the `isInterfaceObject` argument to `@join__type`, and make the `graph` in `@join__field` skippable.
+//  - 0.4: adds the optional `overrideLabel` argument to `@join_field` for progressive override.
 export const JOIN_VERSIONS = new FeatureDefinitions<JoinSpecDefinition>(joinIdentity)
   .add(new JoinSpecDefinition(new FeatureVersion(0, 1)))
   .add(new JoinSpecDefinition(new FeatureVersion(0, 2)))

--- a/query-graphs-js/src/__tests__/graphPath.test.ts
+++ b/query-graphs-js/src/__tests__/graphPath.test.ts
@@ -71,6 +71,7 @@ function createOptions(supergraph: Schema, queryGraph: QueryGraph): Simultaneous
     simpleValidationConditionResolver({ supergraph, queryGraph }),
     [],
     [],
+    new Map(),
   );
 }
 
@@ -103,7 +104,7 @@ describe("advanceSimultaneousPathsWithOperation", () => {
     const initial = createOptions(supergraph, queryGraph)[0];
 
     // Then picking `t`, which should be just the one option of picking it in S1 at this point.
-    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"));
+    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"), new Map());
     assert(allAfterT, 'Should have advanced correctly');
     expect(allAfterT).toHaveLength(1);
     const afterT = allAfterT[0];
@@ -117,7 +118,7 @@ describe("advanceSimultaneousPathsWithOperation", () => {
     expect(indirect.paths[0].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ otherId } ⊢ key()]--> T(S2) (types: [T])`);
     expect(indirect.paths[1].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ id } ⊢ key()]--> T(S3) (types: [T])`);
 
-    const allForId = advanceSimultaneousPathsWithOperation(supergraph, afterT, field(api, "T.id"));
+    const allForId = advanceSimultaneousPathsWithOperation(supergraph, afterT, field(api, "T.id"), new Map());
     assert(allForId, 'Should have advanced correctly');
 
     // Here, `id` is a direct path from both of our indirect paths. However, it makes no sense to use the 2nd
@@ -155,7 +156,7 @@ describe("advanceSimultaneousPathsWithOperation", () => {
     const initial = createOptions(supergraph, queryGraph)[0];
 
     // Then picking `t`, which should be just the one option of picking it in S1 at this point.
-    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"));
+    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"), new Map());
     assert(allAfterT, 'Should have advanced correctly');
     expect(allAfterT).toHaveLength(1);
     const afterT = allAfterT[0];
@@ -169,7 +170,7 @@ describe("advanceSimultaneousPathsWithOperation", () => {
     expect(indirect.paths[0].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ otherId } ⊢ key()]--> T(S2) (types: [T])`);
     expect(indirect.paths[1].toString()).toBe(`Query(S1) --[t]--> T(S1) --[{ id1 id2 } ⊢ key()]--> T(S3) (types: [T])`);
 
-    const allForId = advanceSimultaneousPathsWithOperation(supergraph, afterT, field(api, "T.id1"));
+    const allForId = advanceSimultaneousPathsWithOperation(supergraph, afterT, field(api, "T.id1"), new Map());
     assert(allForId, 'Should have advanced correctly');
 
     // Here, `id1` is a direct path from both of our indirect paths. However, it makes no sense to use the 2nd
@@ -201,7 +202,7 @@ describe("advanceSimultaneousPathsWithOperation", () => {
     const initial = createOptions(supergraph, queryGraph)[0];
 
     // Then picking `t`, which should be just the one option of picking it in S1 at this point.
-    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"));
+    const allAfterT = advanceSimultaneousPathsWithOperation(supergraph, initial, field(api, "Query.t"), new Map());
     assert(allAfterT, 'Should have advanced correctly');
     expect(allAfterT).toHaveLength(1);
     const afterT = allAfterT[0];

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -236,7 +236,7 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
    * That method first look for the biggest common prefix to `this` and `that` (assuming that both path are build as choices
    * of the same "query path"), and the count how many subgraph jumps each of the path has after said prefix.
    *
-   * Note that this method always return someting but the biggest common prefix considered might well be empty. 
+   * Note that this method always returns something but the biggest common prefix considered might well be empty.
    *
    * Please note that this method assumes that the 2 paths have the same root, and will fail if that's not the case.
    */
@@ -558,7 +558,8 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
 
   checkDirectPathFromPreviousSubgraphTo(
     typeName: string,
-    triggerToEdge: (graph: QueryGraph, vertex: Vertex, t: TTrigger) => Edge | null | undefined,
+    triggerToEdge: (graph: QueryGraph, vertex: Vertex, t: TTrigger, overrideConditions: Map<string, boolean>) => Edge | null | undefined,
+    overrideConditions: Map<string, boolean>,
     prevSubgraphStartingVertex?: Vertex,
   ): Vertex | undefined {
     const enteringEdge = this.subgraphEnteringEdge;
@@ -580,7 +581,7 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
     let prevSubgraphVertex = prevSubgraphStartingVertex ?? enteringEdge.edge.head;
     for (let i = enteringEdge.index + 1; i < this.size; i++) {
       const triggerToMatch = this.props.edgeTriggers[i];
-      const prevSubgraphMatchingEdge = triggerToEdge(this.graph, prevSubgraphVertex, triggerToMatch);
+      const prevSubgraphMatchingEdge = triggerToEdge(this.graph, prevSubgraphVertex, triggerToMatch, overrideConditions);
       if (prevSubgraphMatchingEdge === null) {
         // This means the trigger doesn't make us move (it's typically an inline fragment with no conditions, just directive), which we can always match.
         continue;
@@ -833,7 +834,7 @@ export function isRootPath(path: OpGraphPath<any>): path is OpRootPath {
   return isRootVertex(path.root);
 }
 
-export function terminateWithNonRequestedTypenameField<V extends Vertex>(path: OpGraphPath<V>): OpGraphPath<V> {
+export function terminateWithNonRequestedTypenameField<V extends Vertex>(path: OpGraphPath<V>, overrideConditions: Map<string, boolean>): OpGraphPath<V> {
   // If the last step of the path was a fragment/type-condition, we want to remove it before we get __typename.
   // The reason is that this avoid cases where this method would make us build plans like:
   // {
@@ -859,7 +860,7 @@ export function terminateWithNonRequestedTypenameField<V extends Vertex>(path: O
     return path;
   }
   const typenameField = new Field(path.tail.type.typenameField()!);
-  const edge = edgeForField(path.graph, path.tail, typenameField);
+  const edge = edgeForField(path.graph, path.tail, typenameField, overrideConditions);
   assert(edge, () => `We should have an edge from ${path.tail} for ${typenameField}`);
   return path.add(typenameField, edge, noConditionsResolution);
 }
@@ -902,7 +903,8 @@ export enum UnadvanceableReason {
   UNRESOLVABLE_INTERFACE_OBJECT,
   NO_MATCHING_TRANSITION,
   UNREACHABLE_TYPE,
-  IGNORED_INDIRECT_PATH
+  IGNORED_INDIRECT_PATH,
+  UNSATISFIABLE_OVERRIDE_CONDITION,
 }
 
 export type Unadvanceable = {
@@ -924,10 +926,14 @@ export function isUnadvanceable(result: any[] | Unadvanceables): result is Unadv
   return result instanceof Unadvanceables;
 }
 
-function pathTransitionToEdge(graph: QueryGraph, vertex: Vertex, transition: Transition): Edge | null | undefined {
+function pathTransitionToEdge(graph: QueryGraph, vertex: Vertex, transition: Transition, overrideConditions: Map<string, boolean>): Edge | null | undefined {
   for (const edge of graph.outEdges(vertex)) {
     // The edge must match the transition.
-    if (edge.matchesSupergraphTransition(transition)) {
+    if (!edge.matchesSupergraphTransition(transition)) {
+      continue;
+    }
+
+    if (edge.satisfiesOverrideConditions(overrideConditions)) {
       return edge;
     }
   }
@@ -953,14 +959,16 @@ export class TransitionPathWithLazyIndirectPaths<V extends Vertex = Vertex> {
   constructor(
     readonly path: GraphPath<Transition, V>,
     readonly conditionResolver: ConditionResolver,
+    readonly overrideConditions: Map<string, boolean>,
   ) {
   }
 
   static initial<V extends Vertex = Vertex>(
     initialPath: GraphPath<Transition, V>,
     conditionResolver: ConditionResolver,
+    overrideConditions: Map<string, boolean>,
   ): TransitionPathWithLazyIndirectPaths<V> {
-    return new TransitionPathWithLazyIndirectPaths(initialPath, conditionResolver);
+    return new TransitionPathWithLazyIndirectPaths(initialPath, conditionResolver, overrideConditions);
   }
 
   indirectOptions(): IndirectPaths<Transition, V> {
@@ -979,6 +987,7 @@ export class TransitionPathWithLazyIndirectPaths<V extends Vertex = Vertex> {
       [],
       (t) => t,
       pathTransitionToEdge,
+      this.overrideConditions,
     );
   }
 
@@ -998,6 +1007,7 @@ export function advancePathWithTransition<V extends Vertex>(
   subgraphPath: TransitionPathWithLazyIndirectPaths<V>,
   transition: Transition,
   targetType: NamedType,
+  overrideConditions: Map<string, boolean>,
 ) : TransitionPathWithLazyIndirectPaths<V>[] | Unadvanceables {
   // The `transition` comes from the supergraph. Now, it is possible that a transition can be expressed on the supergraph, but correspond
   // to an 'unsatisfiable' condition on the subgraph. Let's consider:
@@ -1074,7 +1084,12 @@ export function advancePathWithTransition<V extends Vertex>(
 
   debug.group(() => `Trying to advance ${subgraphPath} for ${transition}`);
   debug.group('Direct options:');
-  const directOptions = advancePathWithDirectTransition(subgraphPath.path, transition, subgraphPath.conditionResolver);
+  const directOptions = advancePathWithDirectTransition(
+    subgraphPath.path,
+    transition,
+    subgraphPath.conditionResolver,
+    overrideConditions,
+  );
   let options: GraphPath<Transition, V>[];
   const deadEnds: Unadvanceable[] = [];
   if (isUnadvanceable(directOptions)) {
@@ -1087,7 +1102,7 @@ export function advancePathWithTransition<V extends Vertex>(
     // no point in computing all the options.
     if (directOptions.length > 0 && isLeafType(targetType)) {
       debug.groupEnd(() => `reached leaf type ${targetType} so not trying indirect paths`);
-      return createLazyTransitionOptions(directOptions, subgraphPath);
+      return createLazyTransitionOptions(directOptions, subgraphPath, overrideConditions);
     }
     options = directOptions;
   }
@@ -1099,7 +1114,12 @@ export function advancePathWithTransition<V extends Vertex>(
     debug.group('Validating indirect options:');
     for (const nonCollectingPath of pathsWithNonCollecting.paths) {
       debug.group(() => `For indirect path ${nonCollectingPath}:`);
-      const pathsWithTransition = advancePathWithDirectTransition(nonCollectingPath, transition, subgraphPath.conditionResolver);
+      const pathsWithTransition = advancePathWithDirectTransition(
+        nonCollectingPath,
+        transition,
+        subgraphPath.conditionResolver,
+        overrideConditions,
+      );
       if (isUnadvanceable(pathsWithTransition)) {
         debug.groupEnd(() => `Cannot be advanced with ${transition}`);
         deadEnds.push(...pathsWithTransition.reasons);
@@ -1114,7 +1134,7 @@ export function advancePathWithTransition<V extends Vertex>(
   }
   debug.groupEnd(() => options.length > 0 ? advanceOptionsToString(options) : `Cannot advance ${transition} for this path`);
   if (options.length > 0) {
-    return createLazyTransitionOptions(options, subgraphPath);
+    return createLazyTransitionOptions(options, subgraphPath, overrideConditions);
   }
 
   const allDeadEnds = deadEnds.concat(pathsWithNonCollecting.deadEnds.reasons);
@@ -1174,10 +1194,12 @@ export function advancePathWithTransition<V extends Vertex>(
 function createLazyTransitionOptions<V extends Vertex>(
   options: GraphPath<Transition, V>[],
   origin: TransitionPathWithLazyIndirectPaths<V>,
+  overrideConditions: Map<string, boolean>,
 ) : TransitionPathWithLazyIndirectPaths<V>[] {
   return options.map(option => new TransitionPathWithLazyIndirectPaths(
     option,
     origin.conditionResolver,
+    overrideConditions,
   ));
 }
 
@@ -1246,7 +1268,8 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
   excludedDestinations: ExcludedDestinations,
   excludedConditions: ExcludedConditions,
   convertTransitionWithCondition: (transition: Transition, context: PathContext) => TTrigger,
-  triggerToEdge: (graph: QueryGraph, vertex: Vertex, t: TTrigger) => Edge | null | undefined
+  triggerToEdge: (graph: QueryGraph, vertex: Vertex, t: TTrigger, overrideConditions: Map<string, boolean>) => Edge | null | undefined,
+  overrideConditions: Map<string, boolean>,
 ): IndirectPaths<TTrigger, V, TNullEdge, TDeadEnds>  {
   // If we're asked for indirect paths after an "@interfaceObject fake down cast" but that down cast comes just after a non-collecting edges, then
   // we can ignore it (skip indirect paths from there). The reason is that the presence of the non-collecting just before the fake down-cast means
@@ -1418,7 +1441,7 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
           } else {
             backToPreviousSubgraph = subgraphEnteringEdge.edge.head.source === edge.tail.source;
           }
-          const prevSubgraphVertex = toAdvance.checkDirectPathFromPreviousSubgraphTo(edge.tail.type.name, triggerToEdge, prevSubgraphEnteringVertex);
+          const prevSubgraphVertex = toAdvance.checkDirectPathFromPreviousSubgraphTo(edge.tail.type.name, triggerToEdge, overrideConditions, prevSubgraphEnteringVertex);
           const maxCost = toAdvance.subgraphEnteringEdge.cost + (backToPreviousSubgraph ? 0 : conditionResolution.cost);
           if (prevSubgraphVertex
             && (
@@ -1461,7 +1484,7 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
         // edges ('QueryResolution' and 'SubgraphEnteringTransition') however, chaining never give us additional value.
         // Note: one exception is the case of self-edges (which stay on the same vertex/subgraph): those will only be
         // looked at just after a @defer to handle potentially re-entering the same subgraph. When we take this, no point in
-        // looking for chaining since we'll independentely check the other edges already.
+        // looking for chaining since we'll independently check the other edges already.
         if (edge.transition.kind === 'KeyResolution' && edge.head.source !== edge.tail.source) {
           toTry.push(updatedPath);
         }
@@ -1536,7 +1559,8 @@ function hasValidDirectKeyEdge(
 function advancePathWithDirectTransition<V extends Vertex>(
   path: GraphPath<Transition, V>,
   transition: Transition,
-  conditionResolver: ConditionResolver
+  conditionResolver: ConditionResolver,
+  overrideConditions: Map<string, boolean>,
 ) : GraphPath<Transition, V>[] | Unadvanceables {
   assert(transition.collectOperationElements, "Supergraphs shouldn't have transitions that don't collect elements");
 
@@ -1555,6 +1579,7 @@ function advancePathWithDirectTransition<V extends Vertex>(
       path,
       new DownCast(path.tail.type, transition.definition.parent),
       conditionResolver,
+      overrideConditions,
     );
     // The case we described above should be the only case we capture here, and so the current
     // subgraph must have the implementation type (it may not have the field we want, but it
@@ -1572,6 +1597,19 @@ function advancePathWithDirectTransition<V extends Vertex>(
   for (const edge of path.nextEdges()) {
     // The edge must match the transition. If it doesn't, we cannot use it.
     if (!edge.matchesSupergraphTransition(transition)) {
+      continue;
+    }
+
+    if (
+      edge.overrideCondition
+      && !edge.satisfiesOverrideConditions(overrideConditions)
+    ) {
+      deadEnds.push({
+        destSubgraph: edge.tail.source,
+        sourceSubgraph: edge.head.source,
+        reason: UnadvanceableReason.UNSATISFIABLE_OVERRIDE_CONDITION,
+        details: `Unable to take edge ${edge.toString()} because override condition "${edge.overrideCondition.label}" is ${overrideConditions.get(edge.overrideCondition.label)}`,
+      });
       continue;
     }
 
@@ -1813,6 +1851,7 @@ export class SimultaneousPathsWithLazyIndirectPaths<V extends Vertex = Vertex> {
     readonly conditionResolver: ConditionResolver,
     readonly excludedNonCollectingEdges: ExcludedDestinations = [],
     readonly excludedConditionsOnNonCollectingEdges: ExcludedConditions = [],
+    readonly overrideConditions: Map<string, boolean>,
   ) {
     this.lazilyComputedIndirectPaths = new Array(paths.length);
   }
@@ -1841,7 +1880,8 @@ export class SimultaneousPathsWithLazyIndirectPaths<V extends Vertex = Vertex> {
       // the transitions taken by this function are non collecting transitions, and we ship the context as trigger (a slight hack admittedly,
       // but as we'll need the context handy for keys ...).
       (_t, context) => context,
-      opPathTriggerToEdge
+      opPathTriggerToEdge,
+      this.overrideConditions,
     );
   }
 
@@ -1916,6 +1956,7 @@ export function advanceSimultaneousPathsWithOperation<V extends Vertex>(
   supergraphSchema: Schema,
   subgraphSimultaneousPaths: SimultaneousPathsWithLazyIndirectPaths<V>,
   operation: OperationElement,
+  overrideConditions: Map<string, boolean>,
 ) : SimultaneousPathsWithLazyIndirectPaths<V>[] | undefined {
   debug.group(() => `Trying to advance ${simultaneousPathsToString(subgraphSimultaneousPaths)} for ${operation}`);
   const updatedContext = subgraphSimultaneousPaths.context.withContextOf(operation);
@@ -1934,7 +1975,8 @@ export function advanceSimultaneousPathsWithOperation<V extends Vertex>(
         path,
         operation,
         updatedContext,
-        subgraphSimultaneousPaths.conditionResolver
+        subgraphSimultaneousPaths.conditionResolver,
+        overrideConditions,
       );
       options = advanceOptions;
       debug.groupEnd(() => advanceOptionsToString(options));
@@ -1980,7 +2022,8 @@ export function advanceSimultaneousPathsWithOperation<V extends Vertex>(
             pathWithNonCollecting,
             operation,
             updatedContext,
-            subgraphSimultaneousPaths.conditionResolver
+            subgraphSimultaneousPaths.conditionResolver,
+            overrideConditions,
           );
           // If we can't advance the operation after that path, ignore it, it's just not an option.
           if (!pathWithOperation) {
@@ -2038,7 +2081,8 @@ export function advanceSimultaneousPathsWithOperation<V extends Vertex>(
         path,
         operation,
         updatedContext,
-        subgraphSimultaneousPaths.conditionResolver
+        subgraphSimultaneousPaths.conditionResolver,
+        overrideConditions,
       );
       options = advanceOptions ?? [];
       debug.groupEnd(() => advanceOptionsToString(options));
@@ -2057,7 +2101,12 @@ export function advanceSimultaneousPathsWithOperation<V extends Vertex>(
 
   const allOptions: SimultaneousPaths<V>[] = flatCartesianProduct(optionsForEachPath);
   debug.groupEnd(() => advanceOptionsToString(allOptions));
-  return createLazyOptions(allOptions, subgraphSimultaneousPaths, updatedContext);
+  return createLazyOptions(
+    allOptions,
+    subgraphSimultaneousPaths,
+    updatedContext,
+    subgraphSimultaneousPaths.overrideConditions,
+  );
 }
 
 
@@ -2067,17 +2116,19 @@ export function createInitialOptions<V extends Vertex>(
   conditionResolver: ConditionResolver,
   excludedEdges: ExcludedDestinations,
   excludedConditions: ExcludedConditions,
+  overrideConditions: Map<string, boolean>,
 ): SimultaneousPathsWithLazyIndirectPaths<V>[] {
   const lazyInitialPath = new SimultaneousPathsWithLazyIndirectPaths(
     [initialPath],
     initialContext,
     conditionResolver,
     excludedEdges,
-    excludedConditions
+    excludedConditions,
+    overrideConditions,
   );
   if (isFederatedGraphRootType(initialPath.tail.type)) {
     const initialOptions = lazyInitialPath.indirectOptions(initialContext, 0);
-    return createLazyOptions(initialOptions.paths.map(p => [p]), lazyInitialPath, initialContext);
+    return createLazyOptions(initialOptions.paths.map(p => [p]), lazyInitialPath, initialContext, overrideConditions);
   } else {
     return [lazyInitialPath];
   }
@@ -2086,23 +2137,25 @@ export function createInitialOptions<V extends Vertex>(
 function createLazyOptions<V extends Vertex>(
   options: SimultaneousPaths<V>[],
   origin: SimultaneousPathsWithLazyIndirectPaths<V>,
-  context: PathContext
+  context: PathContext,
+  overrideConditions: Map<string, boolean>,
 ) : SimultaneousPathsWithLazyIndirectPaths<V>[] {
   return options.map(option => new SimultaneousPathsWithLazyIndirectPaths(
     option,
     context,
     origin.conditionResolver,
     origin.excludedNonCollectingEdges,
-    origin.excludedConditionsOnNonCollectingEdges
+    origin.excludedConditionsOnNonCollectingEdges,
+    overrideConditions,
   ));
 }
 
-function opPathTriggerToEdge(graph: QueryGraph, vertex: Vertex, trigger: OpTrigger): Edge | null | undefined {
+function opPathTriggerToEdge(graph: QueryGraph, vertex: Vertex, trigger: OpTrigger, overrideConditions: Map<string, boolean>): Edge | null | undefined {
   if (trigger instanceof PathContext) {
     return undefined;
   }
   if (trigger.kind === 'Field') {
-    return edgeForField(graph, vertex, trigger);
+    return edgeForField(graph, vertex, trigger, overrideConditions);
   } else {
     return trigger.typeCondition ? edgeForTypeCast(graph, vertex, trigger.typeCondition.name) : null;
   }
@@ -2296,6 +2349,7 @@ function advanceWithOperation<V extends Vertex>(
   operation: OperationElement,
   context: PathContext,
   conditionResolver: ConditionResolver,
+  overrideConditions: Map<string, boolean>,
 ) : {
   options: SimultaneousPaths<V>[] | undefined,
   hasOnlyTypeExplodedResults?: boolean,
@@ -2314,7 +2368,7 @@ function advanceWithOperation<V extends Vertex>(
     switch (currentType.kind) {
       case 'ObjectType':
         // Just take the edge corresponding to the field, if it exists and can be used.
-        const edge = nextEdgeForField(path, operation);
+        const edge = nextEdgeForField(path, operation, overrideConditions);
         if (!edge) {
           debug.groupEnd(() => `No edge for field ${field} on object type ${currentType}`);
           return { options: undefined };
@@ -2324,7 +2378,7 @@ function advanceWithOperation<V extends Vertex>(
         // is a field of an implementation of the interface. Because we found an edge, we
         // know that the interface has the field and we can use the edge, but we should redact
         // the `operation` to use the current type field, so the operation does not continue
-        // refering to a type that is not in the current subgraph.
+        // referring to a type that is not in the current subgraph.
         if (path.tailIsInterfaceObject() && field.parent.name !== currentType.name) {
           const fieldOnCurrentType = currentType.field(field.name);
           assert(fieldOnCurrentType, () => `We should not have found edge ${edge} for ${field} from ${path}`)
@@ -2355,7 +2409,7 @@ function advanceWithOperation<V extends Vertex>(
         // - either type-exploding cannot work unless taking the interface edge also do (the `anImplementationIsEntityWithFieldShareable`)
         // - or that type-exploding cannot be more efficient than the direct path (when no @provides are involved; if a provide is involved
         //   in one of the implementation, then type-exploding may lead to a shorter overall plan thanks to that @provides)
-        const itfEdge = fieldIsOfAnImplementation ? undefined : nextEdgeForField(path, operation);
+        const itfEdge = fieldIsOfAnImplementation ? undefined : nextEdgeForField(path, operation, overrideConditions);
         let itfPath: OpGraphPath<V> | undefined = undefined;
         let directPathOverrideTypeExplosion = false;
         if (itfEdge) {
@@ -2387,8 +2441,8 @@ function advanceWithOperation<V extends Vertex>(
         // There is 2 main cases to handle here:
         // - the most common is that it's a field of the interface that is queried, and
         //   so we should type-explode because either didn't had a direct edge, or @provides
-        //   makes it potentially worthwile to check with type explosion.
-        // - but, as mentionned earlier, we could be in the case where the field queried is actually of one
+        //   makes it potentially worthwhile to check with type explosion.
+        // - but, as mentioned earlier, we could be in the case where the field queried is actually of one
         //   of the implementation of the interface. In that case, we only want to consider that one
         //   implementation.
         let implementations: readonly ObjectType[];
@@ -2415,8 +2469,9 @@ function advanceWithOperation<V extends Vertex>(
           debug.group(() => `Handling implementation ${implemType}`);
           const implemOptions = advanceSimultaneousPathsWithOperation(
             supergraphSchema,
-            new SimultaneousPathsWithLazyIndirectPaths([path], context, conditionResolver),
-            castOp
+            new SimultaneousPathsWithLazyIndirectPaths([path], context, conditionResolver, [], [], overrideConditions),
+            castOp,
+            overrideConditions,
           );
           // If we find no option for that implementation, we bail (as we need to simultaneously advance all implementations).
           if (!implemOptions) {
@@ -2438,7 +2493,8 @@ function advanceWithOperation<V extends Vertex>(
             const withFieldOptions = advanceSimultaneousPathsWithOperation(
               supergraphSchema,
               optPaths,
-              operation
+              operation,
+              overrideConditions,
             );
             if (!withFieldOptions) {
               debug.groupEnd(() => `Cannot collect ${field}`);
@@ -2469,7 +2525,7 @@ function advanceWithOperation<V extends Vertex>(
         return { options: allOptions, hasOnlyTypeExplodedResults: !itfPath };
       case 'UnionType':
         assert(field.name === typenameFieldName, () => `Invalid field selection ${operation} for union type ${currentType}`);
-        const typenameEdge = nextEdgeForField(path, operation);
+        const typenameEdge = nextEdgeForField(path, operation, overrideConditions);
         assert(typenameEdge, `Should always have an edge for __typename edge on an union`);
         debug.groupEnd(() => `Trivial collection of __typename for union ${currentType}`);
         return { options: pathAsOptions(addFieldEdge(path, operation, typenameEdge, conditionResolver, context)) };
@@ -2512,8 +2568,9 @@ function advanceWithOperation<V extends Vertex>(
           const castOp = new FragmentElement(currentType, tName, operation.appliedDirectives);
           const implemOptions = advanceSimultaneousPathsWithOperation(
             supergraphSchema,
-            new SimultaneousPathsWithLazyIndirectPaths([path], context, conditionResolver),
+            new SimultaneousPathsWithLazyIndirectPaths([path], context, conditionResolver, [], [], overrideConditions),
             castOp,
+            overrideConditions,
           );
           if (!implemOptions) {
             debug.groupEnd();
@@ -2600,17 +2657,24 @@ function pathAsOptions<V extends Vertex>(path: OpGraphPath<V> | undefined): Simu
 
 function nextEdgeForField<V extends Vertex>(
   path: OpGraphPath<V>,
-  field: Field<any>
+  field: Field<any>,
+  overrideConditions: Map<string, boolean>
 ): Edge | undefined {
-  return edgeForField(path.graph, path.tail, field);
+  return edgeForField(path.graph, path.tail, field, overrideConditions);
 }
 
 function edgeForField(
   graph: QueryGraph,
   vertex: Vertex,
-  field: Field<any>
+  field: Field<any>,
+  overrideConditions: Map<string, boolean>
 ): Edge | undefined {
-  const candidates = graph.outEdges(vertex).filter(e => e.transition.kind === 'FieldCollection' && field.selects(e.transition.definition, true));
+  const candidates = graph.outEdges(vertex)
+    .filter(e =>
+      e.transition.kind === 'FieldCollection'
+      && field.selects(e.transition.definition, true)
+      && e.satisfiesOverrideConditions(overrideConditions)
+  );
   assert(candidates.length <= 1, () => `Vertex ${vertex} has multiple edges matching ${field} (${candidates})`);
   return candidates.length === 0 ? undefined : candidates[0];
 }

--- a/query-planner-js/src/__tests__/buildPlan.override.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.override.test.ts
@@ -1,0 +1,488 @@
+import { operationFromDocument } from '@apollo/federation-internals';
+import gql from 'graphql-tag';
+import { composeAndCreatePlanner } from './testHelper';
+
+describe('override with label (progressive)', () => {
+  describe('root fields', () => {
+    const subgraph1 = {
+      name: 's1',
+      typeDefs: gql`
+        type Query {
+          hello: String
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: 's2',
+      typeDefs: gql`
+        type Query {
+          hello: String @override(from: "s1", label: "test")
+        }
+      `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+    const operation = operationFromDocument(
+      api,
+      gql`
+        {
+          hello
+        }
+      `,
+    );
+
+    it('overrides when the label is provided', () => {
+      const overriddenPlan = queryPlanner.buildQueryPlan(operation, {
+        overrideConditions: new Map([['test', true]]),
+      });
+      expect(overriddenPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Fetch(service: "s2") {
+            {
+              hello
+            }
+          },
+        }
+      `);
+    });
+
+    it('does not override when the label is not provided', () => {
+      const nonOverriddenPlan = queryPlanner.buildQueryPlan(operation, {
+        overrideConditions: new Map([['test', false]]),
+      });
+      expect(nonOverriddenPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Fetch(service: "s1") {
+            {
+              hello
+            }
+          },
+        }
+      `);
+    });
+  });
+
+  describe('entity fields', () => {
+    const subgraph1 = {
+      name: 'S1',
+      typeDefs: gql`
+        type Query {
+          t: T
+          t2: T2
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          f1: String
+        }
+
+        type T2 @key(fields: "id") {
+          id: ID!
+          f1: String @override(from: "S2", label: "test2")
+          t: T
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: 'S2',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          f1: String @override(from: "S1", label: "test")
+          f2: String
+        }
+
+        type T2 @key(fields: "id") {
+          id: ID!
+          f1: String
+          f2: String
+        }
+      `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+
+    describe('simple example', () => {
+      const operation = operationFromDocument(
+        api,
+        gql`
+          {
+            t {
+              f1
+              f2
+            }
+          }
+        `,
+      );
+
+      it('overrides when the label is provided', () => {
+        const overriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', true]]),
+        });
+        expect(overriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Sequence {
+              Fetch(service: "S1") {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "S2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      f1
+                      f2
+                    }
+                  }
+                },
+              },
+            },
+          }
+        `);
+      });
+
+      it('does not override when the label is omitted', () => {
+        const nonOverriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', false]]),
+        });
+        expect(nonOverriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Sequence {
+              Fetch(service: "S1") {
+                {
+                  t {
+                    __typename
+                    id
+                    f1
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "S2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      f2
+                    }
+                  }
+                },
+              },
+            },
+          }
+        `);
+      });
+    });
+
+    describe('nested example', () => {
+      const operation = operationFromDocument(
+        api,
+        gql`
+          {
+            t2 {
+              t {
+                f1
+              }
+            }
+          }
+        `,
+      );
+
+      it('overrides when the label is provided', () => {
+        const overriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', true]]),
+        });
+        expect(overriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Sequence {
+              Fetch(service: "S1") {
+                {
+                  t2 {
+                    t {
+                      __typename
+                      id
+                    }
+                  }
+                }
+              },
+              Flatten(path: "t2.t") {
+                Fetch(service: "S2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      f1
+                    }
+                  }
+                },
+              },
+            },
+          }
+        `);
+      });
+
+      it(`doesn't override when the label is omitted`, () => {
+        const nonOverriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', false]]),
+        });
+        expect(nonOverriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Fetch(service: "S1") {
+              {
+                t2 {
+                  t {
+                    f1
+                  }
+                }
+              }
+            },
+          }
+        `);
+      });
+    });
+  });
+
+  describe('@shareable interaction', () => {
+    const subgraph1 = {
+      name: 'S1',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          f1: String @shareable
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: 'S2',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          f1: String @shareable @override(from: "S1", label: "test")
+          f2: String
+        }
+      `,
+    };
+
+    const subgraph3 = {
+      name: 'S3',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          f1: String @shareable
+          f3: String
+        }
+      `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlanner(
+      subgraph1,
+      subgraph2,
+      subgraph3,
+    );
+
+    describe(`through S2's T.f1`, () => {
+      const operation = operationFromDocument(
+        api,
+        gql`
+          {
+            t {
+              f1
+              f2
+            }
+          }
+        `,
+      );
+
+      it('overrides T.f1 resolution to S2 when the label is provided', () => {
+        const overriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', true]]),
+        });
+        expect(overriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Sequence {
+              Fetch(service: "S1") {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "S2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      f2
+                      f1
+                    }
+                  }
+                },
+              },
+            },
+          }
+        `);
+      });
+
+      it('preserves T.f1 resolution in S1 when the label is omitted', () => {
+        const nonOverriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', false]]),
+        });
+        expect(nonOverriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Sequence {
+              Fetch(service: "S1") {
+                {
+                  t {
+                    __typename
+                    id
+                    f1
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "S2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      f2
+                    }
+                  }
+                },
+              },
+            },
+          }
+        `);
+      });
+    });
+
+    // This is very similar to the S2 example. The fact that the @override in S2
+    // specifies _from_ S1 actually affects all T.f1 fields the same way (except
+    // S1). That is to say, it's functionally equivalent to have the `@override`
+    // exist in either S2 or S3 from S2/S3/Sn's perspective. It's helpful to
+    // test here that the QP will take a path through _either_ S2 or S3 when
+    // appropriate to do so. In these tests and the previous S2 tests,
+    // "appropriate" is determined by the other fields being selected in the
+    // query.
+    describe(`through S3's T.f1`, () => {
+      const operation = operationFromDocument(
+        api,
+        gql`
+          {
+            t {
+              f1
+              f3
+            }
+          }
+        `,
+      );
+
+      it('overrides T.f1 resolution to S3 when the label is provided', () => {
+        const overriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', true]]),
+        });
+        expect(overriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Sequence {
+              Fetch(service: "S1") {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "S3") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      f3
+                      f1
+                    }
+                  }
+                },
+              },
+            },
+          }
+        `);
+      });
+
+      it('preserves T.f1 resolution in S1 when the label is omitted', () => {
+        const nonOverriddenPlan = queryPlanner.buildQueryPlan(operation, {
+          overrideConditions: new Map([['test', false]]),
+        });
+        expect(nonOverriddenPlan).toMatchInlineSnapshot(`
+          QueryPlan {
+            Sequence {
+              Fetch(service: "S1") {
+                {
+                  t {
+                    __typename
+                    id
+                    f1
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "S3") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      f3
+                    }
+                  }
+                },
+              },
+            },
+          }
+        `);
+      });
+    });
+  });
+});

--- a/subgraph-js/src/directives.ts
+++ b/subgraph-js/src/directives.ts
@@ -135,6 +135,9 @@ export const OverrideDirective = new GraphQLDirective({
     from: {
       type: new GraphQLNonNull(GraphQLString),
     },
+    label: {
+      type: GraphQLString,
+    }
   },
 });
 


### PR DESCRIPTION
Add new optional `label` arg to `@override` which is a `String`. Capture label in the supergraph via the new `@join__field` arg `overrideLabel` so these values can be used during query graph creation and query planning.

Reviewed in two separate PRs:
#2879
#2902