### PR TITLE
fix(composition): align `@connect/v0.2` spec with federation 2.11

### DIFF
--- a/.changeset/great-bears-study.md
+++ b/.changeset/great-bears-study.md
@@ -1,0 +1,10 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Align `@connect` spec with Rust implementation. As per the [docs](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/versions#v211)
+`@connect/v0.2` version should require Apollo Federation v2.11.
+
+There are no `@join` spec differences between Federation v2.10 and v2.11 so this change will not result in any supergraph
+changes. This change may result in additional/updated hint messages when `@connect/v0.1` spec is auto-upgraded to `v0.2`
+(which may result in auto-upgrading connector virtual subgraph to `v2.11`).

--- a/internals-js/src/specs/connectSpec.ts
+++ b/internals-js/src/specs/connectSpec.ts
@@ -375,7 +375,7 @@ export const CONNECT_VERSIONS = new FeatureDefinitions<ConnectSpecDefinition>(
   .add(
     new ConnectSpecDefinition(
       new FeatureVersion(0, 2),
-      new FeatureVersion(2, 10),
+      new FeatureVersion(2, 11),
     ),
   )
   .add(


### PR DESCRIPTION
As per the [docs](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/versions#v211) `@connect/v0.2` version should require Apollo Federation v2.11.

There are no `@join` spec differences between Federation v2.10 and v2.11 so this change will not result in any supergraph changes. This change may result in additional/updated hint messages when `@connect/v0.1` spec is auto-upgraded to `v0.2` (which may result in auto-upgrading connector virtual subgraph to `v2.11`).