### PR TITLE
Implicitly upgrade federation version to the max required by any used directive

### DIFF
--- a/.changeset/forty-dolls-type.md
+++ b/.changeset/forty-dolls-type.md
@@ -1,0 +1,6 @@
+---
+"@apollo/composition": minor
+"@apollo/federation-internals": minor
+---
+
+When a linked directive requires a federation version higher than the linked federation spec, upgrade with a hint

--- a/.changeset/forty-dolls-type.md
+++ b/.changeset/forty-dolls-type.md
@@ -3,4 +3,4 @@
 "@apollo/federation-internals": minor
 ---
 
-When a linked directive requires a federation version higher than the linked federation spec, upgrade with a hint
+When a linked directive requires a federation version higher than the linked federation spec, upgrade to the implied version and issue a hint

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -25,6 +25,7 @@ import {
   composeAsFed2Subgraphs,
   asFed2Service,
 } from "./testHelper";
+import { CompositionHint, HINTS } from '../hints';
 
 describe('composition', () => {
   it('generates a valid supergraph', () => {
@@ -5245,8 +5246,11 @@ describe('Implicit federation version upgrades', () => {
       typeDefs: autoUpgradedSchema,
     }]);
 
-    expect(result.hints).toContain(
-      'Feature @sourceAPI requires federation version v2.7 or higher. Upgraded from v2.5'
-    );
+    expect(result.hints).toContainEqual(new CompositionHint(
+      HINTS.IMPLICITLY_UPGRADED_FEDERATION_VERSION,
+      'Feature @link(url: \"https://specs.apollo.dev/source/v0.1\", import: [\"@sourceAPI\", \"@sourceType\", \"@sourceField\"]) requires federation version v2.7 or higher',
+      undefined,
+      undefined,
+    ));
   })
 })

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -5240,7 +5240,7 @@ describe('Implicit federation version upgrades', () => {
     }
   `;
 
-  it("should hint that the federation version has been upgraded to satisfy directive requirements", () => {
+  it("should hint that the version was upgraded to satisfy directive requirements", () => {
     const result = composeServices([{
       name: 'upgraded',
       typeDefs: autoUpgradedSchema,
@@ -5248,7 +5248,9 @@ describe('Implicit federation version upgrades', () => {
 
     expect(result.hints).toContainEqual(new CompositionHint(
       HINTS.IMPLICITLY_UPGRADED_FEDERATION_VERSION,
-      'Feature @link(url: \"https://specs.apollo.dev/source/v0.1\", import: [\"@sourceAPI\", \"@sourceType\", \"@sourceField\"]) requires federation version v2.7 or higher',
+      'Feature @link(url: \"https://specs.apollo.dev/source/v0.1\", import: [\"@sourceAPI\", \"@sourceType\", \"@sourceField\"]) requires federation version v2.7 or higher. The following directives are using a lower version:'
+        + '\n- @link(url: \"https://specs.apollo.dev/link/v1.0\")'
+        + '\n- @link(url: \"https://specs.apollo.dev/federation/v2.5\", import: [\"@key\"])',
       undefined,
       undefined,
     ));

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -5101,6 +5101,10 @@ describe('@source* directives', () => {
 
       const messages = result.errors!.map(e => e.message);
 
+      expect(result.hints).toContain(
+        'Feature @sourceAPI requires federation version v2.7 or higher. Upgraded from v2.5'
+      );
+
       expect(messages).toContain(
         '[bad] Schemas that @link to https://specs.apollo.dev/source must also @link to federation version v2.7 or later (found v2.5)'
       );

--- a/composition-js/src/__tests__/hints.test.ts
+++ b/composition-js/src/__tests__/hints.test.ts
@@ -6,7 +6,7 @@ import {
   HINTS,
 } from '../hints';
 import { MergeResult, mergeSubgraphs } from '../merging';
-import { composeAsFed2Subgraphs } from './testHelper';
+import { assertCompositionSuccess, composeAsFed2Subgraphs } from './testHelper';
 import { formatExpectedToMatchReceived } from './matchers/toMatchString';
 import { composeServices } from '../compose';
 
@@ -1247,6 +1247,7 @@ describe('when a directive causes an implicit federation version upgrade', () =>
       }
     ]);
 
+    assertCompositionSuccess(result);
     expect(result).toRaiseHint(
       HINTS.IMPLICITLY_UPGRADED_FEDERATION_VERSION,
       'Subgraph upgraded has been implicitly upgraded from federation v2.5 to v2.7',
@@ -1266,6 +1267,7 @@ describe('when a directive causes an implicit federation version upgrade', () =>
       },
     ]);
 
+    assertCompositionSuccess(result);
     expect(result).toRaiseHint(
       HINTS.IMPLICITLY_UPGRADED_FEDERATION_VERSION,
       'Subgraph upgraded-1 has been implicitly upgraded from federation v2.5 to v2.7',
@@ -1290,6 +1292,7 @@ describe('when a directive causes an implicit federation version upgrade', () =>
       },
     ]);
 
+    assertCompositionSuccess(result);
     expect(result).toNotRaiseHints();
   });
 })

--- a/composition-js/src/hints.ts
+++ b/composition-js/src/hints.ts
@@ -199,6 +199,13 @@ const INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN = makeCodeDefinition({
   description: 'Indicates that a @shareable field returns different sets of runtime types in the different subgraphs in which it is defined.',
 });
 
+const IMPLICITLY_UPGRADED_FEDERATION_VERSION = makeCodeDefinition({
+  code: 'IMPLICITLY_UPGRADED_FEDERATION_VERSION',
+  level: HintLevel.INFO,
+  description: 'Indicates that a directive requires a higher Federation version than is explicitly linked.'
+    + ' In this case, the supergraph uses the Federation version required by the directive.'
+});
+
 export const HINTS = {
   INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE,
   INCONSISTENT_BUT_COMPATIBLE_ARGUMENT_TYPE,
@@ -227,6 +234,7 @@ export const HINTS = {
   DIRECTIVE_COMPOSITION_INFO,
   DIRECTIVE_COMPOSITION_WARN,
   INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN,
+  IMPLICITLY_UPGRADED_FEDERATION_VERSION,
 }
 
 export class CompositionHint {

--- a/composition-js/src/hints.ts
+++ b/composition-js/src/hints.ts
@@ -202,8 +202,8 @@ const INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN = makeCodeDefinition({
 const IMPLICITLY_UPGRADED_FEDERATION_VERSION = makeCodeDefinition({
   code: 'IMPLICITLY_UPGRADED_FEDERATION_VERSION',
   level: HintLevel.INFO,
-  description: 'Indicates that a directive requires a higher Federation version than is explicitly linked.'
-    + ' In this case, the supergraph uses the Federation version required by the directive.'
+  description: 'Indicates that a directive requires a higher federation version than is explicitly linked.'
+    + ' In this case, the supergraph uses the federation version required by the directive.'
 });
 
 export const HINTS = {

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -74,8 +74,8 @@ import {
   LinkDirectiveArgs,
   sourceIdentity,
   FeatureUrl,
-  coreFeatureDefinitionIfKnown,
   CoreFeature,
+  Subgraph,
 } from "@apollo/federation-internals";
 import { ASTNode, GraphQLError, DirectiveLocation } from "graphql";
 import {
@@ -345,59 +345,53 @@ class Merger {
   }
 
   private getLatestFederationVersionUsed(): FeatureVersion {
-    let latestVersion: FeatureVersion | undefined;
-    let featuresWithThisVersion: CoreFeature[] = [];
-    const featuresWithLowerVersion: CoreFeature[] = [];
+    const versions = this.subgraphs.values()
+                        .map((s) => this.getLatestFederationVersionUsedInSubgraph(s))
+                        .filter(isDefined);
 
-    function recordFederationVersion(feature: CoreFeature, federationVersion: FeatureVersion) {
-      // Start by recording the first valid federation version as latest
-      if (!latestVersion) {
-        latestVersion = federationVersion;
-        featuresWithThisVersion = [feature];
+    return FeatureVersion.max(versions) ?? FEDERATION_VERSIONS.latest().version;
+  }
+
+  private getLatestFederationVersionUsedInSubgraph(subgraph: Subgraph): FeatureVersion | undefined {
+    const linkedFederationVersion = subgraph.metadata()?.federationFeature()?.url.version;
+    if (!linkedFederationVersion) {
+      return undefined;
+    }
+
+    const versionsFromFeatures: FeatureVersion[] = [];
+    for (const feature of subgraph.schema.coreFeatures?.allFeatures() ?? []) {
+      const version = feature.minimumFederationVersion();
+      if (version) {
+        versionsFromFeatures.push(version);
       }
-      // If a feature requires a newer (minor) version, bump latestVersion to that new version
-      else if (federationVersion.satisfies(latestVersion) && federationVersion > latestVersion) {
-        latestVersion = federationVersion;
-        featuresWithLowerVersion.push(...featuresWithThisVersion);
-        featuresWithThisVersion = [feature];
-      }
-      // Bucket the implicitly upgraded features for the resulting hint
-      else if (federationVersion < latestVersion) {
-        featuresWithLowerVersion.push(feature);
-      }
-      // Otherwise, this feature matches the current required version
-      else {
-        featuresWithThisVersion.push(feature);
+    }
+    const impliedFederationVersion = FeatureVersion.max(versionsFromFeatures);
+    if (!impliedFederationVersion?.satisfies(linkedFederationVersion) || linkedFederationVersion >= impliedFederationVersion) {
+      return linkedFederationVersion;
+    }
+
+    let featureCausingUpgrade: CoreFeature | undefined;
+    for (const feature of subgraph.schema.coreFeatures?.allFeatures() ?? []) {
+      if (feature.minimumFederationVersion() == impliedFederationVersion) {
+        featureCausingUpgrade = feature;
+        break;
       }
     }
 
-    for (const subgraph of this.subgraphs.values()) {
-      const federationFeature = subgraph.metadata()?.federationFeature();
-      if (federationFeature?.url?.version) {
-        recordFederationVersion(federationFeature, federationFeature.url.version)
-      }
-
-      for (const feature of subgraph.schema.coreFeatures?.allFeatures() ?? []) {
-        const definition = coreFeatureDefinitionIfKnown(feature.url);
-        if (definition?.minimumFederationVersion) {
-          recordFederationVersion(feature, definition.minimumFederationVersion);
-        }
-      }
-    }
-
-    if (featuresWithThisVersion.length && featuresWithLowerVersion.length) {
+    if (featureCausingUpgrade) {
       this.hints.push(new CompositionHint(
         HINTS.IMPLICITLY_UPGRADED_FEDERATION_VERSION,
-        `Feature ${featuresWithThisVersion[0].directive} requires federation version ${latestVersion} or higher.`
-          + ` The following directives are using a lower version:`
-          + featuresWithLowerVersion.map((f) => '\n- ' + f.directive).join('')
-        ,
+        `Subgraph ${subgraph.name} has been implicitly upgraded from federation ${linkedFederationVersion} to ${impliedFederationVersion}`,
         undefined,
+        featureCausingUpgrade.directive.sourceAST ?
+          addSubgraphToASTNode(featureCausingUpgrade.directive.sourceAST, subgraph.name) :
+          undefined
       ));
     }
 
-    return latestVersion ?? FEDERATION_VERSIONS.latest().version;
+    return impliedFederationVersion;
   }
+
 
   private prepareSupergraph(): Map<string, string> {
     // TODO: we will soon need to look for name conflicts for @core and @join with potentially user-defined directives and

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -358,6 +358,7 @@ class Merger {
       return undefined;
     }
 
+    // Check if any of the directives imply a newer version of federation than is explicitly linked
     const versionsFromFeatures: FeatureVersion[] = [];
     for (const feature of subgraph.schema.coreFeatures?.allFeatures() ?? []) {
       const version = feature.minimumFederationVersion();
@@ -370,6 +371,7 @@ class Merger {
       return linkedFederationVersion;
     }
 
+    // If some of the directives are causing an implicit upgrade, put one in the hint
     let featureCausingUpgrade: CoreFeature | undefined;
     for (const feature of subgraph.schema.coreFeatures?.allFeatures() ?? []) {
       if (feature.minimumFederationVersion() == impliedFederationVersion) {
@@ -382,7 +384,7 @@ class Merger {
       this.hints.push(new CompositionHint(
         HINTS.IMPLICITLY_UPGRADED_FEDERATION_VERSION,
         `Subgraph ${subgraph.name} has been implicitly upgraded from federation ${linkedFederationVersion} to ${impliedFederationVersion}`,
-        undefined,
+        featureCausingUpgrade.directive.definition,
         featureCausingUpgrade.directive.sourceAST ?
           addSubgraphToASTNode(featureCausingUpgrade.directive.sourceAST, subgraph.name) :
           undefined

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -547,7 +547,7 @@ class Merger {
     if (featureCausingUpgrade) {
       this.hints.push(new CompositionHint(
         HINTS.IMPLICITLY_UPGRADED_FEDERATION_VERSION,
-        `Feature ${featureCausingUpgrade.directive} requires federation version v${this.latestFedVersionUsed} or higher. Upgraded from v${originalFederationVersion}`,
+        `Feature ${featureCausingUpgrade?.directive} requires federation version ${this.latestFedVersionUsed} or higher. Upgraded from ${originalFederationVersion}`,
         undefined,
         undefined, // TODO: See if we can grab the AST node
       ))

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -27,6 +27,7 @@ import {
   CoreSpecDefinition,
   extractCoreFeatureImports,
   FeatureUrl,
+  FeatureVersion,
   findCoreSpecVersion,
   isCoreSpecDirectiveApplication,
   removeAllCoreFeatures,
@@ -53,6 +54,7 @@ import { validateSchema } from "./validate";
 import { createDirectiveSpecification, createScalarTypeSpecification, DirectiveSpecification, TypeSpecification } from "./directiveAndTypeSpecification";
 import { didYouMean, suggestionList } from "./suggestions";
 import { aggregateError, ERRORS, withModifiedErrorMessage } from "./error";
+import { coreFeatureDefinitionIfKnown } from "./knownCoreFeatures";
 
 const validationErrorCode = 'GraphQLValidationFailed';
 const DEFAULT_VALIDATION_ERROR_MESSAGE = 'The schema is not a valid GraphQL schema.';
@@ -1013,6 +1015,10 @@ export class CoreFeature {
   typeNameInSchema(name: string): string {
     const elementImport = this.imports.find((i) => i.name === name);
     return elementImport ? (elementImport.as ?? name) : this.nameInSchema + '__' + name;
+  }
+
+  minimumFederationVersion(): FeatureVersion | undefined {
+    return coreFeatureDefinitionIfKnown(this.url)?.minimumFederationVersion;
   }
 }
 

--- a/internals-js/src/specs/coreSpec.ts
+++ b/internals-js/src/specs/coreSpec.ts
@@ -641,6 +641,28 @@ export class FeatureVersion {
   }
 
   /**
+   * Find the maximum version in a collection of versions, returning undefined in the case
+   * that the collection is empty.
+   *
+   * # Example
+   * ```
+   * expect(FeatureVersion.max([new FeatureVersion(1, 0), new FeatureVersion(2, 0)])).toBe(new FeatureVersion(2, 0))
+   * expect(FeatureVersion.max([])).toBe(undefined)
+   * ```
+   */
+  public static max(versions: Iterable<FeatureVersion>): FeatureVersion | undefined {
+    let max: FeatureVersion | undefined;
+
+    for (const version of versions) {
+      if (!max || version > max) {
+        max = version;
+      }
+    }
+
+    return max;
+  }
+
+  /**
    * Return true if and only if this FeatureVersion satisfies the `required` version
    *
    * # Example

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -147,14 +147,12 @@ export class SourceSpecDefinition extends FeatureDefinition {
     return this.directive<SourceFieldDirectiveArgs>(schema, 'sourceField')!;
   }
 
-  private getSourceDirectives(schema: Schema, errors: GraphQLError[]) {
+  private getSourceDirectives(schema: Schema) {
     const result: {
       sourceAPI?: DirectiveDefinition<SourceAPIDirectiveArgs>;
       sourceType?: DirectiveDefinition<SourceTypeDirectiveArgs>;
       sourceField?: DirectiveDefinition<SourceFieldDirectiveArgs>;
     } = {};
-
-    let federationVersion: FeatureVersion | undefined;
 
     schema.schemaDefinition.appliedDirectivesOf<LinkDirectiveArgs>('link')
       .forEach(linkDirective => {
@@ -175,24 +173,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
             }
           });
         }
-        if (featureUrl && featureUrl.name === 'federation') {
-          federationVersion = featureUrl.version;
-        }
       });
-
-    if (result.sourceAPI || result.sourceType || result.sourceField) {
-      // Since this subgraph uses at least one of the @source{API,Type,Field}
-      // directives, it must also use v2.7 or later of federation.
-      if (!federationVersion || federationVersion.lt(this.minimumFederationVersion)) {
-        errors.push(ERRORS.SOURCE_FEDERATION_VERSION_REQUIRED.err(
-          `Schemas that @link to ${
-            sourceIdentity
-          } must also @link to federation version ${
-            this.minimumFederationVersion
-          } or later (found ${federationVersion})`,
-        ));
-      }
-    }
 
     return result;
   }
@@ -203,7 +184,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
       sourceAPI,
       sourceType,
       sourceField,
-    } = this.getSourceDirectives(schema, errors);
+    } = this.getSourceDirectives(schema);
 
     if (!(sourceAPI || sourceType || sourceField)) {
       // If none of the @source* directives are present, nothing needs


### PR DESCRIPTION
# Overview

The recent addition of `SourceSpecDefinition` surfaced a case where a subgraph with a `@link` to federation < 2.7 and a `@link` to the source spec (which requires federation >= 2.7) results in an unexpected error during composition. Validation for this case was introduced in https://github.com/apollographql/federation/pull/2914, raising a composition error when the versions are mismatched.

Since the existing behavior will implicitly upgrade to a later minor version of federation when two subgraphs are mismatched, it makes sense to do the same with feature requirements.

# Example

Subgraph A has a `@link` to fed version 2.5
Subgraph B has a `@link` to fed version 2.7
Subgraph C has a `@link` to fed version 2.5 and a separate `@link` to the source spec

Previous behavior:
1. Composing Subgraph A and Subgraph B silently upgrades to fed version 2.7
2. Composing Subgraph A and Subgraph C results in a composition error

New behavior:
1. Composing Subgraph A and Subgraph B silently upgrades to fed version 2.7
2. Composing Subgraph A and Subgraph C upgrades to fed version 2.7 and raises a hint explaining why
