### PR TITLE
fix: make composeDirective argument non-nullable

### DIFF
--- a/.changeset/cool-roses-explode.md
+++ b/.changeset/cool-roses-explode.md
@@ -1,0 +1,11 @@
+---
+"@apollo/federation-internals": patch
+---
+
+fix: make composeDirective argument non-nullable.
+
+Per our [docs](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#composedirective), 
+`@composeDirective` requires non-nullable value to be passed as an argument.
+
+Our [validations](https://github.com/apollographql/federation/blob/main/composition-js/src/composeDirectiveManager.ts#L250-L255) were checking for valid values (it has to be a string that starts with `@`),
+but the generated schema was incorrectly specifying that the argument was nullable.

--- a/internals-js/src/specs/federationSpec.ts
+++ b/internals-js/src/specs/federationSpec.ts
@@ -153,7 +153,7 @@ export class FederationSpecDefinition extends FeatureDefinition {
         name: FederationDirectiveName.COMPOSE_DIRECTIVE,
         locations: [DirectiveLocation.SCHEMA],
         repeatable: true,
-        args: [{ name: 'name', type: (schema) => schema.stringType() }],
+        args: [{ name: 'name', type: (schema) => new NonNullType(schema.stringType()) }],
       }));
     }
 

--- a/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
+++ b/subgraph-js/src/__tests__/buildSubgraphSchema.test.ts
@@ -1349,7 +1349,7 @@ describe('buildSubgraphSchema', () => {
 
         directive @federation__override(from: String!) on FIELD_DEFINITION
 
-        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+        directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 
         type Query {
           x: Int
@@ -1416,7 +1416,7 @@ describe('buildSubgraphSchema', () => {
 
         directive @federation__override(from: String!) on FIELD_DEFINITION
 
-        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+        directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 
         type Query {
           x: Int
@@ -1484,7 +1484,7 @@ describe('buildSubgraphSchema', () => {
 
         directive @federation__override(from: String!) on FIELD_DEFINITION
 
-        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+        directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 
         directive @federation__interfaceObject on OBJECT
 


### PR DESCRIPTION
Per our [docs](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#composedirective), `@composeDirective` requires non-nullable value to be passed as an argument.

Our [validations](https://github.com/apollographql/federation/blob/main/composition-js/src/composeDirectiveManager.ts#L250-L255) were checking for valid values (it has to be a string that starts with `@`), but the generated schema was incorrectly specifying that the argument was nullable.
