### PR TITLE
chore: pin specific version of node for lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ workflows:
                 - "20"
                 - "22"
       - Lint:
-          name: Lint - executing << matrix.script >>
+          name: Lint - << matrix.script >>
           matrix:
             parameters:
               script:


### PR DESCRIPTION
`circleci/node@7.2.0` does not pin specific version of `Node` (and `npm`) that is used to execute `npm-run` commands. Updating circle config to explicitly use node v22 for our lints.