### PR TITLE
 docs: add version notes to updated directives

### DIFF
--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -104,7 +104,7 @@ directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJE
 
 <Note>
 
-`@key` can only use the `resolvable` in v2.0 and later.
+`@key` can only use the `resolvable` flag in v2.0 and later.
 
 </Note>
 

--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -102,12 +102,6 @@ For more information on `@link`, see the [official spec](https://specs.apollo.de
 directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 ```
 
-<Note>
-
-`@key` can only use the `resolvable` flag in v2.0 and later.
-
-</Note>
-
 Designates an object type as an entity and specifies its key fields. Key fields are a set of fields that a subgraph can use to uniquely identify any instance of the entity.
 
 ```graphql {1}
@@ -259,7 +253,7 @@ directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 
 <Note>
 
-`@shareable` is only `repeatable` in v2.2 and later.
+`@shareable` is only `repeatable` in [v2.2](./federation-versions#v22) and later.
 
 </Note>
 
@@ -588,12 +582,6 @@ Indicates to composition that the target element is restricted based on authoriz
 directive @external on FIELD_DEFINITION | OBJECT
 ```
 
-<Note>
-
-`@external` is only applicable on `OBJECT`s in v2.0 and later.
-
-</Note>>
-
 Indicates that this subgraph usually can't resolve a particular object field, but it still needs to define that field for other purposes.
 
 This directive is always used in combination with another directive that references object fields, such as [`@provides`](#provides) or [`@requires`](#requires).
@@ -781,12 +769,6 @@ Examples:
 ```graphql
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 ```
-
-<Note>
-
-`@tag` is only applicable on `SCHEMA`s in v2.0 and later.
-
-</Note>
 
 Applies arbitrary string metadata to a schema location. Custom tooling can use this metadata during any step of the schema delivery flow, including composition, static analysis, and documentation. The GraphOS Enterprise [contracts feature](/graphos/delivery/contracts/) uses `@tag` with its inclusion and exclusion filters.
 

--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -253,7 +253,7 @@ directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 
 <Note>
 
-`@shareable` is only `repeatable` in [v2.2](./federation-versions#v22) and later.
+`@shareable` is only `repeatable` in [v2.2](../federation-versions#v22) and later.
 
 </Note>
 

--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -102,6 +102,12 @@ For more information on `@link`, see the [official spec](https://specs.apollo.de
 directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 ```
 
+<Note>
+
+`@key` can only use the `resolvable` in v2.0 and later.
+
+</Note>
+
 Designates an object type as an entity and specifies its key fields. Key fields are a set of fields that a subgraph can use to uniquely identify any instance of the entity.
 
 ```graphql {1}
@@ -248,8 +254,14 @@ In Federation 1, every subgraph must extend the `Query` and `Mutation` types (if
 </MinVersion>
 
 ```graphql
-directive @shareable on FIELD_DEFINITION | OBJECT
+directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 ```
+
+<Note>
+
+`@shareable` is only `repeatable` in v2.2 and later.
+
+</Note>
 
 Indicates that an object type's field is allowed to be resolved by multiple subgraphs (by default in Federation 2, object fields can be resolved by only one subgraph).
 
@@ -576,6 +588,12 @@ Indicates to composition that the target element is restricted based on authoriz
 directive @external on FIELD_DEFINITION | OBJECT
 ```
 
+<Note>
+
+`@external` is only applicable on `OBJECT`s in v2.0 and later.
+
+</Note>>
+
 Indicates that this subgraph usually can't resolve a particular object field, but it still needs to define that field for other purposes.
 
 This directive is always used in combination with another directive that references object fields, such as [`@provides`](#provides) or [`@requires`](#requires).
@@ -761,8 +779,14 @@ Examples:
 </MinVersion>
 
 ```graphql
-directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 ```
+
+<Note>
+
+`@tag` is only applicable on `SCHEMA`s in v2.0 and later.
+
+</Note>
 
 Applies arbitrary string metadata to a schema location. Custom tooling can use this metadata during any step of the schema delivery flow, including composition, static analysis, and documentation. The GraphOS Enterprise [contracts feature](/graphos/delivery/contracts/) uses `@tag` with its inclusion and exclusion filters.
 

--- a/docs/source/federation-versions.mdx
+++ b/docs/source/federation-versions.mdx
@@ -64,7 +64,7 @@ Minimum router version
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -129,7 +129,7 @@ Minimum router version
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -166,7 +166,7 @@ directive @policy(policies: [[federation__Policy!]!]!) on
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -226,7 +226,7 @@ Minimum router version
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -286,7 +286,7 @@ directive @requiresScopes(scopes: [[federation__Scope!]!]!) on
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -346,7 +346,7 @@ Minimum router version
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -408,7 +408,7 @@ Minimum router version
 <table>
   <thead>
     <tr>
-      <th>Name</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -488,7 +488,7 @@ Minimum router version
 <table>
   <thead>
     <tr>
-      <th>Name</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -555,7 +555,7 @@ Minimum router version
 <table>
   <thead>
     <tr>
-      <th>Name</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -657,7 +657,7 @@ For details on these directives as defined in Federation 2, see [Federation-spec
 <table>
   <thead>
     <tr>
-      <th>Name</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -787,7 +787,7 @@ No changes.
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -849,7 +849,7 @@ Value types
 <table>
   <thead>
     <tr>
-      <th>Name</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -888,7 +888,7 @@ For details on these directives as defined in Federation 1, see the [Federation 
 <table>
   <thead>
     <tr>
-      <th>Name</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -987,7 +987,7 @@ directive @extends on OBJECT | INTERFACE
 <table>
   <thead>
     <tr>
-      <th>Topic</th>
+      <th style={{ minWidth: 200 }}>Topic</th>
       <th>Description</th>
     </tr>
   </thead>


### PR DESCRIPTION
Clarifies if a Federation directive definitions were changed at a certain version.