### PR TITLE
update secops-orb version to 2.0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.1.0
-  secops: apollo/circleci-secops-orb@2.0.6
+  secops: apollo/circleci-secops-orb@2.0.7
 
 jobs:
   # Unfortunately cimg/node doesn't tag its images with major only, you have to specify a minor version.


### PR DESCRIPTION
- Updated config.yml
- This fixed semgrep CI failures.

(This commit was made by Jason Barnett.)