### PR TITLE
docs: Use `--output` rather than redirection

### DIFF
--- a/docs/source/quickstart/local-composition.mdx
+++ b/docs/source/quickstart/local-composition.mdx
@@ -191,10 +191,10 @@ type SubmitReviewResponse
 
 As you can see, this composed schema includes all of the types and fields from our subgraph schemas, along with many additional directives that the router uses to route incoming operations.
 
-Now, append ` > supergraph.graphql` to the above command to write the composed schema to a file:
+Now, append ` --output supergraph.graphql` to the above command to write the composed schema to a file:
 
 ```shell
-rover supergraph compose --config ./supergraph-config.yaml > supergraph.graphql
+rover supergraph compose --config ./supergraph-config.yaml --output supergraph.graphql
 ```
 
 ## 3. Provide the composed schema to the router


### PR DESCRIPTION
This updates the suggestion in the Getting Started guide to use `--output` rather than simple redirection.  While the previous technique redirection does work on Unix, its use on Windows resulted in incorrect file encoding in some cases.

Using `--output` results in a consistent recommendation on all operating systems and also matches documentation [elsewhere], too.

[elsewhere]: https://www.apollographql.com/docs/rover/conventions/#output-to-a-file
