### PR TITLE
Create changeset for #3075

### DIFF
--- a/.changeset/wild-guests-notice.md
+++ b/.changeset/wild-guests-notice.md
@@ -1,0 +1,4 @@
+---
+"@apollo/composition": patch
+---
+Fix logic to compute missing subgraphs when generating composition hints/errors


### PR DESCRIPTION
This PR adds a changeset file for #3075 (even though it's not really necessary for the eventual patch release, it turns out we need it for the changesets GH action to auto-file the PR).