### PR TITLE
fix: fix recursion logic in minimizeSelectionSet

### DIFF
--- a/.changeset/violet-cows-talk.md
+++ b/.changeset/violet-cows-talk.md
@@ -1,0 +1,5 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fix fragment generation recursion logic to apply minification on all subselections.

--- a/internals-js/src/__tests__/operations.test.ts
+++ b/internals-js/src/__tests__/operations.test.ts
@@ -142,8 +142,8 @@ describe('generate query fragments', () => {
     `);
 
     const operation = parseOperation(
-        schema,
-        `
+      schema,
+      `
       query Foo($flag: Boolean!) {
         foo {
           a1

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -1658,10 +1658,10 @@ export class SelectionSet {
         }
 
         return new FragmentSpreadSelection(this.parentType, namedFragments, fragmentDefinition, []);
-      } else if (selection.kind === 'FieldSelection') {
-        if (selection.selectionSet) {
-          selection = selection.withUpdatedSelectionSet(selection.selectionSet.minimizeSelectionSet(namedFragments, seenSelections)[0]);
-        }
+      }
+
+      if (selection.selectionSet) {
+        selection = selection.withUpdatedSelectionSet(selection.selectionSet.minimizeSelectionSet(namedFragments, seenSelections)[0]);
       }
       return selection;
     });


### PR DESCRIPTION
When generating fragments we were only "minimizing" subselections for fields and inline fragments that could be extracted. If inline fragment cannot be replaced with a fragment spread, we should still minimize its selection set as it potentially can be optimized as well.