### PR TITLE
Control join directive usage from the directive definition spec

### DIFF
--- a/.changeset/thick-schools-divide.md
+++ b/.changeset/thick-schools-divide.md
@@ -1,0 +1,6 @@
+---
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
+---
+
+When a directive composes with @join__directive, also use @join__directive for links that import that directive.

--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -71,6 +71,7 @@ describe('composition', () => {
       schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+        @join__directive(graphs: [SUBGRAPH1, SUBGRAPH2], name: "link", args: {url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject", "@authenticated", "@requiresScopes", "@policy", "@sourceAPI", "@sourceType", "@sourceField", "@context", "@fromContext"]})
       {
         query: Query
       }
@@ -232,6 +233,7 @@ describe('composition', () => {
       schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+        @join__directive(graphs: [SUBGRAPH1, SUBGRAPH2], name: "link", args: {url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject", "@authenticated", "@requiresScopes", "@policy", "@sourceAPI", "@sourceType", "@sourceField", "@context", "@fromContext"]})
       {
         query: Query
       }

--- a/composition-js/src/__tests__/override.compose.test.ts
+++ b/composition-js/src/__tests__/override.compose.test.ts
@@ -975,6 +975,7 @@ describe("composition involving @override directive", () => {
         "schema
           @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
           @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
+          @join__directive(graphs: [SUBGRAPH1, SUBGRAPH2], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/federation/v2.8\\", import: [\\"@key\\", \\"@requires\\", \\"@provides\\", \\"@external\\", \\"@tag\\", \\"@extends\\", \\"@shareable\\", \\"@inaccessible\\", \\"@override\\", \\"@composeDirective\\", \\"@interfaceObject\\", \\"@authenticated\\", \\"@requiresScopes\\", \\"@policy\\", \\"@sourceAPI\\", \\"@sourceType\\", \\"@sourceField\\", \\"@context\\", \\"@fromContext\\"]})
         {
           query: Query
         }

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -2894,6 +2894,7 @@ export class DirectiveDefinition<TApplicationArgs extends {[key: string]: any} =
 
   private _args?: MapWithCachedArrays<string, ArgumentDefinition<DirectiveDefinition>>;
   repeatable: boolean = false;
+  usesJoinDirective: boolean = false;
   private readonly _locations: DirectiveLocation[] = [];
   private _referencers?: Directive<SchemaElement<any, any>, TApplicationArgs>[];
 

--- a/internals-js/src/directiveAndTypeSpecification.ts
+++ b/internals-js/src/directiveAndTypeSpecification.ts
@@ -78,6 +78,7 @@ export function createDirectiveSpecification({
   repeatable = false,
   args = [],
   composes = false,
+  usesJoinDirective = false,
   supergraphSpecification = undefined,
   staticArgumentTransform = undefined,
 }: {
@@ -86,6 +87,7 @@ export function createDirectiveSpecification({
   repeatable?: boolean,
   args?: DirectiveArgumentSpecification[],
   composes?: boolean,
+  usesJoinDirective?: boolean,
   supergraphSpecification?: (fedVersion: FeatureVersion) => FeatureDefinition,
   staticArgumentTransform?: (subgraph: Subgraph, args: {[key: string]: any}) => {[key: string]: any},
 }): DirectiveSpecification {
@@ -164,6 +166,7 @@ export function createDirectiveSpecification({
       } else {
         const directive = schema.addDirectiveDefinition(new DirectiveDefinition(actualName, asBuiltIn));
         directive.repeatable = repeatable;
+        directive.usesJoinDirective = usesJoinDirective;
         directive.addLocations(...locations);
         for (const { name, type, defaultValue } of resolvedArgs) {
           directive.addArgument(name, type, defaultValue);

--- a/internals-js/src/specs/sourceSpec.ts
+++ b/internals-js/src/specs/sourceSpec.ts
@@ -27,6 +27,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
       // `@join__directive` mechanism, so they do not need to be composed in the
       // way passing `composes: true` here implies.
       composes: false,
+      usesJoinDirective: true,
     }));
 
     this.registerDirective(createDirectiveSpecification({
@@ -34,6 +35,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
       locations: [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE],
       repeatable: true,
       composes: false,
+      usesJoinDirective: true,
     }));
 
     this.registerDirective(createDirectiveSpecification({
@@ -41,12 +43,14 @@ export class SourceSpecDefinition extends FeatureDefinition {
       locations: [DirectiveLocation.FIELD_DEFINITION],
       repeatable: true,
       composes: false,
+      usesJoinDirective: true,
     }));
   }
 
   addElementsToSchema(schema: Schema): GraphQLError[] {
     const sourceAPI = this.addDirective(schema, 'sourceAPI').addLocations(DirectiveLocation.SCHEMA);
     sourceAPI.repeatable = true;
+    sourceAPI.usesJoinDirective = true;
 
     sourceAPI.addArgument('name', new NonNullType(schema.stringType()));
 
@@ -72,6 +76,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
       // DirectiveLocation.UNION,
     );
     sourceType.repeatable = true;
+    sourceType.usesJoinDirective = true;
     sourceType.addArgument('api', new NonNullType(schema.stringType()));
 
     const URLPathTemplate = this.addScalarType(schema, 'URLPathTemplate');
@@ -101,6 +106,7 @@ export class SourceSpecDefinition extends FeatureDefinition {
       DirectiveLocation.FIELD_DEFINITION,
     );
     sourceField.repeatable = true;
+    sourceField.usesJoinDirective = true;
     sourceField.addArgument('api', new NonNullType(schema.stringType()));
     sourceField.addArgument('selection', JSONSelection);
     sourceField.addArgument('keyTypeMap', KeyTypeMap);


### PR DESCRIPTION
The primary issue with controlling the use of join directives via identity strings is that any logic relying on the presence of `@join__directive` won't work if the affected directive is imported from the federation spec.

More concretely, `@link(url: "https://specs.apollo.dev/source/v0.1", import: ["@sourceAPI"])` results in a `@join__directive` for each use of `@sourceAPI`. In contrast, `@link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@sourceAPI"])` does not.

To make the second case work, we don't determine join usage by the URL used in the `@link`. Instead, each directive definition spec has a `usesJoinDirective` flag which determines this behavior. When we handle `@link` usages, composition will use a `@join__directive` to capture that link if _any_ of its imports have the `usesJoinDirective` flag set. The resulting behavior change is that the supergraph SDL will have a net-new `@join__directive` application if any of the `@source*` directives are imported from the federation spec instead of the source spec.

<!-- ROUTER-384 -->

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
