### PR TITLE
Don't ever add @shareable to subscription fields during schema upgrading

### DIFF
--- a/.changeset/nice-dogs-walk.md
+++ b/.changeset/nice-dogs-walk.md
@@ -2,4 +2,4 @@
 "@apollo/federation-internals": patch
 ---
 
-When auto-upgrading schemas from fed1, never add @shareable since it's not valid. Just let them fail during composition if there is no @override.
+When auto-upgrading schemas from fed1, never add @shareable on subscription fields.

--- a/.changeset/nice-dogs-walk.md
+++ b/.changeset/nice-dogs-walk.md
@@ -1,0 +1,5 @@
+---
+"@apollo/federation-internals": patch
+---
+
+When auto-upgrading schemas from fed1, never add @shareable since it's not valid. Just let them fail during composition if there is no @override.

--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -361,4 +361,7 @@ test("don't add @shareable to subscriptions", () => {
 
   expect(printSchema(result.subgraphs!.get("subgraph1")!.schema!)).not.toContain('update: String! @shareable');
   expect(printSchema(result.subgraphs!.get("subgraph2")!.schema!)).not.toContain('update: String! @shareable');
+  
+  expect(result.subgraphs!.get("subgraph1")!.schema.type('Subscription')?.appliedDirectivesOf('@shareable').length).toBe(0);
+  expect(result.subgraphs!.get("subgraph2")!.schema.type('Subscription')?.appliedDirectivesOf('@shareable').length).toBe(0);
 });

--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -325,3 +325,40 @@ test("fully upgrades a schema with no @link directive", () => {
 }`
   );
 });
+
+test("don't add @shareable to subscriptions", () => {
+  const subgraph1 = buildSubgraph(
+    "subgraph1",
+    "",
+    `#graphql
+    type Query {
+      hello: String
+    }
+    
+    type Subscription { 
+      update: String!
+    }
+  `
+  );
+  
+  const subgraph2 = buildSubgraph(
+    "subgraph2",
+    "",
+    `#graphql
+    type Query {
+      hello: String
+    }
+    
+    type Subscription { 
+      update: String!
+    }
+  `
+  );
+  const subgraphs = new Subgraphs();
+  subgraphs.add(subgraph1);
+  subgraphs.add(subgraph2);
+  const result = upgradeSubgraphsIfNecessary(subgraphs);
+
+  expect(printSchema(result.subgraphs!.get("subgraph1")!.schema!)).not.toContain('update: String! @shareable');
+  expect(printSchema(result.subgraphs!.get("subgraph2")!.schema!)).not.toContain('update: String! @shareable');
+});

--- a/internals-js/src/schemaUpgrader.ts
+++ b/internals-js/src/schemaUpgrader.ts
@@ -714,7 +714,10 @@ class SchemaUpgrader {
     // - to every "value type" (in the fed1 sense of non-root type and non-entity) if it is used in any other subgraphs
     // - to any (non-external) field of an entity/root-type that is not a key field and if another subgraphs resolve it (fully or partially through @provides)
     for (const type of this.schema.objectTypes()) {
-      if (type.hasAppliedDirective(keyDirective) || (type.isRootType() && !type.isSubscriptionRootType())) {
+      if(type.isSubscriptionRootType()) {
+        continue;
+      }
+      if (type.hasAppliedDirective(keyDirective) || (type.isRootType())) {
         for (const field of type.fields()) {
           // To know if the field is a "key" field which doesn't need shareable, we rely on whether the field is shareable in the original
           // schema (the fed1 version), because as fed1 schema will have no @shareable, the key fields will effectively be the only field

--- a/internals-js/src/schemaUpgrader.ts
+++ b/internals-js/src/schemaUpgrader.ts
@@ -714,7 +714,7 @@ class SchemaUpgrader {
     // - to every "value type" (in the fed1 sense of non-root type and non-entity) if it is used in any other subgraphs
     // - to any (non-external) field of an entity/root-type that is not a key field and if another subgraphs resolve it (fully or partially through @provides)
     for (const type of this.schema.objectTypes()) {
-      if (type.hasAppliedDirective(keyDirective) || type.isRootType()) {
+      if (type.hasAppliedDirective(keyDirective) || (type.isRootType() && !type.isSubscriptionRootType())) {
         for (const field of type.fields()) {
           // To know if the field is a "key" field which doesn't need shareable, we rely on whether the field is shareable in the original
           // schema (the fed1 version), because as fed1 schema will have no @shareable, the key fields will effectively be the only field


### PR DESCRIPTION
It could be valid to have two fields of the same that are not shareable if one of them is being overridden. Don't add @sharable to subscription fields and just let it be a composition error if neither are overrides. As @shareable is not allowed on a subscription field, they should never exist there in any case.