### PR TITLE
Avoid sparsely-populated arrays in query graph cache

### DIFF
--- a/.changeset/friendly-tables-mix.md
+++ b/.changeset/friendly-tables-mix.md
@@ -1,0 +1,7 @@
+---
+"@apollo/composition": patch
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+---
+
+Query graph caches now use maps instead of sparsely-populated arrays for per-subgraph data.

--- a/composition-js/src/validate.ts
+++ b/composition-js/src/validate.ts
@@ -705,7 +705,7 @@ class ValidationTraversal {
       conditionResolver: this.conditionResolver,
       overrideConditions: new Map(),
     })));
-    this.previousVisits = new QueryGraphState(supergraphAPI);
+    this.previousVisits = new QueryGraphState();
     this.context = new ValidationContext(
       supergraphSchema,
       subgraphNameToGraphEnumValue,

--- a/query-graphs-js/src/conditionsCaching.ts
+++ b/query-graphs-js/src/conditionsCaching.ts
@@ -1,9 +1,9 @@
 import { SelectionSet, assert } from "@apollo/federation-internals";
 import { ConditionResolution, ConditionResolver, ExcludedConditions, ExcludedDestinations, sameExcludedDestinations } from "./graphPath";
 import { PathContext } from "./pathContext";
-import { Edge, QueryGraph, QueryGraphState } from "./querygraph";
+import { Edge, QueryGraphState } from "./querygraph";
 
-export function cachingConditionResolver(graph: QueryGraph, resolver: ConditionResolver): ConditionResolver {
+export function cachingConditionResolver(resolver: ConditionResolver): ConditionResolver {
   // For every edge having a condition, we cache the resolution its conditions when possible.
   // We save resolution with the set of excluded edges that were used to compute it: the reason we do this is
   // that excluded edges impact the resolution, so we should only used a cached value if we know the excluded
@@ -13,7 +13,7 @@ export function cachingConditionResolver(graph: QueryGraph, resolver: ConditionR
   // when we have no excluded edges, we'd only ever use the cache for the first key of every type. However,
   // as the algorithm always try keys in the same order (the order of the edges in the query graph), including
   // the excluded edges we see on the first ever call is actually the proper thing to do.
-  const cache = new QueryGraphState<undefined, [ConditionResolution, ExcludedDestinations]>(graph);
+  const cache = new QueryGraphState<undefined, [ConditionResolution, ExcludedDestinations]>();
   return (edge: Edge, context: PathContext, excludedDestinations: ExcludedDestinations, excludedConditions: ExcludedConditions, extraConditions?: SelectionSet) => {
     assert(edge.conditions || extraConditions, 'Should not have been called for edge without conditions');
 

--- a/query-graphs-js/src/conditionsValidation.ts
+++ b/query-graphs-js/src/conditionsValidation.ts
@@ -121,5 +121,5 @@ export function simpleValidationConditionResolver({
     // condition is validated. Note that we use a cost of 1 for all conditions as we don't care about efficiency.
     return { satisfied: true, cost: 1 };
   };
-  return withCaching ? cachingConditionResolver(queryGraph, resolver) : resolver;
+  return withCaching ? cachingConditionResolver(resolver) : resolver;
 }

--- a/query-graphs-js/src/graphviz.ts
+++ b/query-graphs-js/src/graphviz.ts
@@ -100,7 +100,7 @@ function addToVizGraph(graph: QueryGraph, vizGraph: GraphBaseModel, noTerminal: 
     }
     return vizGraph;
   }
-  const state = new QueryGraphState<NodeModel, EdgeModel>(graph);
+  const state = new QueryGraphState<NodeModel, EdgeModel>();
   const onEdge = function (edge: Edge): boolean {
     const head = edge.head;
     const tail = edge.tail;

--- a/query-graphs-js/src/nonTrivialEdgePrecomputing.ts
+++ b/query-graphs-js/src/nonTrivialEdgePrecomputing.ts
@@ -2,7 +2,7 @@ import { assert } from "@apollo/federation-internals";
 import { Edge, QueryGraph, QueryGraphState, simpleTraversal } from "./querygraph";
 
 export function preComputeNonTrivialFollowupEdges(graph: QueryGraph): (previousEdge: Edge) => readonly Edge[] {
-  const state = new QueryGraphState<undefined, readonly Edge[]>(graph);
+  const state = new QueryGraphState<undefined, readonly Edge[]>();
   simpleTraversal(graph, () => {}, (edge) => {
     const followupEdges = graph.outEdges(edge.tail);
     state.setEdgeState(edge, computeNonTrivialFollowups(edge, followupEdges));

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -400,7 +400,6 @@ class QueryPlanningTraversal<RV extends Vertex> {
     this.isTopLevel = isRootVertex(root);
     this.optionsLimit = parameters.config.debug?.pathsLimit;
     this.conditionResolver = cachingConditionResolver(
-      federatedQueryGraph,
       (edge, context, excludedEdges, excludedConditions, extras) => this.resolveConditionPlan(edge, context, excludedEdges, excludedConditions, extras),
     );
 


### PR DESCRIPTION
For condition resolution, we use a cache that supports caching data per query graph node or edge.

This cache's code was pre-allocating arrays that would almost always be sparsely populated, and for large schemas this overhead is significant. This PR changes these arrays into maps.