### PR TITLE
Add test / documentation around `SchemaUpgrader` behavior

### DIFF
--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -1,4 +1,4 @@
-import { FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS } from '..';
+import { FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS, printSchema } from '..';
 import { ObjectType } from '../definitions';
 import { buildSubgraph, Subgraphs } from '../federation';
 import { UpgradeChangeID, UpgradeResult, upgradeSubgraphsIfNecessary } from '../schemaUpgrader';
@@ -285,3 +285,44 @@ test('handles the addition of @shareable when an @external is used on a type', (
   expect((s1Upgraded.schema.type('T') as ObjectType).field('x')?.hasAppliedDirective('shareable')).toBe(true);
 
 })
+
+test("fully upgrades a schema with no @link directive", () => {
+  const subgraph = buildSubgraph(
+    "subgraph",
+    "",
+    `#graphql
+    type Query {
+      hello: String
+    }
+  `
+  );
+
+  const subgraphs = new Subgraphs();
+  subgraphs.add(subgraph);
+  const result = upgradeSubgraphsIfNecessary(subgraphs);
+  // Note: this test mostly exists for dev awareness. By design, this will
+  // always require updating when the fed spec version is updated, so hopefully
+  // you're reading this comment. Existing schemas which don't include a @link
+  // directive usage will be upgraded to the latest version of the federation
+  // spec. The downstream effect of this auto-upgrading behavior is:
+  //
+  // GraphOS users who select the new build track you're going to introduce will
+  // immediately start composing with the latest specs without having to update
+  // their @link federation spec version in any of their subgraphs. For this to
+  // be ok, they need to first update to a router version which supports
+  // whatever changes you've introduced in the new spec version. Take care to
+  // ensure that things are released in the correct order.
+  //
+  // Ideally, in the future we ensure that GraphOS users are on a version of
+  // router that supports the build pipeline they're upgrading to, but that
+  // mechanism isn't in place yet.
+  // - Trevor
+  expect(printSchema(result.subgraphs!.get("subgraph")!.schema!)).toContain(
+`schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"])
+{
+  query: Query
+}
+  `);
+});

--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -323,6 +323,6 @@ test("fully upgrades a schema with no @link directive", () => {
   @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"])
 {
   query: Query
-}
-  `);
+}`
+  );
 });


### PR DESCRIPTION
The release of 2.7 and more specifically `join/v0.4` has been troublesome for multiple reasons. One assumption I made that hasn't helped the situation is that at least one subgraph would have to explicitly opt-in to fed 2.7 by updating the version in their federation `@link` directive.

Unfortunately, the schema upgrader upgrades subgraphs to the latest federation spec version by default (when the subgraph is identified as a non-fed2 subgraph, i.e. no `@link` federation spec is provided).

The test added here demonstrates this behavior, but mostly serves as a required touchpoint for upgrading the federation spec version with some documentation describing the behavior and why it might cause challenges.