### PR TITLE
Merge `main` into `next` before 2.12.0 release candidate

### DIFF
--- a/.changeset/lemon-toes-sort.md
+++ b/.changeset/lemon-toes-sort.md
@@ -1,0 +1,7 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Fixed demand control validations
+
+Updated `@cost`/`@listSize` validations to use correct federation spec to look them up in the schema.

--- a/.changeset/many-rings-glow.md
+++ b/.changeset/many-rings-glow.md
@@ -1,0 +1,6 @@
+---
+"@apollo/query-planner": patch
+"@apollo/query-graphs": patch
+---
+
+Fixes a bug where query planning may unexpectedly error due to attempting to generate a plan where a `@shareable` mutation field is called more than once across multiple subgraphs. ([#3304](https://github.com/apollographql/federation/pull/3304))

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@
 
 ---
 
-**Announcement:**   
-Join 1000+ engineers at GraphQL Summit for talks, workshops, and office hours, Oct 8-10 in NYC. [Get your pass here ->](https://summit.graphql.com/?utm_campaign=github_federation_readme)
-
----
-
 # Apollo Federation
 
 Apollo Federation is an architecture for declaratively composing APIs into a unified graph. Each team can own their slice of the graph independently, empowering them to deliver autonomously and incrementally.

--- a/composition-js/CHANGELOG.md
+++ b/composition-js/CHANGELOG.md
@@ -48,6 +48,14 @@
   - @apollo/query-graphs@2.12.0-preview.0
   - @apollo/federation-internals@2.12.0-preview.0
 
+## 2.11.3
+
+### Patch Changes
+
+- Updated dependencies [[`8c7a2cd655ad3060e9f5c3b106cfbdb59251701c`](https://github.com/apollographql/federation/commit/8c7a2cd655ad3060e9f5c3b106cfbdb59251701c)]:
+  - @apollo/federation-internals@2.11.3
+  - @apollo/query-graphs@2.11.3
+
 ## 2.11.2
 
 ### Patch Changes

--- a/composition-js/src/__tests__/connectors.test.ts
+++ b/composition-js/src/__tests__/connectors.test.ts
@@ -1,9 +1,159 @@
 import { composeServices } from "../compose";
-import { printSchema } from "@apollo/federation-internals";
+import { buildSubgraph, printSchema } from "@apollo/federation-internals";
 import { parse } from "graphql/index";
 
 describe("connect spec and join__directive", () => {
+  const subgraphSdl = `
+      extend schema
+      @link(
+          url: "https://specs.apollo.dev/federation/v2.10"
+          import: ["@key"]
+      )
+      @link(
+          url: "https://specs.apollo.dev/connect/v0.1"
+          import: ["@connect", "@source"]
+      )
+      @source(name: "v1", http: { baseURL: "http://v1" })
+
+      type Query {
+          resources: [Resource!]!
+          @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+      }
+
+      type Resource @key(fields: "id") {
+          id: ID!
+          name: String!
+      }
+  `;
+
+  const expectedSupergraphSdl = `
+    "schema
+      @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
+      @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
+      @link(url: \\"https://specs.apollo.dev/connect/v0.3\\", for: EXECUTION)
+      @join__directive(graphs: [WITH_CONNECTORS], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", import: [\\"@connect\\", \\"@source\\"]})
+      @join__directive(graphs: [WITH_CONNECTORS], name: \\"source\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
+    {
+      query: Query
+    }
+
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+    directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+    directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+    directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+    enum link__Purpose {
+      \\"\\"\\"
+      \`SECURITY\` features provide metadata necessary to securely resolve fields.
+      \\"\\"\\"
+      SECURITY
+
+      \\"\\"\\"
+      \`EXECUTION\` features provide metadata necessary for operation execution.
+      \\"\\"\\"
+      EXECUTION
+    }
+
+    scalar link__Import
+
+    enum join__Graph {
+      WITH_CONNECTORS @join__graph(name: \\"with-connectors\\", url: \\"\\")
+    }
+
+    scalar join__FieldSet
+
+    scalar join__DirectiveArguments
+
+    scalar join__FieldValue
+
+    input join__ContextArgument {
+      name: String!
+      type: String!
+      context: String!
+      selection: join__FieldValue!
+    }
+
+    type Query
+      @join__type(graph: WITH_CONNECTORS)
+    {
+      resources: [Resource!]! @join__directive(graphs: [WITH_CONNECTORS], name: \\"connect\\", args: {source: \\"v1\\", http: {GET: \\"/resources\\"}, selection: \\"\\"})
+    }
+
+    type Resource
+      @join__type(graph: WITH_CONNECTORS, key: \\"id\\")
+    {
+      id: ID!
+      name: String!
+    }"
+  `;
+
+  const expectedApiSdl = `
+    "type Query {
+      resources: [Resource!]!
+    }
+
+    type Resource {
+      id: ID!
+      name: String!
+    }"
+  `;
+
   it("composes", () => {
+    const subgraphs = [
+      {
+        name: "with-connectors",
+        typeDefs: parse(subgraphSdl),
+      },
+    ];
+
+    const result = composeServices(subgraphs);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toMatchInlineSnapshot(expectedSupergraphSdl);
+
+    if (result.schema) {
+      expect(printSchema(result.schema.toAPISchema())).toMatchInlineSnapshot(
+        expectedApiSdl
+      );
+    }
+  });
+
+  it("composes with completed definitions", () => {
+    const completedSubgraphSdl = printSchema(
+      buildSubgraph("with-connectors", "", subgraphSdl).schema
+    );
+
+    const subgraphs = [
+      {
+        name: "with-connectors",
+        typeDefs: parse(completedSubgraphSdl),
+      },
+    ];
+
+    const result = composeServices(subgraphs);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toMatchInlineSnapshot(expectedSupergraphSdl);
+
+    if (result.schema) {
+      expect(printSchema(result.schema.toAPISchema())).toMatchInlineSnapshot(
+        expectedApiSdl
+      );
+    }
+  });
+
+  it("does not require importing @connect", () => {
     const subgraphs = [
       {
         name: "with-connectors",
@@ -15,7 +165,7 @@ describe("connect spec and join__directive", () => {
                     )
                     @link(
                         url: "https://specs.apollo.dev/connect/v0.1"
-                        import: ["@connect", "@source"]
+                        import: ["@source"]
                     )
                     @source(name: "v1", http: { baseURL: "http://v1" })
 
@@ -40,7 +190,7 @@ describe("connect spec and join__directive", () => {
         @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
         @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
         @link(url: \\"https://specs.apollo.dev/connect/v0.3\\", for: EXECUTION)
-        @join__directive(graphs: [WITH_CONNECTORS], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", import: [\\"@connect\\", \\"@source\\"]})
+        @join__directive(graphs: [WITH_CONNECTORS], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", import: [\\"@source\\"]})
         @join__directive(graphs: [WITH_CONNECTORS], name: \\"source\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
       {
         query: Query
@@ -571,7 +721,7 @@ describe("connect spec and join__directive", () => {
 
                     type Resource @key(fields: "id")
                       @connect(
-                        id: "conn_id", 
+                        id: "conn_id",
                         source: "v1"
                         http: {
                           GET: "/resources"

--- a/docs/shared/licensed-directive.mdx
+++ b/docs/shared/licensed-directive.mdx
@@ -1,0 +1,5 @@
+<PlanRequired plans={["Free", "Developer", "Standard", "Enterprise"]}>
+
+Rate limits apply on the Free plan.
+
+</PlanRequired>

--- a/docs/shared/progressive-override-enterprise.mdx
+++ b/docs/shared/progressive-override-enterprise.mdx
@@ -1,5 +1,0 @@
-<EnterpriseFeature>
-
-Progressive `@override` is an [Enterprise feature](https://www.apollographql.com/pricing) of the GraphOS Router and requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/). If your organization doesn't have an Enterprise plan, you can test it out by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?referrer=docs).
-
-</EnterpriseFeature>

--- a/docs/source/schema-design/federated-schemas/entities/migrate-fields.mdx
+++ b/docs/source/schema-design/federated-schemas/entities/migrate-fields.mdx
@@ -4,8 +4,6 @@ subtitle: Transfer entity fields from one subgraph to another
 description: Learn how to safely move parts of one subgraph to another subgraph in a federated GraphQL architecture using the @override directive.
 ---
 
-import ProgressiveOverrideEnterprise from '../../../../shared/progressive-override-enterprise.mdx';
-
 As your supergraph grows, you might want to move parts of one subgraph to another subgraph.
 For example, suppose your Payments subgraph defines a `Bill` entity:
 
@@ -63,7 +61,7 @@ See the [Incremental migration with progressive `@override` section](#incrementa
 </Tip>
 
 Follow these steps to migrate a field from one subgraph to another all at once.
-These steps use the `amount` field in the example Payments and Billing subgraphs described at the top of the page, but you can them with any entity field(s).
+These steps use the `amount` field in the example Payments and Billing subgraphs described at the top of the page, but you can use them with any entity field(s).
 
 1. If the `@override` directive isn't already imported, include it in your schema's `@link` imports:
 
@@ -160,10 +158,8 @@ After you deploy the Billing subgraph and publish this final schema change, you'
 
 <MinVersionBadge version="Federation v2.7" />
 
-<ProgressiveOverrideEnterprise/>
-
 Follow these steps to incrementally migrate a field from one subgraph to another.
-These steps use the `amount` field in the example Payments and Billing subgraphs described at the top of the page, but you can them with any entity field(s).
+These steps use the `amount` field in the example Payments and Billing subgraphs described at the top of the page, but you can use them with any entity field(s).
 
 1. If the `@override` directive isn't already imported, include it in your schema's `@link` imports:
 

--- a/docs/source/schema-design/federated-schemas/entities/use-contexts.mdx
+++ b/docs/source/schema-design/federated-schemas/entities/use-contexts.mdx
@@ -5,12 +5,6 @@ description: Use the @context and @fromContext directives to enable a subgraph t
 minVersion: Federation v2.8
 ---
 
-<EnterpriseFeature>
-
-The `@context` and `@fromContext` directives are [Enterprise features](https://www.apollographql.com/pricing) of the Apollo Router and require an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/). If your organization doesn't have an Enterprise plan, you can test it out by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?referrer=docs).
-
-</EnterpriseFeature>
-
 In an entity, a nested object may have a dependency on an ancestor type and thus need access to that ancestor's field(s).
 
 To enable a descendant to access an ancestor's field, you could add it as a `@key` field to every entity along the chain of nested types, but that can become problematic. Deeply nested types can change the `@key` fields of many entities. The added field may be irrelevant to the entities it's added to. Most importantly, overloading `@key` fields often breaks the separation of concerns between different subgraphs.

--- a/docs/source/schema-design/federated-schemas/reference/directives.mdx
+++ b/docs/source/schema-design/federated-schemas/reference/directives.mdx
@@ -4,8 +4,8 @@ subtitle: Reference for Apollo Federation specific GraphQL directives
 description: Reference for GraphQL federation directives including @key, @extends, @sharable, @override, @requires and more.
 ---
 
-import ProgressiveOverrideEnterprise from '../../../../shared/progressive-override-enterprise.mdx';
 import EnterpriseDirective from '../../../../shared/enterprise-directive.mdx';
+import LicensedDirective from '../../../../shared/licensed-directive.mdx';
 import LinkDirective from '../../../../shared/link-directive.mdx';
 
 Apollo Federation defines a collection of directives that you use in your subgraph schemas to enable certain features.
@@ -379,8 +379,6 @@ For more information, see [Migrating entity and root fields](/graphos/schema-des
 
 <MinVersionBadge version="Federation v2.7" />
 
-<ProgressiveOverrideEnterprise/>
-
 Rolling out any change to a production subgraph, including field migration, risks degrading the performance of your graph. Rerouting all traffic from one subgraph to another all at once could overload the overriding subgraph.
 
 The _progressive `@override`_ feature enables the gradual, progressive deployment of a subgraph with an `@override` field. As a subgraph developer, you can customize the percentage of traffic that the overriding and overridden subgraphs each resolve for a field. You apply a label to an `@override` field to set the percentage of traffic for the field that should be resolved by the overriding subgraph, with the remaining percentage resolved by the overridden subgraph. You can then monitor the performance of the subgraphs in Studio, resolve any issues, and iteratively and progressively increase the percentage until all traffic is resolved by the overriding subgraph.
@@ -426,12 +424,6 @@ To learn more, see the [Incremental migration with `@override`](/graphos/schema-
 </td>
 <td>
 
-<EnterpriseFeature>
-
-This argument is available in Apollo Federation 2.7 and later. It is an [Enterprise feature](https://www.apollographql.com/pricing) of the GraphOS Router and requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/). You can test it out by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?referrer=docs).
-
-</EnterpriseFeature>
-
 **Optional.** A string of arbitrary arguments. Supported in this release:
 - `percent(<percent-value>)` - The percentage of traffic for the field that's resolved by this subgraph. The remaining percentage is resolved by the other ([from](#from)) subgraph. To learn more, see [Incremental migration with `@override`](/graphos/schema-design/federated-schemas/entities/migrate-fields#incremental-migration-with-progressive-override).
 
@@ -447,7 +439,7 @@ This argument is available in Apollo Federation 2.7 and later. It is an [Enterpr
 
 <MinVersionBadge version="Federation v2.5" />
 
-<EnterpriseDirective />
+<LicensedDirective />
 
 
 ```graphql
@@ -465,7 +457,7 @@ Indicates to composition that the target element is accessible only to the authe
 
 <MinVersionBadge version="Federation v2.5" />
 
-<EnterpriseDirective />
+<LicensedDirective />
 
 ```graphql
 directive @requiresScopes(scopes: [[federation__Scope!]!]!) on
@@ -512,7 +504,7 @@ Indicates to composition that the target element is accessible only to the authe
 
 <MinVersionBadge version="Federation v2.6" />
 
-<EnterpriseDirective />
+<LicensedDirective />
 
 ```graphql
 directive @policy(policies: [[federation__Policy!]!]!) on
@@ -895,8 +887,6 @@ If different subgraphs use different versions of a directive's corresponding spe
 
 <MinVersionBadge version="Federation v2.8" />
 
-<EnterpriseFeature />
-
 The `@context` directive defines a named context from which a field of the annotated type can be passed to a receiver of the context. The receiver must be a field annotated with the `@fromContext` directive. 
 
 ```graphql
@@ -928,8 +918,6 @@ type U @key(fields: "id") {
 
 <MinVersionBadge version="Federation v2.8" />
 
-<EnterpriseFeature />
-
 The `@fromContext` directive sets the context from which to receive the value of the annotated field. The context must have been defined with the `@context` directive.
 
 ```graphql
@@ -958,7 +946,7 @@ For examples using `@context` and `@fromContext`, see [Using contexts to share d
 
 <MinVersionBadge version="Federation v2.9" />
 
-<EnterpriseFeature />
+<LicensedDirective />
 
 ```graphql
 directive @cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
@@ -1005,7 +993,7 @@ Regardless of whether `@cost` is specified on a field, the field cost for that f
 
 <MinVersionBadge version="Federation v2.9" />
 
-<EnterpriseFeature />
+<LicensedDirective />
 
 ```graphql
 directive @listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
@@ -1162,7 +1150,5 @@ The default value is `true`.
 ## Connectors
 
 <MinVersionBadge version="Federation v2.10" />
-
-<EnterpriseFeature />
 
 Directives for Connectors like `@connect` and `@source` are documented in [Connector Directives Reference](/graphos/schema-design/connectors/directives).

--- a/docs/source/schema-design/federated-schemas/reference/subgraph-spec.mdx
+++ b/docs/source/schema-design/federated-schemas/reference/subgraph-spec.mdx
@@ -78,7 +78,7 @@ directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENU
 directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
-directive @fromContext(field: ContextFieldValue) on ARGUMENT_DEFINITION
+directive @fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
 # This definition is required only for libraries that don't support
 # GraphQL's built-in `extend` keyword

--- a/federation-integration-testsuite-js/CHANGELOG.md
+++ b/federation-integration-testsuite-js/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Federation 2.12 and Connect 0.3 ([#3276](https://github.com/apollographql/federation/pull/3276))
 
+## 2.11.3
+
 ## 2.11.2
 
 ## 2.11.1

--- a/gateway-js/CHANGELOG.md
+++ b/gateway-js/CHANGELOG.md
@@ -40,6 +40,15 @@
   - @apollo/composition@2.12.0-preview.0
   - @apollo/federation-internals@2.12.0-preview.0
 
+## 2.11.3
+
+### Patch Changes
+
+- Updated dependencies [[`4faa114215200daf7ad7518be8e50071fcde783c`](https://github.com/apollographql/federation/commit/4faa114215200daf7ad7518be8e50071fcde783c), [`8c7a2cd655ad3060e9f5c3b106cfbdb59251701c`](https://github.com/apollographql/federation/commit/8c7a2cd655ad3060e9f5c3b106cfbdb59251701c)]:
+  - @apollo/query-planner@2.11.3
+  - @apollo/federation-internals@2.11.3
+  - @apollo/composition@2.11.3
+
 ## 2.11.2
 
 ### Patch Changes

--- a/internals-js/CHANGELOG.md
+++ b/internals-js/CHANGELOG.md
@@ -26,6 +26,16 @@
 
 - Adding new CompositionOption `maxValidationSubgraphPaths`. This value represents the maximum number of SubgraphPathInfo objects that may exist in a ValidationTraversal when checking for satisfiability. Setting this value can help composition error before running out of memory. Default is 1,000,000. ([#3275](https://github.com/apollographql/federation/pull/3275))
 
+## 2.11.3
+
+### Patch Changes
+
+- Update connector spec to allow re-entry ([#3312](https://github.com/apollographql/federation/pull/3312))
+
+  Updates connector spec to follow the same patterns as other federation spec blueprints (i.e. register types/directives in the constructor and use default logic for adding them to the schema that checks whether they need to be added or not).
+
+  NOTE: Support for handling input objects in the spec is severely limited and only handles `@connect` spec. For additional details on limitations see #3311.
+
 ## 2.11.2
 
 ### Patch Changes

--- a/internals-js/src/__tests__/subgraphValidation.test.ts
+++ b/internals-js/src/__tests__/subgraphValidation.test.ts
@@ -1488,9 +1488,6 @@ describe('@interfaceObject/@key on interfaces validation', () => {
 describe('@cost', () => {
   it('rejects applications on interfaces', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@cost"])
-
       type Query {
         a: A
       }
@@ -1500,7 +1497,7 @@ describe('@cost', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'COST_APPLIED_TO_INTERFACE_FIELD',
         `[S] @cost cannot be applied to interface "A.x"`,
@@ -1512,9 +1509,6 @@ describe('@cost', () => {
 describe('@listSize', () => {
   it('rejects applications on non-lists (unless it uses sizedFields)', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a1: A @listSize(assumedSize: 5)
         a2: A @listSize(assumedSize: 10, sizedFields: ["ints"])
@@ -1525,23 +1519,20 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       ['LIST_SIZE_APPLIED_TO_NON_LIST', `[S] "Query.a1" is not a list`],
     ]);
   });
 
   it('rejects negative assumedSize', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a: [Int] @listSize(assumedSize: -5)
         b: [Int] @listSize(assumedSize: 0)
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_ASSUMED_SIZE',
         `[S] Assumed size of "Query.a" cannot be negative`,
@@ -1551,9 +1542,6 @@ describe('@listSize', () => {
 
   it('rejects slicingArguments which are not arguments of the field', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         myField(something: Int): [String]
           @listSize(slicingArguments: ["missing1", "missing2"])
@@ -1562,7 +1550,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SLICING_ARGUMENT',
         `[S] Slicing argument "missing1" is not an argument of "Query.myField"`,
@@ -1580,9 +1568,6 @@ describe('@listSize', () => {
 
   it('rejects slicingArguments which are not Int or Int!', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         sliced(
           first: String
@@ -1597,7 +1582,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SLICING_ARGUMENT',
         `[S] Slicing argument "Query.sliced(first:)" must be Int or Int!`,
@@ -1615,9 +1600,6 @@ describe('@listSize', () => {
 
   it('rejects sizedFields when the output type is not an object', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         notObject: Int @listSize(assumedSize: 1, sizedFields: ["anything"])
         a: A @listSize(assumedSize: 5, sizedFields: ["ints"])
@@ -1633,7 +1615,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SIZED_FIELD',
         `[S] Sized fields cannot be used because "Int" is not a composite type`,
@@ -1643,9 +1625,6 @@ describe('@listSize', () => {
 
   it('rejects sizedFields which are not fields of the output type', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a: A @listSize(assumedSize: 5, sizedFields: ["notOnA"])
       }
@@ -1655,7 +1634,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_INVALID_SIZED_FIELD',
         `[S] Sized field "notOnA" is not a field on type "A"`,
@@ -1665,9 +1644,6 @@ describe('@listSize', () => {
 
   it('rejects sizedFields which are not lists', () => {
     const doc = gql`
-      extend schema
-        @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
       type Query {
         a: A
           @listSize(
@@ -1683,7 +1659,7 @@ describe('@listSize', () => {
       }
     `;
 
-    expect(buildForErrors(doc)).toStrictEqual([
+    expect(buildForErrors(doc, { includeAllImports: true })).toStrictEqual([
       [
         'LIST_SIZE_APPLIED_TO_NON_LIST',
         `[S] Sized field "A.notList" is not a list`,

--- a/internals-js/src/__tests__/testUtils.ts
+++ b/internals-js/src/__tests__/testUtils.ts
@@ -13,7 +13,7 @@ export function buildForErrors(
   }
 ): [string, string][] | undefined {
   try {
-    const doc = (options?.asFed2 ?? true) ? asFed2SubgraphDocument(subgraphDefs, { includeAllImports: options?.includeAllImports }) : subgraphDefs;
+    const doc = (options?.asFed2 ?? true) ? asFed2SubgraphDocument(subgraphDefs, { ...options }) : subgraphDefs;
     const name = options?.subgraphName ?? 'S';
     buildSubgraph(name, `http://${name}`, doc).validate();
     return undefined;

--- a/internals-js/src/directiveAndTypeSpecification.ts
+++ b/internals-js/src/directiveAndTypeSpecification.ts
@@ -67,7 +67,13 @@ export type FieldSpecification = {
   args?: ResolvedArgumentSpecification[],
 }
 
-type ResolvedArgumentSpecification = {
+export type ResolvedArgumentSpecification = {
+  name: string,
+  type: InputType,
+  defaultValue?: any,
+}
+
+export type InputFieldSpecification = {
   name: string,
   type: InputType,
   defaultValue?: any,
@@ -342,7 +348,7 @@ export function createEnumTypeSpecification({
   }
 }
 
-function ensureSameTypeKind(expected: NamedType['kind'], actual: NamedType): GraphQLError[] {
+export function ensureSameTypeKind(expected: NamedType['kind'], actual: NamedType): GraphQLError[] {
   return expected === actual.kind
     ? []
     : [

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -97,7 +97,7 @@ import { createObjectTypeSpecification, createScalarTypeSpecification, createUni
 import { didYouMean, suggestionList } from "./suggestions";
 import { coreFeatureDefinitionIfKnown } from "./knownCoreFeatures";
 import { joinIdentity } from "./specs/joinSpec";
-import { COST_VERSIONS, CostDirectiveArguments, ListSizeDirectiveArguments, costIdentity } from "./specs/costSpec";
+import { CostDirectiveArguments, ListSizeDirectiveArguments } from "./specs/costSpec";
 
 const linkSpec = LINK_VERSIONS.latest();
 const tagSpec = TAG_VERSIONS.latest();
@@ -1828,18 +1828,16 @@ export class FederationBlueprint extends SchemaBlueprint {
       }
     }
 
-    const costFeature = schema.coreFeatures?.getByIdentity(costIdentity);
-    const costSpec = costFeature && COST_VERSIONS.find(costFeature.url.version);
-    const costDirective = costSpec?.costDirective(schema);
-    const listSizeDirective = costSpec?.listSizeDirective(schema);
+    const costDirective = metadata.costDirective();
+    const listSizeDirective = metadata.listSizeDirective();
 
     // Validate @cost
-    for (const application of costDirective?.applications() ?? []) {
+    for (const application of costDirective.applications()) {
       validateCostNotAppliedToInterface(application, errorCollector);
     }
 
     // Validate @listSize
-    for (const application of listSizeDirective?.applications() ?? []) {
+    for (const application of listSizeDirective.applications()) {
       const parent = application.parent;
       assert(parent instanceof FieldDefinition, "@listSize can only be applied to FIELD_DEFINITION");
       validateListSizeAppliedToList(application, parent, errorCollector);

--- a/internals-js/src/specs/connectSpec.ts
+++ b/internals-js/src/specs/connectSpec.ts
@@ -1,4 +1,4 @@
-import { DirectiveLocation, GraphQLError } from 'graphql';
+import { DirectiveLocation } from 'graphql';
 import {
   CorePurpose,
   FeatureDefinition,
@@ -7,23 +7,33 @@ import {
   FeatureVersion,
 } from './coreSpec';
 import {
-  Schema,
-  NonNullType,
+  CoreFeature,
   InputObjectType,
-  InputFieldDefinition,
+  isInputObjectType,
+  isNonNullType,
   ListType,
+  NamedType,
+  NonNullType,
+  ScalarType,
+  Schema,
 } from '../definitions';
 import { registerKnownFeature } from '../knownCoreFeatures';
 import {
   createDirectiveSpecification,
   createScalarTypeSpecification,
+  ensureSameTypeKind,
+  InputFieldSpecification,
+  TypeSpecification,
 } from '../directiveAndTypeSpecification';
+import { ERRORS } from '../error';
+import { sameType } from '../types';
+import { assert } from '../utils';
+import { valueEquals, valueToString } from '../values';
 
 export const connectIdentity = 'https://specs.apollo.dev/connect';
 
 const CONNECT = 'connect';
 const SOURCE = 'source';
-const ID = 'id';
 const URL_PATH_TEMPLATE = 'URLPathTemplate';
 const JSON_SELECTION = 'JSONSelection';
 const CONNECT_HTTP = 'ConnectHTTP';
@@ -42,62 +52,47 @@ export class ConnectSpecDefinition extends FeatureDefinition {
       minimumFederationVersion,
     );
 
-    this.registerDirective(
-      createDirectiveSpecification({
-        name: CONNECT,
-        locations: [DirectiveLocation.FIELD_DEFINITION],
-        repeatable: true,
-        // We "compose" these directives using the  `@join__directive` mechanism,
-        // so they do not need to be composed in the way passing `composes: true`
-        // here implies.
-        composes: false,
-      }),
-    );
+    function lookupFeatureTypeInSchema<T extends NamedType>(name: string, kind: T['kind'], schema: Schema, feature?: CoreFeature): T {
+      assert(feature, `Shouldn't be added without being attached to a @connect spec`);
+      const typeName = feature.typeNameInSchema(name);
+      const type = schema.typeOfKind<T>(typeName, kind);
+      assert(type, () => `Expected "${typeName}" to be defined`);
+      return type;
+    }
 
-    this.registerDirective(
-      createDirectiveSpecification({
-        name: SOURCE,
-        locations: [DirectiveLocation.SCHEMA],
-        repeatable: true,
-        composes: false,
-      }),
-    );
 
-    this.registerType(
-      createScalarTypeSpecification({ name: URL_PATH_TEMPLATE }),
-    );
-    this.registerType(createScalarTypeSpecification({ name: JSON_SELECTION }));
-    this.registerType({ name: CONNECT_HTTP, checkOrAdd: () => [] });
-    this.registerType({ name: SOURCE_HTTP, checkOrAdd: () => [] });
-    this.registerType({ name: HTTP_HEADER_MAPPING, checkOrAdd: () => [] });
-  }
-
-  addElementsToSchema(schema: Schema): GraphQLError[] {
     /* scalar URLPathTemplate */
-    const URLPathTemplate = this.addScalarType(schema, URL_PATH_TEMPLATE);
-
+    this.registerType(
+        createScalarTypeSpecification({ name: URL_PATH_TEMPLATE }),
+    );
     /* scalar JSONSelection */
-    const JSONSelection = this.addScalarType(schema, JSON_SELECTION);
+    this.registerType(createScalarTypeSpecification({ name: JSON_SELECTION }));
 
     /*
-      directive @connect(
-        source: String
-        http: ConnectHTTP
-        selection: JSONSelection!
-        entity: Boolean = false
-        errors: ConnectorErrors
-        isSuccess: JSONSelection
-      ) repeatable on FIELD_DEFINITION
-        | OBJECT # added in v0.2, validation enforced in rust
+      input ConnectorErrors {
+        message: JSONSelection
+        extensions: JSONSelection
+      }
     */
-    const connect = this.addDirective(schema, CONNECT).addLocations(
-      DirectiveLocation.FIELD_DEFINITION,
-      DirectiveLocation.OBJECT,
+    this.registerType(
+        createInputObjectTypeSpecification({
+          name: CONNECTOR_ERRORS,
+          inputFieldsFct: (schema, feature) => {
+            const jsonSelectionType =
+                lookupFeatureTypeInSchema<ScalarType>(JSON_SELECTION, 'ScalarType', schema, feature);
+            return [
+              {
+                name: 'message',
+                type: jsonSelectionType
+              },
+              {
+                name: 'extensions',
+                type: jsonSelectionType
+              },
+            ]
+          }
+        })
     );
-    connect.repeatable = true;
-
-    connect.addArgument(SOURCE, schema.stringType());
-    connect.addArgument(ID, schema.stringType());
 
     /*
       input HTTPHeaderMapping {
@@ -106,15 +101,82 @@ export class ConnectSpecDefinition extends FeatureDefinition {
         value: String
       }
     */
-    const HTTPHeaderMapping = schema.addType(
-      new InputObjectType(this.typeNameInSchema(schema, HTTP_HEADER_MAPPING)!),
+    this.registerType(
+        createInputObjectTypeSpecification({
+          name: HTTP_HEADER_MAPPING,
+          inputFieldsFct: (schema) => [
+            {
+              name: 'name',
+              type: new NonNullType(schema.stringType())
+            },
+            {
+              name: 'from',
+              type: schema.stringType()
+            },
+            {
+              name: 'value',
+              type: schema.stringType()
+            },
+          ]
+        })
     );
-    HTTPHeaderMapping.addField(new InputFieldDefinition('name')).type =
-      new NonNullType(schema.stringType());
-    HTTPHeaderMapping.addField(new InputFieldDefinition('from')).type =
-      schema.stringType();
-    HTTPHeaderMapping.addField(new InputFieldDefinition('value')).type =
-      schema.stringType();
+
+    /*
+      input ConnectBatch {
+        maxSize: Int
+      }
+     */
+    this.registerType(
+        createInputObjectTypeSpecification({
+          name: CONNECT_BATCH,
+          inputFieldsFct: (schema) => [
+            {
+              name: 'maxSize',
+              type: schema.intType()
+            }
+          ]
+        })
+    )
+
+    /*
+      input SourceHTTP {
+        baseURL: String!
+        headers: [HTTPHeaderMapping!]
+
+        # added in v0.2
+        path: JSONSelection
+        queryParams: JSONSelection
+      }
+    */
+    this.registerType(
+        createInputObjectTypeSpecification({
+          name: SOURCE_HTTP,
+          inputFieldsFct: (schema, feature) => {
+            const jsonSelectionType =
+                lookupFeatureTypeInSchema<ScalarType>(JSON_SELECTION, 'ScalarType', schema, feature);
+            const httpHeaderMappingType =
+                lookupFeatureTypeInSchema<InputObjectType>(HTTP_HEADER_MAPPING, 'InputObjectType', schema, feature);
+            return [
+              {
+                name: 'baseURL',
+                type: new NonNullType(schema.stringType())
+              },
+              {
+                name: 'headers',
+                type: new ListType(new NonNullType(httpHeaderMappingType))
+              },
+              {
+                name: 'path',
+                type: jsonSelectionType
+              },
+              {
+                name: 'queryParams',
+                type: jsonSelectionType
+              }
+            ];
+          }
+        })
+    );
 
     /*
       input ConnectHTTP {
@@ -128,85 +190,172 @@ export class ConnectSpecDefinition extends FeatureDefinition {
 
         # added in v0.2
         path: JSONSelection
-        query: JSONSelection
+        queryParams: JSONSelection
       }
     */
-    const ConnectHTTP = schema.addType(
-      new InputObjectType(this.typeNameInSchema(schema, CONNECT_HTTP)!),
+    this.registerType(
+      createInputObjectTypeSpecification({
+        name: CONNECT_HTTP,
+        inputFieldsFct: (schema, feature) => {
+          const urlPathTemplateType =
+              lookupFeatureTypeInSchema<ScalarType>(URL_PATH_TEMPLATE, 'ScalarType', schema, feature);
+          const jsonSelectionType =
+              lookupFeatureTypeInSchema<ScalarType>(JSON_SELECTION, 'ScalarType', schema, feature);
+          const httpHeaderMappingType =
+              lookupFeatureTypeInSchema<InputObjectType>(HTTP_HEADER_MAPPING, 'InputObjectType', schema, feature);
+          return [
+            {
+              name: 'GET',
+              type: urlPathTemplateType
+            },
+            {
+              name: 'POST',
+              type: urlPathTemplateType
+            },
+            {
+              name: 'PUT',
+              type: urlPathTemplateType
+            },
+            {
+              name: 'PATCH',
+              type: urlPathTemplateType
+            },
+            {
+              name: 'DELETE',
+              type: urlPathTemplateType
+            },
+            {
+              name: 'body',
+              type: jsonSelectionType
+            },
+            {
+              name: 'headers',
+              type: new ListType(new NonNullType(httpHeaderMappingType))
+            },
+            {
+              name: 'path',
+              type: jsonSelectionType
+            },
+            {
+              name: 'queryParams',
+              type: jsonSelectionType
+            },
+          ];
+        }
+      })
     );
-    ConnectHTTP.addField(new InputFieldDefinition('GET')).type =
-      URLPathTemplate;
-    ConnectHTTP.addField(new InputFieldDefinition('POST')).type =
-      URLPathTemplate;
-    ConnectHTTP.addField(new InputFieldDefinition('PUT')).type =
-      URLPathTemplate;
-    ConnectHTTP.addField(new InputFieldDefinition('PATCH')).type =
-      URLPathTemplate;
-    ConnectHTTP.addField(new InputFieldDefinition('DELETE')).type =
-      URLPathTemplate;
-    ConnectHTTP.addField(new InputFieldDefinition('body')).type = JSONSelection;
-    ConnectHTTP.addField(new InputFieldDefinition('headers')).type =
-      new ListType(new NonNullType(HTTPHeaderMapping));
 
-    ConnectHTTP.addField(new InputFieldDefinition('path')).type = JSONSelection;
-    ConnectHTTP.addField(new InputFieldDefinition('queryParams')).type =
-      JSONSelection;
-
-    connect.addArgument('http', new NonNullType(ConnectHTTP));
-
-    const ConnectBatch  = schema.addType(new InputObjectType(this.typeNameInSchema(schema, CONNECT_BATCH)!));
-    ConnectBatch.addField(new InputFieldDefinition('maxSize')).type = schema.intType();
-    connect.addArgument('batch', ConnectBatch);
-
-    const ConnectorErrors  = schema.addType(new InputObjectType(this.typeNameInSchema(schema, CONNECTOR_ERRORS)!));
-    ConnectorErrors.addField(new InputFieldDefinition('message')).type = JSONSelection;
-    ConnectorErrors.addField(new InputFieldDefinition('extensions')).type = JSONSelection;
-    connect.addArgument('errors', ConnectorErrors);
-
-    connect.addArgument('selection', new NonNullType(JSONSelection));
-    connect.addArgument('entity', schema.booleanType(), false);
-    connect.addArgument('isSuccess', JSONSelection);
+    /*
+      directive @connect(
+        source: String
+        id: String
+        http: ConnectHTTP!
+        batch: ConnectBatch
+        errors: ConnectorErrors
+        selection: JSONSelection!
+        entity: Boolean = false
+        isSuccess: JSONSelection
+      ) repeatable on FIELD_DEFINITION
+        | OBJECT # added in v0.2, validation enforced in rust
+    */
+    this.registerDirective(
+      createDirectiveSpecification({
+        name: CONNECT,
+        locations: [DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.OBJECT],
+        repeatable: true,
+        args: [
+          {
+            name: 'source',
+            type: (schema) => schema.stringType()
+          },
+          {
+            name: 'id',
+            type: (schema) => schema.stringType()
+          },
+          {
+            name: 'http',
+            type: (schema, feature) => {
+              const connectHttpType =
+                  lookupFeatureTypeInSchema<InputObjectType>(CONNECT_HTTP, 'InputObjectType', schema, feature);
+              return new NonNullType(connectHttpType);
+            }
+          },
+          {
+            name: 'batch',
+            type: (schema, feature) =>
+                lookupFeatureTypeInSchema<InputObjectType>(CONNECT_BATCH, 'InputObjectType', schema, feature)
+          },
+          {
+            name: 'errors',
+            type: (schema, feature) =>
+                lookupFeatureTypeInSchema<InputObjectType>(CONNECTOR_ERRORS, 'InputObjectType', schema, feature)
+          },
+          {
+            name: 'selection',
+            type: (schema, feature) => {
+              const jsonSelectionType =
+                  lookupFeatureTypeInSchema<ScalarType>(JSON_SELECTION, 'ScalarType', schema, feature);
+              return new NonNullType(jsonSelectionType);
+            }
+          },
+          {
+            name: 'entity',
+            type: (schema) => schema.booleanType(),
+            defaultValue: false
+          },
+          {
+            name: 'isSuccess',
+            type: (schema, feature) =>
+                lookupFeatureTypeInSchema<ScalarType>(JSON_SELECTION, 'ScalarType', schema, feature)
+          }
+        ],
+        // We "compose" these directives using the  `@join__directive` mechanism,
+        // so they do not need to be composed in the way passing `composes: true`
+        // here implies.
+        composes: false,
+      }),
+    );
 
     /*
       directive @source(
         name: String!
-        http: ConnectHTTP
+        http: SourceHTTP!
         errors: ConnectorErrors
         isSuccess: JSONSelection
       ) repeatable on SCHEMA
     */
-    const source = this.addDirective(schema, SOURCE).addLocations(
-      DirectiveLocation.SCHEMA,
+    this.registerDirective(
+      createDirectiveSpecification({
+        name: SOURCE,
+        locations: [DirectiveLocation.SCHEMA],
+        repeatable: true,
+        composes: false,
+        args: [
+          {
+            name: 'name',
+            type: (schema) => new NonNullType(schema.stringType())
+          },
+          {
+            name: 'http',
+            type: (schema, feature) => {
+              const sourceHttpType =
+                  lookupFeatureTypeInSchema<InputObjectType>(SOURCE_HTTP, 'InputObjectType', schema, feature);
+              return new NonNullType(sourceHttpType);
+            }
+          },
+          {
+            name: 'errors',
+            type: (schema, feature) =>
+                lookupFeatureTypeInSchema<InputObjectType>(CONNECTOR_ERRORS, 'InputObjectType', schema, feature)
+          },
+          {
+            name: 'isSuccess',
+            type: (schema, feature) =>
+                lookupFeatureTypeInSchema<ScalarType>(JSON_SELECTION, 'ScalarType', schema, feature)
+          }
+        ]
+      }),
     );
-    source.repeatable = true;
-    source.addArgument('name', new NonNullType(schema.stringType()));
-
-    /*
-      input SourceHTTP {
-        baseURL: String!
-        headers: [HTTPHeaderMapping!]
-
-        # added in v0.2
-        path: JSONSelection
-        query: JSONSelection
-      }
-    */
-    const SourceHTTP = schema.addType(
-      new InputObjectType(this.typeNameInSchema(schema, SOURCE_HTTP)!),
-    );
-    SourceHTTP.addField(new InputFieldDefinition('baseURL')).type =
-      new NonNullType(schema.stringType());
-    SourceHTTP.addField(new InputFieldDefinition('headers')).type =
-      new ListType(new NonNullType(HTTPHeaderMapping));
-
-    SourceHTTP.addField(new InputFieldDefinition('path')).type = JSONSelection;
-    SourceHTTP.addField(new InputFieldDefinition('queryParams')).type = JSONSelection;
-
-    source.addArgument('http', new NonNullType(SourceHTTP));
-    source.addArgument('errors', ConnectorErrors);
-    source.addArgument('isSuccess', JSONSelection);
-
-    return [];
   }
 
   get defaultCorePurpose(): CorePurpose {
@@ -237,3 +386,108 @@ export const CONNECT_VERSIONS = new FeatureDefinitions<ConnectSpecDefinition>(
   );
 
 registerKnownFeature(CONNECT_VERSIONS);
+
+// This function is purposefully declared only in this file and without export.
+//
+// Do NOT add this to "internals-js/src/directiveAndTypeSpecification.ts", and
+// do NOT export this function.
+//
+// Subgraph schema building, at this time of writing, does not really support
+// input objects in specs. We did a number of one-off things to support them in
+// the connect spec's case, and it will be non-maintainable/bug-prone to do them
+// again.
+// 
+// There's work to be done to support input objects more generally; please see
+// https://github.com/apollographql/federation/pull/3311 for more information. 
+function createInputObjectTypeSpecification({
+  name,
+  inputFieldsFct,
+}: {
+  name: string,
+  inputFieldsFct: (schema: Schema, feature?: CoreFeature) => InputFieldSpecification[],
+}): TypeSpecification {
+  return {
+    name,
+    checkOrAdd: (schema: Schema, feature?: CoreFeature, asBuiltIn?: boolean) => {
+      const actualName = feature?.typeNameInSchema(name) ?? name;
+      const expectedFields = inputFieldsFct(schema, feature);
+      const existing = schema.type(actualName);
+      if (existing) {
+        let errors = ensureSameTypeKind('InputObjectType', existing);
+        if (errors.length > 0) {
+          return errors;
+        }
+        assert(isInputObjectType(existing), 'Should be an input object type');
+        // The following mimics `ensureSameArguments()`, but with some changes.
+        for (const { name: fieldName, type, defaultValue } of expectedFields) {
+          const existingField = existing.field(fieldName);
+          if (!existingField) {
+            // Not declaring an optional input field is ok: that means you won't
+            // be able to pass a non-default value in your schema, but we allow
+            // you that. But missing a required input field it not ok.
+            if (isNonNullType(type) && defaultValue === undefined) {
+              errors.push(ERRORS.TYPE_DEFINITION_INVALID.err(
+                `Invalid definition for type ${name}: missing required input field "${fieldName}"`,
+                { nodes: existing.sourceAST },
+              ));
+            }
+            continue;
+          }
+
+          let existingType = existingField.type!;
+          if (isNonNullType(existingType) && !isNonNullType(type)) {
+            // It's ok to redefine an optional input field as mandatory. For
+            // instance, if you want to force people on your team to provide a
+            // "maxSize", you can redefine ConnectBatch as
+            // `input ConnectBatch { maxSize: Int! }` to get validation. In
+            // other words, you are allowed to always pass an input field that
+            // is optional if you so wish.
+            existingType = existingType.ofType;
+          }
+          // Note that while `ensureSameArguments()` allows input type
+          // redefinitions (e.g. allowing users to declare `String` instead of a
+          // custom scalar), this behavior can be confusing/error-prone more
+          // generally, so we forbid this for now. We can relax this later on a
+          // case-by-case basis if needed.
+          //
+          // Further, `ensureSameArguments()` would skip default value checking
+          // if the input type was non-nullable. It's unclear why this is there;
+          // it may have been a mistake due to the impression that non-nullable
+          // inputs can't have default values (they can), or this may have been
+          // to avoid some breaking change, but there's no such limitation in
+          // the case of input objects, so we always validate default values
+          // here.
+          if (!sameType(type, existingType)) {
+            errors.push(ERRORS.TYPE_DEFINITION_INVALID.err(
+              `Invalid definition for type ${name}: input field "${fieldName}" should have type "${type}" but found type "${existingField.type!}"`,
+              { nodes: existingField.sourceAST },
+            ));
+          } else if (!valueEquals(defaultValue, existingField.defaultValue)) {
+            errors.push(ERRORS.TYPE_DEFINITION_INVALID.err(
+              `Invalid definition type ${name}: input field "${fieldName}" should have default value ${valueToString(defaultValue)} but found default value ${valueToString(existingField.defaultValue)}`,
+              { nodes: existingField.sourceAST },
+            ));
+          }
+        }
+        for (const existingField of existing.fields()) {
+          // If it's an expected input field, we already validated it. But we
+          // still need to reject unknown input fields.
+          if (!expectedFields.some((field) => field.name === existingField.name)) {
+            errors.push(ERRORS.TYPE_DEFINITION_INVALID.err(
+              `Invalid definition for type ${name}: unknown/unsupported input field "${existingField.name}"`,
+              { nodes: existingField.sourceAST },
+            ));
+          }
+        }
+        return errors;
+      } else {
+        const createdType = schema.addType(new InputObjectType(actualName, asBuiltIn));
+        for (const { name, type, defaultValue } of expectedFields) {
+          const newField = createdType.addField(name, type);
+          newField.defaultValue = defaultValue;
+        }
+        return [];
+      }
+    },
+  }
+}

--- a/query-graphs-js/CHANGELOG.md
+++ b/query-graphs-js/CHANGELOG.md
@@ -32,6 +32,13 @@
 - Updated dependencies [[`468f27842608f4e390cfc88bc7e6b4b0945f95ff`](https://github.com/apollographql/federation/commit/468f27842608f4e390cfc88bc7e6b4b0945f95ff), [`b734ea04d118db09cf6077fdd968c8f04a96327a`](https://github.com/apollographql/federation/commit/b734ea04d118db09cf6077fdd968c8f04a96327a)]:
   - @apollo/federation-internals@2.12.0-preview.0
 
+## 2.11.3
+
+### Patch Changes
+
+- Updated dependencies [[`8c7a2cd655ad3060e9f5c3b106cfbdb59251701c`](https://github.com/apollographql/federation/commit/8c7a2cd655ad3060e9f5c3b106cfbdb59251701c)]:
+  - @apollo/federation-internals@2.11.3
+
 ## 2.11.2
 
 ### Patch Changes

--- a/query-graphs-js/src/__tests__/graphPath.test.ts
+++ b/query-graphs-js/src/__tests__/graphPath.test.ts
@@ -72,6 +72,7 @@ function createOptions(supergraph: Schema, queryGraph: QueryGraph): Simultaneous
     [],
     [],
     new Map(),
+    null,
   );
 }
 

--- a/query-graphs-js/src/nonLocalSelectionsEstimation.ts
+++ b/query-graphs-js/src/nonLocalSelectionsEstimation.ts
@@ -600,6 +600,10 @@ export class NonLocalSelectionsMetadata {
    * This calls {@link checkNonLocalSelectionsLimitExceeded} for each of the
    * selections in the open branches stack; see that function's doc comment for
    * more information.
+   *
+   * To support mutations, we allow indicating the initial subgraph is
+   * constrained, in which case indirect options will be ignored until the first
+   * field (similar to query planning).
    */
   checkNonLocalSelectionsLimitExceededAtRoot(
     stack: [Selection, SimultaneousPathsWithLazyIndirectPaths[]][],
@@ -607,6 +611,7 @@ export class NonLocalSelectionsMetadata {
     supergraphSchema: Schema,
     inconsistentAbstractTypesRuntimes: Set<string>,
     overrideConditions: Map<string, boolean>,
+    isInitialSubgraphConstrained: boolean,
   ): boolean {
     for (const [selection, simultaneousPaths] of stack) {
       const tailVertices = new Set<Vertex>();
@@ -616,7 +621,10 @@ export class NonLocalSelectionsMetadata {
         }
       }
       const tailVerticesInfo =
-        this.estimateVerticesWithIndirectOptions(tailVertices);
+        this.estimateVerticesWithIndirectOptions(
+          tailVertices,
+          isInitialSubgraphConstrained,
+        );
 
       // Note that top-level selections aren't avoided via fully-local selection
       // set optimization, so we always add them here.
@@ -626,12 +634,16 @@ export class NonLocalSelectionsMetadata {
 
       if (selection.selectionSet) {
         const selectionHasDefer = selection.hasDefer();
+        const isInitialSubgraphConstrainedAfterElement =
+          isInitialSubgraphConstrained
+            && selection.kind === 'FragmentSelection';
         const nextVertices = this.estimateNextVerticesForSelection(
           selection.element,
           tailVerticesInfo,
           state,
           supergraphSchema,
           overrideConditions,
+          isInitialSubgraphConstrainedAfterElement,
         );
         if (this.checkNonLocalSelectionsLimitExceeded(
           selection.selectionSet,
@@ -641,6 +653,7 @@ export class NonLocalSelectionsMetadata {
           supergraphSchema,
           inconsistentAbstractTypesRuntimes,
           overrideConditions,
+          isInitialSubgraphConstrainedAfterElement,
         )) {
           return true;
         }
@@ -674,6 +687,10 @@ export class NonLocalSelectionsMetadata {
    * Note that this function takes in whether the parent selection of the
    * selection set has @defer, as that affects whether the optimization is
    * disabled for that selection set.
+   *
+   * To support mutations, we allow indicating the initial subgraph is
+   * constrained, in which case indirect options will be ignored until the first
+   * field (similar to query planning).
    */
   private checkNonLocalSelectionsLimitExceeded(
     selectionSet: SelectionSet,
@@ -683,6 +700,7 @@ export class NonLocalSelectionsMetadata {
     supergraphSchema: Schema,
     inconsistentAbstractTypesRuntimes: Set<string>,
     overrideConditions: Map<string, boolean>,
+    isInitialSubgraphConstrained: boolean,
   ): boolean {
     // Compute whether the selection set is non-local, and if so, add its
     // selections to the count. Any of the following causes the selection set to
@@ -709,12 +727,16 @@ export class NonLocalSelectionsMetadata {
       
       const oldCount = state.count;
       if (selection.selectionSet) {
+        const isInitialSubgraphConstrainedAfterElement =
+          isInitialSubgraphConstrained
+            && selection.kind === 'FragmentSelection';
         const nextVertices = this.estimateNextVerticesForSelection(
           element,
           parentVertices,
           state,
           supergraphSchema,
           overrideConditions,
+          isInitialSubgraphConstrainedAfterElement,
         );
         if (this.checkNonLocalSelectionsLimitExceeded(
           selection.selectionSet,
@@ -724,6 +746,7 @@ export class NonLocalSelectionsMetadata {
           supergraphSchema,
           inconsistentAbstractTypesRuntimes,
           overrideConditions,
+          isInitialSubgraphConstrainedAfterElement,
         )) {
           return true;
         }
@@ -822,6 +845,12 @@ export class NonLocalSelectionsMetadata {
    * selection for a set of parent vertices (including indirect options), this
    * function can be used to estimate an upper bound on the next vertices after
    * taking the selection (also with indirect options).
+   *
+   * To support mutations, we allow indicating the initial subgraph will be
+   * constrained after taking the element, in which case indirect options will
+   * be ignored (and caching will be skipped). This is to ensure that top-level
+   * mutation fields are not executed on a different subgraph than the initial
+   * one during query planning.
    */
   private estimateNextVerticesForSelection(
     element: OperationElement,
@@ -829,6 +858,7 @@ export class NonLocalSelectionsMetadata {
     state: NonLocalSelectionsState,
     supergraphSchema: Schema,
     overrideConditions: Map<string, boolean>,
+    isInitialSubgraphConstrainedAfterElement: boolean,
   ): NextVerticesInfo {
     const selectionKey = element.kind === 'Field'
       ? element.definition.name
@@ -836,6 +866,28 @@ export class NonLocalSelectionsMetadata {
     if (!selectionKey) {
       // For empty type condition, the vertices don't change.
       return parentVertices;
+    }
+    if (isInitialSubgraphConstrainedAfterElement) {
+      // When the initial subgraph is constrained, skip caching entirely. Note
+      // that caching is not skipped when the initial subgraph is constrained
+      // before this element but not after. Because of that, there may be cache
+      // entries for remaining vertices that were actually part of a complete
+      // digraph, but this is only a slight caching inefficiency and doesn't
+      // affect the computation's result.
+      assert(
+        parentVertices.nextVerticesWithIndirectOptions.types.size === 0,
+        () => 'Initial subgraph was constrained which indicates no indirect'
+          + ' options should be taken, but the parent vertices unexpectedly had'
+          + ' a complete digraph which indicates indirect options were taken'
+          + ' upstream in the path.',
+      );
+      return this.estimateNextVerticesForSelectionWithoutCaching(
+        element,
+        parentVertices.nextVerticesWithIndirectOptions.remainingVertices,
+        supergraphSchema,
+        overrideConditions,
+        true,
+      );
     }
     let cache = state.nextVerticesCache.get(selectionKey);
     if (!cache) {
@@ -866,6 +918,7 @@ export class NonLocalSelectionsMetadata {
           indirectOptions.sameTypeOptions,
           supergraphSchema,
           overrideConditions,
+          false,
         );
         cache.typesToNextVertices.set(typeName, cacheEntry);
       }
@@ -879,6 +932,7 @@ export class NonLocalSelectionsMetadata {
           [vertex],
           supergraphSchema,
           overrideConditions,
+          false,
         );
         cache.remainingVerticesToNextVertices.set(vertex, cacheEntry);
       }
@@ -922,16 +976,23 @@ export class NonLocalSelectionsMetadata {
    * (We do account for override conditions, which are relatively
    * straightforward.)
    *
-   * Since we're iterating through next vertices in the process, for efficiency
-   * sake we also compute whether there are any reachable cross-subgraph edges
-   * from the next vertices (without indirect options). This method assumes that
-   * inline fragments have type conditions.
+   * Since we're iterating through next vertices in the process, for
+   * efficiency's sake we also compute whether there are any reachable
+   * cross-subgraph edges from the next vertices (without indirect options).
+   * This method assumes that inline fragments have type conditions.
+   *
+   * To support mutations, we allow indicating the initial subgraph will be
+   * constrained after taking the element, in which case indirect options will
+   * be ignored. This is to ensure that top-level mutation fields are not
+   * executed on a different subgraph than the initial one during query
+   * planning.
    */
   private estimateNextVerticesForSelectionWithoutCaching(
     element: OperationElement,
     parentVertices: Iterable<Vertex>,
     supergraphSchema: Schema,
     overrideConditions: Map<string, boolean>,
+    isInitialSubgraphConstrainedAfterElement: boolean,
   ): NextVerticesInfo {
     const nextVertices = new Set<Vertex>();
     switch (element.kind) {
@@ -955,7 +1016,7 @@ export class NonLocalSelectionsMetadata {
           }
         };
         for (const vertex of parentVertices) {
-          // As an upper bound for efficiency sake, we consider both
+          // As an upper bound for efficiency's sake, we consider both
           // non-type-exploded and type-exploded options.
           processHeadVertex(vertex);
           const downcasts = this.verticesToObjectTypeDowncasts.get(vertex);
@@ -1041,16 +1102,33 @@ export class NonLocalSelectionsMetadata {
         assertUnreachable(element);
     }
 
-    return this.estimateVerticesWithIndirectOptions(nextVertices);
+    return this.estimateVerticesWithIndirectOptions(
+      nextVertices,
+      isInitialSubgraphConstrainedAfterElement,
+    );
   }
 
   /**
-   * Estimate the indirect options for the given next vertices, and add them to
-   * the given vertices. As an upper bound for efficiency's sake, we assume we
-   * can take any indirect option (i.e. ignore any edge conditions).
+   * Estimate the indirect options for the given next vertices, and return the
+   * given next vertices along with `nextVerticesWithIndirectOptions` which
+   * contains these direct and indirect options. As an upper bound for
+   * efficiency's sake, we assume we can take any indirect option (i.e. ignore
+   * any edge conditions).
+   *
+   * Since we're iterating through next vertices in the process, for
+   * efficiency's sake we also compute whether there are any reachable
+   * cross-subgraph edges from the next vertices (without indirect options).
+   *
+   * To support mutations, we allow ignoring indirect options, as we don't want
+   * top-level mutation fields to be executed on a different subgraph than the
+   * initial one. In that case, `nextVerticesWithIndirectOptions` will not have
+   * any `types`, and the given vertices will be added to `remainingVertices`
+   * (despite them potentially being part of the complete digraph for their
+   * type). This is fine, as caching logic accounts for this accordingly.
    */
   private estimateVerticesWithIndirectOptions(
     nextVertices: Set<Vertex>,
+    ignoreIndirectOptions: boolean,
   ): NextVerticesInfo {
     const nextVerticesInfo: NextVerticesInfo = {
       nextVertices,
@@ -1063,7 +1141,16 @@ export class NonLocalSelectionsMetadata {
     for (const nextVertex of nextVertices) {
       nextVerticesInfo.nextVerticesHaveReachableCrossSubgraphEdges ||=
         nextVertex.hasReachableCrossSubgraphEdges;
-      
+
+      // As noted above, we don't want top-level mutation fields to be executed
+      // on a different subgraph than the initial one, so we support ignoring
+      // indirect options here.
+      if (ignoreIndirectOptions) {
+        nextVerticesInfo.nextVerticesWithIndirectOptions.remainingVertices
+          .add(nextVertex);
+        continue;
+      }
+
       const typeName = nextVertex.type.name
       const optionsMetadata = this.typesToIndirectOptions.get(typeName);
       if (optionsMetadata) {
@@ -1085,7 +1172,7 @@ export class NonLocalSelectionsMetadata {
           continue;
         }
       }
-      // We need to add the remaining vertex, and if its our first time seeing
+      // We need to add the remaining vertex, and if it's our first time seeing
       // it, we also add any of its interface object options.
       if (
         !nextVerticesInfo.nextVerticesWithIndirectOptions.remainingVertices

--- a/query-planner-js/CHANGELOG.md
+++ b/query-planner-js/CHANGELOG.md
@@ -36,6 +36,16 @@
   - @apollo/query-graphs@2.12.0-preview.0
   - @apollo/federation-internals@2.12.0-preview.0
 
+## 2.11.3
+
+### Patch Changes
+
+- Fix bug in query planning where a subgraph jump for `@requires` can sometimes try to fetch `@key` fields from a subgraph that doesn't have them. This bug would previously cause query planning to error with a message that looks like "Cannot add selection of field `T.id` to selection set of parent type `T`". ([#3307](https://github.com/apollographql/federation/pull/3307))
+
+- Updated dependencies [[`8c7a2cd655ad3060e9f5c3b106cfbdb59251701c`](https://github.com/apollographql/federation/commit/8c7a2cd655ad3060e9f5c3b106cfbdb59251701c)]:
+  - @apollo/federation-internals@2.11.3
+  - @apollo/query-graphs@2.11.3
+
 ## 2.11.2
 
 ### Patch Changes

--- a/subgraph-js/CHANGELOG.md
+++ b/subgraph-js/CHANGELOG.md
@@ -34,6 +34,15 @@
 - Updated dependencies [[`468f27842608f4e390cfc88bc7e6b4b0945f95ff`](https://github.com/apollographql/federation/commit/468f27842608f4e390cfc88bc7e6b4b0945f95ff), [`b734ea04d118db09cf6077fdd968c8f04a96327a`](https://github.com/apollographql/federation/commit/b734ea04d118db09cf6077fdd968c8f04a96327a)]:
   - @apollo/federation-internals@2.12.0-preview.0
 
+## 2.11.3
+
+### Patch Changes
+
+- When a `GraphQLScalarType` resolver is provided to `buildSubgraphSchema()`, omitted configuration options in the `GraphQLScalarType` no longer cause the corresponding properties in the GraphQL document/AST to be cleared. To explicitly clear these properties, use `null` for the configuration option instead. ([#3285](https://github.com/apollographql/federation/pull/3285)) ([#3285](https://github.com/apollographql/federation/pull/3285))
+
+- Updated dependencies [[`8c7a2cd655ad3060e9f5c3b106cfbdb59251701c`](https://github.com/apollographql/federation/commit/8c7a2cd655ad3060e9f5c3b106cfbdb59251701c)]:
+  - @apollo/federation-internals@2.11.3
+
 ## 2.11.2
 
 ### Patch Changes


### PR DESCRIPTION
Most of the commits visible below were on `main` but not yet on `next`. The merge commit at the end (https://github.com/apollographql/federation/pull/3316/commits/c8f5465f2a01bb00c0d5fe6bd38c3e2bc03bfb75) is my attempt to reconcile the branches without discarding any functionality, so it probably deserves review the most.