### PR TITLE
Relax external field requirements

### DIFF
--- a/.changeset/slow-cups-exist.md
+++ b/.changeset/slow-cups-exist.md
@@ -1,0 +1,5 @@
+---
+"@apollo/composition": patch
+---
+
+Relax error for detecting whether `@external` field matches. If the external field has extra optional parameters, allow it to pass composition as being able to pass the parameter is not necessary for a required field.

--- a/composition-js/src/__tests__/compose.external.test.ts
+++ b/composition-js/src/__tests__/compose.external.test.ts
@@ -62,7 +62,7 @@ describe('tests related to @external', () => {
       typeDefs: gql`
         type T @key(fields: "id") {
           id: ID!
-          f(x: Int): String @shareable
+          f(x: Int!): String @shareable
         }
       `,
     };
@@ -73,6 +73,38 @@ describe('tests related to @external', () => {
       ['EXTERNAL_ARGUMENT_MISSING', 'Field "T.f" is missing argument "T.f(x:)" in some subgraphs where it is marked @external: argument "T.f(x:)" is declared in subgraph "subgraphB" but not in subgraph "subgraphA" (where "T.f" is @external).'],
     ]);
   });
+  
+  it('succeeds on @external definition where difference between definitions is an optional argument', () => {
+    const subgraphA = {
+      name: 'subgraphA',
+      typeDefs: gql`
+        type Query {
+          locations: [Location]
+        }
+
+        type Location @key(fields: "id") {
+            id: ID!
+            name: String!
+            photo(smallVersion: Boolean): String! # New optional arg shouldn't break existing clients
+        }
+      `,
+    };
+
+    const subgraphB = {
+      name: 'subgraphB',
+      typeDefs: gql`
+        type Location @key(fields: "id") {
+            id: ID!
+            photo: String! @external
+            banner: String @requires(fields: "photo")
+        }
+      `,
+    };
+
+    const result = composeAsFed2Subgraphs([subgraphA, subgraphB]);
+    assertCompositionSuccess(result);
+  });
+
 
   it('errors on incompatible argument types in @external declaration', () => {
     const subgraphA = {

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1788,7 +1788,9 @@ class Merger {
         const name = destArg.name;
         const arg = source.argument(name);
         if (!arg) {
-          invalidArgsPresence.add(name);
+          if (!destArg.type || destArg.type.kind === 'NonNullType') {
+            invalidArgsPresence.add(name);
+          }
           continue;
         }
         if (!sameType(destArg.type!, arg.type!) && !this.isStrictSubtype(arg.type!, destArg.type!)) {


### PR DESCRIPTION
Relax error for detecting whether `@external` field matches. If the external field has extra optional parameters, allow it to pass composition as being able to pass the parameter is not necessary for a required field.