### PR TITLE
fix: printHumanReadableList now correctly checks for max length

### DIFF
--- a/.changeset/gentle-schools-flow.md
+++ b/.changeset/gentle-schools-flow.md
@@ -1,0 +1,9 @@
+---
+"apollo-federation-integration-testsuite": patch
+"@apollo/composition": patch
+"@apollo/federation-internals": patch
+"@apollo/gateway": patch
+---
+
+Fixed print logic when calculating the max number of elements to include in the message. Previously we were not passing
+the current calculated length correctly leading to inclusion of additional elements in the error/hints message.

--- a/internals-js/src/__tests__/utils.test.ts
+++ b/internals-js/src/__tests__/utils.test.ts
@@ -13,7 +13,7 @@ it('subgraph names are truncated correctly', () => {
   expect(printedNames).toEqual(
     'subgraphs "some-graphql-service", "another-graphql-service", "third-graphql-service-name", ...',
   );
-})
+});
 
 describe('OrderedMap', () => {
   it('updating value works', () => {

--- a/internals-js/src/__tests__/utils.test.ts
+++ b/internals-js/src/__tests__/utils.test.ts
@@ -1,4 +1,19 @@
 import { OrderedMap } from '../utils';
+import { printSubgraphNames } from '../federation';
+
+it('subgraph names are truncated correctly', () => {
+  const printedNames = printSubgraphNames([
+    'some-graphql-service',
+    'another-graphql-service',
+    'third-graphql-service-name',
+    // total length 112 which is greater than 100 limit
+    'some-very-long-graphql-service-name',
+    'short-service-name',
+  ]);
+  expect(printedNames).toEqual(
+    'subgraphs "some-graphql-service", "another-graphql-service", "third-graphql-service-name", ...',
+  );
+})
 
 describe('OrderedMap', () => {
   it('updating value works', () => {

--- a/internals-js/src/utils.ts
+++ b/internals-js/src/utils.ts
@@ -375,15 +375,18 @@ export function printHumanReadableList(
 
   const { lastIdx } = names.reduce(
     ({ lastIdx, length }, name) => {
-      if (length + name.length > cutoff) {
+      const newLength = length + name.length;
+      if (newLength > cutoff) {
+        // there is no short-circuit logic in reduce
+        // if we already exceeded the cutoff length we need to pass the length that exceeded cutoff
         return {
           lastIdx,
-          length,
+          length: newLength,
         };
       }
       return {
         lastIdx: lastIdx + 1,
-        length: length + name.length,
+        length: newLength,
       };
     },
     { lastIdx: 0, length: 0}


### PR DESCRIPTION
Fixed reduce logic when calculating the max number of elements to include in the message. Since there is no short-circuit logic in reduce, we need to pass the length that exceeded the cutoff for subsequent evaluations (as otherwise check may fail on a subgraph with a very long name BUT succeed on a subsequent subgraph name that is shorter and as a result we would include too many items in the list).
