### PR TITLE
Fix a query planning bug where invalid subgraph queries are generated with `reuseQueryFragments` set true

### DIFF
--- a/.changeset/invalid-reused-fragment.md
+++ b/.changeset/invalid-reused-fragment.md
@@ -1,0 +1,7 @@
+---
+"@apollo/query-planner": patch
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
+---
+
+Fix a query planning bug where invalid subgraph queries are generated with `reuseQueryFragments` set true. ([#2952](https://github.com/apollographql/federation/issues/2952))

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -3127,7 +3127,7 @@ describe('named fragment selection set restrictions at type', () => {
 
     const frag = operation.fragments?.get('FonT1')!;
 
-    let { selectionSet, validator } = expandAtType(frag, schema, 'T1');
+    const { selectionSet, validator } = expandAtType(frag, schema, 'T1');
     expect(selectionSet.toString()).toBe('{ x y }');
     expect(validator?.toString()).toBeUndefined();
   });

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1224,6 +1224,14 @@ export class NamedFragmentDefinition extends DirectiveTargetElement<NamedFragmen
     const expandedSelectionSet = this.expandedSelectionSet();
     const selectionSet = expandedSelectionSet.normalize({ parentType: type });
 
+    if( ! isObjectType(this.typeCondition) ) {
+      // When the type condition of the fragment is not an object type, the `FieldsInSetCanMerge` rule is more
+      // restrictive and any fields can create conflicts. Thus, we have to use the full validator in this case.
+      // (see https://github.com/graphql/graphql-spec/issues/1085 for details.)
+      const validator = FieldsConflictValidator.build(expandedSelectionSet);
+      return { selectionSet, validator };
+    }
+
     // Note that `trimmed` is the difference of 2 selections that may not have been normalized on the same parent type,
     // so in practice, it is possible that `trimmed` contains some of the selections that `selectionSet` contains, but
     // that they have been simplified in `selectionSet` in such a way that the `minus` call does not see it. However,

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -2880,7 +2880,7 @@ class FieldsConflictValidator {
         continue;
       }
 
-      // We're basically checking [FieldInSetCanMerge](https://spec.graphql.org/draft/#FieldsInSetCanMerge()),
+      // We're basically checking [FieldsInSetCanMerge](https://spec.graphql.org/draft/#FieldsInSetCanMerge()),
       // but from 2 set of fields (`thisFields` and `thatFields`) of the same response that we know individually
       // merge already.
       for (const [thisField, thisValidator] of thisFields.entries()) {

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1224,7 +1224,7 @@ export class NamedFragmentDefinition extends DirectiveTargetElement<NamedFragmen
     const expandedSelectionSet = this.expandedSelectionSet();
     const selectionSet = expandedSelectionSet.normalize({ parentType: type });
 
-    if( ! isObjectType(this.typeCondition) ) {
+    if (!isObjectType(this.typeCondition)) {
       // When the type condition of the fragment is not an object type, the `FieldsInSetCanMerge` rule is more
       // restrictive and any fields can create conflicts. Thus, we have to use the full validator in this case.
       // (see https://github.com/graphql/graphql-spec/issues/1085 for details.)

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -4,6 +4,7 @@ import {
   operationFromDocument,
   ServiceDefinition,
   Supergraph,
+  buildSubgraph,
 } from '@apollo/federation-internals';
 import gql from 'graphql-tag';
 import {
@@ -12,7 +13,7 @@ import {
   SequenceNode,
   serializeQueryPlan,
 } from '../QueryPlan';
-import { FieldNode, OperationDefinitionNode, parse } from 'graphql';
+import { FieldNode, OperationDefinitionNode, parse, validate, GraphQLError } from 'graphql';
 import {
   composeAndCreatePlanner,
   composeAndCreatePlannerWithOptions,
@@ -5041,7 +5042,138 @@ describe('Named fragments preservation', () => {
       }
     `);
   });
+
+  it('validates fragments on non-object types across spreads', () => {
+    const subgraph1 = {
+      name: 'subgraph1',
+      typeDefs: gql`
+        type Query {
+            theEntity: AnyEntity
+        }
+
+        union AnyEntity = EntityTypeA | EntityTypeB
+
+        type EntityTypeA @key(fields: "unifiedEntityId") {
+            unifiedEntityId: ID!
+            unifiedEntity: UnifiedEntity
+        }
+
+        type EntityTypeB @key(fields: "unifiedEntityId") {
+            unifiedEntityId: ID!
+            unifiedEntity: UnifiedEntity
+        }
+
+        interface UnifiedEntity {
+            id: ID!
+        }
+
+        type Generic implements UnifiedEntity @key(fields: "id"){
+            id: ID!
+        }
+
+        type Movie implements UnifiedEntity @key(fields: "id") {
+            id: ID!
+        }
+
+        type Show implements UnifiedEntity @key(fields: "id") {
+            id: ID!
+        }
+        `,
+    };
+
+    const subgraph2 = {
+      name: 'subgraph2',
+      typeDefs: gql`
+        interface Video {
+            videoId: Int!
+            taglineMessage(uiContext: String): String
+        }
+
+        interface UnifiedEntity {
+            id: ID!
+        }
+
+        type Generic implements UnifiedEntity @key(fields: "id") {
+            id: ID!
+            taglineMessage(uiContext: String): String
+        }
+
+        type Movie implements UnifiedEntity & Video @key(fields: "id") {
+            videoId: Int!
+            id: ID!
+            taglineMessage(uiContext: String): String
+        }
+
+        type Show implements UnifiedEntity & Video @key(fields: "id") {
+            videoId: Int!
+            id: ID!
+            taglineMessage(uiContext: String): String
+        }
+        `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlannerWithOptions([subgraph1, subgraph2],
+        {reuseQueryFragments: true});
+
+    let query = gql`
+      query Search {
+          theEntity {
+              ... on EntityTypeA {
+                  unifiedEntity {
+                      ... on Generic {
+                          taglineMessage(uiContext: "Generic")
+                      }
+                  }
+              }
+              ... on EntityTypeB {
+                  unifiedEntity {
+                      ...VideoSummary
+                  }
+              }
+          }
+      }
+
+      fragment VideoSummary on Video {
+          videoId # Note: This extra field selection is necessary, so this fragment is not ignored.
+          taglineMessage(uiContext: "Video")
+      }
+      `;
+    const operation = operationFromDocument(
+        api,
+        query,
+        {validate: true }
+    );
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    let validationErrors = validateSubFetches(plan.node, subgraph2);
+    expect(validationErrors).toHaveLength(0);
+  });
 });
+
+/**
+ * For each fetch in a PlanNode validate the generated operation is actually spec valid against its subgraph schema
+ * @param plan
+ * @param subgraphs
+ */
+function validateSubFetches(plan: any, subgraphDef: ServiceDefinition):
+    { errors: readonly GraphQLError[], serviceName: string, fetchNode: FetchNode }[]
+{
+  if (!plan) {
+    return [];
+  }
+  let fetches = findFetchNodes(subgraphDef.name, plan);
+  var results: { errors: readonly GraphQLError[], serviceName: string, fetchNode: FetchNode }[] = [];
+  for (let fetch of fetches) {
+    let subgraphName: string = fetch.serviceName;
+    let operation: string = fetch.operation;
+    let subgraph = buildSubgraph(subgraphName, 'http://subgraph', subgraphDef.typeDefs);
+    let gql_errors = validate(subgraph.schema.toGraphQLJSSchema(), parse(operation));
+    if (gql_errors.length > 0) {
+      results.push({ errors : gql_errors, serviceName: subgraphName, fetchNode: fetch });
+    }
+  }
+  return results;
+}
 
 describe('Fragment autogeneration', () => {
   const subgraph = {

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -5125,7 +5125,7 @@ describe('Named fragments preservation', () => {
       { reuseQueryFragments: true },
     );
 
-    let query = gql`
+    const query = gql`
       query Search {
         theEntity {
           ... on EntityTypeA {
@@ -5151,7 +5151,7 @@ describe('Named fragments preservation', () => {
     const operation = operationFromDocument(api, query, { validate: true });
 
     const plan = queryPlanner.buildQueryPlan(operation);
-    let validationErrors = validateSubFetches(plan.node, subgraph2);
+    const validationErrors = validateSubFetches(plan.node, subgraph2);
     expect(validationErrors).toHaveLength(0);
   });
 });
@@ -5172,21 +5172,21 @@ function validateSubFetches(
   if (!plan) {
     return [];
   }
-  let fetches = findFetchNodes(subgraphDef.name, plan);
-  var results: {
+  const fetches = findFetchNodes(subgraphDef.name, plan);
+  const results: {
     errors: readonly GraphQLError[];
     serviceName: string;
     fetchNode: FetchNode;
   }[] = [];
-  for (let fetch of fetches) {
-    let subgraphName: string = fetch.serviceName;
-    let operation: string = fetch.operation;
-    let subgraph = buildSubgraph(
+  for (const fetch of fetches) {
+    const subgraphName: string = fetch.serviceName;
+    const operation: string = fetch.operation;
+    const subgraph = buildSubgraph(
       subgraphName,
       'http://subgraph',
       subgraphDef.typeDefs,
     );
-    let gql_errors = validate(
+    const gql_errors = validate(
       subgraph.schema.toGraphQLJSSchema(),
       parse(operation),
     );

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -10,7 +10,9 @@ import gql from 'graphql-tag';
 import {
   FetchNode,
   FlattenNode,
+  PlanNode,
   SequenceNode,
+  SubscriptionNode,
   serializeQueryPlan,
 } from '../QueryPlan';
 import {
@@ -5160,7 +5162,7 @@ describe('Named fragments preservation', () => {
  * @param subgraphs
  */
 function validateSubFetches(
-  plan: any,
+  plan: PlanNode | SubscriptionNode | undefined,
   subgraphDef: ServiceDefinition,
 ): {
   errors: readonly GraphQLError[];

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -13,7 +13,13 @@ import {
   SequenceNode,
   serializeQueryPlan,
 } from '../QueryPlan';
-import { FieldNode, OperationDefinitionNode, parse, validate, GraphQLError } from 'graphql';
+import {
+  FieldNode,
+  OperationDefinitionNode,
+  parse,
+  validate,
+  GraphQLError,
+} from 'graphql';
 import {
   composeAndCreatePlanner,
   composeAndCreatePlannerWithOptions,
@@ -5048,101 +5054,99 @@ describe('Named fragments preservation', () => {
       name: 'subgraph1',
       typeDefs: gql`
         type Query {
-            theEntity: AnyEntity
+          theEntity: AnyEntity
         }
 
         union AnyEntity = EntityTypeA | EntityTypeB
 
         type EntityTypeA @key(fields: "unifiedEntityId") {
-            unifiedEntityId: ID!
-            unifiedEntity: UnifiedEntity
+          unifiedEntityId: ID!
+          unifiedEntity: UnifiedEntity
         }
 
         type EntityTypeB @key(fields: "unifiedEntityId") {
-            unifiedEntityId: ID!
-            unifiedEntity: UnifiedEntity
+          unifiedEntityId: ID!
+          unifiedEntity: UnifiedEntity
         }
 
         interface UnifiedEntity {
-            id: ID!
+          id: ID!
         }
 
-        type Generic implements UnifiedEntity @key(fields: "id"){
-            id: ID!
+        type Generic implements UnifiedEntity @key(fields: "id") {
+          id: ID!
         }
 
         type Movie implements UnifiedEntity @key(fields: "id") {
-            id: ID!
+          id: ID!
         }
 
         type Show implements UnifiedEntity @key(fields: "id") {
-            id: ID!
+          id: ID!
         }
-        `,
+      `,
     };
 
     const subgraph2 = {
       name: 'subgraph2',
       typeDefs: gql`
         interface Video {
-            videoId: Int!
-            taglineMessage(uiContext: String): String
+          videoId: Int!
+          taglineMessage(uiContext: String): String
         }
 
         interface UnifiedEntity {
-            id: ID!
+          id: ID!
         }
 
         type Generic implements UnifiedEntity @key(fields: "id") {
-            id: ID!
-            taglineMessage(uiContext: String): String
+          id: ID!
+          taglineMessage(uiContext: String): String
         }
 
         type Movie implements UnifiedEntity & Video @key(fields: "id") {
-            videoId: Int!
-            id: ID!
-            taglineMessage(uiContext: String): String
+          videoId: Int!
+          id: ID!
+          taglineMessage(uiContext: String): String
         }
 
         type Show implements UnifiedEntity & Video @key(fields: "id") {
-            videoId: Int!
-            id: ID!
-            taglineMessage(uiContext: String): String
+          videoId: Int!
+          id: ID!
+          taglineMessage(uiContext: String): String
         }
-        `,
+      `,
     };
 
-    const [api, queryPlanner] = composeAndCreatePlannerWithOptions([subgraph1, subgraph2],
-        {reuseQueryFragments: true});
+    const [api, queryPlanner] = composeAndCreatePlannerWithOptions(
+      [subgraph1, subgraph2],
+      { reuseQueryFragments: true },
+    );
 
     let query = gql`
       query Search {
-          theEntity {
-              ... on EntityTypeA {
-                  unifiedEntity {
-                      ... on Generic {
-                          taglineMessage(uiContext: "Generic")
-                      }
-                  }
+        theEntity {
+          ... on EntityTypeA {
+            unifiedEntity {
+              ... on Generic {
+                taglineMessage(uiContext: "Generic")
               }
-              ... on EntityTypeB {
-                  unifiedEntity {
-                      ...VideoSummary
-                  }
-              }
+            }
           }
+          ... on EntityTypeB {
+            unifiedEntity {
+              ...VideoSummary
+            }
+          }
+        }
       }
 
       fragment VideoSummary on Video {
-          videoId # Note: This extra field selection is necessary, so this fragment is not ignored.
-          taglineMessage(uiContext: "Video")
+        videoId # Note: This extra field selection is necessary, so this fragment is not ignored.
+        taglineMessage(uiContext: "Video")
       }
-      `;
-    const operation = operationFromDocument(
-        api,
-        query,
-        {validate: true }
-    );
+    `;
+    const operation = operationFromDocument(api, query, { validate: true });
 
     const plan = queryPlanner.buildQueryPlan(operation);
     let validationErrors = validateSubFetches(plan.node, subgraph2);
@@ -5155,21 +5159,41 @@ describe('Named fragments preservation', () => {
  * @param plan
  * @param subgraphs
  */
-function validateSubFetches(plan: any, subgraphDef: ServiceDefinition):
-    { errors: readonly GraphQLError[], serviceName: string, fetchNode: FetchNode }[]
-{
+function validateSubFetches(
+  plan: any,
+  subgraphDef: ServiceDefinition,
+): {
+  errors: readonly GraphQLError[];
+  serviceName: string;
+  fetchNode: FetchNode;
+}[] {
   if (!plan) {
     return [];
   }
   let fetches = findFetchNodes(subgraphDef.name, plan);
-  var results: { errors: readonly GraphQLError[], serviceName: string, fetchNode: FetchNode }[] = [];
+  var results: {
+    errors: readonly GraphQLError[];
+    serviceName: string;
+    fetchNode: FetchNode;
+  }[] = [];
   for (let fetch of fetches) {
     let subgraphName: string = fetch.serviceName;
     let operation: string = fetch.operation;
-    let subgraph = buildSubgraph(subgraphName, 'http://subgraph', subgraphDef.typeDefs);
-    let gql_errors = validate(subgraph.schema.toGraphQLJSSchema(), parse(operation));
+    let subgraph = buildSubgraph(
+      subgraphName,
+      'http://subgraph',
+      subgraphDef.typeDefs,
+    );
+    let gql_errors = validate(
+      subgraph.schema.toGraphQLJSSchema(),
+      parse(operation),
+    );
     if (gql_errors.length > 0) {
-      results.push({ errors : gql_errors, serviceName: subgraphName, fetchNode: fetch });
+      results.push({
+        errors: gql_errors,
+        serviceName: subgraphName,
+        fetchNode: fetch,
+      });
     }
   }
   return results;


### PR DESCRIPTION
This PR fixes https://github.com/apollographql/federation/issues/2952.

### Summary of changes

- updated computeExpandedSelectionSetAtType function not to trim fragment's validators if the fragment's type condition is not an object type.
- This change is necessary because `FieldsInSetCanMerge` rule is more restrictive in that case.
- The untrimmed validator should avoid generating invalid queries, but it may be less efficient.

### Test plan

- The operations.test.ts confirms the changes of named fragments' validators.
- Added a new test (based on the github issue's reproducer) confirming that subgraph queries are no longer invalid.