### PR TITLE
[docs] Document new dry-run query plan header

### DIFF
--- a/docs/source/schema-design/federated-schemas/reference/query-plans.mdx
+++ b/docs/source/schema-design/federated-schemas/reference/query-plans.mdx
@@ -493,7 +493,7 @@ With [the Apollo Router Core](https://github.com/apollographql/router) v1.61.0+ 
 
 - The header `Apollo-Expose-Query-Plan` must be set with one of the following options:
   - A value of `true` returns a human-readable string and JSON blob of the query plan
-  - A value of `dry-run` will generate the query plan and then abort exectution. This can be helpful if you want to warm up any internal or external [query plan caches](https://www.apollographql.com/docs/graphos/routing/performance/caching/in-memory)
+  - A value of `dry-run` will generate the query plan and then abort execution. This can be helpful if you want to warm up any internal or external [query plan caches](https://www.apollographql.com/docs/graphos/routing/performance/caching/in-memory)
 
 ### Legacy header options
 

--- a/docs/source/schema-design/federated-schemas/reference/query-plans.mdx
+++ b/docs/source/schema-design/federated-schemas/reference/query-plans.mdx
@@ -489,14 +489,22 @@ You can view the query plan for a particular operation in any of the following w
 
 ### Outputting query plans with headers
 
-With [the Apollo Router Core](https://github.com/apollographql/router) v0.16.0+ and [`@apollo/gateway`](/apollo-server/using-federation/api/apollo-gateway/) v2.5.4+, you can pass the following headers to return the query plans in the GraphQL response extensions:
+With [the Apollo Router Core](https://github.com/apollographql/router) v1.61.0+  or v2.x+, you can pass the following header to return the query plans in the GraphQL response extensions:
+
+- The header `Apollo-Expose-Query-Plan` must be set with one of the following options:
+  - A value of `true` returns a human-readable string and JSON blob of the query plan
+  - A value of `dry-run` will generate the query plan and then abort exectution. This can be helpful if you want to warm up any internal or external [query plan caches](https://www.apollographql.com/docs/graphos/routing/performance/caching/in-memory)
+
+### Legacy header options
+
+In older versions of [the Apollo Router Core](https://github.com/apollographql/router) v0.16.0+ and [`@apollo/gateway`](/apollo-server/using-federation/api/apollo-gateway/) v2.5.4+, you can pass the following headers to return the query plans in the GraphQL response extensions:
 
 - Including the `Apollo-Query-Plan-Experimental` header returns the query plan in the response extensions
 - Additionally including the `Apollo-Query-Plan-Experimental-Format` header with one of the supported options changes the output format:
   - A value of `prettified` returns a human-readable string  of the query plan
   - A value of `internal` returns a JSON representation of the query plan
 
-### Outputting query plans with `@apollo/gateway`
+#### Manually outputting query plans with `@apollo/gateway`
 
 Your gateway can output the query plan for each incoming operation as it's calculated. To do so, add the following to the file where you initalize your `ApolloGateway` instance:
 


### PR DESCRIPTION
This new header option was added but only mentioned in release notes