### PR TITLE
chore(docs): rename supported subgraphs to compatible subgraphs

### DIFF
--- a/.cspell/cspell.yml
+++ b/.cspell/cspell.yml
@@ -40,6 +40,6 @@ overrides:
       - "\\]\\([^)]+\\)"
       - "youTubeID=.+/>"
   # Ignore user and repo names in GitHub links to supported subgraph libraries.
-  - filename: '**/supported-subgraphs.md'
+  - filename: '**/compatible-subgraphs.md'
     ignoreRegExpList:
       - "Github: <a .+</a>"

--- a/docs/source/_redirects
+++ b/docs/source/_redirects
@@ -1,8 +1,8 @@
 /subgraphs/ /docs/apollo-server/using-federation/apollo-subgraph-setup/
 /gateway/ /docs/federation/building-supergraphs/router/
 /router/ /docs/federation/building-supergraphs/router/
-/supported-subgraphs/ /docs/federation/building-supergraphs/supported-subgraphs/
-/other-servers/ /docs/federation/building-supergraphs/supported-subgraphs/
+/supported-subgraphs/ /docs/federation/building-supergraphs/compatible-subgraphs/
+/other-servers/ /docs/federation/building-supergraphs/compatible-subgraphs/
 /federation-spec/ /docs/federation/subgraph-spec/
 /building-supergraphs/subgraphs-apollo-server/ /docs/apollo-server/using-federation/apollo-subgraph-setup/
 /api/apollo-subgraph /docs/apollo-server/using-federation/api/apollo-subgraph/

--- a/docs/source/building-supergraphs/compatible-subgraphs.md
+++ b/docs/source/building-supergraphs/compatible-subgraphs.md
@@ -128,7 +128,7 @@ Type: Code first | SDL first<br/>
 Stars: 4.9k ⭐<br/>
 Last Release: 2024-04-22<br/>
 <br/>
-Federation Library: <a href="https://github.com/apollographql/federation-hotchocolate">apollographql/federation-hotchocolate&nbsp;&nbsp;<img style="display:inline-block; height:1em; width:auto;" alt="Maintained by Apollo" src="https://raw.githubusercontent.com/apollographql/apollo-federation-subgraph-compatibility/d7829ef89441c337749bf6538711a642cfa2689c/docs/assets/horizon_logo.png"/></a>
+Federation Library: <a href="https://github.com/apollographql/federation-hotchocolate">apollographql/federation-hotchocolate</a>
       </td>
       <td>
         <table>

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -16,7 +16,7 @@
     "Changelog": "/federation-versions",
     "Building Your Supergraph": {
       "Subgraphs": "/building-supergraphs/subgraphs-overview",
-      "Supported Subgraph Libraries": "/building-supergraphs/supported-subgraphs",
+      "Compatible Subgraph Libraries": "/building-supergraphs/compatible-subgraphs",
       "Router": "/building-supergraphs/router",
       "Apollo Server Subgraphs": "https://apollographql.com/docs/apollo-server/using-federation/apollo-subgraph-setup",
       "JetBrains IDE Support": "/building-supergraphs/jetbrains-ide-support"


### PR DESCRIPTION
Renaming page in order to avoid any confusion on what subgraph implementations are actually supported by Apollo.