### PR TITLE
Avoid unnecessary array copying in `ConditionValidationState.advance()`

### DIFF
--- a/query-graphs-js/src/conditionsValidation.ts
+++ b/query-graphs-js/src/conditionsValidation.ts
@@ -25,7 +25,7 @@ class ConditionValidationState {
   ) {}
 
   advance(supergraph: Schema): ConditionValidationState[] | null {
-    let newOptions: SimultaneousPathsWithLazyIndirectPaths[] = [];
+    const newOptions: SimultaneousPathsWithLazyIndirectPaths[] = [];
     for (const paths of this.subgraphOptions) {
       const pathsOptions = advanceSimultaneousPathsWithOperation(
         supergraph,
@@ -40,7 +40,7 @@ class ConditionValidationState {
       if (!pathsOptions) {
         continue;
       }
-      newOptions = newOptions.concat(pathsOptions);
+      newOptions.push(...pathsOptions);
     }
 
     // If we got no options, it means that particular selection of the conditions cannot be satisfied, so the


### PR DESCRIPTION
We were using `concat()` in `ConditionValidationState.advance()`, which was frequently copying the array. Shifting this to use `push()` instead increases performance significantly for some graphs.