### PR TITLE
Fix entity detection in mismatch reporter

### DIFF
--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1118,7 +1118,7 @@ class Merger {
         supergraphElement: dest,
         subgraphElements: sources,
         // All we use the string of the next line for is to categorize source with a @key of the others.
-        elementToString: type => type.hasAppliedDirective('key') ? 'yes' : 'no',
+        elementToString: type => sourceAsEntity.find(entity => entity === type) ? 'yes' : 'no',
         // Note that the first callback is for element that are "like the supergraph". As the supergraph has no @key ...
         supergraphElementPrinter: (_, subgraphs) => `it has no @key in ${subgraphs}`,
         otherElementsPrinter: (_, subgraphs) => ` but has some @key in ${subgraphs}`,


### PR DESCRIPTION
Fixes bug introduced in `2.10.0` where we could potentially throw in `hintOnInconsistentEntity` if subgraphs use `@federation__key` rather than `@key`.