### PR TITLE
Use sparse `Map`s rather than dense `sources` arrays in `mergeType` code.

### DIFF
--- a/.changeset/smooth-melons-study.md
+++ b/.changeset/smooth-melons-study.md
@@ -1,0 +1,5 @@
+---
+"@apollo/composition": patch
+---
+
+Type merging now uses maps instead of sparsely-populated arrays for per-subgraph data.

--- a/composition-js/src/composeDirectiveManager.ts
+++ b/composition-js/src/composeDirectiveManager.ts
@@ -15,6 +15,7 @@ import {
 import { GraphQLError } from 'graphql';
 import { CompositionHint, HINTS } from './hints';
 import { MismatchReporter } from './merging/reporter';
+import { sourcesFromArray } from './merging';
 
 /**
  * Return true if the directive from the same core feature has a different name in the subgraph
@@ -367,7 +368,7 @@ export class ComposeDirectiveManager {
         this.mismatchReporter.reportMismatchErrorWithoutSupergraph(
           ERRORS.DIRECTIVE_COMPOSITION_ERROR,
           'Composed directive is not named consistently in all subgraphs',
-          this.subgraphs.values()
+          sourcesFromArray(this.subgraphs.values()
             .map(sg => {
               const item = items.find(item => sg.name === item.sgName);
               return item ? {
@@ -384,7 +385,7 @@ export class ComposeDirectiveManager {
                 sourceAST,
                 item: val.item,
               } : undefined;
-            }),
+            })),
           (elt) => elt ? `"@${elt.item.directiveNameAs}"` : undefined
         );
       }

--- a/composition-js/src/merging/reporter.ts
+++ b/composition-js/src/merging/reporter.ts
@@ -1,6 +1,7 @@
 import { addSubgraphToASTNode, assert, ErrorCodeDefinition, joinStrings, MultiMap, NamedSchemaElement, printSubgraphNames, SubgraphASTNode } from '@apollo/federation-internals';
 import { ASTNode, GraphQLError } from 'graphql';
 import { CompositionHint, HintCodeDefinition } from '../hints';
+import { Sources } from './merge';
 
 export class MismatchReporter {
   pushError: (error: GraphQLError) => void;
@@ -15,7 +16,7 @@ export class MismatchReporter {
     code: ErrorCodeDefinition,
     message: string,
     mismatchedElement:TMismatched,
-    subgraphElements: (TMismatched | undefined)[],
+    subgraphElements: Sources<TMismatched>,
     mismatchAccessor: (elt: TMismatched, isSupergraph: boolean) => string | undefined
   ) {
     this.reportMismatch(
@@ -37,7 +38,7 @@ export class MismatchReporter {
   reportMismatchErrorWithoutSupergraph<TMismatched extends { sourceAST?: ASTNode }>(
     code: ErrorCodeDefinition,
     message: string,
-    subgraphElements: (TMismatched | undefined)[],
+    subgraphElements: Sources<TMismatched>,
     mismatchAccessor: (elt: TMismatched, isSupergraph: boolean) => string | undefined
   ) {
     this.reportMismatch(
@@ -71,7 +72,7 @@ export class MismatchReporter {
     code: ErrorCodeDefinition,
     message: string,
     mismatchedElement: TMismatched,
-    subgraphElements: (TMismatched | undefined)[],
+    subgraphElements: Sources<TMismatched>,
     mismatchAccessor: (elt: TMismatched | undefined, isSupergraph: boolean) => string | undefined,
     supergraphElementPrinter: (elt: string, subgraphs: string | undefined) => string,
     otherElementsPrinter: (elt: string, subgraphs: string) => string,
@@ -112,7 +113,7 @@ export class MismatchReporter {
     code: HintCodeDefinition,
     message: string,
     supergraphElement: TMismatched,
-    subgraphElements: (TMismatched | undefined)[],
+    subgraphElements: Sources<TMismatched>,
     targetedElement?: NamedSchemaElement<any, any, any>
     elementToString: (elt: TMismatched, isSupergraph: boolean) => string | undefined,
     supergraphElementPrinter: (elt: string, subgraphs: string | undefined) => string,
@@ -143,7 +144,7 @@ export class MismatchReporter {
   // Not meant to be used directly: use `reportMismatchError` or `reportMismatchHint` instead.
   private reportMismatch<TMismatched extends { sourceAST?: ASTNode }>(
     supergraphElement:TMismatched | undefined,
-    subgraphElements: (TMismatched | undefined)[],
+    subgraphElements: Sources<TMismatched>,
     mismatchAccessor: (element: TMismatched, isSupergraph: boolean) => string | undefined,
     supergraphElementPrinter: (elt: string, subgraphs: string | undefined) => string,
     otherElementsPrinter: (elt: string, subgraphs: string) => string,


### PR DESCRIPTION
From @benjamn :

In the `mergeType` code responsible for merging subgraphs schemas into a supergraph schema, I noticed we were often looping over a `sources` array with as many elements as the number of subgraphs, inside a loop over all the fields currently being merged, leading to running time proportional to the product of the number of subgraphs and the total number of fields being merged.

This PR demonstrates that we can instead represent just the contributions from various subgraphs that are directly relevant to the current type or field being merged, so the `sources` data structure does not always remain as large as the number of subgraphs. Swapping the `type Sources<T> = Map<number, T | undefined>` type for all the array parameters can be done without altering behavior or performance (see the 2nd commit), and that foundation enables the sparse representation optimization (preserving behavior while improving performance; see the `addFieldsShallow` changes in the 3rd commit).