### PR TITLE
fix: improve composeDirective error message

### DIFF
--- a/composition-js/src/__tests__/compose.composeDirective.test.ts
+++ b/composition-js/src/__tests__/compose.composeDirective.test.ts
@@ -759,10 +759,28 @@ describe('composing custom core directives', () => {
     ]);
   });
 
-  it('ensure that composeDirective argument cannot be null', () => {
+  it('ensure that composeDirective argument cannot be undefined', () => {
     const subgraphA = generateSubgraph({
       name: 'subgraphA',
       composeText: '@composeDirective',
+    });
+    const subgraphB = generateSubgraph({
+      name: 'subgraphB',
+    });
+
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(errors(result)).toStrictEqual([
+      [
+        'DIRECTIVE_COMPOSITION_ERROR',
+        'Argument to @composeDirective in subgraph "subgraphA" cannot be NULL or an empty String',
+      ]
+    ]);
+  });
+
+  it('ensure that composeDirective argument cannot be null', () => {
+    const subgraphA = generateSubgraph({
+      name: 'subgraphA',
+      composeText: '@composeDirective(name: null)',
     });
     const subgraphB = generateSubgraph({
       name: 'subgraphB',

--- a/composition-js/src/__tests__/compose.composeDirective.test.ts
+++ b/composition-js/src/__tests__/compose.composeDirective.test.ts
@@ -759,6 +759,42 @@ describe('composing custom core directives', () => {
     ]);
   });
 
+  it('ensure that composeDirective argument cannot be null', () => {
+    const subgraphA = generateSubgraph({
+      name: 'subgraphA',
+      composeText: '@composeDirective',
+    });
+    const subgraphB = generateSubgraph({
+      name: 'subgraphB',
+    });
+
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(errors(result)).toStrictEqual([
+      [
+        'DIRECTIVE_COMPOSITION_ERROR',
+        'Argument to @composeDirective in subgraph "subgraphA" cannot be NULL or an empty String',
+      ]
+    ]);
+  });
+
+  it('ensure that composeDirective argument cannot be empty', () => {
+    const subgraphA = generateSubgraph({
+      name: 'subgraphA',
+      composeText: '@composeDirective(name: "")',
+    });
+    const subgraphB = generateSubgraph({
+      name: 'subgraphB',
+    });
+
+    const result = composeServices([subgraphA, subgraphB]);
+    expect(errors(result)).toStrictEqual([
+      [
+        'DIRECTIVE_COMPOSITION_ERROR',
+        'Argument to @composeDirective in subgraph "subgraphA" cannot be NULL or an empty String',
+      ]
+    ]);
+  });
+
   it('ensure that composeDirective argument must start with an @', () => {
     const subgraphA = generateSubgraph({
       name: 'subgraphA',

--- a/composition-js/src/composeDirectiveManager.ts
+++ b/composition-js/src/composeDirectiveManager.ts
@@ -246,6 +246,14 @@ export class ComposeDirectiveManager {
         .applications();
 
       for (const composeInstance of composeDirectives) {
+        if (composeInstance.arguments().name == null || composeInstance.arguments().name === '') {
+          this.pushError(ERRORS.DIRECTIVE_COMPOSITION_ERROR.err(
+              `Argument to @composeDirective in subgraph "${sg.name}" cannot be NULL or an empty String`,
+              { nodes: composeInstance.sourceAST },
+          ));
+          continue;
+        }
+
         if (composeInstance.arguments().name[0] !== '@') {
           this.pushError(ERRORS.DIRECTIVE_COMPOSITION_ERROR.err(
             `Argument to @composeDirective "${composeInstance.arguments().name}" in subgraph "${sg.name}" must have a leading "@"`,


### PR DESCRIPTION
Since we cannot easily fix incorrect directive definition (https://github.com/apollographql/federation/pull/3281) without breaking our clients. This PR improves error messages when `@composeDirective` arguments are NULL or empty strings.

Previous message on undefined/null argument value

`Cannot read properties of undefined (reading '0')`

New message

`Argument to @composeDirective in subgraph "${sg.name}" cannot be NULL or an empty String`
