### PR TITLE
chore: Use node 24 and npm trusted publishing, and update cspell (backport of #3411 for 2.11)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@5.1.0
+  node: circleci/node@7.2.0
 
 jobs:
   # Unfortunately cimg/node doesn't tag its images with major only, you have to specify a minor version.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,11 @@ jobs:
           node-version: << parameters.node-version >>
       # node v14 defaults to npm 6, which is too old for our package-lock.json
       # should be able to remove this step when we drop node v14
-      - run: npm install -g npm@9
+      - when:
+          condition:
+            equal: [ "14", << parameters.node-version >> ]
+          steps:
+            - run: npm install -g npm@9
       - node/install-packages
       - run:
           name: Run tests
@@ -61,6 +65,9 @@ workflows:
                 - "16"
                 - "18"
                 - "20"
+                - "22"
+                - "24"
+                - "latest"
       - Lint:
           name: Lint - << matrix.script >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,24 @@ jobs:
           command: npm run coverage:upload
       - store_test_results:
           path: junit.xml
+  Lint:
+    description: "Run a lint command using a specific Node.js version"
+    parameters:
+      script:
+        type: string
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - node/install:
+          node-version: '24'
+      - node/install-packages
+      - run:
+          name: Compile
+          command: npm run compile
+      - run:
+          name: Run lint
+          command: npm run << parameters.script >>
 
 workflows:
   Build:
@@ -43,34 +61,13 @@ workflows:
                 - "16"
                 - "18"
                 - "20"
-      - node/run:
-          name: Check Error Code Doc
-          npm-run: error-code-doc:check
-          setup:
-            - node/install:
-                node-version: "20"
-      - node/run:
-          name: Check GraphQL Types
-          npm-run: codegen:check
-          setup:
-            - node/install:
-                node-version: "20"
-      - node/run:
-          name: Check Hints Code Doc
-          override-ci-command: npm ci && npm run compile
-          npm-run: hints-doc:check
-          setup:
-            - node/install:
-                node-version: "20"
-      - node/run:
-          name: Check Spelling
-          npm-run: spell:check
-          setup:
-            - node/install:
-                node-version: "20"
-      - node/run:
-          name: Check Prettier (tests)
-          npm-run: prettier:check
-          setup:
-            - node/install:
-                node-version: "20"
+      - Lint:
+          name: Lint - << matrix.script >>
+          matrix:
+            parameters:
+              script:
+                - "error-code-doc:check"
+                - "codegen:check"
+                - "hints-doc:check"
+                - "spell:check"
+                - "prettier:check"

--- a/.cspell/cspell-dict.txt
+++ b/.cspell/cspell-dict.txt
@@ -290,5 +290,3 @@ webp
 whith
 wizz
 woudl
-pfjj
-rvmh

--- a/.cspell/cspell.yml
+++ b/.cspell/cspell.yml
@@ -34,6 +34,10 @@ overrides:
   - filename: '**/CHANGELOG*.md'
     ignoreRegExpList:
       - "@[-\\w]+"
+  # Ignore GitHub GHSA IDs.
+  - filename: '**/*.md*'
+    ignoreRegExpList:
+      - "GHSA-[2-9cfghjmpqrvwx]{4}-[2-9cfghjmpqrvwx]{4}-[2-9cfghjmpqrvwx]{4}"
   # Ignore the targets of links and YouTube IDs in Markdown/MDX files.
   - filename: '**/*.md*'
     ignoreRegExpList:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16
-        uses: actions/setup-node@v3
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm i

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
-        run: npm i
+        run: npm ci
 
       - name: Set env
         run: echo "FEDERATION_VERSION=$(npm --prefix ./internals-js version --json |jq -r '.["@apollo/federation-internals"]')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - next
-      - version-*
+      - version-[0-9]+.[0-9]+
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -27,13 +27,22 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Determine npm tag override for version branches
+        id: npm-tag
+        run: |
+          if [[ ! -f .changeset/pre.json ]] && [[ "${{ github.ref_name }}" =~ ^version-.+$ ]]; then
+            echo "args=-- --tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "args=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           title: "release: on branch ${{ github.ref_name }}"
           createGithubReleases: true
-          publish: npm run build-and-publish
+          publish: npm run build-and-publish ${{ steps.npm-tag.outputs.args }}
           # workaround for https://github.com/changesets/action/issues/203, includes an `npm i` after running the version command
           version: npm run changeset-version
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Set env
-        run: echo "FEDERATION_VERSION=$(npm --prefix ./internals-js version --json |jq -r '.["@apollo/federation-internals"]')" >> $GITHUB_ENV
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: write  # Required for changesets to push release branch
+  pull-requests: write  # Required for changesets to create release PR
+
 jobs:
   release:
     name: Release
@@ -16,7 +21,7 @@ jobs:
     if: github.repository == 'apollographql/federation'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 24
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,15 @@ jobs:
           version: npm run changeset-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Sleep for 20 seconds (arbitrary, give NPM time to populate new `latest` versions)
         if: steps.changesets.outputs.published == 'true'
         run: sleep 20
         shell: bash
 
+      # While "npm publish" can use OIDC tokens, "npm dist-tag" sadly cannot, so we'll still need to
+      # regenerate a granular access token every 90 days via the npmjs.com UI and set the NPM_TOKEN
+      # secret in GitHub. The relevant npm GitHub issue is at https://github.com/npm/cli/issues/8547
       - name: Write token to the NPM rc file (login)
         if: steps.changesets.outputs.published == 'true'
         # write token to the NPM rc file (npm login)

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       },
       "engines": {
         "node": ">=14.15.0",
-        "npm": "<11"
+        "npm": "<12"
       }
     },
     "composition-js": {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "changeset-version": "changeset version && npm i",
     "build-and-publish": "npm run compile && changeset publish",
     "spell:check": "cspell lint --no-progress --config .cspell/cspell.yml  || (echo 'Add any real words to ./cspell/cspell-dict.txt.'; exit 1)",
-    "//": "This only needs to use prettier@2 for as long as jest disallows using prettier@3",
+    "__comment_for_prettier": "This only needs to use prettier@2 for as long as jest disallows using prettier@3",
     "prettier:check": "node ./node_modules/prettier-2/bin-prettier.js --check ./**/__tests__/**/*.test.ts",
     "prettier:fix": "node ./node_modules/prettier-2/bin-prettier.js --write ./**/__tests__/**/*.test.ts",
-    "//": "Optional: run this to configure git hooks and blame ignore revs",
+    "__comment_for_git:configure": "Optional: run this to configure git hooks and blame ignore revs",
     "git:configure": "git config core.hooksPath .git-hooks; git config blame.ignoreRevsFile .git-blame-ignore-revs"
   },
   "engines": {
@@ -106,7 +106,7 @@
     ]
   },
   "volta": {
-    "node": "20.10.0",
-    "npm": "10.2.4"
+    "node": "24.14.0",
+    "npm": "11.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "engines": {
     "node": ">=14.15.0",
-    "npm": "<11"
+    "npm": "<12"
   },
   "workspaces": [
     "internals-js",


### PR DESCRIPTION
This PR is a backport of #3411 for the `version-2.11` branch. Specifically, this PR:
- Adds an ignore rule to cspell for GHSA IDs.
- Backports the node orb version bump and lint CircleCI jobs from `main` (previously using `node/run`).
- Bumps `actions/checkout` to v4 and adds OIDC/changesets permissions in the release GitHub action.
- Bumps node to v24 for the repo (which is bundled with npm v11), updating the lint CircleCI jobs and release GitHub action as well.
  - This is because npm trusted publishing requires at least npm v11.5.1.
- Bumps the npm constraint in `engines` in `package.json` to `<12` (to allow running npm v11).
- Runs the test CircleCI jobs for node v22, v24, and latest.
  - The job was previously installing npm v9 because node v14's bundled npm version was too low to support the `package-lock.json`, but it was doing this for all node versions. We've now changed this to only happen for node v14.
- Stops passing `NPM_TOKEN` to `changesets/action` in the release GitHub action.
  - Note that npm versions that support trusted publishing will [ignore locally configured tokens when OIDC environment variables are present](https://github.com/npm/cli/blob/8afa3bd21461c0984caf1bcc2e486c4881bda516/lib/utils/oidc.js#L141) (which they are for GH actions, since we've set that up), so `NPM_TOKEN` would be ignored anyway. But the main reason for this change is to stop `changesets/action` from printing a misleading log message saying `NPM_TOKEN` has been placed into `.npmrc` (which, while true, will be ignored by `npm publish`).
  - Note that we still need to keep the `NPM_TOKEN` GitHub secret around to run any tag-changing scripts, as `npm dist-tag` sadly doesn't support OIDC yet (see https://github.com/npm/cli/issues/8547 for discussion). This means we'll need to manually rotate the token every 90 days.
- Uses `npm ci` instead of `npm i` in the release GitHub action.
  - As a requirement for releasing (or filing a release PR), the `package-lock.json` should be aligned with the `package.json`.
- Stops setting `FEDERATION_VERSION` in the release GitHub action since it's no longer used.
- Sets the tag for npm publishes to the branch name for `version-*` branches.
  - Previously, it was the default of `latest`, which was causing backport releases to mistakenly change the `latest` tag (used when someone `npm i`s without a version number).
  - We also tightened the `version-*` branch pattern down to `version-[0-9]+.[0-9]+` (since it's getting passed around in bash now).