### PR TITLE
Don't auto-upgrade 0.2 connect subgraphs to fed 2.11

### DIFF
--- a/internals-js/src/specs/connectSpec.ts
+++ b/internals-js/src/specs/connectSpec.ts
@@ -220,7 +220,7 @@ export const CONNECT_VERSIONS = new FeatureDefinitions<ConnectSpecDefinition>(
   .add(
     new ConnectSpecDefinition(
       new FeatureVersion(0, 2),
-      new FeatureVersion(2, 11),
+      new FeatureVersion(2, 10),
     ),
   );
 


### PR DESCRIPTION
Now that we're auto-upgrading 0.1 specs to 0.2 during composition, setting the minimum fed spec at 2.11 creates warnings for all users who upgrade composition to 2.11.

This isn't necessary, so we're getting rid of that noise here.

<!-- [CNN-759] -->

[CNN-759]: https://apollographql.atlassian.net/browse/CNN-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ