### PR TITLE
docs: clarify context and fromContext are enterprise directives

### DIFF
--- a/docs/source/federated-schemas/federated-directives.mdx
+++ b/docs/source/federated-schemas/federated-directives.mdx
@@ -924,7 +924,7 @@ If different subgraphs use different versions of a directive's corresponding spe
 
 </MinVersion>
 
-<EnterpriseFeature />
+<EnterpriseDirective />
 
 The `@context` directive defines a named context from which a field of the annotated type can be passed to a receiver of the context. The receiver must be a field annotated with the `@fromContext` directive. 
 
@@ -959,7 +959,7 @@ type U @key(fields: "id") {
 
 </MinVersion>
 
-<EnterpriseFeature />
+<EnterpriseDirective />
 
 The `@fromContext` directive sets the context from which to receive the value of the annotated field. The context must have been defined with the `@context` directive.
 


### PR DESCRIPTION
Change to `<EnterpriseDirective>` for `@context` and `@fromContext` to call out GraphOS Router and enterprise license requirements.