### PR TITLE
Fix links in federation docs 

### DIFF
--- a/docs/source/entities/index.mdx
+++ b/docs/source/entities/index.mdx
@@ -89,7 +89,7 @@ type Product @key(fields: "id") {
 
 </CodeColumns>
 
-For more information on advanced key options, like defining [multiple keys](./define-keys/#multiple-keys) or [compound keys](./define-keys/#compound-keys), see the guide on [Defining keys]](./define-keys).
+For more information on advanced key options, like defining [multiple keys](./define-keys/#multiple-keys) or [compound keys](./define-keys/#compound-keys), see the guide on [Defining keys](./define-keys).
 
 #### Key field limitations
 

--- a/docs/source/entities/index.mdx
+++ b/docs/source/entities/index.mdx
@@ -64,10 +64,10 @@ Key fields' uniqueness enable your router to associate fields from different sub
 
 In most cases, the `@key` field(s) for the same entity will be the same across subgraphs.
 For example, if one subgraph uses `id` as the `@key` field for the `Product` entity, other subgraphs should likely do the same.
-However, this [isn't strictly required](./define-keys#differing-keys-across-subgraphs).
+However, this [isn't strictly required](./define-advanced-keys#differing-keys-across-subgraphs).
 
 If coming from a database context, it can be helpful to think of a `@key` as an entity's [primary key](https://en.wikipedia.org/wiki/Primary_key).
-This term isn't completely accurate for entities since a single entity can have [multiple `@key`s](./define-keys#multiple-keys). The field(s) you select for an entity's `@key` must, however, uniquely identify the entity.
+This term isn't completely accurate for entities since a single entity can have [multiple `@key`s](./define-advanced-keys#multiple-keys). The field(s) you select for an entity's `@key` must, however, uniquely identify the entity.
 In that way, `@key`s are similar to [candidate keys](https://en.wikipedia.org/wiki/Candidate_key).
 
 <CodeColumns>
@@ -89,7 +89,7 @@ type Product @key(fields: "id") {
 
 </CodeColumns>
 
-For more information on advanced key options, like defining [multiple keys](./define-keys/#multiple-keys) or [compound keys](./define-keys/#compound-keys), see the guide on [Defining keys](./define-keys).
+For more information on advanced key options, like defining [multiple keys](./define-advanced-keys/#multiple-keys) or [compound keys](./define-advanced-keys/#compound-keys), see the guide on [Defining keys](./define-advanced-keys).
 
 #### Key field limitations
 

--- a/docs/source/federated-schemas/federated-directives.mdx
+++ b/docs/source/federated-schemas/federated-directives.mdx
@@ -382,7 +382,7 @@ You can apply `@override` to a [`@shareable`](#shareable) field. If you do, only
 
 Only one subgraph can `@override` any given field. If multiple subgraphs attempt to `@override` the same field, a composition error occurs.
 
-For more information, see [Migrating entity and root fields](../entities/migrating-fields).
+For more information, see [Migrating entity and root fields](../entities/migrate-fields).
 
 <MinVersion version="2.7">
 


### PR DESCRIPTION
Hello 👋 

While reading the docs on Apollo Federation, I found following issues:
1. This page contains invalid link: https://www.apollographql.com/docs/federation/federated-schemas/federated-directives/#override
Old link leads to this URL, which gives 404:
https://www.apollographql.com/docs/federation/entities/migrating-fields
A correct link was already used on this page (`/migrate-fields`), I used it for the fix.

2. This page has broken link: https://www.apollographql.com/docs/federation/entities/
<img width="929" alt="Screenshot 2024-07-25 at 14 04 22" src="https://github.com/user-attachments/assets/f16a9cc2-9be8-4e2d-8f32-cae50a99875c">

3. This page has broken links to /define-keys: https://www.apollographql.com/docs/federation/entities/
e.g. https://www.apollographql.com/docs/federation/entities/define-keys/#multiple-keys -> 404