### PR TITLE
Update versioning changes from previous PR from minor to patch

### DIFF
--- a/.changeset/forty-dolls-type.md
+++ b/.changeset/forty-dolls-type.md
@@ -1,6 +1,6 @@
 ---
-"@apollo/composition": minor
-"@apollo/federation-internals": minor
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
 ---
 
 When a linked directive requires a federation version higher than the linked federation spec, upgrade to the implied version and issue a hint


### PR DESCRIPTION
This change updates the changeset log from https://github.com/apollographql/federation/pull/2929 to indicate patch version bumps instead of minor version bumps.
