### PR TITLE
Fix bug in context-matching logic for interfaces-implementing-interfaces

### DIFF
--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -1924,7 +1924,7 @@ function canSatisfyConditions<TTrigger, V extends Vertex, TNullEdge extends null
               if (parentInSupergraph.name === t) {
                 return true;
               }
-              if (isObjectType(parentInSupergraph)) {
+              if (isObjectType(parentInSupergraph) || isInterfaceType(parentInSupergraph)) {
                 if (parentInSupergraph.interfaces().some(i => i.name === t)) {
                   return true;
                 }


### PR DESCRIPTION
A field is considered to match a context if the field's parent type (in the original query) either has `@context` on it, or implements/is a member of a type with `@context` on it. We ended up missing the case where interfaces implement interfaces; this PR introduces a fix.