### PR TITLE
allow `@connect` as default import

### DIFF
--- a/composition-js/src/__tests__/connectors.test.ts
+++ b/composition-js/src/__tests__/connectors.test.ts
@@ -121,6 +121,243 @@ describe("connect spec and join__directive", () => {
     }
   });
 
+  it("does not require importing @connect", () => {
+    const subgraphs = [
+      {
+        name: "with-connectors",
+        typeDefs: parse(`
+                    extend schema
+                    @link(
+                        url: "https://specs.apollo.dev/federation/v2.10"
+                        import: ["@key"]
+                    )
+                    @link(
+                        url: "https://specs.apollo.dev/connect/v0.1"
+                        import: ["@source"]
+                    )
+                    @source(name: "v1", http: { baseURL: "http://v1" })
+
+                    type Query {
+                        resources: [Resource!]!
+                        @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    }
+
+                    type Resource @key(fields: "id") {
+                        id: ID!
+                        name: String!
+                    }
+                `),
+      },
+    ];
+
+    const result = composeServices(subgraphs);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toMatchInlineSnapshot(`
+      "schema
+        @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
+        @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
+        @link(url: \\"https://specs.apollo.dev/connect/v0.1\\", for: EXECUTION)
+        @join__directive(graphs: [WITH_CONNECTORS], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", import: [\\"@source\\"]})
+        @join__directive(graphs: [WITH_CONNECTORS], name: \\"source\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
+      {
+        query: Query
+      }
+
+      directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+      directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+      directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+      enum link__Purpose {
+        \\"\\"\\"
+        \`SECURITY\` features provide metadata necessary to securely resolve fields.
+        \\"\\"\\"
+        SECURITY
+
+        \\"\\"\\"
+        \`EXECUTION\` features provide metadata necessary for operation execution.
+        \\"\\"\\"
+        EXECUTION
+      }
+
+      scalar link__Import
+
+      enum join__Graph {
+        WITH_CONNECTORS @join__graph(name: \\"with-connectors\\", url: \\"\\")
+      }
+
+      scalar join__FieldSet
+
+      scalar join__DirectiveArguments
+
+      scalar join__FieldValue
+
+      input join__ContextArgument {
+        name: String!
+        type: String!
+        context: String!
+        selection: join__FieldValue!
+      }
+
+      type Query
+        @join__type(graph: WITH_CONNECTORS)
+      {
+        resources: [Resource!]! @join__directive(graphs: [WITH_CONNECTORS], name: \\"connect\\", args: {source: \\"v1\\", http: {GET: \\"/resources\\"}, selection: \\"\\"})
+      }
+
+      type Resource
+        @join__type(graph: WITH_CONNECTORS, key: \\"id\\")
+      {
+        id: ID!
+        name: String!
+      }"
+    `);
+
+    if (result.schema) {
+      expect(printSchema(result.schema.toAPISchema())).toMatchInlineSnapshot(`
+                      "type Query {
+                        resources: [Resource!]!
+                      }
+
+                      type Resource {
+                        id: ID!
+                        name: String!
+                      }"
+                  `);
+    }
+  });
+
+  it("using as:", () => {
+    const subgraphs = [
+      {
+        name: "with-connectors",
+        typeDefs: parse(`
+                    extend schema
+                    @link(
+                        url: "https://specs.apollo.dev/federation/v2.10"
+                        import: ["@key"]
+                    )
+                    @link(
+                        url: "https://specs.apollo.dev/connect/v0.1"
+                        as: "http"
+                        import: ["@source"]
+                    )
+                    @source(name: "v1", http: { baseURL: "http://v1" })
+
+                    type Query {
+                        resources: [Resource!]!
+                        @http(source: "v1", http: { GET: "/resources" }, selection: "")
+                    }
+
+                    type Resource @key(fields: "id") {
+                        id: ID!
+                        name: String!
+                    }
+                `),
+      },
+    ];
+
+    const result = composeServices(subgraphs);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toMatchInlineSnapshot(`
+      "schema
+        @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
+        @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
+        @link(url: \\"https://specs.apollo.dev/connect/v0.1\\", for: EXECUTION)
+        @join__directive(graphs: [WITH_CONNECTORS], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", as: \\"http\\", import: [\\"@source\\"]})
+        @join__directive(graphs: [WITH_CONNECTORS], name: \\"source\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
+      {
+        query: Query
+      }
+
+      directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+      directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+      directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+      enum link__Purpose {
+        \\"\\"\\"
+        \`SECURITY\` features provide metadata necessary to securely resolve fields.
+        \\"\\"\\"
+        SECURITY
+
+        \\"\\"\\"
+        \`EXECUTION\` features provide metadata necessary for operation execution.
+        \\"\\"\\"
+        EXECUTION
+      }
+
+      scalar link__Import
+
+      enum join__Graph {
+        WITH_CONNECTORS @join__graph(name: \\"with-connectors\\", url: \\"\\")
+      }
+
+      scalar join__FieldSet
+
+      scalar join__DirectiveArguments
+
+      scalar join__FieldValue
+
+      input join__ContextArgument {
+        name: String!
+        type: String!
+        context: String!
+        selection: join__FieldValue!
+      }
+
+      type Query
+        @join__type(graph: WITH_CONNECTORS)
+      {
+        resources: [Resource!]! @join__directive(graphs: [WITH_CONNECTORS], name: \\"http\\", args: {source: \\"v1\\", http: {GET: \\"/resources\\"}, selection: \\"\\"})
+      }
+
+      type Resource
+        @join__type(graph: WITH_CONNECTORS, key: \\"id\\")
+      {
+        id: ID!
+        name: String!
+      }"
+    `);
+
+    if (result.schema) {
+      expect(printSchema(result.schema.toAPISchema())).toMatchInlineSnapshot(`
+                      "type Query {
+                        resources: [Resource!]!
+                      }
+
+                      type Resource {
+                        id: ID!
+                        name: String!
+                      }"
+                  `);
+    }
+  });
+
   it("composes v0.2", () => {
     const subgraphs = [
       {

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -3118,14 +3118,19 @@ class Merger {
     // identity url in a Map, reachable from all its imported names.
     const map = new Map<string, FeatureUrl>();
     for (const linkDirective of schema.schemaDefinition.appliedDirectivesOf<LinkDirectiveArgs>('link')) {
-      const { url, import: imports } = linkDirective.arguments();
+      const { url, as, import: imports } = linkDirective.arguments();
       const parsedUrl = FeatureUrl.maybeParse(url);
-      if (parsedUrl && imports) {
-        for (const i of imports) {
-          if (typeof i === 'string') {
-            map.set(i, parsedUrl);
-          } else {
-            map.set(i.as ?? i.name, parsedUrl);
+
+      if (parsedUrl) {
+        // always add the main directive to the map, regardless of whether it is imported
+        map.set(`@${as ?? parsedUrl.name}`, parsedUrl);
+        if (imports) {
+          for (const i of imports) {
+            if (typeof i === 'string') {
+              map.set(i, parsedUrl);
+            } else {
+              map.set(i.as ?? i.name, parsedUrl);
+            }
           }
         }
       }


### PR DESCRIPTION
according to https://specs.apollo.dev/link/v1.0/, we actually shouldn't be importing `@connect` — it's available by default when importing the spec. it can be renamed with `as:`. calling `import: ["@connect"]` should actually be importing something called `@connect__connect`, but we'll leave the current behavior.

this change applies only to join__directive serialization.

<!-- https://apollographql.atlassian.net/browse/CNN-714 --> 

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
