### PR TITLE
fix: regenerate package-lock using Node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -158,6 +158,7 @@
       "version": "1.2.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -610,7 +611,6 @@
       "version": "7.21.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
@@ -2227,6 +2227,7 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -2248,12 +2249,14 @@
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.23.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2270,6 +2273,7 @@
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2281,6 +2285,7 @@
       "version": "0.20.2",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2292,6 +2297,7 @@
       "version": "8.36.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -3056,6 +3062,7 @@
       "version": "0.11.8",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -3069,6 +3076,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -3080,7 +3088,8 @@
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3615,7 +3624,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.4.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4114,8 +4122,7 @@
     },
     "node_modules/@types/node": {
       "version": "14.18.63",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.9",
@@ -4266,6 +4273,7 @@
       "version": "5.55.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.55.0",
         "@typescript-eslint/types": "5.55.0",
@@ -4292,6 +4300,7 @@
       "version": "5.55.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.55.0",
         "@typescript-eslint/visitor-keys": "5.55.0"
@@ -4308,6 +4317,7 @@
       "version": "5.55.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.55.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -4416,6 +4426,7 @@
       "version": "5.55.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -4428,6 +4439,7 @@
       "version": "5.55.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.55.0",
         "@typescript-eslint/visitor-keys": "5.55.0",
@@ -4454,6 +4466,7 @@
       "version": "5.55.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.55.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -4663,7 +4676,6 @@
       "version": "8.11.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4703,6 +4715,7 @@
       "version": "5.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -4752,6 +4765,7 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5320,7 +5334,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -7007,6 +7020,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -7501,12 +7515,14 @@
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -7522,6 +7538,7 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7533,6 +7550,7 @@
       "version": "7.2.2",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -7548,6 +7566,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -7556,6 +7575,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -7571,6 +7591,7 @@
       "version": "13.23.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -7587,6 +7608,7 @@
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7598,6 +7620,7 @@
       "version": "6.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -7612,6 +7635,7 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -7626,6 +7650,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -7640,6 +7665,7 @@
       "version": "0.20.2",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7651,6 +7677,7 @@
       "version": "9.5.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -7679,6 +7706,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -7690,6 +7718,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -8070,7 +8099,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-equals": {
       "version": "4.0.3",
@@ -8586,6 +8616,7 @@
       "version": "6.0.2",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -8675,7 +8706,6 @@
     "node_modules/graphql": {
       "version": "16.8.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -8800,7 +8830,6 @@
       "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9275,6 +9304,17 @@
         }
       }
     },
+    "node_modules/inquirer/node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/inquirer/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -9315,12 +9355,12 @@
       }
     },
     "node_modules/inquirer/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/inquirer/node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -9649,6 +9689,7 @@
       "version": "3.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9966,7 +10007,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -12744,6 +12784,7 @@
       "version": "4.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -12910,7 +12951,8 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify": {
       "version": "1.0.2",
@@ -12926,7 +12968,8 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -13013,6 +13056,7 @@
       "version": "0.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -14228,6 +14272,7 @@
       "version": "0.9.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
@@ -14665,6 +14710,7 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -16968,7 +17014,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -17194,7 +17241,6 @@
       "version": "10.9.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17303,6 +17349,7 @@
       "version": "0.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -17380,7 +17427,6 @@
       "version": "5.3.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17432,7 +17478,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -17621,6 +17668,7 @@
       "version": "4.4.1",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -17995,7 +18043,6 @@
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
Current `pacakge-lock.json` was generated using newer node version which breaks CI testing using older Node version.