### PR TITLE
fix(federation): add reference resolver type to resolver map

### DIFF
--- a/subgraph-js/src/schema-helper/resolverMap.ts
+++ b/subgraph-js/src/schema-helper/resolverMap.ts
@@ -1,4 +1,5 @@
 import { GraphQLFieldResolver, GraphQLScalarType, DocumentNode } from 'graphql';
+import type { GraphQLReferenceResolver } from '../schemaExtensions';
 
 export interface GraphQLSchemaModule {
   typeDefs: DocumentNode;
@@ -6,9 +7,9 @@ export interface GraphQLSchemaModule {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export interface GraphQLResolverMap<TContext = {}> {
+export interface GraphQLResolverMap<TContext = {}, TReference extends object = any> {
   [typeName: string]:
-    | {
+    | ({
         [fieldName: string]:
           | GraphQLFieldResolver<any, TContext>
           | {
@@ -16,7 +17,9 @@ export interface GraphQLResolverMap<TContext = {}> {
               resolve?: GraphQLFieldResolver<any, TContext>;
               subscribe?: GraphQLFieldResolver<any, TContext>;
             };
-      }
+      } & {
+        __resolveReference?: GraphQLReferenceResolver<TContext, TReference>;
+      })
     | GraphQLScalarType
     | {
         [enumValue: string]: string | number;

--- a/subgraph-js/src/schemaExtensions.ts
+++ b/subgraph-js/src/schemaExtensions.ts
@@ -5,8 +5,8 @@ import {
   GraphQLUnionTypeExtensions
 } from 'graphql';
 
-export type GraphQLReferenceResolver<TContext> = (
-  reference: object,
+export type GraphQLReferenceResolver<TContext, TReference extends object = any> = (
+  reference: TReference,
   context: TContext,
   info: GraphQLResolveInfo,
 ) => any;


### PR DESCRIPTION
Fixes #2205 by adding a type definition for `__resolveReference` to the existing `GraphQLResolverMap` interface.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* Federation versions
        Please make sure you're targeting the federation version you're opening the PR for.  Federation 2 (alpha) is currently located on the `main` branch and prior versions of Federation live on the `version-0.x` branch.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/federation/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
