### PR TITLE
fix(composition): Handle output type covariance properly in satisfiability

### DIFF
--- a/.changeset/ten-gorillas-boil.md
+++ b/.changeset/ten-gorillas-boil.md
@@ -1,0 +1,6 @@
+---
+"@apollo/composition": patch
+"@apollo/query-graphs": patch
+---
+
+Fix bug in composition where, when a field's type in a subgraph is a subtype of the field's type in the supergraph, the satisfiability validation spuriously succeeds/errors.

--- a/composition-js/src/validate.ts
+++ b/composition-js/src/validate.ts
@@ -641,6 +641,7 @@ export class ValidationState {
     for (const pathInfo of this.subgraphPathInfos) {
       const tailSubgraphName = pathInfo.path.path.tail.source;
       const tailSubgraphEnumValue = subgraphNameToGraphEnumValue.get(tailSubgraphName);
+      const tailTypeName = pathInfo.path.path.tail.type.name;
       const entryKeys = [];
       const contexts = Array.from(pathInfo.contexts.entries());
       contexts.sort((a, b) => a[0].localeCompare(b[0]));
@@ -649,7 +650,7 @@ export class ValidationState {
         entryKeys.push(`${context}=${subgraphEnumValue}.${typeName}`);
       }
       subgraphContextKeys.add(
-        `${tailSubgraphEnumValue}[${entryKeys.join(',')}]`
+        `${tailSubgraphEnumValue}.${tailTypeName}[${entryKeys.join(',')}]`
       );
     }
     return subgraphContextKeys;

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -1735,6 +1735,15 @@ function advancePathWithDirectTransition<V extends Vertex>(
     // We can now continue on dealing with the actual field.
   }
 
+  if (
+    transition.kind === 'DownCast'
+    && transition.castedType.name === path.tail.type.name
+  ) {
+    // Due to output type covariance, a downcast supergraph transition may be a no-op on the
+    // subgraph path. In these cases, we effectively ignore the type condition.
+    return [path];
+  }
+
   const options: GraphPath<Transition, V>[] = [];
   const deadEndClosures: UnadvanceableClosure[] = [];
 


### PR DESCRIPTION
This PR fixes two bugs in the satisfiability code when the subgraph type differs from the supergraph type due to output type covariance:
1. It now handles no-op inline fragments when advancing a subgraph path with a graph transition.
    - Previously, the code assumed this was impossible, but it can happen in the case of output type covariance where the subgraph type matches the inline fragment type, which doesn't match the supergraph type. Since we don't store no-op edges in the query graph, this led to no edge being found, making satisfiability believe the transition was mistakenly unsatisfiable.
3. The data of previous vertex visits now additionally includes the tail's type name for a given subgraph path.
    - Previously, the code assumed the tail's type name always matched the type name of the vertex in the key of the previous vertex visit state store. This is not the case when there's output type covariance, which led to satisfiability mistakenly believing a previous vertex visit was matching the current one (i.e. a loop's been detected) when it wasn't.

<!-- FED-656 -->