### PR TITLE
Split out satisfiability from `composeServices`

### DIFF
--- a/composition-js/src/compose.ts
+++ b/composition-js/src/compose.ts
@@ -141,7 +141,7 @@ type ValidateSubgraphsAndMergeResult = MergeResult | { errors: GraphQLError[] };
  * @param subgraphs 
  * @returns ValidateSubgraphsAndMergeResult
  */
-export function validateSubgraphsAndMerge(subgraphs: Subgraphs) : ValidateSubgraphsAndMergeResult {
+function validateSubgraphsAndMerge(subgraphs: Subgraphs) : ValidateSubgraphsAndMergeResult {
   const upgradeResult = upgradeSubgraphsIfNecessary(subgraphs);
   if (upgradeResult.errors) {
     return { errors: upgradeResult.errors };

--- a/composition-js/src/compose.ts
+++ b/composition-js/src/compose.ts
@@ -14,7 +14,7 @@ import {
 } from "@apollo/federation-internals";
 import { GraphQLError } from "graphql";
 import { buildFederatedQueryGraph, buildSupergraphAPIQueryGraph } from "@apollo/query-graphs";
-import { mergeSubgraphs } from "./merging";
+import { MergeResult, mergeSubgraphs } from "./merging";
 import { validateGraphComposition } from "./validate";
 import { CompositionHint } from "./hints";
 
@@ -133,7 +133,15 @@ export function validateSatisfiability({ supergraphSchema, supergraphSdl} : Sati
   return validateGraphComposition(supergraph.schema, supergraph.subgraphNameToGraphEnumValue(), supergraphQueryGraph, federatedQueryGraph);
 }
 
-export function validateSubgraphsAndMerge(subgraphs: Subgraphs){
+type ValidateSubgraphsAndMergeResult = MergeResult | { errors: GraphQLError[] };
+
+/**
+ * Upgrade subgraphs if necessary, then validates subgraphs before attempting to merge
+ * 
+ * @param subgraphs 
+ * @returns ValidateSubgraphsAndMergeResult
+ */
+export function validateSubgraphsAndMerge(subgraphs: Subgraphs) : ValidateSubgraphsAndMergeResult {
   const upgradeResult = upgradeSubgraphsIfNecessary(subgraphs);
   if (upgradeResult.errors) {
     return { errors: upgradeResult.errors };


### PR DESCRIPTION
Create a `validateSatisfiability` function separate from `composeServces`. Allow fow disabling satisfiability when running `composeServices`.

This is part of #3046, split out for easier review.