### PR TITLE
fix(supergraph): Fix null check in error message

### DIFF
--- a/gateway-js/src/supergraphManagers/UplinkSupergraphManager/loadSupergraphSdlFromStorage.ts
+++ b/gateway-js/src/supergraphManagers/UplinkSupergraphManager/loadSupergraphSdlFromStorage.ts
@@ -160,7 +160,7 @@ export async function loadSupergraphSdlFromStorage({
       response = await result.json();
     } catch (e) {
       // Bad response
-      throw new UplinkFetcherError(fetchErrorMsg + result.status + ' ' + e.message ?? e);
+      throw new UplinkFetcherError(fetchErrorMsg + result.status + ' ' + (e.message ?? e));
     }
 
     if ('errors' in response) {


### PR DESCRIPTION
This PR fixes an error thrown by Typescript 5.x.

> TS2869: Right operand of ?? is unreachable because the left operand is never nullish.

On line 163:

```typescript
throw new UplinkFetcherError(fetchErrorMsg + result.status + ' ' + e.message ?? e);
```

Closes #3229 