### PR TITLE
Handle edge cases with subgraph extraction logic

### DIFF
--- a/.changeset/light-ties-chew.md
+++ b/.changeset/light-ties-chew.md
@@ -1,0 +1,5 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fix edge cases for subgraph extraction logic when using spec renaming or specs URLs that look similar to `specs.apollo.dev`.

--- a/internals-js/src/specs/costSpec.ts
+++ b/internals-js/src/specs/costSpec.ts
@@ -1,7 +1,7 @@
 import { DirectiveLocation } from 'graphql';
 import { createDirectiveSpecification } from '../directiveAndTypeSpecification';
 import { FeatureDefinition, FeatureDefinitions, FeatureUrl, FeatureVersion } from './coreSpec';
-import { ListType, NonNullType } from '../definitions';
+import { DirectiveDefinition, ListType, NonNullType, Schema } from '../definitions';
 import { registerKnownFeature } from '../knownCoreFeatures';
 import { ARGUMENT_COMPOSITION_STRATEGIES } from '../argumentCompositionStrategies';
 
@@ -40,6 +40,14 @@ export class CostSpecDefinition extends FeatureDefinition {
       repeatable: false,
       supergraphSpecification: (fedVersion) => COST_VERSIONS.getMinimumRequiredVersion(fedVersion)
     }));
+  }
+
+  costDirective(schema: Schema): DirectiveDefinition<CostDirectiveArguments> | undefined {
+    return this.directive(schema, 'cost');
+  }
+
+  listSizeDirective(schema: Schema): DirectiveDefinition<ListSizeDirectiveArguments> | undefined {
+    return this.directive(schema, 'listSize');
   }
 }
 

--- a/internals-js/src/supergraphs.ts
+++ b/internals-js/src/supergraphs.ts
@@ -1,7 +1,9 @@
 import { DocumentNode, GraphQLError } from "graphql";
-import { ErrCoreCheckFailed, FeatureUrl, FeatureVersion } from "./specs/coreSpec";
 import { CoreFeatures, Schema, sourceASTs } from "./definitions";
+import { ErrCoreCheckFailed, FeatureUrl, FeatureVersion } from "./specs/coreSpec";
 import { joinIdentity, JoinSpecDefinition, JOIN_VERSIONS } from "./specs/joinSpec";
+import { CONTEXT_VERSIONS, ContextSpecDefinition } from "./specs/contextSpec";
+import { COST_VERSIONS, costIdentity, CostSpecDefinition } from "./specs/costSpec";
 import { buildSchema, buildSchemaFromAST } from "./buildSchema";
 import { extractSubgraphsNamesAndUrlsFromSupergraph, extractSubgraphsFromSupergraph } from "./extractSubgraphsFromSupergraph";
 import { ERRORS } from "./error";
@@ -81,11 +83,17 @@ function checkFeatureSupport(coreFeatures: CoreFeatures, supportedFeatures: Set<
   }
 }
 
-export function validateSupergraph(supergraph: Schema): [CoreFeatures, JoinSpecDefinition] {
+export function validateSupergraph(supergraph: Schema): [
+  CoreFeatures,
+  JoinSpecDefinition,
+  ContextSpecDefinition | undefined,
+  CostSpecDefinition | undefined,
+] {
   const coreFeatures = supergraph.coreFeatures;
   if (!coreFeatures) {
     throw ERRORS.INVALID_FEDERATION_SUPERGRAPH.err("Invalid supergraph: must be a core schema");
   }
+
   const joinFeature = coreFeatures.getByIdentity(joinIdentity);
   if (!joinFeature) {
     throw ERRORS.INVALID_FEDERATION_SUPERGRAPH.err("Invalid supergraph: must use the join spec");
@@ -95,7 +103,27 @@ export function validateSupergraph(supergraph: Schema): [CoreFeatures, JoinSpecD
     throw ERRORS.INVALID_FEDERATION_SUPERGRAPH.err(
       `Invalid supergraph: uses unsupported join spec version ${joinFeature.url.version} (supported versions: ${JOIN_VERSIONS.versions().join(', ')})`);
   }
-  return [coreFeatures, joinSpec];
+
+  const contextFeature = coreFeatures.getByIdentity(ContextSpecDefinition.identity);
+  let contextSpec = undefined;
+  if (contextFeature) {
+    contextSpec = CONTEXT_VERSIONS.find(contextFeature.url.version);
+    if (!contextSpec) {
+      throw ERRORS.INVALID_FEDERATION_SUPERGRAPH.err(
+        `Invalid supergraph: uses unsupported context spec version ${contextFeature.url.version} (supported versions: ${CONTEXT_VERSIONS.versions().join(', ')})`);
+    }
+  }
+
+  const costFeature = coreFeatures.getByIdentity(costIdentity);
+  let costSpec = undefined;
+  if (costFeature) {
+    costSpec = COST_VERSIONS.find(costFeature.url.version);
+    if (!costSpec) {
+      throw ERRORS.INVALID_FEDERATION_SUPERGRAPH.err(
+        `Invalid supergraph: uses unsupported cost spec version ${costFeature.url.version} (supported versions: ${COST_VERSIONS.versions().join(', ')})`);
+    }
+  }
+  return [coreFeatures, joinSpec, contextSpec, costSpec];
 }
 
 export function isFed1Supergraph(supergraph: Schema): boolean {


### PR DESCRIPTION
While reviewing recent code changes that released in `2.9.0`, I noticed a few bugs in the code. This PR contains fixes for subgraph extraction bugs.

Specifically, this PR updates subgraph extraction to use pre-existing functions/patterns instead of repeating logic, to avoid copy/pasting and bugs/divergence (the copied logic wasn't looking at spec renaming, for example).