### PR TITLE
docs: review subgraph should contribute to rating

### DIFF
--- a/docs/source/schema-design/federated-schemas/entities/intro.mdx
+++ b/docs/source/schema-design/federated-schemas/entities/intro.mdx
@@ -106,7 +106,7 @@ type Product @key(fields: "upc") {
 ```graphql title="Reviews subgraph"
 type Product @key(fields: "productUpc") {
   productUpc: ID!
-  inStock: Boolean!
+  rating: Int!
 }
 ```
 


### PR DESCRIPTION
It seems a bit counterintuitive that the `Reviews` subgraph contributes to the `inStock` field of the `Product` type. I'd like to update the code example so that it contributes to the `rating` field instead. This change is also consistent with the code example in the overview section of [the document](http://apollographql.com/docs/graphos/schema-design/federated-schemas/entities/intro).