### PR TITLE
fix(composition): Don't remove scalar properties in `buildSubgraphSchema()` when providing resolvers

### DIFF
--- a/.changeset/smooth-terms-decide.md
+++ b/.changeset/smooth-terms-decide.md
@@ -1,0 +1,5 @@
+---
+"@apollo/subgraph": patch
+---
+
+When a `GraphQLScalarType` resolver is provided to `buildSubgraphSchema()`, omitted configuration options in the `GraphQLScalarType` no longer cause the corresponding properties in the GraphQL document/AST to be cleared. To explicitly clear these properties, use `null` for the configuration option instead. 

--- a/subgraph-js/src/schema-helper/buildSchemaFromSDL.ts
+++ b/subgraph-js/src/schema-helper/buildSchemaFromSDL.ts
@@ -133,7 +133,16 @@ export function addResolversToSchema(
 
     if (isScalarType(type)) {
       for (const fn in fieldConfigs) {
-        (type as any)[fn] = (fieldConfigs as any)[fn];
+        const fnValue = (fieldConfigs as any)[fn];
+        // When users provide a `GraphQLScalarType` for resolvers, they often
+        // omit several config options (effectively providing `undefined`), but
+        // they probably don't mean for this to unset values in the existing
+        // `GraphQLScalarType` (e.g., clearing the AST nodes or description).
+        // So we explicitly ignore `undefined` values here; if users do want to
+        // unset existing values, they can use `null` instead.
+        if (fnValue !== undefined) {
+          (type as any)[fn] = fnValue;
+        }
       }
     }
 


### PR DESCRIPTION
When a `GraphQLScalarType` is provided in resolvers to `buildSubgraphSchema()`, its properties overwrite the existing one in the schema created from `typeDefs`. However, this also includes non-provided/`undefined` properties, which probably isn't what users expect. This PR updates resolver addition so that `undefined` properties are skipped; if users want to unset/clear scalar properties, they should use an explicit `null` for those properties.

<!-- FED-681 -->