### PR TITLE
Skip directive extraction for custom directives which happen to conflict with default federation directive names

### DIFF
--- a/internals-js/src/__tests__/schemaUpgrader.test.ts
+++ b/internals-js/src/__tests__/schemaUpgrader.test.ts
@@ -366,8 +366,8 @@ test('fully upgrades a schema with no @link directive', () => {
 
 test("don't add @shareable to subscriptions", () => {
   const subgraph1 = buildSubgraph(
-    "subgraph1",
-    "",
+    'subgraph1',
+    '',
     `#graphql
     type Query {
       hello: String
@@ -376,12 +376,12 @@ test("don't add @shareable to subscriptions", () => {
     type Subscription { 
       update: String!
     }
-  `
+  `,
   );
-  
+
   const subgraph2 = buildSubgraph(
-    "subgraph2",
-    "",
+    'subgraph2',
+    '',
     `#graphql
     type Query {
       hello: String
@@ -390,16 +390,30 @@ test("don't add @shareable to subscriptions", () => {
     type Subscription { 
       update: String!
     }
-  `
+  `,
   );
   const subgraphs = new Subgraphs();
   subgraphs.add(subgraph1);
   subgraphs.add(subgraph2);
   const result = upgradeSubgraphsIfNecessary(subgraphs);
 
-  expect(printSchema(result.subgraphs!.get("subgraph1")!.schema!)).not.toContain('update: String! @shareable');
-  expect(printSchema(result.subgraphs!.get("subgraph2")!.schema!)).not.toContain('update: String! @shareable');
-  
-  expect(result.subgraphs!.get("subgraph1")!.schema.type('Subscription')?.appliedDirectivesOf('@shareable').length).toBe(0);
-  expect(result.subgraphs!.get("subgraph2")!.schema.type('Subscription')?.appliedDirectivesOf('@shareable').length).toBe(0);
+  expect(
+    printSchema(result.subgraphs!.get('subgraph1')!.schema!),
+  ).not.toContain('update: String! @shareable');
+  expect(
+    printSchema(result.subgraphs!.get('subgraph2')!.schema!),
+  ).not.toContain('update: String! @shareable');
+
+  expect(
+    result
+      .subgraphs!.get('subgraph1')!
+      .schema.type('Subscription')
+      ?.appliedDirectivesOf('@shareable').length,
+  ).toBe(0);
+  expect(
+    result
+      .subgraphs!.get('subgraph2')!
+      .schema.type('Subscription')
+      ?.appliedDirectivesOf('@shareable').length,
+  ).toBe(0);
 });


### PR DESCRIPTION
When we extract demand control directives from the supergraph to the query planner's subgraphs, we look for well-known directive names and copy instances of them over. When looking up the directive name from the imports, we would use the default expected name. If a custom directive with the default name was imported, we would wrongly try to copy it over as the federation directive.

This change makes it so we only extract directives which are imported from `specs.apollo.dev`, such that we don't confuse a custom `@cost` directive with the one defined in federation.