### PR TITLE
fix: normalize field set selection

### DIFF
--- a/.changeset/slow-dots-explode.md
+++ b/.changeset/slow-dots-explode.md
@@ -1,0 +1,8 @@
+---
+"@apollo/query-planner": patch
+"@apollo/federation-internals": patch
+---
+
+fix: normalize field set selection sets
+
+`FieldSet` scalar represents a selection set without outer braces. This means that users could potentially specify some selections that could be normalized (i.e. eliminate duplicate field selections, hoist/collapse unnecessary inline fragments, etc). Previously we were using `@requires` field set selection AS-IS for edge conditions. With this change we will now normalize the `FieldSet` selections before using them as fetch node conditions.

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -2302,7 +2302,7 @@ export function parseFieldSetArgument({
         }
       });
     }
-    return selectionSet;
+    return selectionSet.normalize({ parentType, recursive: true });
   } catch (e) {
     if (!(e instanceof GraphQLError) || !decorateValidationErrors) {
       throw e;

--- a/query-planner-js/src/__tests__/buildPlan.test.ts
+++ b/query-planner-js/src/__tests__/buildPlan.test.ts
@@ -2999,7 +2999,7 @@ describe('@requires', () => {
           id: ID!
           a: A
         }
-        
+
         type A {
           a1: Int
           a2: Int
@@ -3025,14 +3025,14 @@ describe('@requires', () => {
 
     const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
     const operation = operationFromDocument(
-        api,
-        gql`
-          {
-            t {
-              b
-            }
+      api,
+      gql`
+        {
+          t {
+            b
           }
-        `,
+        }
+      `,
     );
 
     const plan = queryPlanner.buildQueryPlan(operation);


### PR DESCRIPTION
`FieldSet` scalar represents a selection set without outer braces. This means that users could potentially specify some selections that could be normalized (i.e. eliminate duplicate field selections, hoist/collapse unnecessary inline fragments, etc). Previously we were using `@requires` field set selection AS-IS for edge conditions. With this change we will now normalize the `FieldSet` selections before using them as fetch node conditions.

<!-- FED-390 -->
