### PR TITLE
Make enum addValue() faster by using an Map rather than an array

### DIFF
--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -32,7 +32,7 @@ import {
   isCoreSpecDirectiveApplication,
   removeAllCoreFeatures,
 } from "./specs/coreSpec";
-import { assert, mapValues, MapWithCachedArrays, removeArrayElement, TimeOrderedSet } from "./utils";
+import { assert, mapValues, MapWithCachedArrays, removeArrayElement } from "./utils";
 import {
   withDefaultValues,
   valueEquals,
@@ -2291,7 +2291,7 @@ export class UnionType extends BaseNamedType<OutputTypeReferencer, UnionType> {
 export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   readonly kind = 'EnumType' as const;
   readonly astDefinitionKind = Kind.ENUM_TYPE_DEFINITION;
-  private _values = new TimeOrderedSet<EnumValue>();
+  private _values = new Map<string, EnumValue>();
 
   get values(): readonly EnumValue[] {
     // Because our abstractions are mutable, and removal is done by calling
@@ -2319,7 +2319,7 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
     }
     const existing = this.value(toAdd.name);
     if (!existing) {
-      this._values.add(toAdd);
+      this._values.set(toAdd.name, toAdd);
       Element.prototype['setParent'].call(toAdd, this);
       this.onModification();
       return toAdd;
@@ -2333,7 +2333,7 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   }
 
   private removeValueInternal(value: EnumValue) {
-    this._values.remove(value);
+    this._values.delete(value.name);
   }
 
   protected removeInnerElements(): void {
@@ -2345,7 +2345,7 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   }
 
   protected hasNonExtensionInnerElements(): boolean {
-    return this._values.values().some(v => v.ofExtension() === undefined);
+    return Array.from(this._values.values()).some(v => v.ofExtension() === undefined);
   }
 
   protected removeReferenceRecursive(ref: OutputTypeReferencer): void {
@@ -2353,7 +2353,9 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   }
 
   protected removeInnerElementsExtensions(): void {
-    this._values.values().forEach(v => v.removeOfExtension());
+    for (const v of this._values.values()) {
+      v.removeOfExtension();
+    }
   }
 }
 

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -32,7 +32,7 @@ import {
   isCoreSpecDirectiveApplication,
   removeAllCoreFeatures,
 } from "./specs/coreSpec";
-import { assert, mapValues, MapWithCachedArrays, removeArrayElement } from "./utils";
+import { assert, mapValues, MapWithCachedArrays, removeArrayElement, TimeOrderedSet } from "./utils";
 import {
   withDefaultValues,
   valueEquals,
@@ -2291,7 +2291,7 @@ export class UnionType extends BaseNamedType<OutputTypeReferencer, UnionType> {
 export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   readonly kind = 'EnumType' as const;
   readonly astDefinitionKind = Kind.ENUM_TYPE_DEFINITION;
-  protected readonly _values: EnumValue[] = [];
+  private _values = new TimeOrderedSet<EnumValue>();
 
   get values(): readonly EnumValue[] {
     // Because our abstractions are mutable, and removal is done by calling
@@ -2299,11 +2299,11 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
     // try to iterate on the result of this method and call `remove()` on
     // some of the return value based on some condition. But this will break
     // in an error-prone way if we don't copy, so we do.
-    return Array.from(this._values);
+    return Array.from(this._values.values());
   }
-
+  
   value(name: string): EnumValue | undefined {
-    return this._values.find(v => v.name === name);
+    return this._values.get(name);
   }
 
   addValue(value: EnumValue): EnumValue;
@@ -2319,7 +2319,7 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
     }
     const existing = this.value(toAdd.name);
     if (!existing) {
-      this._values.push(toAdd);
+      this._values.add(toAdd);
       Element.prototype['setParent'].call(toAdd, this);
       this.onModification();
       return toAdd;
@@ -2333,7 +2333,7 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   }
 
   private removeValueInternal(value: EnumValue) {
-    removeArrayElement(value, this._values);
+    this._values.remove(value);
   }
 
   protected removeInnerElements(): void {
@@ -2345,7 +2345,7 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   }
 
   protected hasNonExtensionInnerElements(): boolean {
-    return this._values.some(v => v.ofExtension() === undefined);
+    return this._values.values().some(v => v.ofExtension() === undefined);
   }
 
   protected removeReferenceRecursive(ref: OutputTypeReferencer): void {
@@ -2353,7 +2353,7 @@ export class EnumType extends BaseNamedType<OutputTypeReferencer, EnumType> {
   }
 
   protected removeInnerElementsExtensions(): void {
-    this._values.forEach(v => v.removeOfExtension());
+    this._values.values().forEach(v => v.removeOfExtension());
   }
 }
 

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -480,15 +480,6 @@ export function setsEqual<T>(s1: Set<T> | null, s2: Set<T> | null): boolean {
   return true;
 }
 
-export function makeTimer() {
-  let last = Date.now();
-  return (message: string) => {
-    const temp = Date.now();
-    console.log(`${message} took ${temp - last} ms`);
-    last = temp;
-  }
-}
-
 // ordering is done based on order that elements were added
 export class TimeOrderedSet<V extends { name: string }> {
   private _values: V[] = [];

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -479,29 +479,3 @@ export function setsEqual<T>(s1: Set<T> | null, s2: Set<T> | null): boolean {
   }
   return true;
 }
-
-// ordering is done based on order that elements were added
-export class TimeOrderedSet<V extends { name: string }> {
-  private _values: V[] = [];
-  private _valueMap: Map<string, V> = new Map();
-  
-  constructor() {}
-  
-  add(v: V) {
-    this._valueMap.set(v.name, v);
-    this._values.push(v);
-  }
-  
-  values(): V[] {
-    return this._values;
-  }
-  
-  get(name: string): V | undefined {
-    return this._valueMap.get(name);
-  }
-  
-  remove(v: V) {
-    this._valueMap.delete(v.name);
-    removeArrayElement(v, this._values);
-  }
-}

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -479,3 +479,38 @@ export function setsEqual<T>(s1: Set<T> | null, s2: Set<T> | null): boolean {
   }
   return true;
 }
+
+export function makeTimer() {
+  let last = Date.now();
+  return (message: string) => {
+    const temp = Date.now();
+    console.log(`${message} took ${temp - last} ms`);
+    last = temp;
+  }
+}
+
+// ordering is done based on order that elements were added
+export class TimeOrderedSet<V extends { name: string }> {
+  private _values: V[] = [];
+  private _valueMap: Map<string, V> = new Map();
+  
+  constructor() {}
+  
+  add(v: V) {
+    this._valueMap.set(v.name, v);
+    this._values.push(v);
+  }
+  
+  values(): V[] {
+    return this._values;
+  }
+  
+  get(name: string): V | undefined {
+    return this._valueMap.get(name);
+  }
+  
+  remove(v: V) {
+    this._valueMap.delete(v.name);
+    removeArrayElement(v, this._values);
+  }
+}


### PR DESCRIPTION
Merging enums was previously a O(n^3) operation. 