### PR TITLE
docs: fix ContextFieldValue scalar

### DIFF
--- a/docs/source/federated-types/federated-directives.mdx
+++ b/docs/source/federated-types/federated-directives.mdx
@@ -960,21 +960,21 @@ type U @key(fields: "id") {
 The `@fromContext` directive sets the context from which to receive the value of the annotated field. The context must have been defined with the `@context` directive.
 
 ```graphql
-scalar FieldValue;
+scalar ContextFieldValue;
 
-directive @fromContext(field: FieldValue!) on ARGUMENT_DEFINITION;
+directive @fromContext(field: ContextFieldValue) on ARGUMENT_DEFINITION;
 ```
 
-A `@fromContext` directive must be used as an argument on a field. Its field value—the `FieldValue` scalar—must contain the name of a defined context and a selection of a field from the context's type.
+A `@fromContext` directive must be used as an argument on a field. Its field value—the `ContextFieldValue` scalar—must contain the name of a defined context and a selection of a field from the context's type.
 
-The selection syntax for `@fromContext` used in its `FieldValue` is similar to GraphQL field selection syntax, with some additional rules: 
+The selection syntax for `@fromContext` used in its `ContextFieldValue` is similar to GraphQL field selection syntax, with some additional rules:
 - The first element must be the name of a context defined by `@context` and prefixed with `$` (for example, `$myContext`). This is the only context that can be referenced by the annotated field.
 - The `@skip` and `@include` directives must not be used.
 - The second element must be a selection set that resolves to a single field.
 - Top-level type conditions must not overlap with one another, so that the field can be resolved to a single value.
-- All fields referenced in the `FieldValue` must be expressed within the current subgraph. If the fields are referenced across multiple subgraphs, they must be annotated with [`@external`](../entities-advanced/#referencing-fields-across-subgraphs) .
+- All fields referenced in the `ContextFieldValue` must be expressed within the current subgraph. If the fields are referenced across multiple subgraphs, they must be annotated with [`@external`](../entities-advanced/#referencing-fields-across-subgraphs) .
 - The argument must be nullable. Because validation is done at the subgraph level, the referenced field may become nullable when merging subgraphs, such as when the field is nullable in one subgraph but not in another.
 
-When the same contextual value is set in multiple places, the `FieldValue` must resolve all types from each place into a single value that matches the parameter type. 
+When the same contextual value is set in multiple places, the `ContextFieldValue` must resolve all types from each place into a single value that matches the parameter type.
 
 For examples using `@context` and `@fromContext`, see [Using contexts to share data along type hierarchies](../entities-advanced/#using-contexts-to-share-data-along-type-hierarchies).

--- a/docs/source/federation-versions.mdx
+++ b/docs/source/federation-versions.mdx
@@ -99,9 +99,9 @@ directive @context(name: String!) on OBJECT | INTERFACE | UNION;
 Introduced. [Learn more](./federated-types/federated-directives/#fromcontext).
 
 ```graphql
-scalar FieldValue;
+scalar ContextFieldValue;
 
-directive @fromContext(field: FieldValue!) on ARGUMENT_DEFINITION;
+directive @fromContext(field: ContextFieldValue) on ARGUMENT_DEFINITION;
 ```
 
 </td>

--- a/docs/source/subgraph-spec.mdx
+++ b/docs/source/subgraph-spec.mdx
@@ -35,6 +35,7 @@ union _Entity
 scalar _Any
 scalar FieldSet
 scalar link__Import
+scalar federation__ContextFieldValue
 scalar federation__Scope
 scalar federation__Policy
 
@@ -73,6 +74,8 @@ directive @interfaceObject on OBJECT
 directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+directive @fromContext(field: ContextFieldValue) on ARGUMENT_DEFINITION
 
 # This definition is required only for libraries that don't support
 # GraphQL's built-in `extend` keyword


### PR DESCRIPTION
`FieldValue` scalar was renamed to `ContextFieldValue`.