### PR TITLE
feat: support interface object chains

### DIFF
--- a/composition-js/src/__tests__/compose.test.ts
+++ b/composition-js/src/__tests__/compose.test.ts
@@ -4214,6 +4214,59 @@ describe('composition', () => {
       result = composeAsFed2Subgraphs([subgraph2, subgraph1]);
       assertCompositionSuccess(result);
     })
+
+    it('composes interface object chain', () => {
+      const s1 = {
+        name: "S1",
+        url: "http://s1",
+        typeDefs: gql`
+        type Query {
+          i: I1
+        }
+
+        interface I1 @key(fields: "id") {
+          id: ID!
+          data: String!
+        }
+
+        interface I2 implements I1 @key(fields: "id") {
+          id: ID!
+          data: String!
+          data2: String!
+        }
+
+        type T implements I1 & I2 @key(fields: "id") {
+          id: ID!
+          data: String!
+          data2: String!
+        }
+      `
+      };
+      const s2 = {
+        name: "S2",
+        url: "http://s2",
+        typeDefs: gql`
+        type I1 @interfaceObject @key(fields: "id") {
+          id: ID!
+          data3: Int
+        }
+      `
+      }
+
+      const s3 = {
+        name: "S3",
+        url: "http://s3",
+        typeDefs: gql`
+        type I2 @interfaceObject @key(fields: "id") {
+          id: ID!
+          data4: Int
+        }
+      `
+      }
+
+      const result = composeAsFed2Subgraphs([s1, s2, s3]);
+      assertCompositionSuccess(result);
+    });
   });
 
   describe('@authenticated', () => {

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1221,10 +1221,10 @@ class Merger {
   }
 
   private addMissingInterfaceObjectFieldsToImplementations() {
-    // For each merged object types, we check if we're missing a field from one of the implemented interface.
+    // For each merged object and interface types, we check if we're missing a field from one of the implemented interface.
     // If we do, then we look if one of the subgraph provides that field as a (non-external) interface object
     // type, and if that's the case, we add the field to the object.
-    for (const type of this.merged.objectTypes()) {
+    for (const type of [...this.merged.objectTypes(), ...this.merged.interfaceTypes()]) {
       for (const implementedItf of type.interfaces()) {
         for (const itfField of implementedItf.fields()) {
           if (type.field(itfField.name)) {


### PR DESCRIPTION
Current merge logic only propagates `@interfaceObject` fields to object types. This means that if we have an interface implementing `@interfaceObject` interface, those fields won't be propagated resulting in a failed composition.

Updates `addMissingInterfaceObjectFieldsToImplementations` to propagate `@interfaceObject` fields to object and interface types.