### PR TITLE
Inconsistent value type hints should not be duplicated per subgraph

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1077,6 +1077,7 @@ class Merger {
           supergraphElementPrinter: (_, subgraphs) => `"${field.coordinate}" is defined in ${subgraphs}`,
           otherElementsPrinter: (_, subgraphs) => ` but not in ${subgraphs}`,
         });
+        break;
       }
     }
   }


### PR DESCRIPTION
When we discover a field that's inconsistently defined for a value type, we generate a hint describing which subgraphs have (and don't have) the field. However, this was being generated multiple times for a field (once per subgraph). This PR fixes the duplication.