### PR TITLE
Composition issue infinite recursion with @requires use

### DIFF
--- a/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
+++ b/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
@@ -744,4 +744,40 @@ describe('override', () => {
     const result = composeServices([subgraphA,]);
     assertCompositionSuccess(result);
   });
+
+  it('@requires on a key selecting another field', () => {
+    const subgraphA = {
+      typeDefs: gql`
+        type Query {
+          T: T!
+        }
+
+        type T @key(fields: "a") {
+          a: String
+          d: String
+        }
+      `,
+      name: 'subgraphA',
+    };
+
+    const subgraphB = {
+      typeDefs: gql`
+        type Query {
+          foo: T
+        }
+
+        type T @key(fields: "a") @extends {
+          a: String @external @requires(fields: "d")
+          d: String @external
+        }
+      `,
+      name: 'subgraphB',
+    };
+
+    const result = composeServices([subgraphA, subgraphB]);
+
+    expect(result.errors).toBeDefined();
+    expect(errors(result)).toStrictEqual([
+    ]);
+  });
 });


### PR DESCRIPTION
## Description

When using `@requires` on a key field selecting a non-key field, our graph composition fails with a stack overflow:

```
Maximum call stack size exceeded
RangeError: Maximum call stack size exceeded
    at GraphPath.get tail [as tail] (/Users/antoineb/IdeaProjects/federation/query-graphs-js/src/graphPath.ts:199:11)
    at advanceWithOperation (/Users/antoineb/IdeaProjects/federation/query-graphs-js/src/graphPath.ts:2572:28)
    at advanceSimultaneousPathsWithOperation (/Users/antoineb/IdeaProjects/federation/query-graphs-js/src/graphPath.ts:2186:71)
    at ConditionValidationState.advance (/Users/antoineb/IdeaProjects/federation/query-graphs-js/src/conditionsValidation.ts:30:65)
    at resolver (/Users/antoineb/IdeaProjects/federation/query-graphs-js/src/conditionsValidation.ts:114:31)
    at /Users/antoineb/IdeaProjects/federation/query-graphs-js/src/conditionsCaching.ts:39:26
    at canSatisfyConditions (/Users/antoineb/IdeaProjects/federation/query-graphs-js/src/graphPath.ts:2007:22)
```

I added a unit test to reproduce the issue. 
I'm having doubts whether this is actually a legitimate use case of `@requires`. To me it feels not, and if this is correct, we could probably raise a validation error earlier in the composition process as key fields are either provided by the router or or expected to be provided by the subgraph.