### PR TITLE
[Perf] Filter out undefined entries earlier in needsJoinField

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1662,7 +1662,7 @@ class Merger {
     }
     
     // if there is a @fromContext directive on one of the source's arguments, we need a join__field
-    if (sources.some((s, idx) => {
+    if (sources.filter(isDefined).some((s, idx) => {
       const fromContextDirective = this.subgraphs.values()[idx].metadata().fromContextDirective();
       if (s && isFederationDirectiveDefinedInSchema(fromContextDirective)) {
         return s.kind === 'FieldDefinition' && s.arguments().some(arg => arg.appliedDirectivesOf(fromContextDirective).length > 0);


### PR DESCRIPTION
## Description
This PR filters out undefined entries from the sources array in needsJoinField yielding a ~4x performance improvement when merging a large set of subgraphs.

Without the change timing of `mergeSubgraphs` function is `6:59.349 (m:ss.mmm)`, the flamegraph below shows lots of CPU time spent in `needsJoinField`:

![Screenshot 2024-06-11 at 10 28 07 AM](https://github.com/apollographql/federation/assets/1523863/1299cbf6-3fbd-48a2-96da-0065bba0a893)

With the change, timing of `mergeSubgraphs` function is `1:30.084 (m:ss.mmm)`, updated flamegraph afterwards:

![Screenshot 2024-06-11 at 10 30 29 AM](https://github.com/apollographql/federation/assets/1523863/e50ce149-a225-4e57-a418-902e5b26bb53)

We might be able to write a bench suite for composition, including large graphs as it's currently relatively easy to regress.