### PR TITLE
Add new `generateQueryFragments` option to query planner config

### DIFF
--- a/.changeset/spicy-falcons-learn.md
+++ b/.changeset/spicy-falcons-learn.md
@@ -1,0 +1,9 @@
+---
+"apollo-federation-integration-testsuite": minor
+"@apollo/query-planner": minor
+"@apollo/federation-internals": minor
+---
+
+Add new `generateQueryFragments` option to query planner config
+
+If enabled, the query planner will extract inline fragments into fragment definitions before sending queries to subgraphs. This can significantly reduce the size of the query sent to subgraphs, but may increase the time it takes to plan the query.

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1553,13 +1553,13 @@ export class SelectionSet {
    */
   minimizeSelectionSet(
     namedFragments: NamedFragments = new NamedFragments(),
-    seenSelections: Map<number, [SelectionSet, NamedFragmentDefinition][]> = new Map(),
+    seenSelections: Map<string, [SelectionSet, NamedFragmentDefinition][]> = new Map(),
   ): [SelectionSet, NamedFragments] {
     const minimizedSelectionSet = this.lazyMap((selection) => {
       if (selection.kind === 'FragmentSelection' && selection.element.typeCondition && selection.element.appliedDirectives.length === 0 && selection.selectionSet) {
         // No proper hash code, so we use a unique enough number that's cheap to
         // compute and handle collisions as necessary.
-        const mockHashCode = selection.key().length + selection.selectionSet.selections().length;
+        const mockHashCode = `on${selection.element.typeCondition}` + selection.selectionSet.selections().length;
         const equivalentSelectionSetCandidates = seenSelections.get(mockHashCode);
         if (equivalentSelectionSetCandidates) {
           // See if any candidates have an equivalent selection set, i.e. {x y} and {y x}.
@@ -1576,7 +1576,7 @@ export class SelectionSet {
         const [minimizedSelectionSet] = selection.selectionSet.minimizeSelectionSet(namedFragments, seenSelections);
         const fragmentDefinition = new NamedFragmentDefinition(
           this.parentType.schema(),
-          `_generated_on_${selection.element.typeCondition!.name}_${mockHashCode}_${equivalentSelectionSetCandidates?.length ?? 0}`,
+          `_generated_${mockHashCode}_${equivalentSelectionSetCandidates?.length ?? 0}`,
           selection.element.typeCondition
         ).setSelectionSet(minimizedSelectionSet);
 

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1565,7 +1565,7 @@ export class SelectionSet {
         const minimizedSelectionSet = selection.selectionSet.minimizeSelectionSet(namedFragments, fragmentDefinitionsById);
         const fragmentDefinition = new NamedFragmentDefinition(
           this.parentType.schema(),
-          `qp__${id}_${equivalentSelectionSetCandidates?.length ?? 0}`,
+          `__generated_on_${selection.element.typeCondition!.name}_${id}_${equivalentSelectionSetCandidates?.length ?? 0}`,
           selection.element.typeCondition
         ).setSelectionSet(minimizedSelectionSet);
 

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1553,7 +1553,7 @@ export class SelectionSet {
   minimizeSelectionSet(namedFragments: NamedFragments, fragmentDefinitionsById: Map<number, [SelectionSet, NamedFragmentDefinition][]>): SelectionSet {
     return this.lazyMap((selection) => {
       if (selection.kind === 'FragmentSelection' && selection.element.typeCondition && selection.element.appliedDirectives.length === 0 && selection.selectionSet) {
-        const id = selection.toString().length;
+        const id = selection.key().length + selection.selectionSet.selections().length;
         const equivalentSelectionSetCandidates = fragmentDefinitionsById.get(id);
         if (equivalentSelectionSetCandidates) {
           const match = equivalentSelectionSetCandidates.find(([candidateSet]) => candidateSet.equals(selection.selectionSet!));

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1582,10 +1582,10 @@ export class SelectionSet {
 
         // Create a new "hash code" bucket or add to the existing one.
         if (!equivalentSelectionSetCandidates) {
-          seenSelections.set(mockHashCode, [[minimizedSelectionSet, fragmentDefinition]]);
+          seenSelections.set(mockHashCode, [[selection.selectionSet, fragmentDefinition]]);
           namedFragments.add(fragmentDefinition);
         } else {
-          equivalentSelectionSetCandidates.push([minimizedSelectionSet, fragmentDefinition]);
+          equivalentSelectionSetCandidates.push([selection.selectionSet, fragmentDefinition]);
         }
 
         return new FragmentSpreadSelection(this.parentType, namedFragments, fragmentDefinition, []);

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1576,7 +1576,7 @@ export class SelectionSet {
         const [minimizedSelectionSet] = selection.selectionSet.minimizeSelectionSet(namedFragments, seenSelections);
         const fragmentDefinition = new NamedFragmentDefinition(
           this.parentType.schema(),
-          `__generated_on_${selection.element.typeCondition!.name}_${mockHashCode}_${equivalentSelectionSetCandidates?.length ?? 0}`,
+          `_generated_on_${selection.element.typeCondition!.name}_${mockHashCode}_${equivalentSelectionSetCandidates?.length ?? 0}`,
           selection.element.typeCondition
         ).setSelectionSet(minimizedSelectionSet);
 

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5094,17 +5094,17 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__16_0
-              ...qp__14_0
+              ...qp__10_0
+              ...qp__9_0
             }
           }
           
-          fragment qp__16_0 on A {
+          fragment qp__10_0 on A {
             x
             y
           }
           
-          fragment qp__14_0 on B {
+          fragment qp__9_0 on B {
             z
           }
         },
@@ -5149,22 +5149,22 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__63_0
-              ...qp__14_1
+              ...qp__11_0
+              ...qp__9_1
             }
           }
           
-          fragment qp__14_0 on A {
+          fragment qp__9_0 on A {
             x
           }
           
-          fragment qp__63_0 on A {
+          fragment qp__11_0 on A {
             x
             y
             t {
               __typename
-              ...qp__14_0
-              ...qp__14_1
+              ...qp__9_0
+              ...qp__9_1
             }
           }
         },
@@ -5204,15 +5204,15 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__16_0
+              ...qp__10_0
             }
             t2 {
               __typename
-              ...qp__16_0
+              ...qp__10_0
             }
           }
           
-          fragment qp__16_0 on A {
+          fragment qp__10_0 on A {
             x
             y
           }

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -3912,7 +3912,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment FooChildSelect on Foo {
             __typename
             foo
@@ -3927,7 +3927,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment FooSelect on Foo {
             __typename
             foo
@@ -4101,7 +4101,7 @@ describe('Named fragments preservation', () => {
                   }
                 }
               }
-              
+
               fragment OnV on V {
                 a
                 b
@@ -4175,7 +4175,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment Selection on A {
             x
             y
@@ -4269,7 +4269,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment OnV on V {
             v1
             v2
@@ -4377,7 +4377,7 @@ describe('Named fragments preservation', () => {
               ...OnT @include(if: $test2)
             }
           }
-          
+
           fragment OnT on T {
             a
             b
@@ -4577,7 +4577,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               inner {
                 v {
@@ -4716,7 +4716,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               w
               inner {
@@ -4857,7 +4857,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               inner {
                 v
@@ -4996,7 +4996,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               w
               inner {
@@ -5036,6 +5036,162 @@ describe('Named fragments preservation', () => {
               },
             },
           },
+        },
+      }
+    `);
+  });
+});
+
+describe('Fragment autogeneration', () => {
+  it('respects generateQueryFragments option', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        union T = A | B
+
+        type A {
+          x: Int
+          y: Int
+        }
+
+        type B {
+          z: Int
+        }
+      `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlannerWithOptions(
+      [subgraph1],
+      { generateQueryFragments: true },
+    );
+    const operation = operationFromDocument(
+      api,
+      gql`
+        query {
+          t {
+            ... on A {
+              x
+              y
+            }
+            ... on B {
+              z
+            }
+          }
+        }
+      `,
+    );
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+
+    expect(serializeQueryPlan(plan)).toMatchString(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            t {
+              __typename
+              ...qp__0
+              ...qp__1
+            }
+          }
+
+          fragment qp__0 on A {
+            x
+            y
+          }
+
+          fragment qp__1 on B {
+            z
+          }
+        },
+      }
+    `);
+  });
+
+  it('handles nested fragment generation', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        union T = A | B
+
+        type A {
+          x: Int
+          y: Int
+          t: T
+        }
+
+        type B {
+          z: Int
+        }
+      `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlannerWithOptions(
+      [subgraph1],
+      { generateQueryFragments: true },
+    );
+    const operation = operationFromDocument(
+      api,
+      gql`
+        query {
+          t {
+            ... on A {
+              x
+              y
+              t {
+                ... on A {
+                  x
+                }
+                ... on B {
+                  z
+                }
+              }
+            }
+            ... on B {
+              z
+            }
+          }
+        }
+      `,
+    );
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+
+    expect(serializeQueryPlan(plan)).toMatchString(`
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            t {
+              __typename
+              ...qp__2
+              ...qp__1
+            }
+          }
+
+          fragment qp__0 on A {
+            x
+          }
+
+          fragment qp__1 on B {
+            z
+          }
+
+          fragment qp__2 on A {
+            x
+            y
+            t {
+              __typename
+              ...qp__0
+              ...qp__1
+            }
+          }
         },
       }
     `);
@@ -6820,7 +6976,7 @@ describe('named fragments', () => {
               }
             }
           }
-          
+
           fragment Fragment4 on I {
             __typename
             id1
@@ -6893,7 +7049,7 @@ describe('named fragments', () => {
               }
             }
           }
-          
+
           fragment Fragment4 on I {
             id1
             id2
@@ -7035,7 +7191,7 @@ describe('named fragments', () => {
                 id
               }
             }
-            
+
             fragment allTFields on T {
               v0
               v1
@@ -7183,7 +7339,7 @@ describe('named fragments', () => {
                   }
                 }
               }
-              
+
               fragment allUFields on U {
                 v0
                 v1

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5172,7 +5172,7 @@ describe('Fragment autogeneration', () => {
     `);
   });
 
-  it('identifies and reuses equivalent fragments that arent identical', () => {
+  it("identifies and reuses equivalent fragments that aren't identical", () => {
     const [api, queryPlanner] = composeAndCreatePlannerWithOptions([subgraph], {
       generateQueryFragments: true,
     });

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5093,11 +5093,11 @@ describe('Fragment autogeneration', () => {
             }
           }
           
-          fragment qp__0 on A {
+	  fragment qp__0 on A {
             x
             y
           }
-
+          
           fragment qp__1 on B {
             z
           }
@@ -5159,7 +5159,7 @@ describe('Fragment autogeneration', () => {
 
     const plan = queryPlanner.buildQueryPlan(operation);
 
-    expect(serializeQueryPlan(plan)).toMatchString(`
+    expect(plan).toMatchString(`
       QueryPlan {
         Fetch(service: "Subgraph1") {
           {
@@ -5169,15 +5169,15 @@ describe('Fragment autogeneration', () => {
               ...qp__1
             }
           }
-
+          
           fragment qp__0 on A {
             x
           }
-
+          
           fragment qp__1 on B {
             z
           }
-
+          
           fragment qp__2 on A {
             x
             y

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5094,17 +5094,17 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__0
-              ...qp__1
+              ...qp__16_0
+              ...qp__14_0
             }
           }
           
-          fragment qp__0 on A {
+          fragment qp__16_0 on A {
             x
             y
           }
           
-          fragment qp__1 on B {
+          fragment qp__14_0 on B {
             z
           }
         },
@@ -5149,26 +5149,22 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__2
-              ...qp__1
+              ...qp__63_0
+              ...qp__14_1
             }
           }
           
-          fragment qp__0 on A {
+          fragment qp__14_0 on A {
             x
           }
           
-          fragment qp__1 on B {
-            z
-          }
-          
-          fragment qp__2 on A {
+          fragment qp__63_0 on A {
             x
             y
             t {
               __typename
-              ...qp__0
-              ...qp__1
+              ...qp__14_0
+              ...qp__14_1
             }
           }
         },
@@ -5208,22 +5204,17 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__0
+              ...qp__16_0
             }
             t2 {
               __typename
-              ...qp__1
+              ...qp__16_0
             }
           }
           
-          fragment qp__0 on A {
+          fragment qp__16_0 on A {
             x
             y
-          }
-          
-          fragment qp__1 on A {
-            y
-            x
           }
         },
       }

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -1,4 +1,4 @@
-import { QueryPlanner, serializeQueryPlan } from '@apollo/query-planner';
+import { QueryPlanner } from '@apollo/query-planner';
 import {
   assert,
   operationFromDocument,
@@ -6,7 +6,12 @@ import {
   Supergraph,
 } from '@apollo/federation-internals';
 import gql from 'graphql-tag';
-import { FetchNode, FlattenNode, SequenceNode } from '../QueryPlan';
+import {
+  FetchNode,
+  FlattenNode,
+  SequenceNode,
+  serializeQueryPlan,
+} from '../QueryPlan';
 import { FieldNode, OperationDefinitionNode, parse } from 'graphql';
 import {
   composeAndCreatePlanner,
@@ -3907,7 +3912,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment FooChildSelect on Foo {
             __typename
             foo
@@ -3922,7 +3927,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment FooSelect on Foo {
             __typename
             foo
@@ -4096,7 +4101,7 @@ describe('Named fragments preservation', () => {
                   }
                 }
               }
-
+              
               fragment OnV on V {
                 a
                 b
@@ -4170,7 +4175,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment Selection on A {
             x
             y
@@ -4264,7 +4269,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment OnV on V {
             v1
             v2
@@ -4372,7 +4377,7 @@ describe('Named fragments preservation', () => {
               ...OnT @include(if: $test2)
             }
           }
-
+          
           fragment OnT on T {
             a
             b
@@ -4572,7 +4577,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               inner {
                 v {
@@ -4711,7 +4716,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               w
               inner {
@@ -4852,7 +4857,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               inner {
                 v
@@ -4991,7 +4996,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               w
               inner {
@@ -5082,7 +5087,7 @@ describe('Fragment autogeneration', () => {
 
     const plan = queryPlanner.buildQueryPlan(operation);
 
-    expect(serializeQueryPlan(plan)).toMatchString(`
+    expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Fetch(service: "Subgraph1") {
           {
@@ -5092,12 +5097,12 @@ describe('Fragment autogeneration', () => {
               ...qp__1
             }
           }
-
-	         fragment qp__0 on A {
+          
+          fragment qp__0 on A {
             x
             y
           }
-
+          
           fragment qp__1 on B {
             z
           }
@@ -5159,7 +5164,7 @@ describe('Fragment autogeneration', () => {
 
     const plan = queryPlanner.buildQueryPlan(operation);
 
-    expect(serializeQueryPlan(plan)).toMatchString(`
+    expect(plan).toMatchInlineSnapshot(`
       QueryPlan {
         Fetch(service: "Subgraph1") {
           {
@@ -5169,15 +5174,15 @@ describe('Fragment autogeneration', () => {
               ...qp__1
             }
           }
-
+          
           fragment qp__0 on A {
             x
           }
-
+          
           fragment qp__1 on B {
             z
           }
-
+          
           fragment qp__2 on A {
             x
             y
@@ -6971,7 +6976,7 @@ describe('named fragments', () => {
               }
             }
           }
-
+          
           fragment Fragment4 on I {
             __typename
             id1
@@ -7044,7 +7049,7 @@ describe('named fragments', () => {
               }
             }
           }
-
+          
           fragment Fragment4 on I {
             id1
             id2
@@ -7186,7 +7191,7 @@ describe('named fragments', () => {
                 id
               }
             }
-
+            
             fragment allTFields on T {
               v0
               v1
@@ -7334,7 +7339,7 @@ describe('named fragments', () => {
                   }
                 }
               }
-
+              
               fragment allUFields on U {
                 v0
                 v1

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5092,7 +5092,7 @@ describe('Fragment autogeneration', () => {
               ...qp__1
             }
           }
-
+          
           fragment qp__0 on A {
             x
             y

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5094,17 +5094,17 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ..._generated_on_A_10_0
-              ..._generated_on_B_9_0
+              ..._generated_onA2_0
+              ..._generated_onB1_0
             }
           }
           
-          fragment _generated_on_A_10_0 on A {
+          fragment _generated_onA2_0 on A {
             x
             y
           }
           
-          fragment _generated_on_B_9_0 on B {
+          fragment _generated_onB1_0 on B {
             z
           }
         },
@@ -5149,22 +5149,26 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ..._generated_on_A_11_0
-              ..._generated_on_B_9_1
+              ..._generated_onA3_0
+              ..._generated_onB1_0
             }
           }
           
-          fragment _generated_on_A_9_0 on A {
+          fragment _generated_onA1_0 on A {
             x
           }
           
-          fragment _generated_on_A_11_0 on A {
+          fragment _generated_onB1_0 on B {
+            z
+          }
+          
+          fragment _generated_onA3_0 on A {
             x
             y
             t {
               __typename
-              ..._generated_on_A_9_0
-              ..._generated_on_B_9_1
+              ..._generated_onA1_0
+              ..._generated_onB1_0
             }
           }
         },
@@ -5204,15 +5208,15 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ..._generated_on_A_10_0
+              ..._generated_onA2_0
             }
             t2 {
               __typename
-              ..._generated_on_A_10_0
+              ..._generated_onA2_0
             }
           }
           
-          fragment _generated_on_A_10_0 on A {
+          fragment _generated_onA2_0 on A {
             x
             y
           }

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -3907,7 +3907,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment FooChildSelect on Foo {
             __typename
             foo
@@ -3922,7 +3922,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment FooSelect on Foo {
             __typename
             foo
@@ -4096,7 +4096,7 @@ describe('Named fragments preservation', () => {
                   }
                 }
               }
-              
+
               fragment OnV on V {
                 a
                 b
@@ -4170,7 +4170,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment Selection on A {
             x
             y
@@ -4264,7 +4264,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-          
+
           fragment OnV on V {
             v1
             v2
@@ -4372,7 +4372,7 @@ describe('Named fragments preservation', () => {
               ...OnT @include(if: $test2)
             }
           }
-          
+
           fragment OnT on T {
             a
             b
@@ -4572,7 +4572,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               inner {
                 v {
@@ -4711,7 +4711,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               w
               inner {
@@ -4852,7 +4852,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               inner {
                 v
@@ -4991,7 +4991,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-            
+
             fragment OuterFrag on Outer {
               w
               inner {
@@ -5092,12 +5092,12 @@ describe('Fragment autogeneration', () => {
               ...qp__1
             }
           }
-          
-	  fragment qp__0 on A {
+
+	         fragment qp__0 on A {
             x
             y
           }
-          
+
           fragment qp__1 on B {
             z
           }
@@ -5159,7 +5159,7 @@ describe('Fragment autogeneration', () => {
 
     const plan = queryPlanner.buildQueryPlan(operation);
 
-    expect(plan).toMatchString(`
+    expect(serializeQueryPlan(plan)).toMatchString(`
       QueryPlan {
         Fetch(service: "Subgraph1") {
           {
@@ -5169,15 +5169,15 @@ describe('Fragment autogeneration', () => {
               ...qp__1
             }
           }
-          
+
           fragment qp__0 on A {
             x
           }
-          
+
           fragment qp__1 on B {
             z
           }
-          
+
           fragment qp__2 on A {
             x
             y
@@ -6971,7 +6971,7 @@ describe('named fragments', () => {
               }
             }
           }
-          
+
           fragment Fragment4 on I {
             __typename
             id1
@@ -7044,7 +7044,7 @@ describe('named fragments', () => {
               }
             }
           }
-          
+
           fragment Fragment4 on I {
             id1
             id2
@@ -7186,7 +7186,7 @@ describe('named fragments', () => {
                 id
               }
             }
-            
+
             fragment allTFields on T {
               v0
               v1
@@ -7334,7 +7334,7 @@ describe('named fragments', () => {
                   }
                 }
               }
-              
+
               fragment allUFields on U {
                 v0
                 v1

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -1,4 +1,4 @@
-import { QueryPlanner } from '@apollo/query-planner';
+import { QueryPlanner, serializeQueryPlan } from '@apollo/query-planner';
 import {
   assert,
   operationFromDocument,
@@ -6,12 +6,7 @@ import {
   Supergraph,
 } from '@apollo/federation-internals';
 import gql from 'graphql-tag';
-import {
-  FetchNode,
-  FlattenNode,
-  SequenceNode,
-  serializeQueryPlan,
-} from '../QueryPlan';
+import { FetchNode, FlattenNode, SequenceNode } from '../QueryPlan';
 import { FieldNode, OperationDefinitionNode, parse } from 'graphql';
 import {
   composeAndCreatePlanner,
@@ -3912,7 +3907,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment FooChildSelect on Foo {
             __typename
             foo
@@ -3927,7 +3922,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment FooSelect on Foo {
             __typename
             foo
@@ -4101,7 +4096,7 @@ describe('Named fragments preservation', () => {
                   }
                 }
               }
-
+              
               fragment OnV on V {
                 a
                 b
@@ -4175,7 +4170,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment Selection on A {
             x
             y
@@ -4269,7 +4264,7 @@ describe('Named fragments preservation', () => {
               }
             }
           }
-
+          
           fragment OnV on V {
             v1
             v2
@@ -4377,7 +4372,7 @@ describe('Named fragments preservation', () => {
               ...OnT @include(if: $test2)
             }
           }
-
+          
           fragment OnT on T {
             a
             b
@@ -4577,7 +4572,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               inner {
                 v {
@@ -4716,7 +4711,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               w
               inner {
@@ -4857,7 +4852,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               inner {
                 v
@@ -4996,7 +4991,7 @@ describe('Named fragments preservation', () => {
                 id
               }
             }
-
+            
             fragment OuterFrag on Outer {
               w
               inner {
@@ -6976,7 +6971,7 @@ describe('named fragments', () => {
               }
             }
           }
-
+          
           fragment Fragment4 on I {
             __typename
             id1
@@ -7049,7 +7044,7 @@ describe('named fragments', () => {
               }
             }
           }
-
+          
           fragment Fragment4 on I {
             id1
             id2
@@ -7191,7 +7186,7 @@ describe('named fragments', () => {
                 id
               }
             }
-
+            
             fragment allTFields on T {
               v0
               v1
@@ -7339,7 +7334,7 @@ describe('named fragments', () => {
                   }
                 }
               }
-
+              
               fragment allUFields on U {
                 v0
                 v1

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5094,17 +5094,17 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__10_0
-              ...qp__9_0
+              ...__generated_on_A_10_0
+              ...__generated_on_B_9_0
             }
           }
           
-          fragment qp__10_0 on A {
+          fragment __generated_on_A_10_0 on A {
             x
             y
           }
           
-          fragment qp__9_0 on B {
+          fragment __generated_on_B_9_0 on B {
             z
           }
         },
@@ -5149,22 +5149,22 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__11_0
-              ...qp__9_1
+              ...__generated_on_A_11_0
+              ...__generated_on_B_9_1
             }
           }
           
-          fragment qp__9_0 on A {
+          fragment __generated_on_A_9_0 on A {
             x
           }
           
-          fragment qp__11_0 on A {
+          fragment __generated_on_A_11_0 on A {
             x
             y
             t {
               __typename
-              ...qp__9_0
-              ...qp__9_1
+              ...__generated_on_A_9_0
+              ...__generated_on_B_9_1
             }
           }
         },
@@ -5204,15 +5204,15 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...qp__10_0
+              ...__generated_on_A_10_0
             }
             t2 {
               __typename
-              ...qp__10_0
+              ...__generated_on_A_10_0
             }
           }
           
-          fragment qp__10_0 on A {
+          fragment __generated_on_A_10_0 on A {
             x
             y
           }

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5094,17 +5094,17 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...__generated_on_A_10_0
-              ...__generated_on_B_9_0
+              ..._generated_on_A_10_0
+              ..._generated_on_B_9_0
             }
           }
           
-          fragment __generated_on_A_10_0 on A {
+          fragment _generated_on_A_10_0 on A {
             x
             y
           }
           
-          fragment __generated_on_B_9_0 on B {
+          fragment _generated_on_B_9_0 on B {
             z
           }
         },
@@ -5149,22 +5149,22 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...__generated_on_A_11_0
-              ...__generated_on_B_9_1
+              ..._generated_on_A_11_0
+              ..._generated_on_B_9_1
             }
           }
           
-          fragment __generated_on_A_9_0 on A {
+          fragment _generated_on_A_9_0 on A {
             x
           }
           
-          fragment __generated_on_A_11_0 on A {
+          fragment _generated_on_A_11_0 on A {
             x
             y
             t {
               __typename
-              ...__generated_on_A_9_0
-              ...__generated_on_B_9_1
+              ..._generated_on_A_9_0
+              ..._generated_on_B_9_1
             }
           }
         },
@@ -5204,15 +5204,15 @@ describe('Fragment autogeneration', () => {
           {
             t {
               __typename
-              ...__generated_on_A_10_0
+              ..._generated_on_A_10_0
             }
             t2 {
               __typename
-              ...__generated_on_A_10_0
+              ..._generated_on_A_10_0
             }
           }
           
-          fragment __generated_on_A_10_0 on A {
+          fragment _generated_on_A_10_0 on A {
             x
             y
           }

--- a/query-planner-js/src/config.ts
+++ b/query-planner-js/src/config.ts
@@ -34,6 +34,14 @@ export type QueryPlannerConfig = {
    */
   reuseQueryFragments?: boolean,
 
+  /**
+   * If enabled, the query planner will extract inline fragments into fragment
+   * definitions before sending queries to subgraphs. This can significantly
+   * reduce the size of the query sent to subgraphs, but may increase the time
+   * it takes to plan the query.
+   */
+  generateQueryFragments?: boolean,
+
   // Side-note: implemented as an object instead of single boolean because we expect to add more to this soon
   // enough. In particular, once defer-passthrough to subgraphs is implemented, the idea would be to add a
   // new `passthroughSubgraphs` option that is the list of subgraph to which we can pass-through some @defer
@@ -60,7 +68,7 @@ export type QueryPlannerConfig = {
   debug?: {
     /**
      * If used and the supergraph is built from a single subgraph, then user queries do not go through the
-     * normal query planning and instead a fetch to the one subgraph is built directly from the input query. 
+     * normal query planning and instead a fetch to the one subgraph is built directly from the input query.
      */
     bypassPlannerForSingleSubgraph?: boolean,
 
@@ -68,7 +76,7 @@ export type QueryPlannerConfig = {
      * Query planning is an exploratory process. Depending on the specificities and feature used by
      * subgraphs, there could exist may different theoretical valid (if not always efficient) plans
      * for a given query, and at a high level, the query planner generates those possible choices,
-     * evaluate them, and return the best one. In some complex cases however, the number of 
+     * evaluate them, and return the best one. In some complex cases however, the number of
      * theoretically possible plans can be very large, and to keep query planning time acceptable,
      * the query planner cap the maximum number of plans it evaluates. This config allows to configure
      * that cap. Note if planning a query hits that cap, then the planner will still always return a
@@ -92,7 +100,7 @@ export type QueryPlannerConfig = {
      * each constituent object type. The number of options generated in this computation can grow
      * large if the schema or query are sufficiently complex, and that will increase the time spent
      * planning.
-     * 
+     *
      * This config allows specifying a per-path limit to the number of options considered. If any
      * path's options exceeds this limit, query planning will abort and the operation will fail.
      *
@@ -108,6 +116,7 @@ export function enforceQueryPlannerConfigDefaults(
   return {
     exposeDocumentNodeInFetchNode: false,
     reuseQueryFragments: true,
+    generateQueryFragments: false,
     cache: new InMemoryLRUCache<QueryPlan>({maxSize: Math.pow(2, 20) * 50 }),
     ...config,
     incrementalDelivery: {


### PR DESCRIPTION
If enabled, the query planner will extract inline fragments into fragment definitions before sending queries to subgraphs. This can significantly reduce the size of the query sent to subgraphs, but may increase the time it takes to plan the query.

This is a reimplementation of https://github.com/apollographql/federation/pull/2893 that applies transformations on the selection set instead of AST.

Credit to @samuelAndalon for suggesting the new approach. Resolves https://github.com/apollographql/federation/issues/2892