### PR TITLE
Fix value comparison, argument merging, and link feature addition/extraction in composition

### DIFF
--- a/.changeset/proud-days-press.md
+++ b/.changeset/proud-days-press.md
@@ -1,0 +1,7 @@
+---
+"@apollo/federation-internals": patch
+"@apollo/gateway": patch
+"@apollo/composition": patch
+---
+
+Fix bugs in composition when merging nulls in directive applications and when handling renames.

--- a/composition-js/src/__tests__/compose.directiveArgumentMergeStrategies.test.ts
+++ b/composition-js/src/__tests__/compose.directiveArgumentMergeStrategies.test.ts
@@ -89,17 +89,19 @@ describe('composition of directive with non-trivial argument strategies', () => 
       t: 2, k: 1, b: 4,
     },
   }, {
-    name: 'sum',
-    type: (schema: Schema) => new NonNullType(schema.intType()),
-    compositionStrategy: ARGUMENT_COMPOSITION_STRATEGIES.SUM,
-    argValues: {
-      s1: { t: 3, k: 1 },
-      s2: { t: 2, k: 5, b: 4 },
-    },
-    resultValues: {
-      t: 5, k: 6, b: 4,
-    },
-  }, {
+  // NOTE: See the note for the SUM strategy in argumentCompositionStrategies.ts
+  // for more information on why this is commented out.
+  //   name: 'sum',
+  //   type: (schema: Schema) => new NonNullType(schema.intType()),
+  //   compositionStrategy: ARGUMENT_COMPOSITION_STRATEGIES.SUM,
+  //   argValues: {
+  //     s1: { t: 3, k: 1 },
+  //     s2: { t: 2, k: 5, b: 4 },
+  //   },
+  //   resultValues: {
+  //     t: 5, k: 6, b: 4,
+  //   },
+  // }, {
     name: 'intersection',
     type: (schema: Schema) => new NonNullType(new ListType(new NonNullType(schema.stringType()))),
     compositionStrategy: ARGUMENT_COMPOSITION_STRATEGIES.INTERSECTION,
@@ -219,7 +221,7 @@ describe('composition of directive with non-trivial argument strategies', () => 
     const s = result.schema;
 
     expect(directiveStrings(s.schemaDefinition, name)).toStrictEqual([
-      `@link(url: "https://specs.apollo.dev/${name}/v0.1", import: ["@${name}"])`
+      `@link(url: "https://specs.apollo.dev/${name}/v0.1")`
     ]);
 
     const t = s.type('T') as ObjectType;

--- a/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/gateway-js/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -149,7 +149,7 @@ describe('lifecycle hooks', () => {
     // the supergraph (even just formatting differences), this ID will change
     // and this test will have to updated.
     expect(secondCall[0]!.compositionId).toMatchInlineSnapshot(
-      `"4aa2278e35df345ff5959a30546d2e9ef9e997204b4ffee4a42344b578b36068"`,
+      `"6dc1bde2b9818fabec62208c5d8825abaa1bae89635fa6f3a5ffea7b78fc6d82"`,
     );
     // second call should have previous info in the second arg
     expect(secondCall[1]!.compositionId).toEqual(expectedFirstId);

--- a/internals-js/src/__tests__/values.test.ts
+++ b/internals-js/src/__tests__/values.test.ts
@@ -414,5 +414,6 @@ describe('objectEquals tests', () => {
     expect(valueEquals({ foo: 'foo', bar: undefined }, { foo: 'foo' })).toBe(
       false,
     );
+    expect(valueEquals({}, null)).toBe(false);
   });
 });

--- a/internals-js/src/argumentCompositionStrategies.ts
+++ b/internals-js/src/argumentCompositionStrategies.ts
@@ -13,87 +13,105 @@ export type ArgumentCompositionStrategy = {
 function supportFixedTypes(types: (schema: Schema) => InputType[]): TypeSupportValidator {
   return (schema, type) => {
     const supported = types(schema);
-    if (!supported.some((t) => sameType(t, type))) {
-      return { valid: false, supportedMsg: `type(s) ${supported.join(', ')}` };
-    }
-    return { valid: true };
+    return supported.some((t) => sameType(t, type))
+      ? { valid: true }
+      : { valid: false, supportedMsg: `type(s) ${supported.join(', ')}` };
   };
 }
 
 function supportAnyNonNullArray(): TypeSupportValidator {
-  return (_, type) => {
-    if (!isNonNullType(type) || !isListType(type.ofType)) {
-      return { valid: false, supportedMsg: 'non nullable list types of any type'};
-    }
-    return { valid: true };
+  return (_, type) => isNonNullType(type) && isListType(type.ofType)
+    ? { valid: true }
+    : { valid: false, supportedMsg: 'non nullable list types of any type' }
+}
+
+function supportAnyArray(): TypeSupportValidator {
+  return (_, type) => isListType(type) || (isNonNullType(type) && isListType(type.ofType))
+    ? { valid: true }
+    : { valid: false, supportedMsg: 'list types of any type' };
+}
+
+// NOTE: This function makes the assumption that for the directive argument
+// being merged, it is not "nullable with non-null default" in the supergraph
+// schema (this kind of type/default combo is confusing and should be avoided,
+// if possible). This assumption allows this function to replace null with
+// undefined, which makes for a cleaner supergraph schema.
+function mergeNullableValues<T>(
+  mergeValues: (values: T[]) => T
+): (values: (T | null | undefined)[]) => T | undefined {
+  return (values: (T | null | undefined)[]) => {
+    const nonNullValues = values.filter((v) => v !== null && v !== undefined) as T[];
+    return nonNullValues.length > 0
+      ? mergeValues(nonNullValues)
+      : undefined;
   };
+}
+
+function unionValues(values: any[]): any {
+  return values.reduce((acc, next) => {
+    const newValues = next.filter((v1: any) => !acc.some((v2: any) => valueEquals(v1, v2)));
+    return acc.concat(newValues);
+  }, []);
 }
 
 export const ARGUMENT_COMPOSITION_STRATEGIES = {
   MAX: {
     name: 'MAX',
     isTypeSupported: supportFixedTypes((schema: Schema) => [new NonNullType(schema.intType())]),
-    mergeValues: (values: any[]) => Math.max(...values),
+    mergeValues: (values: number[]) => Math.max(...values),
   },
   MIN: {
     name: 'MIN',
     isTypeSupported: supportFixedTypes((schema: Schema) => [new NonNullType(schema.intType())]),
-    mergeValues: (values: any[]) => Math.min(...values),
+    mergeValues: (values: number[]) => Math.min(...values),
   },
-  SUM: {
-    name: 'SUM',
-    isTypeSupported: supportFixedTypes((schema: Schema) => [new NonNullType(schema.intType())]),
-    mergeValues: (values: any[]) => values.reduce((acc, val) => acc + val, 0),
-  },
+  // NOTE: This doesn't work today because directive applications are de-duped
+  // before being merged, we'd need to modify merge logic if we need this kind
+  // of behavior.
+  // SUM: {
+  //   name: 'SUM',
+  //   isTypeSupported: supportFixedTypes((schema: Schema) => [new NonNullType(schema.intType())]),
+  //   mergeValues: (values: any[]) => values.reduce((acc, val) => acc + val, 0),
+  // },
   INTERSECTION: {
     name: 'INTERSECTION',
     isTypeSupported: supportAnyNonNullArray(),
-    mergeValues: (values: any[]) => values.reduce((acc, val) => acc.filter((v1: any) => val.some((v2: any) => valueEquals(v1, v2))), values[0]),
+    mergeValues: (values: any[]) => values.reduce((acc, next) => {
+      if (acc === undefined) {
+        return next;
+      } else {
+        return acc.filter((v1: any) => next.some((v2: any) => valueEquals(v1, v2)));
+      }  
+    }, undefined) ?? [],
   },
   UNION: {
     name: 'UNION',
     isTypeSupported: supportAnyNonNullArray(),
-    mergeValues: (values: any[]) =>
-      values.reduce((acc, val) => {
-        const newValues = val.filter((v1: any) => !acc.some((v2: any) => valueEquals(v1, v2)));
-        return acc.concat(newValues);
-      }, []),
+    mergeValues: unionValues,
   },
   NULLABLE_AND: {
     name: 'NULLABLE_AND',
-    isTypeSupported: supportFixedTypes((schema: Schema) => [schema.booleanType()]),
-    mergeValues: (values: (boolean | null | undefined)[]) => values.reduce((acc, next) => {
-      if (acc === null || acc === undefined) {
-        return next;
-      } else if (next === null || next === undefined) {
-        return acc;
-      } else {
-        return acc && next;
-      }
-    }, undefined),
+    isTypeSupported: supportFixedTypes((schema: Schema) => [
+      schema.booleanType(),
+      new NonNullType(schema.booleanType())
+    ]),
+    mergeValues: mergeNullableValues(
+      (values: boolean[]) => values.every((v) => v)
+    ),
   },
   NULLABLE_MAX: {
     name: 'NULLABLE_MAX',
-    isTypeSupported: supportFixedTypes((schema: Schema) => [schema.intType(), new NonNullType(schema.intType())]),
-    mergeValues: (values: any[]) => values.reduce((a: any, b: any) => a !== undefined && b !== undefined ? Math.max(a, b) : a ?? b, undefined),
+    isTypeSupported: supportFixedTypes((schema: Schema) => [
+      schema.intType(),
+      new NonNullType(schema.intType())
+    ]),
+    mergeValues: mergeNullableValues(
+      (values: number[]) => Math.max(...values)
+    )
   },
   NULLABLE_UNION: {
     name: 'NULLABLE_UNION',
-    isTypeSupported: (_: Schema, type: InputType) => ({ valid: isListType(type) }),
-    mergeValues: (values: any[]) => {
-      if (values.every((v) => v === undefined)) {
-        return undefined;
-      }
-
-      const combined = new Set();
-      for (const subgraphValues of values) {
-        if (Array.isArray(subgraphValues)) {
-          for (const value of subgraphValues) {
-            combined.add(value);
-          }
-        }
-      }
-      return Array.from(combined);
-    }
+    isTypeSupported: supportAnyArray(),
+    mergeValues: mergeNullableValues(unionValues),
   }
 }

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -984,12 +984,28 @@ export class CoreFeature {
   }
 
   directiveNameInSchema(name: string): string {
-    const elementImport = this.imports.find((i) => i.name.charAt(0) === '@' && i.name.slice(1) === name);
+    return CoreFeature.directiveNameInSchemaForCoreArguments(
+      this.url,
+      this.nameInSchema,
+      this.imports,
+      name,
+    );
+  }
+
+  static directiveNameInSchemaForCoreArguments(
+    specUrl: FeatureUrl,
+    specNameInSchema: string,
+    imports: CoreImport[],
+    directiveNameInSpec: string,
+  ): string {
+    const elementImport = imports.find((i) =>
+      i.name.charAt(0) === '@' && i.name.slice(1) === directiveNameInSpec
+    );
     return elementImport
-      ? (elementImport.as?.slice(1) ?? name)
-      : (name === this.url.name
-        ? this.nameInSchema
-        : this.nameInSchema + '__' + name
+      ? (elementImport.as?.slice(1) ?? directiveNameInSpec)
+      : (directiveNameInSpec === specUrl.name
+        ? specNameInSchema
+        : specNameInSchema + '__' + directiveNameInSpec
       );
   }
 
@@ -1064,7 +1080,7 @@ export class CoreFeatures {
       const feature = this.byAlias.get(splitted[0]);
       return feature ? {
         feature,
-        nameInFeature: splitted[1],
+        nameInFeature: splitted.slice(1).join('__'),
         isImported: false,
       } : undefined;
     } else {
@@ -1076,7 +1092,7 @@ export class CoreFeatures {
           if ((as ?? name) === importName) {
             return {
               feature,
-              nameInFeature: name.slice(1),
+              nameInFeature: isDirective ? name.slice(1) : name,
               isImported: true,
             };
           }
@@ -1088,8 +1104,8 @@ export class CoreFeatures {
       if (directFeature && isDirective) {
         return {
           feature: directFeature,
-          nameInFeature: directFeature.imports.find(imp => imp.as === `@${element.name}`)?.name.slice(1) ?? element.name,
-          isImported: true,
+          nameInFeature: element.name,
+          isImported: false,
         };
       }
 

--- a/internals-js/src/specs/coreSpec.ts
+++ b/internals-js/src/specs/coreSpec.ts
@@ -195,7 +195,8 @@ export type CoreDirectiveArgs = {
   url: undefined,
   feature: string,
   as?: string,
-  for?: string
+  for?: string,
+  import: undefined,
 }
 
 export type LinkDirectiveArgs = {
@@ -203,7 +204,7 @@ export type LinkDirectiveArgs = {
   feature: undefined,
   as?: string,
   for?: string,
-  import?: (string | CoreImport)[]
+  import?: (string | CoreImport)[],
 }
 
 export type CoreOrLinkDirectiveArgs = CoreDirectiveArgs | LinkDirectiveArgs;
@@ -539,36 +540,36 @@ export class CoreSpecDefinition extends FeatureDefinition {
     return feature.url.version;
   }
 
-  applyFeatureToSchema(schema: Schema, feature: FeatureDefinition, as?: string, purpose?: CorePurpose): GraphQLError[] {
+  applyFeatureToSchema(
+    schema: Schema,
+    feature: FeatureDefinition,
+    as?: string,
+    purpose?: CorePurpose,
+    imports?: CoreImport[],
+  ): GraphQLError[] {
     const coreDirective = this.coreDirective(schema);
     const args = {
       [this.urlArgName()]: feature.toString(),
       as,
-    } as CoreDirectiveArgs;
-    if (this.supportPurposes() && purpose) {
-      args.for = purpose;
+    } as CoreOrLinkDirectiveArgs;
+    if (purpose) {
+      if (this.supportPurposes()) {
+        args.for = purpose;
+      } else {
+        return [new GraphQLError(
+          `Cannot apply feature ${feature} with purpose since the schema's @core/@link version does not support it.`
+        )];
+      }
     }
-    schema.schemaDefinition.applyDirective(coreDirective, args);
-    return feature.addElementsToSchema(schema);
-  }
-
-  applyFeatureAsLink(schema: Schema, feature: FeatureDefinition, purpose?: CorePurpose, imports?: CoreImport[]): GraphQLError[] {
-    const existing = schema.schemaDefinition.appliedDirectivesOf(linkDirectiveDefaultName).find((link) => link.arguments().url === feature.toString());
-    if (existing) {
-      existing.remove();
+    if (imports && imports.length > 0) {
+      if (this.supportImport()) {
+        args.import = imports.map(i => i.as ? i : i.name);
+      } else {
+        return [new GraphQLError(
+          `Cannot apply feature ${feature} with imports since the schema's @core/@link version does not support it.`
+        )];
+      }
     }
-
-    const coreDirective = this.coreDirective(schema);
-    const args: LinkDirectiveArgs = {
-      url: feature.toString(),
-      import: (existing?.arguments().import ?? []).concat(imports?.map((i) => i.as ? { name: `@${i.name}`, as: `@${i.as}` } : `@${i.name}`)),
-      feature: undefined,
-    };
-
-    if (this.supportPurposes() && purpose) {
-      args.for = purpose;
-    }
-
     schema.schemaDefinition.applyDirective(coreDirective, args);
     return feature.addElementsToSchema(schema);
   }


### PR DESCRIPTION
While reviewing recent code changes that released in `2.9.0`, I noticed a few bugs in the code, so I've pushed some fixes for them in this PR (along with some fixes for more ancient bugs).

I'll comment on the code with more details, but to summarize the fixes:
- Value comparison/default value application has been updated to handle `null`s/`undefined`s better.
- Composition argument strategy code has been refactored to handle nullability more cleanly (and fix some bugs around nullability).
  - Note I've commented out the unused `SUM` strategy, as using it currently wouldn't yield expected results since directive applications are deduped before being merged.
- The logic that applies `@link` applications to the supergraph schema for supergraph specs needed by subgraph directives has been updated to handle specs that have multiple directives that need composing (the behavior before was adding spurious directive definitions to the supergraph schema).
- Some ancient logic around computing directive/type names for `@core`/`@link` was off.