### PR TITLE
Use a priority queue instead of a stack for satisfiability

### DIFF
--- a/composition-js/package.json
+++ b/composition-js/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "@apollo/federation-internals": "2.10.2",
-    "@apollo/query-graphs": "2.10.2"
+    "@apollo/query-graphs": "2.10.2",
+    "fastpriorityqueue": "^0.7.5"
   },
   "peerDependencies": {
     "graphql": "^16.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,8 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@apollo/federation-internals": "2.10.2",
-        "@apollo/query-graphs": "2.10.2"
+        "@apollo/query-graphs": "2.10.2",
+        "fastpriorityqueue": "^0.7.5"
       },
       "engines": {
         "node": ">=14.15.0"
@@ -8027,6 +8028,12 @@
       "version": "1.4.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastpriorityqueue": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.7.5.tgz",
+      "integrity": "sha512-3Pa0n9gwy8yIbEsT3m2j/E9DXgWvvjfiZjjqcJ+AdNKTAlVMIuFYrYG5Y3RHEM8O6cwv9hOpOWY/NaMfywoQVA==",
+      "license": "Apache-2.0"
     },
     "node_modules/fastq": {
       "version": "1.15.0",


### PR DESCRIPTION
This PR updates satisfiability logic to use a (heap-based) priority queue instead of a stack to store validation state, where a state is higher priority if it has less possible subgraph paths. This is because supergraphs with high connectivity can lead to states with many possible subgraph paths for a supergraph path, and repeatedly processing such states can cause an explosion in possible subgraph paths in the worst case. To avoid this explosion, we prioritize supergraph paths with fewer possible subgraph paths, and this helps us reach more types using smaller states in practice. Loop detection then prevents us from having to consider the larger states to begin with.