### PR TITLE
docs: update and move IDE support page

### DIFF
--- a/docs/source/schema-design/federated-schemas/ide-support.mdx
+++ b/docs/source/schema-design/federated-schemas/ide-support.mdx
@@ -7,7 +7,7 @@ redirectFrom:
     - /graphos/reference/federation/ide-support
 ---
 
-Many IDEs provide features to streamline federated GraphQL development, such as GraphQL-aware syntax highlighting, inline performance information, and autocomplete for fields, types, and federation directives. Learn how to enable federation-specific features in tools like VS Code and JetBrains IDEs.
+Many IDEs provide features to streamline federated GraphQL development, such as federation-aware syntax highlighting, inline performance information, and autocomplete for fields, types, and federation directives. Learn how to enable federation-specific features in tools like VS Code and JetBrains IDEs.
 
 ## Visual Studio Code
 
@@ -47,4 +47,5 @@ This plugin supports all IntelliJ-based IDEs, including:
 ## Additional resources
 
 If your graph uses the Apollo Router, make sure to enable [router configuration awareness](/graphos/reference/router/configuration#configuration-awareness-in-your-text-editor) in your editor.
+
 If you're developing with Apollo Connectors, refer to the connectors-specific [VS Code Extension](/graphos/schema-design/connectors/vs-code) and [Vim/NeoVim](/graphos/schema-design/connectors/vim) pages.

--- a/docs/source/schema-design/federated-schemas/ide-support.mdx
+++ b/docs/source/schema-design/federated-schemas/ide-support.mdx
@@ -4,13 +4,14 @@ subtitle: Streamline federated GraphQL development
 description: Enhance your development workflow with federation-specific features in VSCode and IntelliJ-based IDEs.
 redirectFrom:
     - /graphos/reference/federation/jetbrains-ide-support
+    - /graphos/reference/federation/ide-support
 ---
 
 Many IDEs provide features to streamline federated GraphQL development, such as GraphQL-aware syntax highlighting, inline performance information, and autocomplete for fields, types, and federation directives. Learn how to enable federation-specific features in tools like VS Code and JetBrains IDEs.
 
 ## Visual Studio Code
 
-Apollo's [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) provides an all-in-one tooling experience for developing apps with Apollo. See the [dedicated documentation page](/vs-code-extension) for configuration details. If you're developing with Apollo Connectors, refer to the connectors-specific [VS Code Extension page](/graphos/schema-design/connectors/vs-code).
+Apollo's [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) provides an all-in-one tooling experience for developing apps with Apollo. See the [dedicated documentation page](/vs-code-extension) for configuration details.
 
 ## JetBrains
 
@@ -46,3 +47,4 @@ This plugin supports all IntelliJ-based IDEs, including:
 ## Additional resources
 
 If your graph uses the Apollo Router, make sure to enable [router configuration awareness](/graphos/reference/router/configuration#configuration-awareness-in-your-text-editor) in your editor.
+If you're developing with Apollo Connectors, refer to the connectors-specific [VS Code Extension](/graphos/schema-design/connectors/vs-code) and [Vim/NeoVim](/graphos/schema-design/connectors/vim) pages.


### PR DESCRIPTION
Updates:
- Include reference to new Vim/NeoVim doc
- Move page from reference to main federation docs for better visibility