### PR TITLE
chore: update auth directives documentation

### DIFF
--- a/docs/source/schema-design/federated-schemas/reference/directives.mdx
+++ b/docs/source/schema-design/federated-schemas/reference/directives.mdx
@@ -441,6 +441,11 @@ To learn more, see the [Incremental migration with `@override`](/graphos/schema-
 
 <LicensedDirective />
 
+<Caution>
+
+Federation v2.9 and above doesn't allow `@authenticated` on interfaces. Applying `@authenticated` to an interface or interface field results in a composition error.
+
+</Caution>
 
 ```graphql
 directive @authenticated on
@@ -458,6 +463,12 @@ Indicates to composition that the target element is accessible only to the authe
 <MinVersionBadge version="Federation v2.5" />
 
 <LicensedDirective />
+
+<Caution>
+
+    Federation v2.9 and above doesn't allow `@requiresScopes` on interfaces. Applying `@requiresScopes` to an interface or interface field results in a composition error.
+
+</Caution>
 
 ```graphql
 directive @requiresScopes(scopes: [[federation__Scope!]!]!) on
@@ -505,6 +516,12 @@ Indicates to composition that the target element is accessible only to the authe
 <MinVersionBadge version="Federation v2.6" />
 
 <LicensedDirective />
+
+<Caution>
+
+    Federation v2.9 and above doesn't allow `@policy` on interfaces. Applying `@policy` to an interface or interface field results in a composition error.
+
+</Caution>
 
 ```graphql
 directive @policy(policies: [[federation__Policy!]!]!) on


### PR DESCRIPTION
Adds `<Caution>` admonition on `@authenticated`, @requiresScopes` and `@policy` directives to notify users that those directives can no longer be applied on interfaces and interface fields.
