### PR TITLE
[docs] Update @fromContext directive to use federation type

### DIFF
--- a/docs/source/schema-design/federated-schemas/reference/subgraph-spec.mdx
+++ b/docs/source/schema-design/federated-schemas/reference/subgraph-spec.mdx
@@ -78,7 +78,7 @@ directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENU
 directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
-directive @fromContext(field: ContextFieldValue) on ARGUMENT_DEFINITION
+directive @fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
 # This definition is required only for libraries that don't support
 # GraphQL's built-in `extend` keyword


### PR DESCRIPTION
Fix the reference Federation spec in docs. This SDL is not valid. The `federation__` prefix may be removed in libraries using `@link`, however we define the scalar above with the prefix


