### PR TITLE
fix(composition): Relax spec alias name validation slightly

### DIFF
--- a/composition-js/src/__tests__/compose.composeDirective.test.ts
+++ b/composition-js/src/__tests__/compose.composeDirective.test.ts
@@ -1105,6 +1105,34 @@ describe('composing custom core directives', () => {
     expect(printSchema(schema)).toMatchSnapshot();
   });
 
+  it('spec aliases with "-" and "." are renamed in supergraph schema', () => {
+    const subgraphA = generateSubgraph({
+      name: 'subgraphA',
+      linkText: '@link(url: "https://specs.apollo.dev/f-oo/v1.0", import: ["@foo"])',
+      composeText: '@composeDirective(name: "@foo")',
+      directiveText: 'directive @foo(name: String!) on FIELD_DEFINITION',
+      usage: '@foo(name: "a")',
+    });
+    const subgraphB = generateSubgraph({
+      name: 'subgraphB',
+      linkText: '@link(url: "https://specs.apollo.dev/b.ar/v1.0", import: ["@bar"])',
+      composeText: '@composeDirective(name: "@bar")',
+      directiveText: 'directive @bar(name: String!) on FIELD_DEFINITION',
+      usage: '@bar(name: "b")',
+    });
+
+    const result = composeServices([subgraphA, subgraphB]);
+    const schema = expectNoErrors(result);
+
+    expectDirectiveDefinition(schema, 'foo', [DirectiveLocation.FIELD_DEFINITION], ['name']);
+    expectDirectiveDefinition(schema, 'bar', [DirectiveLocation.FIELD_DEFINITION], ['name']);
+    expectDirectiveOnElement(schema, 'User.subgraphA', 'foo', { name: 'a' });
+    expectDirectiveOnElement(schema, 'User.subgraphB', 'bar', { name: 'b' });
+
+    expectCoreFeature(schema, 'https://specs.apollo.dev/f-oo', '1.0', [{ name: '@foo' }], '_0foo');
+    expectCoreFeature(schema, 'https://specs.apollo.dev/b.ar', '1.0', [{ name: '@bar' }], '_1bar');
+  })
+
   it('repeatable custom directives', () => {
     const subgraphA = {
       typeDefs: gql`

--- a/internals-js/src/definitions.ts
+++ b/internals-js/src/definitions.ts
@@ -1182,10 +1182,18 @@ export class CoreFeatures {
         `Cannot link feature "${identity}" as "${alias}" since it ends in "_". Please rename to a compliant name via "as".`,
       );
     }
-    // Don't allow spec name-in-schemas/aliases to not be valid GraphQL names,
-    // since they may be used as prefixes for namespaced schema element names,
-    // and those have to be valid GraphQL names.
-    if (!nameRegexp.test(alias)) {
+    // Ideally here, we wouldn't allow spec name-in-schemas/aliases to not be
+    // valid GraphQL names. However, enough supergraph schemas use "." and "-"
+    // after the first character that we can't impose that validation now. So
+    // instead, we match using a slightly relaxed regex than allows "." and "-"
+    // after the first character. For schemas that have "." or "-", they won't
+    // be able to use namespaced names for their spec schema elements due to
+    // GraphQL validation, but imports will still work.
+    //
+    // Note the error message below purposely says "not a valid GraphQL name"
+    // because we want to encourage users to actually use GraphQL names and
+    // avoid creating more exceptional cases.
+    if (!aliasRegexp.test(alias)) {
       throw ERRORS.INVALID_LINK_DIRECTIVE_USAGE.err(
         `Cannot link feature "${identity}" as "${alias}" since it is not a valid GraphQL name. Please rename to a compliant name via "as".`,
       );
@@ -1333,18 +1341,19 @@ export class CoreFeatures {
   }
 
   /**
-   * Returns whether the spec alias would pass the checks in `validate()`,
-   * except import conflicts are taken from the given map, which should be
-   * computed via `computeAliasConflicts()`.
+   * Returns whether the spec alias would pass the checks in `add()`, except
+   * import conflicts are taken from the given map, which should be computed via
+   * `computeAliasConflicts()`.
    */
   isAliasValid(
     alias: string,
     identity: string,
     importConflictsByIdentity: ImportConflictsByIdentity,
   ) {
-    // Don't allow aliases to have "__" in them. Note that this function is only
-    // used in merging, so we don't need the exception for "federation__tag" and
-    // "federation__inaccessible" here.
+    // Don't allow aliases to have "__" in them. Note that this method is only
+    // used in merging to detect whether we need to rename the spec, so we don't
+    // need the exception for "federation__tag" and "federation__inaccessible"
+    // here.
     if (alias.indexOf('__') !== -1) {
       return false;
     }
@@ -1352,7 +1361,12 @@ export class CoreFeatures {
     if (alias.charAt(alias.length - 1) === '_') {
       return false;
     }
-    // Don't allow aliases to not be valid GraphQL names.
+    // Don't allow aliases to not be valid GraphQL names. Note that unlike
+    // `add()`, we consider "." and "-" to not be valid here, but since this
+    // method is only used in merging to detect whether we need to rename the
+    // spec, this has the effect of ensuring that supergraph schemas don't use
+    // "." and "-" in their alias (which will help later if we want to fully
+    // forbid "." and "-" in aliases).
     if (!nameRegexp.test(alias)) {
       return false;
     }
@@ -1857,6 +1871,10 @@ export type StreamDirectiveArgs = {
   initialCount: number,
   if?: boolean,
 }
+
+// A valid alias. Almost a valid GraphQL name, but we need to allow "." and "-"
+// after the first character for supergraph schema backwards compatibility.
+const aliasRegexp = /^[_A-Za-z][_0-9A-Za-z.-]*$/;
 
 // A valid GraphQL name.
 const nameRegexp = /^[_A-Za-z][_0-9A-Za-z]*$/;

--- a/internals-js/src/specs/__tests__/coreSpec.test.ts
+++ b/internals-js/src/specs/__tests__/coreSpec.test.ts
@@ -313,6 +313,23 @@ describe('@link alias and import conflicts', () => {
     expectErrors(schema, []);
   });
 
+  // See the relevant code in CoreFeatures.add() for why we have this exception.
+  // That exception and this test may be removed in the future during a major
+  // version bump.
+  it('allows exception in GraphQL name validation for "." and "-', () => {
+    const schema = gql`
+      extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.0")
+        @link(url: "https://custom.dev/f-o.o/v1.0")
+
+      type Query {
+        q: Int
+      }
+    `;
+
+    expectErrors(schema, []);
+  });
+
   it('errors for spec alias that conflicts with past namespaced directive', () => {
     const schema = gql`
       extend schema


### PR DESCRIPTION
In #3430, we try to enforce that spec aliases/name-in-schemas are valid GraphQL names. Unfortunately, there's some supergraph schemas where the aliases have `"-"` and `"."`, and that validation can cause supergraph schema loading to fail for those supergraph schemas. So instead, this PR:
- Relaxes the validation to allow `-` and `.` after the first character (so almost a GraphQL name).
- Does not change the logic that checks whether a spec alias is valid in the supergraph schema (this means if someone is currently using spec aliases with `"-"` and `"."`, new composition will generate an alias that's a valid GraphQL name, so in the future we should eventually drive down the number of supergraph schemas with such spec aliases).

Note that `"-"` and `"."` in the spec alias means they can't use namespaced names for their spec elements (but in their cases, they were only using imports).