### PR TITLE
fix(graph-path): When eliminating suboptimal indirect paths, properly check for direct key edge

### DIFF
--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -1586,7 +1586,7 @@ function advancePathWithNonCollectingAndTypePreservingTransitions<TTrigger, V ex
           if (prevSubgraphVertex
             && (
               backToPreviousSubgraph
-              || hasValidDirectKeyEdge(toAdvance.graph, prevSubgraphVertex, edge.tail.source, conditionResolver, maxCost) != undefined
+              || hasValidDirectKeyEdge(toAdvance.graph, prevSubgraphVertex, edge.tail.source, conditionResolver, maxCost)
             )
           ) {
             debug.groupEnd(


### PR DESCRIPTION
This PR fixes a bug where when removing suboptimal indirect paths, we didn't properly check for a direct key edge at the end of the potential direct path.