### PR TITLE
Fixes issue where there can be naming collisions in contextual parameter names

### DIFF
--- a/.changeset/tame-paws-return.md
+++ b/.changeset/tame-paws-return.md
@@ -1,0 +1,6 @@
+---
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+---
+
+Fixes issue where contextual parameters can have naming collisions if used in multiple subgraphs

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -934,17 +934,6 @@ function federateSubgraphs(supergraph: Schema, subgraphs: QueryGraph[]): QueryGr
       }
     }
     
-    for (const [subgraphName, args] of subgraphToArgs) {
-      args.sort();
-      const argToIndex = new Map();
-      for (let idx=0; idx < args.length; idx++) {
-        argToIndex.set(args[idx], `contextualArgument_${i}_${idx}`);
-      }
-      subgraphToArgIndices.set(subgraphName, argToIndex);
-    }
-    
-    builder.setContextMaps(subgraphToArgs, subgraphToArgIndices);
-    
     simpleTraversal(
       subgraph,
       _v => { return undefined; },
@@ -965,6 +954,22 @@ function federateSubgraphs(supergraph: Schema, subgraphs: QueryGraph[]): QueryGr
    
   }
 
+  // add contextual argument maps to builder
+  for (const [i, subgraph] of subgraphs.entries()) {
+    const subgraphName = subgraph.name;
+    const args = subgraphToArgs.get(subgraph.name);
+    if (args) {
+      args.sort();
+      const argToIndex = new Map();
+      for (let idx=0; idx < args.length; idx++) {
+        argToIndex.set(args[idx], `contextualArgument_${i+1}_${idx}`);
+      }
+      subgraphToArgIndices.set(subgraphName, argToIndex);
+    }
+  }
+  
+  builder.setContextMaps(subgraphToArgs, subgraphToArgIndices);
+      
   // Now we handle @provides
   let provideId = 0;
   for (const [i, subgraph] of subgraphs.entries()) {

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -9164,7 +9164,7 @@ describe('@fromContext impacts on query planning', () => {
               } =>
               {
                 ... on U {
-                  field(a: $contextualArgument_1_0)
+                  field(a: $contextualArgument_2_0)
                 }
               }
             },
@@ -9176,7 +9176,7 @@ describe('@fromContext impacts on query planning', () => {
       {
         kind: 'KeyRenamer',
         path: ['..', '... on T', 'prop'],
-        renameKeyTo: 'contextualArgument_1_0',
+        renameKeyTo: 'contextualArgument_2_0',
       },
     ]);
   });


### PR DESCRIPTION
Subgraph number set for a contextual paramter was colliding if used in multiple subgraphs