### PR TITLE
add changeset for #2982

### DIFF
--- a/.changeset/fix_directives_to_subgraph_passing.md
+++ b/.changeset/fix_directives_to_subgraph_passing.md
@@ -1,0 +1,6 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+---
+
+Fixed a regression created by PR (#2967), where directives would not be properly attached to their parent. (#2982)


### PR DESCRIPTION
#2982 was missing a changeset, which prevents us from curating a patch release. this changes fixes it.