### PR TITLE
Ignore non-resolvable keys in locally satisfiable key checking 

### DIFF
--- a/.changeset/rich-tips-study.md
+++ b/.changeset/rich-tips-study.md
@@ -1,0 +1,6 @@
+---
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+---
+
+Ignore non-resolvable keys when adding a subgraph jump for `@requires`/`@fromContext`. 

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -1930,6 +1930,9 @@ export function getLocallySatisfiableKey(graph: QueryGraph, typeVertex: Vertex):
   assert(metadata, () => `Could not find federation metadata for source ${typeVertex.source}`);
   const keyDirective = metadata.keyDirective();
   for (const key of type.appliedDirectivesOf(keyDirective)) {
+    if (!(key.arguments().resolvable ?? true)) {
+      continue;
+    }
     const selection = parseFieldSetArgument({ parentType: type, directive: key });
     if (!metadata.selectionSelectsAnyExternalField(selection)) {
       return selection;


### PR DESCRIPTION
This PR fixes a bug where `getLocallySatisfiableKey()` would mistakenly consider non-resolvable keys, which would sometimes result in self jumps for `@requires` using non-resolvable keys.