### PR TITLE
collect typename at context branch point

### DIFF
--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -8899,6 +8899,7 @@ describe('@fromContext impacts on query planning', () => {
           Fetch(service: "Subgraph1") {
             {
               t {
+                __typename
                 prop
                 u {
                   __typename
@@ -9144,6 +9145,7 @@ describe('@fromContext impacts on query planning', () => {
           Fetch(service: "Subgraph1") {
             {
               t {
+                __typename
                 prop
                 u {
                   __typename
@@ -9322,6 +9324,7 @@ describe('@fromContext impacts on query planning', () => {
           Fetch(service: "Subgraph1") {
             {
               t {
+                __typename
                 prop
                 u {
                   __typename
@@ -9589,6 +9592,7 @@ describe('@fromContext impacts on query planning', () => {
               t {
                 __typename
                 ... on A {
+                  __typename
                   prop
                   u {
                     __typename
@@ -9597,6 +9601,7 @@ describe('@fromContext impacts on query planning', () => {
                   }
                 }
                 ... on B {
+                  __typename
                   prop
                   u {
                     __typename

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -4355,7 +4355,14 @@ function computeGroupsForTree(
             );
             updated.group = requireResult.group;
             updated.path = requireResult.path;
-            
+
+            // add __typename to site where we are retrieving context from
+            // this is necessary because the context rewrites path will start with a type condition
+            if (contextToSelection) {
+              assert(isCompositeType(edge.head.type), () => `Expected a composite type for ${edge.head.type}`);
+              updated.group.addAtPath(path.inGroup().concat(new Field(edge.head.type.typenameField()!)));
+            }
+
             if (contextToSelection) {
               const newContextToConditionsGroups = new Map<string, FetchGroup[]>([...contextToConditionsGroups]);
               for (const context of contextToSelection) {
@@ -4365,6 +4372,11 @@ function computeGroupsForTree(
             }
             updateCreatedGroups(createdGroups, ...requireResult.createdGroups);
           } else if (conditions) {
+            // add __typename to site where we are retrieving context from
+            // this is necessary because the context rewrites path will start with a type condition
+            assert(isCompositeType(edge.head.type), () => `Expected a composite type for ${edge.head.type}`);
+            group.addAtPath(path.inGroup().concat(new Field(edge.head.type.typenameField()!)));
+
             const conditionsGroups = computeGroupsForTree({
               dependencyGraph, 
               pathTree: conditions, 


### PR DESCRIPTION
When looking up a condition that will be used by a context, make sure you also collect the __typename field at the branch point