### PR TITLE
generateQueryFragments error with nested selection set

### DIFF
--- a/.changeset/calm-candles-rest.md
+++ b/.changeset/calm-candles-rest.md
@@ -1,0 +1,5 @@
+---
+"@apollo/federation-internals": patch
+---
+
+generateQueryFragments() could generate fragments with naming collisions when nested

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -69,31 +69,25 @@ describe('generate query fragments', () => {
     `);
 
     const withGeneratedFragments = operation.generateQueryFragments();
+    console.log(withGeneratedFragments.toString());
     expect(withGeneratedFragments.toString()).toMatchString(`
-      {
-        t {
-          ... on T1 {
-            a
-            b
-          }
-          ... on T2 {
-            x
-            y
-          }
+      fragment _generated_onB1_0 on B {
+        ... on B {
           b
-          u {
-            ... on I {
-              b
-            }
-            ... on T1 {
-              a
-              b
-            }
-            ... on T2 {
-              x
-              y
-            }
-          }
+        }
+      }
+      
+      fragment _generated_onB1_1 on B {
+        ..._generated_onB1_0
+      }
+      
+      fragment _generated_onB1_2 on B {
+        ..._generated_onB1_1
+      }
+      
+      {
+        entities {
+          ..._generated_onB1_2
         }
       }
     `);

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1594,16 +1594,17 @@ export class SelectionSet {
         // No match, so we need to create a new fragment. First, we minimize the
         // selection set before creating the fragment with it.
         const [minimizedSelectionSet] = selection.selectionSet.minimizeSelectionSet(namedFragments, seenSelections);
+        const updatedEquivalentSelectionSetCandidates = seenSelections.get(mockHashCode); // may have changed after previous statement
         const fragmentDefinition = new NamedFragmentDefinition(
           this.parentType.schema(),
-          `_generated_${mockHashCode}_${equivalentSelectionSetCandidates?.length ?? 0}`,
+          `_generated_${mockHashCode}_${updatedEquivalentSelectionSetCandidates?.length ?? 0}`,
           selection.element.typeCondition
         ).setSelectionSet(minimizedSelectionSet);
         namedFragments.add(fragmentDefinition);
 
         // Create a new "hash code" bucket or add to the existing one.
-        if (equivalentSelectionSetCandidates) {
-          equivalentSelectionSetCandidates.push([selection.selectionSet, fragmentDefinition]);
+        if (updatedEquivalentSelectionSetCandidates) {
+          updatedEquivalentSelectionSetCandidates.push([selection.selectionSet, fragmentDefinition]);
         } else {
             seenSelections.set(mockHashCode, [[selection.selectionSet, fragmentDefinition]]);
         }


### PR DESCRIPTION
Fixes #3042 

generateQueryFragments does't handle repeated (... on B { ... on B ... on B } } }) fragments well. Given the query planner can actually generate these query structures, this causes this option to be potentially dangerous, generating invalid subgraph queries.