### PR TITLE
Only run override validation when field has an `@override` in at least one subgraph

### DIFF
--- a/.changeset/good-shoes-chew.md
+++ b/.changeset/good-shoes-chew.md
@@ -1,0 +1,5 @@
+---
+"@apollo/composition": patch
+---
+
+Add a fast path to skip override validation for fields without any subgraph `@override`s.


### PR DESCRIPTION
This PR updates merging to pre-compute which fields have `@override` in at least one subgraph, which allows override validation to be more easily skipped for non-overridden fields.