### PR TITLE
Use a `Set` for referencers

### DIFF
--- a/composition-js/src/merging/coreDirectiveCollector.ts
+++ b/composition-js/src/merging/coreDirectiveCollector.ts
@@ -21,7 +21,7 @@ export function collectCoreDirectivesToCompose(
       const source = features.sourceFeature(directive);
       // We ignore directives that are not "core" ones, or the ones that are defined but unused (note that this
       // happen to ignore execution directives as a by-product)
-      if (!source || directive.applications().length === 0) {
+      if (!source || directive.applications().size === 0) {
         continue;
       }
 

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -59,6 +59,8 @@ import { coreFeatureDefinitionIfKnown } from "./knownCoreFeatures";
 const validationErrorCode = 'GraphQLValidationFailed';
 const DEFAULT_VALIDATION_ERROR_MESSAGE = 'The schema is not a valid GraphQL schema.';
 
+const EMPTY_SET = new Set<never>();
+
 export const ErrGraphQLValidationFailed = (causes: GraphQLError[], message: string = DEFAULT_VALIDATION_ERROR_MESSAGE) =>
   aggregateError(validationErrorCode, message, causes);
 
@@ -660,7 +662,7 @@ export abstract class NamedSchemaElement<TOwnType extends NamedSchemaElement<TOw
 }
 
 abstract class BaseNamedType<TReferencer, TOwnType extends NamedType & NamedSchemaElement<TOwnType, Schema, TReferencer>> extends NamedSchemaElement<TOwnType, Schema, TReferencer> {
-  protected _referencers?: TReferencer[];
+  protected _referencers?: Set<TReferencer>;
   protected _extensions?: Extension<TOwnType>[];
   public preserveEmptyDefinition: boolean = false;
 
@@ -669,19 +671,12 @@ abstract class BaseNamedType<TReferencer, TOwnType extends NamedType & NamedSche
   }
 
   private addReferencer(referencer: TReferencer) {
-    if (this._referencers) {
-      if (!this._referencers.includes(referencer)) {
-        this._referencers.push(referencer);
-      }
-    } else {
-      this._referencers = [ referencer ];
-    }
+    this._referencers ??= new Set();
+    this._referencers.add(referencer);
   }
 
   private removeReferencer(referencer: TReferencer) {
-    if (this._referencers) {
-      removeArrayElement(referencer, this._referencers);
-    }
+    this._referencers?.delete(referencer)
   }
 
   get coordinate(): string {
@@ -789,10 +784,11 @@ abstract class BaseNamedType<TReferencer, TOwnType extends NamedType & NamedSche
     this.removeAppliedDirectives();
     this.removeInnerElements();
     // Remove this type's references.
-    const toReturn = this._referencers?.map(r => {
+    const toReturn: TReferencer[] = [];
+    this._referencers?.forEach(r => {
       SchemaElement.prototype['removeTypeReferenceInternal'].call(r, this);
-      return r;
-    }) ?? [];
+      toReturn.push(r);
+    });
     this._referencers = undefined;
     // Remove this type from its parent schema.
     Schema.prototype['removeTypeInternal'].call(this._parent, this);
@@ -820,8 +816,8 @@ abstract class BaseNamedType<TReferencer, TOwnType extends NamedType & NamedSche
 
   protected abstract removeReferenceRecursive(ref: TReferencer): void;
 
-  referencers(): readonly TReferencer[] {
-    return this._referencers ?? [];
+  referencers(): ReadonlySet<TReferencer> {
+    return this._referencers ?? EMPTY_SET;
   }
 
   isReferenced(): boolean {
@@ -2124,7 +2120,13 @@ export class ObjectType extends FieldBasedType<ObjectType, ObjectTypeReferencer>
   }
 
   unionsWhereMember(): readonly UnionType[] {
-    return this._referencers?.filter<UnionType>((r): r is UnionType => r instanceof BaseNamedType && isUnionType(r)) ?? [];
+    const unions: UnionType[] = [];
+    this._referencers?.forEach((r) => {
+      if (r instanceof BaseNamedType && isUnionType(r)) {
+	unions.push(r);
+      }
+    });
+    return unions;
   }
 }
 
@@ -2133,7 +2135,13 @@ export class InterfaceType extends FieldBasedType<InterfaceType, InterfaceTypeRe
   readonly astDefinitionKind = Kind.INTERFACE_TYPE_DEFINITION;
 
   allImplementations(): (ObjectType | InterfaceType)[] {
-    return this.referencers().filter(ref => ref.kind === 'ObjectType' || ref.kind === 'InterfaceType') as (ObjectType | InterfaceType)[];
+    const implementations: (ObjectType | InterfaceType)[] = [];
+    this.referencers().forEach(ref => {
+      if (ref.kind === 'ObjectType' || ref.kind === 'InterfaceType') {
+	implementations.push(ref);
+      }
+    });
+    return implementations;
   }
 
   possibleRuntimeTypes(): readonly ObjectType[] {
@@ -2895,7 +2903,7 @@ export class DirectiveDefinition<TApplicationArgs extends {[key: string]: any} =
   private _args?: MapWithCachedArrays<string, ArgumentDefinition<DirectiveDefinition>>;
   repeatable: boolean = false;
   private readonly _locations: DirectiveLocation[] = [];
-  private _referencers?: Directive<SchemaElement<any, any>, TApplicationArgs>[];
+  private _referencers?: Set<Directive<SchemaElement<any, any>, TApplicationArgs>>;
 
   constructor(name: string, readonly isBuiltIn: boolean = false) {
     super(name);
@@ -2999,25 +3007,19 @@ export class DirectiveDefinition<TApplicationArgs extends {[key: string]: any} =
     return this.locations.some((loc) => isTypeSystemDirectiveLocation(loc));
   }
 
-  applications(): readonly Directive<SchemaElement<any, any>, TApplicationArgs>[] {
-    return this._referencers ?? [];
+  applications(): ReadonlySet<Directive<SchemaElement<any, any>, TApplicationArgs>> {
+    this._referencers ??= new Set();
+    return this._referencers;
   }
 
   private addReferencer(referencer: Directive<SchemaElement<any, any>, TApplicationArgs>) {
     assert(referencer, 'Referencer should exists');
-    if (this._referencers) {
-      if (!this._referencers.includes(referencer)) {
-        this._referencers.push(referencer);
-      }
-    } else {
-      this._referencers = [ referencer ];
-    }
+    this._referencers ??= new Set();
+    this._referencers.add(referencer);
   }
 
   private removeReferencer(referencer: Directive<SchemaElement<any, any>, TApplicationArgs>) {
-    if (this._referencers) {
-      removeArrayElement(referencer, this._referencers);
-    }
+    this._referencers?.delete(referencer);
   }
 
   protected removeTypeReference(type: NamedType) {
@@ -3048,7 +3050,7 @@ export class DirectiveDefinition<TApplicationArgs extends {[key: string]: any} =
     // doesn't store a link to that definition. Instead, we fetch the definition
     // from the schema when requested. So we don't have to do anything on the
     // referencers other than clear them (and return the pre-cleared set).
-    const toReturn = this._referencers ?? [];
+    const toReturn = Array.from(this._referencers ?? []);
     this._referencers = undefined;
     // Remove this directive definition from its parent schema.
     Schema.prototype['removeDirectiveInternal'].call(this._parent, this);

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -2123,7 +2123,7 @@ export class ObjectType extends FieldBasedType<ObjectType, ObjectTypeReferencer>
     const unions: UnionType[] = [];
     this._referencers?.forEach((r) => {
       if (r instanceof BaseNamedType && isUnionType(r)) {
-	unions.push(r);
+        unions.push(r);
       }
     });
     return unions;
@@ -2138,7 +2138,7 @@ export class InterfaceType extends FieldBasedType<InterfaceType, InterfaceTypeRe
     const implementations: (ObjectType | InterfaceType)[] = [];
     this.referencers().forEach(ref => {
       if (ref.kind === 'ObjectType' || ref.kind === 'InterfaceType') {
-	implementations.push(ref);
+        implementations.push(ref);
       }
     });
     return implementations;

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -1195,7 +1195,7 @@ export class FederationMetadata {
   ): Post20FederationDirectiveDefinition<TApplicationArgs> {
     return this.getFederationDirective<TApplicationArgs>(name) ?? {
       name,
-      applications: () => new Array<Directive<any, TApplicationArgs>>(),
+      applications: () => new Set<Directive<any, TApplicationArgs>>(),
     };
   }
 
@@ -1391,7 +1391,7 @@ export class FederationMetadata {
 
 export type FederationDirectiveNotDefinedInSchema<TApplicationArgs extends {[key: string]: any}> = {
   name: string,
-  applications: () => readonly Directive<any, TApplicationArgs>[],
+  applications: () => ReadonlySet<Directive<any, TApplicationArgs>>,
 }
 
 export type Post20FederationDirectiveDefinition<TApplicationArgs extends {[key: string]: any}> =
@@ -2040,7 +2040,7 @@ function completeFed1SubgraphSchema(schema: Schema): GraphQLError[] {
     // definition to re-add the "correct" version, we'd have to re-attach existing applications (doable but not
     // done). This assert is so we notice it quickly if that ever happens (again, unlikely, because fed1 schema
     // is a backward compatibility thing and there is no reason to expand that too much in the future).
-    assert(directive.applications().length === 0, `${directive} shouldn't have had validation at that places`);
+    assert(directive.applications().size === 0, `${directive} shouldn't have had validation at that places`);
 
     // The patterns we recognize and "correct" (by essentially ignoring the definition)
     // are:

--- a/internals-js/src/schemaUpgrader.ts
+++ b/internals-js/src/schemaUpgrader.ts
@@ -233,7 +233,7 @@ export function upgradeSubgraphsIfNecessary(inputs: Subgraphs): UpgradeResult {
   for (const subgraph of inputs.values()) {
     if (subgraph.isFed2Subgraph()) {
       subgraphs.add(subgraph);
-      if (subgraph.metadata().interfaceObjectDirective().applications().length > 0) {
+      if (subgraph.metadata().interfaceObjectDirective().applications().size > 0) {
         subgraphsUsingInterfaceObject.push(subgraph.name);
       }
     } else {

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -3187,9 +3187,11 @@ export class QueryPlanner {
 
   private collectAllOverrideLabels() {
     // inspect every join__field directive application in the supergraph and collect all `overrideLabel` argument values
+    const applications = this.supergraph.schema.directives()
+      .find((d) => d.name === 'join__field')
+      ?.applications() ?? new Set();
     this._defaultOverrideConditions = new Map(
-      this.supergraph.schema.directives()
-        .find((d) => d.name === 'join__field')?.applications()
+      Array.from(applications)
         .map((application) => application.arguments().overrideLabel)
         .filter(Boolean)
         .map(label => [label, false])


### PR DESCRIPTION
When working with elements with many referencers, `addReferencer()` became very hot.
    
If you have eg. 100 referencers, each one is added one by one, and each new addition iterates the entire existing referencers list. This could cause quadratic performance.

This changes the `_referencers` values to be JS `Set`s. This maintains the same order for algorithms that rely on order.