### PR TITLE
various setContext bug fixes

### DIFF
--- a/.changeset/popular-chairs-happen.md
+++ b/.changeset/popular-chairs-happen.md
@@ -1,0 +1,11 @@
+---
+"apollo-federation-integration-testsuite": patch
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
+"@apollo/subgraph": patch
+"@apollo/gateway": patch
+---
+
+Various set context bugfixes

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1661,11 +1661,11 @@ class Merger {
       return true;
     }
     
-    // if there is a @fromContext directive on one of the sources, we need a join__field
+    // if there is a @fromContext directive on one of the source's arguments, we need a join__field
     if (sources.some((s, idx) => {
       const fromContextDirective = this.subgraphs.values()[idx].metadata().fromContextDirective();
-      if (isFederationDirectiveDefinedInSchema(fromContextDirective)) {
-        return (s?.appliedDirectivesOf(fromContextDirective).length ?? 0) > 0;
+      if (s && isFederationDirectiveDefinedInSchema(fromContextDirective)) {
+        return s.kind === 'FieldDefinition' && s.arguments().some(arg => arg.appliedDirectivesOf(fromContextDirective).length > 0);
       }
       return false;
     })) {

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -413,7 +413,10 @@ const validateFieldValueType = ({
     }
     const { element, selectionSet: childSelectionSet } = selection;
     assert(element.definition.type, 'Element type definition should exist');
-    const type = element.definition.type;
+    let type = element.definition.type;
+    if (type.kind === 'NonNullType') {
+      type = type.ofType;
+    }
     if (childSelectionSet) {
       assert(isCompositeType(type), 'Child selection sets should only exist on composite types');
       const { resolvedType } = validateFieldValueType({

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -414,13 +414,11 @@ const validateFieldValueType = ({
     const { element, selectionSet: childSelectionSet } = selection;
     assert(element.definition.type, 'Element type definition should exist');
     let type = element.definition.type;
-    if (type.kind === 'NonNullType') {
-      type = type.ofType;
-    }
+
     if (childSelectionSet) {
-      assert(isCompositeType(type), 'Child selection sets should only exist on composite types');
+      assert(isCompositeType(baseType(type)), 'Child selection sets should only exist on composite types');
       const { resolvedType } = validateFieldValueType({
-        currentType: type,
+        currentType: baseType(type) as CompositeType,
         selectionSet: childSelectionSet,
         errorCollector,
         metadata,

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -377,7 +377,9 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     const fromContextDirective = federationMetadata(parentType.schema())?.fromContextDirective();
     if (fromContextDirective && isFederationDirectiveDefinedInSchema(fromContextDirective)) {
       const fieldInParent = parentType.field(this.name);
-      if (fieldInParent && fieldInParent.arguments().some(arg => arg.appliedDirectivesOf(fromContextDirective).length > 0)) {
+      if (fieldInParent && fieldInParent.arguments()
+          .some(arg => arg.appliedDirectivesOf(fromContextDirective).length > 0 && (!this.args || this.args[arg.name] === undefined))
+        ) {
         return undefined;
       }  
     }

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -368,10 +368,21 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     if (this.name === typenameFieldName) {
       return parentType.typenameField()?.type;
     }
-
-    return this.canRebaseOn(parentType)
+    
+    const returnType = this.canRebaseOn(parentType)
       ? parentType.field(this.name)?.type
       : undefined;
+      
+    // If the field has an argument with fromContextDirective on it. We should not rebase it.
+    const fromContextDirective = federationMetadata(parentType.schema())?.fromContextDirective();
+    if (fromContextDirective && isFederationDirectiveDefinedInSchema(fromContextDirective)) {
+      const fieldInParent = parentType.field(this.name);
+      if (fieldInParent && fieldInParent.arguments().some(arg => arg.appliedDirectivesOf(fromContextDirective).length > 0)) {
+        return undefined;
+      }  
+    }
+
+    return returnType;
   }
 
   hasDefer(): boolean {

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -653,6 +653,12 @@ export class GraphPath<TTrigger, RV extends Vertex = Vertex, TNullEdge extends n
     if (!enteringEdge) {
       return undefined;
     }
+    
+    // TODO: Temporary fix to avoid optimization if context exists.
+    // permanent fix is described here: https://github.com/apollographql/federation/pull/3017#pullrequestreview-2083949094
+    if (this.graph.subgraphToArgs.size > 0) {
+      return undefined;
+    }
 
     // Usually, the starting subgraph in which we want to look for a direct path is the head of
     // `subgraphEnteringEdge`, that is, where we were just before coming to the current subgraph.

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -9643,4 +9643,224 @@ describe('@fromContext impacts on query planning', () => {
       },
     ]);
   });
+
+  it('fromContext accesses a different top level query', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      url: 'https://Subgraph1',
+      typeDefs: gql`
+        type Query @context(name: "topLevelQuery") {
+          me: User!
+          product: Product
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+          locale: String!
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          price(
+            locale: String
+              @fromContext(field: "$topLevelQuery { me { locale } }")
+          ): Int!
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      url: 'https://Subgraph2',
+      typeDefs: gql`
+        type Query {
+          randomId: ID!
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+        }
+      `,
+    };
+
+    const asFed2Service = (service: ServiceDefinition) => {
+      return {
+        ...service,
+        typeDefs: asFed2SubgraphDocument(service.typeDefs, {
+          includeAllImports: true,
+        }),
+      };
+    };
+
+    const composeAsFed2Subgraphs = (services: ServiceDefinition[]) => {
+      return composeServices(services.map((s) => asFed2Service(s)));
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    expect(result.errors).toBeUndefined();
+    const [api, queryPlanner] = [
+      result.schema!.toAPISchema(),
+      new QueryPlanner(Supergraph.buildForTests(result.supergraphSdl!)),
+    ];
+    // const [api, queryPlanner] = composeFed2SubgraphsAndCreatePlanner(subgraph1, subgraph2);
+    const operation = operationFromDocument(
+      api,
+      gql`
+        {
+          product {
+            price
+          }
+        }
+      `,
+    );
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              __typename
+              me {
+                locale
+              }
+              product {
+                __typename
+                id
+              }
+            }
+          },
+          Flatten(path: "product") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on Product {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Product {
+                  price(locale: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', 'me', 'locale'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+  });
+
+  it('fromContext type does not exist on other subgraph', () => {
+    const subgraph1 = {
+      name: 'Subgraph1',
+      url: 'https://Subgraph1',
+      typeDefs: gql`
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: 'Subgraph2',
+      url: 'https://Subgraph2',
+      typeDefs: gql`
+        type Query {
+          randomId: ID!
+        }
+      `,
+    };
+
+    const asFed2Service = (service: ServiceDefinition) => {
+      return {
+        ...service,
+        typeDefs: asFed2SubgraphDocument(service.typeDefs, {
+          includeAllImports: true,
+        }),
+      };
+    };
+
+    const composeAsFed2Subgraphs = (services: ServiceDefinition[]) => {
+      return composeServices(services.map((s) => asFed2Service(s)));
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    expect(result.errors).toBeUndefined();
+    const [api, queryPlanner] = [
+      result.schema!.toAPISchema(),
+      new QueryPlanner(Supergraph.buildForTests(result.supergraphSdl!)),
+    ];
+    // const [api, queryPlanner] = composeFed2SubgraphsAndCreatePlanner(subgraph1, subgraph2);
+    const operation = operationFromDocument(
+      api,
+      gql`
+        {
+          t {
+            u {
+              field
+            }
+          }
+        }
+      `,
+    );
+
+    const plan = queryPlanner.buildQueryPlan(operation);
+    expect(plan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                prop
+                u {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+    `);
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on T', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Some setContext bug fixes
- needsJoinDirective() logic is incorrect. We need to make sure that we add a join field when @fromDirective exists on the arguments, not the definition
- Query plans were incorrect if type was entirely in one subgraph. selectionIsFullyLocalFromAllVertices was calling SelectionSet.canRebaseOn so we fixed to return false if the selection contained a field with a contextual argument
- For top level queries, we don't want to have "... on Query" in the rewrite path.
- Fixed up  selectionSetAsKeyRenamers() logic
