### PR TITLE
Use node 18 for `changesets/action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 16
+      - name: Setup Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies


### PR DESCRIPTION
This PR updates the Github Action for changeset PRs to use node 18, to avoid accidentally generating a `package-lock.json` version that breaks tests for node 18/20.