### PR TITLE
Improve validation of `URLPathTemplate` and `JSONSelection` strings passed to `@source{Type,Field}` directives

### DIFF
--- a/.cspell/cspell-dict.txt
+++ b/.cspell/cspell-dict.txt
@@ -61,6 +61,7 @@ Didnt
 diretive
 doesn
 Dont
+ebnf
 effecient
 elimiate
 elts

--- a/internals-js/package.json
+++ b/internals-js/package.json
@@ -23,9 +23,10 @@
     "node": ">=14.15.0"
   },
   "dependencies": {
-    "chalk": "^4.1.0",
-    "js-levenshtein": "^1.1.6",
     "@types/uuid": "^9.0.0",
+    "chalk": "^4.1.0",
+    "ebnf": "^1.9.1",
+    "js-levenshtein": "^1.1.6",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/internals-js/src/specs/__tests__/sourceSpec.test.ts
+++ b/internals-js/src/specs/__tests__/sourceSpec.test.ts
@@ -1,7 +1,121 @@
-import { sourceIdentity } from '../index';
+import {
+  sourceIdentity,
+  parseURLPathTemplate,
+  getURLPathTemplateVars,
+} from '../index';
 
 describe('SourceSpecDefinition', () => {
   it('should export expected identity URL', () => {
     expect(sourceIdentity).toBe('https://specs.apollo.dev/source');
+  });
+});
+
+describe('parseURLPathTemplate', () => {
+  it('allows an empty path', () => {
+    const ast = parseURLPathTemplate('/');
+    expect(ast.errors).toEqual([]);
+    expect(getURLPathTemplateVars(ast)).toEqual({});
+  });
+
+  it('allows query params only', () => {
+    const ast = parseURLPathTemplate('/?param={param}&other={other}');
+    expect(ast.errors).toEqual([]);
+    const vars = getURLPathTemplateVars(ast);
+    expect(Object.keys(vars).sort()).toEqual([
+      'other',
+      'param',
+    ]);
+  });
+
+  it('allows empty query parameters after a /?', () => {
+    const ast = parseURLPathTemplate('/?');
+    expect(ast.errors).toEqual([]);
+    expect(getURLPathTemplateVars(ast)).toEqual({});
+  });
+
+  it('allows valueless keys in query parameters', () => {
+    const ast = parseURLPathTemplate('/?a&b=&c&d=&e');
+    expect(ast.errors).toEqual([]);
+    const vars = getURLPathTemplateVars(ast);
+    expect(Object.keys(vars).sort()).toEqual([]);
+  });
+
+  it.each([
+    '/users/{userId}/posts/{postId}',
+    '/users/{userId}/posts/{postId}/',
+    '/users/{userId}/posts/{postId}/junk',
+  ] as const)('parses path-only templates with variables: %s', pathTemplate => {
+    const ast = parseURLPathTemplate(pathTemplate);
+    expect(ast.errors).toEqual([]);
+    const vars = getURLPathTemplateVars(ast);
+    expect(Object.keys(vars).sort()).toEqual([
+      'postId',
+      'userId',
+    ]);
+  });
+
+  it.each([
+    '/users/{user.id}/posts/{post.id}',
+    '/users/{user.id}/posts/{post.id}/',
+    '/users/{user.id}/posts/{post.id}/junk',
+  ] as const)('parses path template with nested vars: %s', pathTemplate => {
+    const ast = parseURLPathTemplate(pathTemplate);
+    expect(ast.errors).toEqual([]);
+    const vars = getURLPathTemplateVars(ast);
+    expect(Object.keys(vars).sort()).toEqual([
+      'post.id',
+      'user.id',
+    ]);
+  });
+
+  it.each([
+    '/users/{user.id}?param={param}',
+    '/users/{user.id}/?param={param}',
+    '/users/{user.id}/junk?param={param}',
+    '/users/{user.id}/{param}?',
+  ] as const)('parses templates with query parameters: %s', pathTemplate => {
+    const ast = parseURLPathTemplate(pathTemplate);
+    expect(ast.errors).toEqual([]);
+    const vars = getURLPathTemplateVars(ast);
+    expect(Object.keys(vars).sort()).toEqual([
+      'param',
+      'user.id',
+    ]);
+  });
+
+  it.each([
+    '/location/{latitude},{longitude}?filter={filter}',
+    '/location/{latitude},{longitude}/?filter={filter}',
+    '/location/{latitude},{longitude}/junk?filter={filter}',
+    '/location/lat:{latitude},lon:{longitude}?filter={filter}',
+    '/location/lat:{latitude},lon:{longitude}/?filter={filter!}',
+    '/location/lat:{latitude},lon:{longitude}/junk?filter={filter!}',
+    '/?lat={latitude}&lon={longitude}&filter={filter}',
+    '/?location={latitude},{longitude}&filter={filter}',
+    '/?filter={filter}&location={latitude!}-{longitude!}',
+  ] as const)('should parse a template with multi-var segments: %s', pathTemplate => {
+    const ast = parseURLPathTemplate(pathTemplate);
+    expect(ast.errors).toEqual([]);
+    const vars = getURLPathTemplateVars(ast);
+    expect(Object.keys(vars).sort()).toEqual([
+      'filter',
+      'latitude',
+      'longitude',
+    ]);
+  });
+
+  it.each([
+    '/users?ids={uid,...}&filter={filter}',
+    '/users_batch/{uid,...}?filter={filter}',
+  ] as const)('can parse batch endpoints: %s', pathTemplate => {
+    const ast = parseURLPathTemplate(pathTemplate);
+    expect(ast.errors).toEqual([]);
+    const vars = getURLPathTemplateVars(ast);
+    expect(vars).toEqual({
+      uid: {
+        batchSep: ',',
+      },
+      filter: {},
+    });
   });
 });

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -556,8 +556,30 @@ function validateHTTPHeaders(
   }
 }
 
-function parseJSONSelection(_selection: string): any {
-  // TODO
+const selectionParser = new Grammars.W3C.Parser(`
+  Selection ::= NamedSelection* StarSelection? S? | PathSelection
+  NamedSelection ::= NamedFieldSelection | NamedQuotedSelection | NamedPathSelection | NamedGroupSelection
+  NamedFieldSelection ::= Alias? S? Identifier S? SubSelection?
+  NamedQuotedSelection ::= Alias StringLiteral S? SubSelection?
+  NamedPathSelection ::= Alias PathSelection
+  NamedGroupSelection ::= Alias SubSelection
+  PathSelection ::= S? ("." Property)+ S? SubSelection?
+  SubSelection ::= S? "{" S? NamedSelection* StarSelection? S? "}" S?
+  StarSelection ::= Alias? S? "*" S? SubSelection?
+  Alias ::= S? Identifier S? ":" S?
+  Property ::= Identifier | Integer | StringLiteral
+  Identifier ::= [a-zA-Z_][0-9a-zA-Z_]*
+  Integer ::= "0" | [1-9][0-9]*
+  StringLiteral ::= SQStrLit | DQStrLit
+  SQStrLit ::= "'" ("\\'" | [^'])* "'"
+  DQStrLit ::= '"' ('\\"' | [^"])* '"'
+  S ::= (Spaces | Comment)+
+  Spaces ::= [ \t\r\n]+
+  Comment ::= "#" [^\n]*
+`);
+
+export function parseJSONSelection(selection: string): IToken {
+  return selectionParser.getAST(selection, 'Selection');
 }
 
 const urlParser = new Grammars.W3C.Parser(`

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -588,32 +588,33 @@ function validateHTTPHeaders(
   }
 }
 
-const selectionParser = new Grammars.W3C.Parser(`
-  Selection ::= NamedSelection* StarSelection? S? | PathSelection
-  NamedSelection ::= NamedFieldSelection | NamedQuotedSelection | NamedPathSelection | NamedGroupSelection
-  NamedFieldSelection ::= Alias? S? Identifier S? SubSelection?
-  NamedQuotedSelection ::= Alias StringLiteral S? SubSelection?
-  NamedPathSelection ::= Alias PathSelection
-  NamedGroupSelection ::= Alias SubSelection
-  PathSelection ::= S? ("." Property)+ S? SubSelection?
-  SubSelection ::= S? "{" S? NamedSelection* StarSelection? S? "}" S?
-  StarSelection ::= Alias? S? "*" S? SubSelection?
-  Alias ::= S? Identifier S? ":" S?
-  Property ::= Identifier | Integer | StringLiteral
-  Identifier ::= [a-zA-Z_][0-9a-zA-Z_]*
-  Integer ::= "0" | [1-9][0-9]*
-  StringLiteral ::= SQStrLit | DQStrLit
-  SQStrLit ::= "'" ("\\'" | [^'])* "'"
-  DQStrLit ::= '"' ('\\"' | [^"])* '"'
-  S ::= (Spaces | Comment)+
-  Spaces ::= [ \t\r\n]+
-  Comment ::= "#" [^\n]*
-`);
 
 type ebnfASTNode = Pick<IToken, 'type' | 'children' | 'text' | 'errors'>
 type Shape = string | { [key: string]: Shape }
 
+let selectionParser: Grammars.W3C.Parser | undefined;
 export function parseJSONSelection(selection: string): ebnfASTNode | null {
+  selectionParser = selectionParser || new Grammars.W3C.Parser(`
+    Selection ::= NamedSelection* StarSelection? S? | PathSelection
+    NamedSelection ::= NamedFieldSelection | NamedQuotedSelection | NamedPathSelection | NamedGroupSelection
+    NamedFieldSelection ::= Alias? S? Identifier S? SubSelection?
+    NamedQuotedSelection ::= Alias StringLiteral S? SubSelection?
+    NamedPathSelection ::= Alias PathSelection
+    NamedGroupSelection ::= Alias SubSelection
+    PathSelection ::= S? ("." Property)+ S? SubSelection?
+    SubSelection ::= S? "{" S? NamedSelection* StarSelection? S? "}" S?
+    StarSelection ::= Alias? S? "*" S? SubSelection?
+    Alias ::= S? Identifier S? ":" S?
+    Property ::= Identifier | Integer | StringLiteral
+    Identifier ::= [a-zA-Z_][0-9a-zA-Z_]*
+    Integer ::= "0" | [1-9][0-9]*
+    StringLiteral ::= SQStrLit | DQStrLit
+    SQStrLit ::= "'" ("\\'" | [^'])* "'"
+    DQStrLit ::= '"' ('\\"' | [^"])* '"'
+    S ::= (Spaces | Comment)+
+    Spaces ::= [ \t\r\n]+
+    Comment ::= "#" [^\n]*
+  `);
   return selectionParser.getAST(selection, 'Selection');
 }
 
@@ -723,23 +724,23 @@ export function getSelectionOutputShape(node: ebnfASTNode): Shape {
   }
 }
 
-const urlParser = new Grammars.W3C.Parser(`
-  URLPathTemplate ::= "/" PathParamList? QueryParamList?
-  PathParamList ::= VarSeparatedText ("/" VarSeparatedText)* "/"?
-  QueryParamList ::= "?" (QueryParam ("&" QueryParam)*)?
-  QueryParam ::= URLSafeText "=" VarSeparatedText | URLSafeText "="?
-  VarSeparatedText ::= OneOrMoreVars | URLSafeText
-  OneOrMoreVars ::= URLSafeText? "{" Var "}" (URLSafeText "{" Var "}")* URLSafeText?
-  Var ::= IdentifierPath Required? Batch?
-  IdentifierPath ::= Identifier ("." Identifier)*
-  Required ::= "!"
-  Batch ::= BatchSeparator "..."
-  BatchSeparator ::= "," | ";" | "|" | "+" | " "
-  URLSafeText ::= [^{}/?&=]+
-  Identifier ::= [a-zA-Z_$][0-9a-zA-Z_$]*
-`);
-
+let urlParser: Grammars.W3C.Parser | undefined;
 export function parseURLPathTemplate(template: string): ebnfASTNode | null {
+  urlParser = urlParser || new Grammars.W3C.Parser(`
+    URLPathTemplate ::= "/" PathParamList? QueryParamList?
+    PathParamList ::= VarSeparatedText ("/" VarSeparatedText)* "/"?
+    QueryParamList ::= "?" (QueryParam ("&" QueryParam)*)?
+    QueryParam ::= URLSafeText "=" VarSeparatedText | URLSafeText "="?
+    VarSeparatedText ::= OneOrMoreVars | URLSafeText
+    OneOrMoreVars ::= URLSafeText? "{" Var "}" (URLSafeText "{" Var "}")* URLSafeText?
+    Var ::= IdentifierPath Required? Batch?
+    IdentifierPath ::= Identifier ("." Identifier)*
+    Required ::= "!"
+    Batch ::= BatchSeparator "..."
+    BatchSeparator ::= "," | ";" | "|" | "+" | " "
+    URLSafeText ::= [^{}/?&=]+
+    Identifier ::= [a-zA-Z_$][0-9a-zA-Z_$]*
+  `);
   return urlParser.getAST(template, 'URLPathTemplate');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
       "dependencies": {
         "@types/uuid": "^9.0.0",
         "chalk": "^4.1.0",
+        "ebnf": "^1.9.1",
         "js-levenshtein": "^1.1.6",
         "uuid": "^9.0.0"
       },
@@ -7009,6 +7010,14 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/ebnf": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ebnf/-/ebnf-1.9.1.tgz",
+      "integrity": "sha512-uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw==",
+      "bin": {
+        "ebnf": "dist/bin.js"
       }
     },
     "node_modules/ee-first": {


### PR DESCRIPTION
Follow-up to #2910.

This work is not finished because we ultimately want to validate that the variables used by `URLPathTemplate` strings and the output shapes of `JSONSelection` strings match the available field and argument names.

This PR adds parsers for the two syntaxes and tests of those parsers, which allows us to validate the strings have the expected syntax, even if we're not validating semantics yet.

As another `TODO`, when we use `JSONSelection` for `body` parameters, it's the input shape of the selection that needs to be validated, rather than the output shape, so `getSelectionOutputShape` may not be sufficient.