### PR TITLE
Wrap dead-end logic with closures

### DIFF
--- a/.changeset/afraid-phones-reflect.md
+++ b/.changeset/afraid-phones-reflect.md
@@ -1,0 +1,6 @@
+---
+"@apollo/composition": patch
+"@apollo/query-graphs": patch
+---
+
+Error messages are now lazily evaluated for satisfiability validations.


### PR DESCRIPTION
While looking at satisfiability validations, @duckki noticed that we were throwing away dead-end/unadvanceable data. I wanted to check whether we could use closures to avoid executing dead-logic entirely unless it's needed (when no options are found for a path), and it turns out it's possible (specifically, the closure's state ends up being immutable, so delaying execution shouldn't change behavior). This PR accordingly wraps the dead-end logic with closures, and only executes them when needed for generating satisfiability errors.