### PR TITLE
Mark connect/v0.4 as preview to prevent supergraph @link leak

### DIFF
--- a/.changeset/fix-connect-v04-preview.md
+++ b/.changeset/fix-connect-v04-preview.md
@@ -1,0 +1,6 @@
+---
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
+---
+
+Mark connect/v0.4 as a preview version so composition does not inject it into the supergraph `@link` unless a subgraph explicitly uses it. Previously, upgrading to Federation v2.13 would unconditionally stamp `connect/v0.4` into the supergraph, causing Router to require the `connectors.preview_connect_v0_4` flag even when no subgraph used v0.4 features. (RH-1321)

--- a/composition-js/src/__tests__/connectors.test.ts
+++ b/composition-js/src/__tests__/connectors.test.ts
@@ -29,7 +29,7 @@ describe("connect spec and join__directive", () => {
   const expectedSupergraphSdl = `schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION)
   @join__directive(graphs: [WITH_CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
   @join__directive(graphs: [WITH_CONNECTORS], name: "source", args: {name: "v1", http: {baseURL: "http://v1"}})
 {
@@ -240,7 +240,7 @@ type Resource
       "schema
         @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
         @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
-        @link(url: \\"https://specs.apollo.dev/connect/v0.4\\", for: EXECUTION)
+        @link(url: \\"https://specs.apollo.dev/connect/v0.3\\", for: EXECUTION)
         @join__directive(graphs: [WITH_CONNECTORS], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", import: [\\"@source\\"]})
         @join__directive(graphs: [WITH_CONNECTORS], name: \\"source\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
       {
@@ -459,7 +459,7 @@ type Resource
       "schema
         @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
         @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
-        @link(url: \\"https://specs.apollo.dev/connect/v0.4\\", for: EXECUTION)
+        @link(url: \\"https://specs.apollo.dev/connect/v0.3\\", for: EXECUTION)
         @join__directive(graphs: [WITH_CONNECTORS_V0_1_], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", import: [\\"@connect\\", \\"@source\\"]})
         @join__directive(graphs: [WITH_CONNECTORS_V0_2_], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.2\\", import: [\\"@connect\\", \\"@source\\"]})
         @join__directive(graphs: [WITH_CONNECTORS_V0_1_], name: \\"source\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
@@ -643,7 +643,7 @@ type Resource
       "schema
         @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
         @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
-        @link(url: \\"https://specs.apollo.dev/connect/v0.4\\", for: EXECUTION)
+        @link(url: \\"https://specs.apollo.dev/connect/v0.3\\", for: EXECUTION)
         @join__directive(graphs: [WITH_CONNECTORS_V0_1_], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", import: [\\"@connect\\", \\"@source\\"]})
         @join__directive(graphs: [WITH_CONNECTORS_V0_3_], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.3\\", import: [\\"@connect\\", \\"@source\\"]})
         @join__directive(graphs: [WITH_CONNECTORS_V0_1_], name: \\"source\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
@@ -744,6 +744,81 @@ type Resource
     }
   });
 
+  it("uses v0.4 in supergraph @link when a subgraph explicitly links to v0.4", () => {
+    const subgraphs = [
+      {
+        name: "with-connectors-v0_4",
+        typeDefs: parse(`
+                    extend schema
+                    @link(
+                        url: "https://specs.apollo.dev/federation/v2.13"
+                        import: ["@key"]
+                    )
+                    @link(
+                        url: "https://specs.apollo.dev/connect/v0.4"
+                        import: ["@connect", "@source"]
+                    )
+                    @source(name: "v1", http: { baseURL: "http://v1" })
+
+                    type Query {
+                        resources: [Resource!]!
+                        @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    }
+
+                    type Resource @key(fields: "id") {
+                        id: ID!
+                        name: String!
+                    }
+                `),
+      },
+    ];
+
+    const result = composeServices(subgraphs);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toContain(
+      '@link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)'
+    );
+  });
+
+  it("uses v0.3 (not v0.4) in supergraph @link when subgraphs only use v0.3 and earlier", () => {
+    const subgraphs = [
+      {
+        name: "with-connectors-v0_3",
+        typeDefs: parse(`
+                    extend schema
+                    @link(
+                        url: "https://specs.apollo.dev/federation/v2.12"
+                        import: ["@key"]
+                    )
+                    @link(
+                        url: "https://specs.apollo.dev/connect/v0.3"
+                        import: ["@connect", "@source"]
+                    )
+                    @source(name: "v1", http: { baseURL: "http://v1" })
+
+                    type Query {
+                        resources: [Resource!]!
+                        @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    }
+
+                    type Resource @key(fields: "id") {
+                        id: ID!
+                        name: String!
+                    }
+                `),
+      },
+    ];
+
+    const result = composeServices(subgraphs);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toContain(
+      '@link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION)'
+    );
+    expect(printed).not.toContain('connect/v0.4');
+  });
+
   it("composes with renames", () => {
     const subgraphs = [
       {
@@ -784,7 +859,7 @@ type Resource
       "schema
         @link(url: \\"https://specs.apollo.dev/link/v1.0\\")
         @link(url: \\"https://specs.apollo.dev/join/v0.5\\", for: EXECUTION)
-        @link(url: \\"https://specs.apollo.dev/connect/v0.4\\", for: EXECUTION)
+        @link(url: \\"https://specs.apollo.dev/connect/v0.3\\", for: EXECUTION)
         @join__directive(graphs: [WITH_CONNECTORS], name: \\"link\\", args: {url: \\"https://specs.apollo.dev/connect/v0.1\\", as: \\"http\\", import: [{name: \\"@connect\\", as: \\"@http\\"}, {name: \\"@source\\", as: \\"@api\\"}]})
         @join__directive(graphs: [WITH_CONNECTORS], name: \\"api\\", args: {name: \\"v1\\", http: {baseURL: \\"http://v1\\"}})
       {

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -3522,7 +3522,7 @@ class Merger {
     // (The original feature version is still recorded in a @join__directive
     // so we're not losing any information.)
     const latestOrHighestLinkByIdentity = [...linksToPersist].reduce((map, link) => {
-      let latest = this.joinDirectiveFeatureDefinitionsByIdentity.get(link.identity)?.latest();
+      let latest = this.joinDirectiveFeatureDefinitionsByIdentity.get(link.identity)?.latestNonPreview();
 
       const existing = map.get(link.identity) ?? link;
       if (!latest || existing?.version.gt(latest.version)) {

--- a/internals-js/src/specs/connectSpec.ts
+++ b/internals-js/src/specs/connectSpec.ts
@@ -389,6 +389,7 @@ export const CONNECT_VERSIONS = new FeatureDefinitions<ConnectSpecDefinition>(
       new FeatureVersion(0, 4),
       new FeatureVersion(2, 13),
     ),
+    { preview: true },
   );
 
 registerKnownFeature(CONNECT_VERSIONS);

--- a/internals-js/src/specs/coreSpec.ts
+++ b/internals-js/src/specs/coreSpec.ts
@@ -578,6 +578,10 @@ export class CoreSpecDefinition extends FeatureDefinition {
   }
 }
 
+interface FeatureDefinitionAddOptions {
+  preview?: boolean;
+}
+
 export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition> {
   // The list of definition corresponding to the known version of the particular feature this object handles,
   // sorted by _decreased_ versions.
@@ -587,7 +591,7 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
   constructor(readonly identity: string) {
   }
 
-  add(definition: T, options?: { preview?: boolean }): FeatureDefinitions<T> {
+  add(definition: T, options?: FeatureDefinitionAddOptions): FeatureDefinitions<T> {
     if (definition.identity !== this.identity) {
       throw buildError(`Cannot add definition for ${definition} to the versions of definitions for ${this.identity}`);
     }

--- a/internals-js/src/specs/coreSpec.ts
+++ b/internals-js/src/specs/coreSpec.ts
@@ -578,6 +578,11 @@ export class CoreSpecDefinition extends FeatureDefinition {
   }
 }
 
+/**
+ * Options for {@link FeatureDefinitions.add}. Currently only used for the
+ * connect spec, where v0.4 is a preview version that should not be
+ * automatically selected by {@link FeatureDefinitions.latestNonPreview}.
+ */
 interface FeatureDefinitionAddOptions {
   preview?: boolean;
 }
@@ -607,13 +612,8 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
     return this;
   }
 
-  private isPreview(def: T): boolean {
-    return this._previewVersions.has(def.version.toString());
-  }
-
   /**
    * Returns the definition corresponding to the requested version if known.
-   * Finds both stable and preview versions.
    */
   find(requested: FeatureVersion): T | undefined {
     return this._definitions.find((def) => def.version.equals(requested));
@@ -625,16 +625,26 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
 
   latest(): T {
     assert(this._definitions.length > 0, 'Trying to get latest when no definitions exist');
-    return this._definitions.find(def => !this.isPreview(def)) ?? this._definitions[0];
+    return this._definitions[0];
+  }
+
+  /**
+   * Like {@link latest}, but skips versions marked as preview. Used by
+   * `addJoinDirectiveDirectives` in the composition merger to avoid
+   * stamping a preview spec version (e.g. connect/v0.4) into the
+   * supergraph `@link` when no subgraph explicitly uses it. Falls back
+   * to {@link latest} if all versions are preview.
+   */
+  latestNonPreview(): T {
+    assert(this._definitions.length > 0, 'Trying to get latest when no definitions exist');
+    return this._definitions.find(def => !this._previewVersions.has(def.version.toString())) ?? this._definitions[0];
   }
 
   getMinimumRequiredVersion(fedVersion: FeatureVersion): T {
     // this._definitions is already sorted with the most recent first
     // get the first definition that is compatible with the federation version
     // if the minimum version is not present, assume that we won't look for an older version
-    const def = this._definitions.find(def =>
-      !this.isPreview(def) && (def.minimumFederationVersion ? fedVersion.gte(def.minimumFederationVersion) : true)
-    );
+    const def = this._definitions.find(def => def.minimumFederationVersion ? fedVersion.gte(def.minimumFederationVersion) : true);
     assert(def, `No compatible definition exists for federation version ${fedVersion}`);
 
     // note that it's necessary that we can only get versions that have the same major version as the latest,
@@ -642,7 +652,7 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
     // the same major version as the latest.
     const latestMajor = this.latest().version.major;
     if (def.version.major !== latestMajor) {
-      return findLast(this._definitions, def => def.version.major === latestMajor && !this.isPreview(def)) ?? this.latest();
+      return findLast(this._definitions, def => def.version.major === latestMajor) ?? this.latest();
     }
     return def;
   }

--- a/internals-js/src/specs/coreSpec.ts
+++ b/internals-js/src/specs/coreSpec.ts
@@ -582,11 +582,12 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
   // The list of definition corresponding to the known version of the particular feature this object handles,
   // sorted by _decreased_ versions.
   private readonly _definitions: T[] = [];
+  private readonly _previewVersions = new Set<string>();
 
   constructor(readonly identity: string) {
   }
 
-  add(definition: T): FeatureDefinitions<T> {
+  add(definition: T, options?: { preview?: boolean }): FeatureDefinitions<T> {
     if (definition.identity !== this.identity) {
       throw buildError(`Cannot add definition for ${definition} to the versions of definitions for ${this.identity}`);
     }
@@ -594,13 +595,21 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
       return this;
     }
     this._definitions.push(definition);
-    // We sort by decreased versions sa it feels somewhat natural anyway to have more recent versions first.
+    // We sort by decreased versions as it feels somewhat natural anyway to have more recent versions first.
     this._definitions.sort((def1, def2) => -def1.version.compareTo(def2.version));
+    if (options?.preview) {
+      this._previewVersions.add(definition.version.toString());
+    }
     return this;
+  }
+
+  private isPreview(def: T): boolean {
+    return this._previewVersions.has(def.version.toString());
   }
 
   /**
    * Returns the definition corresponding to the requested version if known.
+   * Finds both stable and preview versions.
    */
   find(requested: FeatureVersion): T | undefined {
     return this._definitions.find((def) => def.version.equals(requested));
@@ -612,14 +621,16 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
 
   latest(): T {
     assert(this._definitions.length > 0, 'Trying to get latest when no definitions exist');
-    return this._definitions[0];
+    return this._definitions.find(def => !this.isPreview(def)) ?? this._definitions[0];
   }
 
   getMinimumRequiredVersion(fedVersion: FeatureVersion): T {
     // this._definitions is already sorted with the most recent first
     // get the first definition that is compatible with the federation version
     // if the minimum version is not present, assume that we won't look for an older version
-    const def = this._definitions.find(def => def.minimumFederationVersion ? fedVersion.gte(def.minimumFederationVersion) : true);
+    const def = this._definitions.find(def =>
+      !this.isPreview(def) && (def.minimumFederationVersion ? fedVersion.gte(def.minimumFederationVersion) : true)
+    );
     assert(def, `No compatible definition exists for federation version ${fedVersion}`);
 
     // note that it's necessary that we can only get versions that have the same major version as the latest,
@@ -627,7 +638,7 @@ export class FeatureDefinitions<T extends FeatureDefinition = FeatureDefinition>
     // the same major version as the latest.
     const latestMajor = this.latest().version.major;
     if (def.version.major !== latestMajor) {
-      return findLast(this._definitions, def => def.version.major === latestMajor) ?? this.latest();
+      return findLast(this._definitions, def => def.version.major === latestMajor && !this.isPreview(def)) ?? this.latest();
     }
     return def;
   }


### PR DESCRIPTION
## Summary

- Adds a `preview` option to `FeatureDefinitions.add()` so that `latest()` and `getMinimumRequiredVersion()` skip preview versions
- Marks connect/v0.4 as preview, mirroring the Rust router's `ConnectSpec::latest()` (v0.3) vs `::next()` (v0.4) distinction
- Subgraphs that explicitly `@link` to v0.4 still get v0.4 in the supergraph — only the automatic upgrade is suppressed

## Problem

Upgrading to Federation v2.13 unconditionally stamped `connect/v0.4` into the supergraph `@link`, even when subgraphs only used v0.1–v0.3. This caused Router v2.11 to refuse startup without the experimental `connectors.preview_connect_v0_4` flag, blocking customers from upgrading.

## Test plan

- [x] Updated existing connector composition tests (5 inline snapshots changed from v0.4 → v0.3)
- [x] Added test: "uses v0.4 in supergraph @link when a subgraph explicitly links to v0.4"
- [x] Added test: "uses v0.3 (not v0.4) in supergraph @link when subgraphs only use v0.3 and earlier"
- [x] Full composition-js test suite passes (400 tests)
- [x] Full internals-js test suite passes (265 tests)

Resolves: [RH-1321](https://apollographql.atlassian.net/browse/RH-1321)

[RH-1321]: https://apollographql.atlassian.net/browse/RH-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ