### PR TITLE
Sending null default values if the remote gql server is down

### DIFF
--- a/federation-integration-testsuite-js/src/fixtures/index.ts
+++ b/federation-integration-testsuite-js/src/fixtures/index.ts
@@ -9,6 +9,12 @@ import * as accountsWithoutTag from './special-cases/accountsWithoutTag';
 import * as reviewsWithoutTag from './special-cases/reviewsWithoutTag';
 import { DocumentNode } from 'graphql';
 import { GraphQLResolverMap } from '../resolverMap';
+import * as dep1 from './multi-service-require-cases/dep1';
+import * as dep2 from './multi-service-require-cases/dep2';
+import * as xfield from './multi-service-require-cases/xfield';
+import * as mainEntity from './multi-service-require-cases/mainEntity';
+import * as dep1Ex from './multi-service-require-cases/dep1WithException';
+import * as dep2Ex from './multi-service-require-cases/dep2WithException';
 
 export interface Fixture {
   name: string;
@@ -66,4 +72,10 @@ export {
   fixturesWithUpdate,
   fixturesWithoutTag,
   fixtureNames,
+  dep1,
+  dep2,
+  dep1Ex,
+  dep2Ex,
+  xfield,
+  mainEntity,
 };

--- a/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep1.ts
+++ b/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep1.ts
@@ -1,0 +1,30 @@
+import {gql} from "../../utils";
+
+
+export const typeDefs = gql`
+  extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.1"
+    import: [
+      "@key"
+      "@shareable"
+      "@inaccessible"
+      "@external"
+      "@requires"
+    ]
+  )
+
+  type TempType @key(fields: "id") {
+    id: ID!
+    dep1: Int!
+  }
+`;
+
+export const resolvers = {
+  TempType: {
+    dep1: () => {
+      return 1000;
+    },
+  },
+};

--- a/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep1WithException.ts
+++ b/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep1WithException.ts
@@ -1,0 +1,29 @@
+import {gql} from "../../utils";
+
+export const typeDefs = gql`
+  extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.1"
+    import: [
+      "@key"
+      "@shareable"
+      "@inaccessible"
+      "@external"
+      "@requires"
+    ]
+  )
+
+  type TempType @key(fields: "id") {
+    id: ID!
+    dep1: Int!
+  }
+`;
+
+export const resolvers = {
+  TempType: {
+    dep1: () => {
+      throw new Error('This is a custom error message dep1 non-nullable');
+    },
+  },
+};

--- a/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep2.ts
+++ b/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep2.ts
@@ -1,0 +1,30 @@
+import {gql} from "../../utils";
+
+export const typeDefs = gql`
+  extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.1"
+    import: [
+      "@key"
+      "@shareable"
+      "@inaccessible"
+      "@external"
+      "@provides"
+      "@requires"
+    ]
+  )
+
+  type TempType @key(fields: "id") {
+    id: ID!
+    dep2: Int 
+  }
+`;
+
+export const resolvers = {
+  TempType: {
+    dep2: () => {
+      return 999;
+    },
+  },
+};

--- a/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep2WithException.ts
+++ b/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/dep2WithException.ts
@@ -1,0 +1,30 @@
+import {gql} from "../../utils";
+
+export const typeDefs = gql`
+  extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.1"
+    import: [
+      "@key"
+      "@shareable"
+      "@inaccessible"
+      "@external"
+      "@provides"
+      "@requires"
+    ]
+  )
+
+  type TempType @key(fields: "id") {
+    id: ID!
+    dep2: Int 
+  }
+`;
+
+export const resolvers = {
+  TempType: {
+    dep2: () => {
+      throw new Error('This is a custom error message');
+    },
+  },
+};

--- a/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/mainEntity.ts
+++ b/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/mainEntity.ts
@@ -1,0 +1,35 @@
+import {gql} from "../../utils";
+
+export const typeDefs = gql`
+  extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.1"
+    import: [
+      "@key"
+      "@shareable"
+      "@inaccessible"
+      "@external"
+      "@requires"
+    ]
+  )
+
+  type TempType @key(fields: "id") {
+    id: ID!
+    myText: String
+  }
+  type Query {
+    getTemp(id: ID): TempType
+  }
+`;
+
+export const resolvers = {
+  Query: {
+    getTemp: () => {
+      return {
+        id: 123134431,
+        myText: 'this is a sample',
+      };
+    },
+  },
+};

--- a/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/xfield.ts
+++ b/federation-integration-testsuite-js/src/fixtures/multi-service-require-cases/xfield.ts
@@ -1,0 +1,40 @@
+import {gql} from "../../utils";
+
+export const typeDefs = gql`
+  extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.1"
+    import: [
+      "@key"
+      "@shareable"
+      "@composeDirective"
+      "@external"
+      "@requires"
+    ]
+  )
+
+  type TempType
+  @key(fields: "id") { #  <--------------- ENTITY
+    id: ID!
+    dep1: Int! @external
+    dep2: Int @external
+    xfield: Int @requires(fields: "dep1 dep2")
+  }
+`;
+
+export const resolvers = {
+  TempType: {
+    xfield: (
+        arg1: { dep2: number | null; dep1: number | null },
+    ) => {
+      if (arg1.dep2 == null) {
+        return arg1.dep1;
+      }
+      if (arg1.dep1 == null) {
+        return arg1.dep2;
+      }
+      return arg1.dep1 * arg1.dep2;
+    },
+  },
+};

--- a/gateway-js/src/__tests__/multi-service/multiService.test.ts
+++ b/gateway-js/src/__tests__/multi-service/multiService.test.ts
@@ -1,0 +1,373 @@
+import { unwrapSingleResultKind } from '../gateway/testUtils';
+import {ApolloGateway, IntrospectAndCompose, RemoteGraphQLDataSource} from "../../index";
+import {ApolloServer} from "@apollo/server";
+import {startStandaloneServer} from "@apollo/server/standalone";
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import {
+  dep1,
+  dep2,
+  dep1Ex,
+  dep2Ex,
+  xfield,
+  mainEntity,
+} from 'apollo-federation-integration-testsuite';
+
+async function buildGateway(port: number, useDefaultNullValuesForConnectionErrors: boolean = false) {
+  const gateway = new ApolloGateway({
+    buildService(x) {
+      return new RemoteGraphQLDataSource({ url: x.url }, useDefaultNullValuesForConnectionErrors);
+    },
+    debug: false,
+    supergraphSdl: new IntrospectAndCompose({
+      subgraphs: [
+        {
+          name: 'DEP2',
+          url: 'http://localhost:4001/graphql',
+        },
+        {
+          name: 'DEP1',
+          url: 'http://localhost:4002/graphql',
+        },
+        {
+          name: 'XFIELD',
+          url: 'http://localhost:4003/graphql',
+        },
+        {
+          name: 'BASEGRAPH',
+          url: 'http://localhost:4004/graphql',
+        },
+      ],
+    }),
+  });
+
+  const server = new ApolloServer({
+    gateway,
+  });
+  const { url } = await startStandaloneServer(server, {
+    listen: { port: port },
+  });
+  console.log(`Gateway running running ${url}`);
+  return server;
+}
+
+async function buildGQLServer(port: number, definition: any) {
+  const typeDefs = definition.typeDefs;
+  const resolvers = definition.resolvers;
+  const schema = buildSubgraphSchema({ typeDefs, resolvers });
+  const server = new ApolloServer({
+    schema,
+  });
+  const { url } = await startStandaloneServer(server, {
+    listen: { port: port },
+  });
+
+  console.log(`Subgraph running ${url}`);
+  return server;
+}
+
+describe('Multi-service', () => {
+  describe('Multi-service success', () => {
+    it('successfully starts and serves requests to the proper services', async () => {
+      const dep2ServerRef = await buildGQLServer(4001, dep2);
+      const dep1ServerRef = await buildGQLServer(4002, dep1);
+      const xfieldServerRef = await buildGQLServer(4003, xfield);
+      const mainEntityServerRef = await buildGQLServer(4004, mainEntity);
+
+      const server = await buildGateway(4000);
+
+      const result = await server.executeOperation({
+        query:
+          '{\n' +
+          '  getTemp {\n' +
+          '    dep1\n' +
+          '    dep2\n' +
+          '    xfield\n' +
+          '    id\n' +
+          '    myText\n' +
+          '  }\n' +
+          '}',
+      });
+
+      expect(unwrapSingleResultKind(result).data).toMatchInlineSnapshot(`
+              Object {
+                "getTemp": Object {
+                  "dep1": 1000,
+                  "dep2": 999,
+                  "id": "123134431",
+                  "myText": "this is a sample",
+                  "xfield": 999000,
+                },
+              }
+          `);
+      expect(unwrapSingleResultKind(result).errors).toMatchInlineSnapshot(
+        `undefined`,
+      );
+      await server.stop();
+      await dep2ServerRef.stop();
+      await dep1ServerRef.stop();
+      await xfieldServerRef.stop();
+      await mainEntityServerRef.stop();
+    });
+  });
+
+  describe('Multi-service exception returned for a nullable field', () => {
+    it('Ignores the nullable dep2 while calculating xfield in case an exception is returned instead of dep2', async () => {
+      const dep2ServerExRef = await buildGQLServer(4001, dep2Ex);
+      const dep1ServerRef = await buildGQLServer(4002, dep1);
+      const xfieldServerRef = await buildGQLServer(4003, xfield);
+      const mainEntityServerRef = await buildGQLServer(4004, mainEntity);
+
+      const server = await buildGateway(4000);
+
+      const resul = await server.executeOperation({
+        query:
+            '{\n' +
+            '  getTemp {\n' +
+            '    dep1\n' +
+            '    dep2\n' +
+            '    xfield\n' +
+            '    id\n' +
+            '    myText\n' +
+            '  }\n' +
+            '}',
+      });
+
+      expect(unwrapSingleResultKind(resul).data).toMatchInlineSnapshot(`
+              Object {
+                "getTemp": Object {
+                  "dep1": 1000,
+                  "dep2": null,
+                  "id": "123134431",
+                  "myText": "this is a sample",
+                  "xfield": 1000,
+                },
+              }
+          `);
+      expect(unwrapSingleResultKind(resul).errors).toMatchInlineSnapshot(`
+              Array [
+                Object {
+                  "extensions": Object {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "serviceName": "DEP2",
+                  },
+                  "message": "This is a custom error message",
+                  "path": Array [
+                    "getTemp",
+                    "dep2",
+                  ],
+                },
+              ]
+          `);
+      await server.stop();
+      await dep2ServerExRef.stop();
+      await dep1ServerRef.stop();
+      await xfieldServerRef.stop();
+      await mainEntityServerRef.stop();
+    });
+  });
+
+  describe('Multi-service exception returned for a non-nullable field', () => {
+    it('Fails in case the non-nullable dep1 returned an exception instead of a value while calculating xfield', async () => {
+      const dep2ServerRef = await buildGQLServer(4001, dep2);
+      const dep1ServerExRef = await buildGQLServer(4002, dep1Ex);
+      const xfieldServerRef = await buildGQLServer(4003, xfield);
+      const mainEntityServerRef = await buildGQLServer(4004, mainEntity);
+
+      const server = await buildGateway(4000);
+
+      const result = await server.executeOperation({
+        query:
+          '{\n' +
+          '  getTemp {\n' +
+          '    dep1\n' +
+          '    dep2\n' +
+          '    xfield\n' +
+          '    id\n' +
+          '    myText\n' +
+          '  }\n' +
+          '}',
+      });
+
+      expect(unwrapSingleResultKind(result).data).toMatchInlineSnapshot(`
+              Object {
+                "getTemp": null,
+              }
+          `);
+      expect(unwrapSingleResultKind(result).errors).toMatchInlineSnapshot(`
+              Array [
+                Object {
+                  "extensions": Object {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "serviceName": "DEP1",
+                  },
+                  "message": "This is a custom error message dep1 non-nullable",
+                  "path": Array [
+                    "getTemp",
+                    "dep1",
+                  ],
+                },
+              ]
+          `);
+      await server.stop();
+      await dep2ServerRef.stop();
+      await dep1ServerExRef.stop();
+      await xfieldServerRef.stop();
+      await mainEntityServerRef.stop();
+    });
+  });
+
+  describe('Multi-service server is down for a nullable field without enabling default null response fix', () => {
+    it('It fails to calculate xfield in case the dep2 server is down', async () => {
+      const dep2ServerRef = await buildGQLServer(4001, dep2);
+      const dep1ServerRef = await buildGQLServer(4002, dep1);
+      const xfieldServerRef = await buildGQLServer(4003, xfield);
+      const mainEntityServerRef = await buildGQLServer(4004, mainEntity);
+
+      const server = await buildGateway(4000);
+      await dep2ServerRef.stop();
+      const result = await server.executeOperation({
+        query:
+          '{\n' +
+          '  getTemp {\n' +
+          '    dep1\n' +
+          '    dep2\n' +
+          '    xfield\n' +
+          '    id\n' +
+          '    myText\n' +
+          '  }\n' +
+          '}',
+      });
+
+      expect(unwrapSingleResultKind(result).data).toMatchInlineSnapshot(`
+        Object {
+          "getTemp": Object {
+            "dep1": 1000,
+            "dep2": null,
+            "id": "123134431",
+            "myText": "this is a sample",
+            "xfield": null,
+          },
+        }
+      `);
+      expect(unwrapSingleResultKind(result).errors).toMatchInlineSnapshot(`
+              Array [
+                Object {
+                  "extensions": Object {
+                    "code": "INTERNAL_SERVER_ERROR",
+                  },
+                  "message": "request to http://localhost:4001/graphql failed, reason: connect ECONNREFUSED ::1:4001",
+                },
+              ]
+          `);
+
+      await server.stop();
+
+      await dep1ServerRef.stop();
+      await xfieldServerRef.stop();
+      await mainEntityServerRef.stop();
+    });
+  });
+
+  describe('Multi-service server is down for a nullable field with enabling default null response fix', () => {
+    it('Should ignore the nullable dep2 while calculating xfield in case the dep2 server is down', async () => {
+      const dep2ServerRef = await buildGQLServer(4001, dep2);
+      const dep1ServerRef = await buildGQLServer(4002, dep1);
+      const xfieldServerRef = await buildGQLServer(4003, xfield);
+      const mainEntityServerRef = await buildGQLServer(4004, mainEntity);
+
+      const server = await buildGateway(4000, true);
+      await dep2ServerRef.stop();
+      const result = await server.executeOperation({
+        query:
+          '{\n' +
+          '  getTemp {\n' +
+          '    dep1\n' +
+          '    dep2\n' +
+          '    xfield\n' +
+          '    id\n' +
+          '    myText\n' +
+          '  }\n' +
+          '}',
+      });
+
+      expect(unwrapSingleResultKind(result).data).toMatchInlineSnapshot(`
+              Object {
+                "getTemp": Object {
+                  "dep1": 1000,
+                  "dep2": null,
+                  "id": "123134431",
+                  "myText": "this is a sample",
+                  "xfield": 1000,
+                },
+              }
+          `);
+      expect(unwrapSingleResultKind(result).errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "extensions": Object {
+              "code": "INTERNAL_SERVER_ERROR",
+              "serviceName": "DEP2",
+            },
+            "message": "Error while connecting to service sending default null values- original error message is:request to http://localhost:4001/graphql failed, reason: connect ECONNREFUSED ::1:4001",
+          },
+        ]
+      `);
+
+      await server.stop();
+
+      await dep1ServerRef.stop();
+      await xfieldServerRef.stop();
+      await mainEntityServerRef.stop();
+    });
+  });
+
+  describe('Multi-service server is down for a non-nullable field with enabling default null response fix (preserve behaviour from before the fix)', () => {
+    it('Should fail  while calculating xfield in case the non-nullable dep1 server is down', async () => {
+      const dep2ServerRef = await buildGQLServer(4001, dep2);
+      const dep1ServerRef = await buildGQLServer(4002, dep1);
+      const xfieldServerRef = await buildGQLServer(4003, xfield);
+      const mainEntityServerRef = await buildGQLServer(4004, mainEntity);
+
+      const server = await buildGateway(4000, true);
+      await dep1ServerRef.stop();
+      const result = await server.executeOperation({
+        query:
+          '{\n' +
+          '  getTemp {\n' +
+          '    dep2\n' +
+          '    xfield\n' +
+          '    id\n' +
+          '    myText\n' +
+          '  }\n' +
+          '}',
+      });
+
+      expect(unwrapSingleResultKind(result).data).toMatchInlineSnapshot(`
+        Object {
+          "getTemp": Object {
+            "dep2": 999,
+            "id": "123134431",
+            "myText": "this is a sample",
+            "xfield": null,
+          },
+        }
+      `);
+      expect(unwrapSingleResultKind(result).errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "extensions": Object {
+              "code": "INTERNAL_SERVER_ERROR",
+            },
+            "message": "request to http://localhost:4002/graphql failed, reason: connect ECONNREFUSED ::1:4002",
+          },
+        ]
+      `);
+
+      await server.stop();
+
+      await dep2ServerRef.stop();
+      await xfieldServerRef.stop();
+      await mainEntityServerRef.stop();
+    });
+  });
+});

--- a/gateway-js/src/__tests__/multi-service/multiService.test.ts
+++ b/gateway-js/src/__tests__/multi-service/multiService.test.ts
@@ -179,7 +179,6 @@ describe('Multi-service', () => {
         query:
           '{\n' +
           '  getTemp {\n' +
-          '    dep1\n' +
           '    dep2\n' +
           '    xfield\n' +
           '    id\n' +
@@ -189,10 +188,15 @@ describe('Multi-service', () => {
       });
 
       expect(unwrapSingleResultKind(result).data).toMatchInlineSnapshot(`
-              Object {
-                "getTemp": null,
-              }
-          `);
+        Object {
+          "getTemp": Object {
+            "dep2": 999,
+            "id": "123134431",
+            "myText": "this is a sample",
+            "xfield": null,
+          },
+        }
+      `);
       expect(unwrapSingleResultKind(result).errors).toMatchInlineSnapshot(`
               Array [
                 Object {


### PR DESCRIPTION
Hi Apollo devs,
I'm submitting this pull request to fix an issue that was discussed in our direct slack communication in our shared slack channel with @daljitsumman  with me and @cernst11 (I had a call with Daljit and explained the issue and I'll provide an explanation here as well).

### General explanation:

While working on linking multiple services through the same entity using @require directive we encountered an unexpected behaviour that if a service is requiring input from 2 other services ( non-nullable dep1 and  nullable dep2 ) to calculate some field (xfield for example) we expect the nullable service to be ignored in case there is an internal exception or if the service is down, and continue trying to calculate xfield using the non-nullable data dep1.

Observed behaviour was:
* if the nullable service is down; the execution chain stops and no call is made to the service that is providing xfield. (as demonstrated in the tests of this pull request)
* if the nullable service is having an exception and this service is a java service then execution chain also stops (for this one we could figure that the service should return some empty array in case of an exception). (we didn't include this in this pull request since the fix is on the gateway it will handle the errors regardless of the services implemntation) 
* if the nullable service is having an exception and this service is a nodejs service then execution chain continues normally and xfield is called with only the result of the non-nullable dep1 (as demonstrated in the tests of this pull request).


**Why is this so important to us?**
   since we are creating links between the services with the @require directive we would like to ensure that a soft link (a dependency on a nullable field) is not going to implicitly create a hard link between the services. So if we have a critical path of execution that is reading some additional not critical data, we don't fail the whole execution if the non-critical data  service is down or having any kind of troubles.

### Technical explanation of the changes:

This pull request basically sets Null values only for nullable fields if the call to the providing service fails or is having any issue. and if any non-nullable field is found we are throwing the exception back so the same usual flow of the gateway will be executed.
the variable useDefaultNullValuesForConnectionErrors is used to enable this fix with a default value of false.
We wrapped the whole "process" method in a try-catch block and added this logic to the catch block, we then parse the query to check what should be set to null, and we get the entityTypeMap as well to check for any non-nullable fields to break out of this logic.
After getting the response with null values filled for the requested fields we set a custom message saying "Error while connecting to service sending default null values- original error message is:" and then we add the actual error message, we are using 'INTERNAL_SERVER_ERROR' as a generic error here as well.

(Note we tested if there are more than 1 entity, a call is made for each entity)

### Explanation of the tests:

## schema and files:
The files are in federation-integration-testsuite-js/src/fixtures/multi-service-require-cases folder.
the entity that we are using for tests is called "TempType" and is composed from 4 different services:
1. mainEntity: provides the "id" and "myText" (static text) fields 
2. dep1: provide the non-nullable field "dep1" with value of 1000
3. dep2: provide the nullable field "dep2" with value of 999
4. xfield: provides "xfield" as the multiplication of "dep1" and "dep2" if both are available, or if one is missing then it returns the value of the available field.

there are 2 more files called dep1WithException and dep2WithException  which basically throws an exception instead of returning a value for dep1 and dep2 .

## Tests:
1. "Multi-service success" -> "successfully starts and serves requests to the proper services": happy path with creation and running of all the services and the gateway, then querying the gateway with all fields and getting the expected response with no error.
2. "Multi-service exception returned for a nullable field" -> "Ignores the nullable dep2 while calculating xfield in case an exception is returned instead of dep2": same setup as Test 1 but using dep2WithException to throw an exception instead of returning dep2, we get here null as a value for dep2 and xfield returns the value of dep1 which is 1000. we get also an error in the list of errors
3. "Multi-service exception returned for a non-nullable field" -> "Fails in case the non-nullable dep1 returned an exception instead of a value while calculating xfield": same setup as Test 1 but using dep1WithException to throw an exception instead of returning dep1, and because dep1 is not nullable we get a null back as a result of xfield and we get an error as well. (the second commit is to remove requesting non-null dep1 from the query here since it has a null value and result in a validation error with the whole query result to be null which will hide the behaviour of xfield)
4. "Multi-service server is down for a nullable field without enabling default null response fix" -> "It fails to calculate xfield in case the dep2 server is down": this is the **targeted behaviour** to fix, we do the same setup as Test1 but we close the dep2 server before querying (the server is down) and we get null values for both xfield and dep2, which indicated xfield not being called (contradicting with Test 2 result) and we get a connection error message with a "INTERNAL_SERVER_ERROR" code.
5. "Multi-service server is down for a nullable field with enabling default null response fix" -> "Should ignore the nullable dep2 while calculating xfield in case the dep2 server is down": same setup with Test 4 but we enable the fix provided with "buildGateway(4000, true)", here we get null value for dep2 and we get 1000 as a value for xfield we also get an error message indicating the issue, which is in alignment with the results that we get in Test 2.
6. "Multi-service server is down for a non-nullable field with enabling default null response fix (preserve behaviour from before the fix)" -> "Should fail while calculating xfield in case the non-nullable dep1 server is down": here we are also enabling the fix but closing dep1 server and we get as a result a null value for xfield and we get the connection error as well.

Note: Test 6 is to make sure we don't introduce a new behaviour, by commenting out the condition "if (entityTypeMap[name].type.toString().indexOf('!') > -1) return null;" this test will fail as then xfield will have 999 value, so this way we ensure we are not producing a new behaviour

