### PR TITLE
Fix existing changesets

### DIFF
--- a/.changeset/lovely-dryers-arrive.md
+++ b/.changeset/lovely-dryers-arrive.md
@@ -1,6 +1,0 @@
----
-"@apollo/federation-internals": patch
----
-
-updating form-data dependency due to vulnerabilities in the old version
-  

--- a/.changeset/smooth-terms-decide.md
+++ b/.changeset/smooth-terms-decide.md
@@ -2,4 +2,4 @@
 "@apollo/subgraph": patch
 ---
 
-When a `GraphQLScalarType` resolver is provided to `buildSubgraphSchema()`, omitted configuration options in the `GraphQLScalarType` no longer cause the corresponding properties in the GraphQL document/AST to be cleared. To explicitly clear these properties, use `null` for the configuration option instead. 
+When a `GraphQLScalarType` resolver is provided to `buildSubgraphSchema()`, omitted configuration options in the `GraphQLScalarType` no longer cause the corresponding properties in the GraphQL document/AST to be cleared. To explicitly clear these properties, use `null` for the configuration option instead. ([#3285](https://github.com/apollographql/federation/pull/3285))


### PR DESCRIPTION
This PR makes the following fixes to the existing changesets:
- `.changeset/smooth-terms-decide.md` needs a PR link.
- `.changeset/lovely-dryers-arrive.md` doesn't need to exist, since the PR just changes `package-lock.json` (npm dependents use our `package.json` and not `package-lock.json`, it's just relevant for development/testing).