### PR TITLE
generate proper errors for invalid context name

### DIFF
--- a/composition-js/src/__tests__/compose.setContext.test.ts
+++ b/composition-js/src/__tests__/compose.setContext.test.ts
@@ -1331,4 +1331,45 @@ describe("setContext tests", () => {
       '[Subgraph1] @fromContext argument cannot be used on a field implementing an interface field "I.field".'
     );
   });
+  
+  test("invalid context name shouldn't throw", () => {
+    const subgraph1 = {
+      name: "Subgraph1",
+      utl: "https://Subgraph1",
+      typeDefs: gql`
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") @context(name: "") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          field(a: String): Int!
+        }
+      `,
+    };
+
+    const subgraph2 = {
+      name: "Subgraph2",
+      utl: "https://Subgraph2",
+      typeDefs: gql`
+        type Query {
+          a: Int!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+    expect(result.schema).toBeUndefined();
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors?.[0].message).toBe(
+      '[Subgraph1] Context name "" is invalid. It should have only alphanumeric characters.'
+    );
+  });
 });

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -1577,9 +1577,16 @@ export class FederationBlueprint extends SchemaBlueprint {
       const parent = application.parent;
       const name = application.arguments().name as string;
       
+      const match = name.match(/^([A-Za-z]\w*)$/);
       if (name.includes('_')) {
         errorCollector.push(ERRORS.CONTEXT_NAME_INVALID.err(
           `Context name "${name}" may not contain an underscore.`,
+          { nodes: sourceASTs(application) }
+        ));
+      }
+      else if (!match) {
+        errorCollector.push(ERRORS.CONTEXT_NAME_INVALID.err(
+          `Context name "${name}" is invalid. It should have only alphanumeric characters.`,
           { nodes: sourceASTs(application) }
         ));
       }


### PR DESCRIPTION
We were triggering an assert in extractSubgraphsFromSupergraph because we weren't properly detecting an invalid name at validation time. Make sure regex matches.