### PR TITLE
Test file that triggers module import order problems.

### DIFF
--- a/internals-js/src/specs/__tests__/sourceSpec.test.ts
+++ b/internals-js/src/specs/__tests__/sourceSpec.test.ts
@@ -1,0 +1,7 @@
+import { sourceIdentity } from '../sourceSpec';
+
+describe('SourceSpecDefinition', () => {
+  it('should export expected identity URL', () => {
+    expect(sourceIdentity).toBe('https://specs.apollo.dev/source');
+  });
+});


### PR DESCRIPTION
While attempting to write new tests in the `internals-js/src/specs/__tests__/` directory, I found some circularities in the import structure of the `FeatureDefinition` subclasses, triggered by importing a different entry point module than usual.

See for example [this CI run](https://app.circleci.com/pipelines/github/apollographql/federation/13729/workflows/66c0d835-a3b8-4bc0-9277-66db1d4d0f3f/jobs/90547) which fails with the following error:
```ts
 FAIL  internals-js/src/specs/__tests__/sourceSpec.test.ts
  ● Test suite failed to run

    TypeError: Class extends value undefined is not a constructor or null

      35 | export const inaccessibleIdentity = 'https://specs.apollo.dev/inaccessible';
      36 |
    > 37 | export class InaccessibleSpecDefinition extends FeatureDefinition {
         |                                                 ^
      38 |   public readonly inaccessibleLocations: DirectiveLocation[];
      39 |   public readonly inaccessibleDirectiveSpec: DirectiveSpecification;
      40 |   private readonly printedInaccessibleDefinition: string;

      at Object.<anonymous> (src/specs/inaccessibleSpec.ts:37:49)
      at Object.<anonymous> (src/definitions.ts:45:1)
      at Object.<anonymous> (src/specs/coreSpec.ts:3:1)
      at Object.<anonymous> (src/specs/sourceSpec.ts:2:1)
      at Object.<anonymous> (src/specs/__tests__/sourceSpec.test.ts:1:1)
```
If you examine that stack trace, the crux of the problem is the `inaccessibleSpec.ts` module attempts to import `FeatureDefinition` from `coreSpec.ts` while the `coreSpec.ts` module is still being evaluated, so `FeatureDefinition` has not been exported yet from `coreSpec.ts` at the moment `InaccessibleSpecDefinition` tries to extend it.

I'll be the first to argue import cycles are not necessarily evil in JavaScript (ES2015+), but cycles do potentially lead to different module load order depending on which module you import first, and the `internals-js/specs/*Spec.ts` code is especially sensitive to load order because of synchronous use of imports like `FeatureDefinition` in module scope.

There are some tricks for getting `extends FeatureDefinition` not to complain if `FeatureDefinition` is undefined (until the first instance of the subclass is created), but, based on some light internet research, a more robust solution (for my money) is to fix the load order among the sensitive files using a "barrel" `specs/index.ts` module, and then make sure other code only imports from that `specs/index.ts` module, rather than importing from individual `internals-js/specs/*Spec.ts` modules. Here's [a good writeup](https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de) of this approach.

I'll be pushing commits incrementally so you can see the errors before/after I fix them.