### PR TITLE
Set Accept header when fetching remote source

### DIFF
--- a/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
+++ b/gateway-js/src/datasources/RemoteGraphQLDataSource.ts
@@ -89,6 +89,8 @@ export class RemoteGraphQLDataSource<
         headers.append(name, value);
       }
     }
+
+    headers.set('Accept', 'application/graphql-response+json, application/json');
     headers.set('Content-Type', 'application/json');
 
     request.http = {


### PR DESCRIPTION
Hi :)

**What?**
Explicitly set default [Accept](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) header to `application/graphql-response+json` or `application/json`.

**Why?**

1. The current code breaks if the client passes text containing JSON
    * (This was the case when I tried adding a basic [Quarkus](https://quarkus.io/) subgraph).
2. This change also seems consistent with the [draft spec](https://graphql.github.io/graphql-over-http/draft/#sec-Accept) of graphql

A valid workaround seems to be:
```
    supergraphSdl: new IntrospectAndCompose({
      subgraphs: [
      ...
      ],
      introspectionHeaders: {
        Accept: 'application/json',
      }
   })
```
**Considerations**
- Sorry I've I'm missing anything!
- I didn't write tests since most of the `RemoteGraphQLDataSource` are private and I couldn't see how to do that.