### PR TITLE
Bump `form-data` in `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3938,11 +3938,14 @@
       }
     },
     "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "4.0.0",
-      "license": "MIT",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -7073,7 +7076,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",


### PR DESCRIPTION
<!-- OE-1176 -->

This PR bumps the `form-data` package (major version `3.x`) from `3.0.1` to `3.0.4` in `package-lock.json`, and the `form-data` package (major version `4.x`) from `4.0.0` to `4.0.5` in `package-lock.json`. Note that this requires no release, as no `package.json`s have been updated.