### PR TITLE
docs: add deprecation notices on v1.x versions in changelog

### DIFF
--- a/docs/source/reference/federation/versions.mdx
+++ b/docs/source/reference/federation/versions.mdx
@@ -981,6 +981,12 @@ Value types
 
 ## v1.1
 
+<Caution>
+
+Apollo Router Core v1.60 and later and v2.0 and later don't support Federation v1.x supergraphs.
+
+</Caution>
+
 #### Directive changes
 
 <table>
@@ -1017,6 +1023,12 @@ directive @tag(name: String!) repeatable on
 </table>
 
 ## v1.0
+
+<Caution>
+
+Apollo Router Core v1.60 and later and v2.0 and later don't support Federation v1.x supergraphs.
+
+</Caution>
 
 #### Directive changes
 

--- a/docs/source/reference/federation/versions.mdx
+++ b/docs/source/reference/federation/versions.mdx
@@ -983,7 +983,7 @@ Value types
 
 <Caution>
 
-Apollo Router Core v1.60 and later and v2.0 and later don't support Federation v1.x supergraphs.
+Apollo Router Core and GraphOS Router v1.60 and later don't support Federation v1.x supergraphs.
 
 </Caution>
 
@@ -1026,7 +1026,7 @@ directive @tag(name: String!) repeatable on
 
 <Caution>
 
-Apollo Router Core v1.60 and later and v2.0 and later don't support Federation v1.x supergraphs.
+Apollo Router Core and GraphOS Router v1.60 and later don't support Federation v1.x supergraphs.
 
 </Caution>
 


### PR DESCRIPTION
Add deprecation `<Caution>` on v1.x versions in changelog