### PR TITLE
[DXM-483] Fix "Learn More" link for Connectors 0.3 prerequisite note

### DIFF
--- a/docs/source/schema-design/federated-schemas/reference/versions.mdx
+++ b/docs/source/schema-design/federated-schemas/reference/versions.mdx
@@ -46,7 +46,7 @@ Federation v2.13 is a prerequisite for the Connector specification version 0.4.
 | **November 2025** | **Yes** | **`2.8.0`** |
 
 Federation v2.12 is a prerequisite for the Connector specification version 0.3.
-[Learn more.](/graphos/connectors/reference/changelog)
+[Learn more.](/graphos/connectors/reference/changelog#connectors-03--federation-2120)
 
 #### Directive changes
 


### PR DESCRIPTION
## Summary

- The Federation v2.12 changelog entry states "Federation v2.12 is a prerequisite for the Connector specification version 0.3" with a "Learn more." link
- Previously the link pointed to the top of the connectors changelog page (`/graphos/connectors/reference/changelog`), which doesn't directly surface what changed in Connectors 0.3
- Updated the link to include the anchor `#connectors-03--federation-2120`, pointing users directly to the Connectors 0.3 section

## Why this change

A State Farm customer reported confusion: the "Learn more." link didn't explain what was actually in the Connectors v0.3 update. Adding the anchor makes the link land directly on the relevant changelog section, immediately answering the customer's question.

## Acceptance criteria

- [ ] "Learn more." link in the v2.12 section of `docs/source/schema-design/federated-schemas/reference/versions.mdx` points to `/graphos/connectors/reference/changelog#connectors-03--federation-2120`
- [ ] The v2.13 link (for Connectors 0.4) is unchanged

## Jira ticket

https://apollographql.atlassian.net/browse/DXM-483

🤖 Generated with [Claude Code](https://claude.com/claude-code)