### PR TITLE
fix: fixed demand control validations

### DIFF
--- a/.changeset/lemon-toes-sort.md
+++ b/.changeset/lemon-toes-sort.md
@@ -1,0 +1,7 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fixed demand control validations
+
+Updated `@cost`/`@listSize` validations to use correct federation spec to look them up in the schema.

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -1488,9 +1488,6 @@ describe('@interfaceObject/@key on interfaces validation', () => {
 describe('@cost', () => {
   it('rejects applications on interfaces', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@cost"])
-
       type Query {
         a: A
       }
@@ -1500,7 +1497,7 @@ describe('@cost', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'COST_APPLIED_TO_INTERFACE_FIELD',
         `[S] @cost cannot be applied to interface "A.x"`,
@@ -1512,9 +1509,6 @@ describe('@cost', () => {
 describe('@listSize', () => {
   it('rejects applications on non-lists (unless it uses sizedFields)', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a1: A @listSize(assumedSize: 5)
         a2: A @listSize(assumedSize: 10, sizedFields: ["ints"])
@@ -1525,23 +1519,20 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       ['LIST_SIZE_APPLIED_TO_NON_LIST', `[S] "Query.a1" is not a list`],
     ]);
   });
 
   it('rejects negative assumedSize', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a: [Int] @listSize(assumedSize: -5)
         b: [Int] @listSize(assumedSize: 0)
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_ASSUMED_SIZE',
         `[S] Assumed size of "Query.a" cannot be negative`,
@@ -1551,9 +1542,6 @@ describe('@listSize', () => {
 
   it('rejects slicingArguments which are not arguments of the field', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         myField(something: Int): [String]
           @listSize(slicingArguments: ["missing1", "missing2"])
@@ -1562,7 +1550,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SLICING_ARGUMENT',
         `[S] Slicing argument "missing1" is not an argument of "Query.myField"`,
@@ -1580,9 +1568,6 @@ describe('@listSize', () => {
 
   it('rejects slicingArguments which are not Int or Int!', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         sliced(
           first: String
@@ -1597,7 +1582,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SLICING_ARGUMENT',
         `[S] Slicing argument "Query.sliced(first:)" must be Int or Int!`,
@@ -1615,9 +1600,6 @@ describe('@listSize', () => {
 
   it('rejects sizedFields when the output type is not an object', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         notObject: Int @listSize(assumedSize: 1, sizedFields: ["anything"])
         a: A @listSize(assumedSize: 5, sizedFields: ["ints"])
@@ -1633,7 +1615,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SIZED_FIELD',
         `[S] Sized fields cannot be used because "Int" is not a composite type`,
@@ -1643,9 +1625,6 @@ describe('@listSize', () => {
 
   it('rejects sizedFields which are not fields of the output type', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a: A @listSize(assumedSize: 5, sizedFields: ["notOnA"])
       }
@@ -1655,7 +1634,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SIZED_FIELD',
         `[S] Sized field "notOnA" is not a field on type "A"`,
@@ -1665,9 +1644,6 @@ describe('@listSize', () => {
 
   it('rejects sizedFields which are not lists', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a: A
           @listSize(
@@ -1683,7 +1659,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_APPLIED_TO_NON_LIST',
         `[S] Sized field "A.notList" is not a list`,

--- a/internals-js/src/__tests__/testUtils.ts
+++ b/internals-js/src/__tests__/testUtils.ts
@@ -9,10 +9,11 @@ export function buildForErrors(
   options?: {
     subgraphName?: string,
     asFed2?: boolean,
+    includeAllImports?: boolean,
   }
 ): [string, string][] | undefined {
   try {
-    const doc = (options?.asFed2 ?? true) ? asFed2SubgraphDocument(subgraphDefs) : subgraphDefs;
+    const doc = (options?.asFed2 ?? true) ? asFed2SubgraphDocument(subgraphDefs, { ...options }) : subgraphDefs;
     const name = options?.subgraphName ?? 'S';
     buildSubgraph(name, `http://${name}`, doc).validate();
     return undefined;

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -97,7 +97,7 @@ import { createObjectTypeSpecification, createScalarTypeSpecification, createUni
 import { didYouMean, suggestionList } from "./suggestions";
 import { coreFeatureDefinitionIfKnown } from "./knownCoreFeatures";
 import { joinIdentity } from "./specs/joinSpec";
-import { COST_VERSIONS, CostDirectiveArguments, ListSizeDirectiveArguments, costIdentity } from "./specs/costSpec";
+import { CostDirectiveArguments, ListSizeDirectiveArguments } from "./specs/costSpec";
 
 const linkSpec = LINK_VERSIONS.latest();
 const tagSpec = TAG_VERSIONS.latest();
@@ -1820,18 +1820,16 @@ export class FederationBlueprint extends SchemaBlueprint {
       }
     }
 
-    const costFeature = schema.coreFeatures?.getByIdentity(costIdentity);
-    const costSpec = costFeature && COST_VERSIONS.find(costFeature.url.version);
-    const costDirective = costSpec?.costDirective(schema);
-    const listSizeDirective = costSpec?.listSizeDirective(schema);
+    const costDirective = metadata.costDirective();
+    const listSizeDirective = metadata.listSizeDirective();
 
     // Validate @cost
-    for (const application of costDirective?.applications() ?? []) {
+    for (const application of costDirective.applications()) {
       validateCostNotAppliedToInterface(application, errorCollector);
     }
 
     // Validate @listSize
-    for (const application of listSizeDirective?.applications() ?? []) {
+    for (const application of listSizeDirective.applications()) {
       const parent = application.parent;
       assert(parent instanceof FieldDefinition, "@listSize can only be applied to FIELD_DEFINITION");
       validateListSizeAppliedToList(application, parent, errorCollector);


### PR DESCRIPTION
Validations are run against subgraphs so we need to verify `@cost`/`@listSize` from federation spec and not the supergraph cost spec.