### PR TITLE
chore: fix SHAREABLE_HAS_MISMATCHED_RUNTIME_TYPES hint message

### DIFF
--- a/composition-js/src/__tests__/validation_errors.test.ts
+++ b/composition-js/src/__tests__/validation_errors.test.ts
@@ -341,7 +341,7 @@ describe('when shared field has non-intersecting runtime types in different subg
       Shared field "Query.a" return type "A" has a non-intersecting set of possible runtime types across subgraphs. Runtime types in subgraphs are:
        - in subgraph "A", type "I1";
        - in subgraph "B", type "I2".
-      This is not allowed as shared fields must resolve the same way in all subgraphs, and that imply at least some common runtime types between the subgraphs.
+      This is not allowed as shared fields must resolve the same way in all subgraphs, and that implies at least some common runtime types between the subgraphs.
       `
     ]);
   });
@@ -407,7 +407,7 @@ describe('when shared field has non-intersecting runtime types in different subg
       Shared field "E.s" return type "U!" has a non-intersecting set of possible runtime types across subgraphs. Runtime types in subgraphs are:
        - in subgraph "A", types "A" and "B";
        - in subgraph "B", types "C" and "D".
-      This is not allowed as shared fields must resolve the same way in all subgraphs, and that imply at least some common runtime types between the subgraphs.
+      This is not allowed as shared fields must resolve the same way in all subgraphs, and that implies at least some common runtime types between the subgraphs.
       `
     ]);
   });

--- a/composition-js/src/validate.ts
+++ b/composition-js/src/validate.ts
@@ -114,7 +114,7 @@ function shareableFieldNonIntersectingRuntimeTypesError(
   const message = `For the following supergraph API query:\n${operation}`
     + `\nShared field "${field.coordinate}" return type "${field.type}" has a non-intersecting set of possible runtime types across subgraphs. Runtime types in subgraphs are:`
     + `\n${typeStrings.join(';\n')}.`
-    + `\nThis is not allowed as shared fields must resolve the same way in all subgraphs, and that imply at least some common runtime types between the subgraphs.`;
+    + `\nThis is not allowed as shared fields must resolve the same way in all subgraphs, and that implies at least some common runtime types between the subgraphs.`;
   const error = new ValidationError(message, invalidState.supergraphPath, invalidState.allSubgraphPathInfos().map((p) => p.path.path), witness);
   return ERRORS.SHAREABLE_HAS_MISMATCHED_RUNTIME_TYPES.err(error.message, {
     nodes: subgraphNodes(invalidState, (s) => (s.type(field.parent.name) as CompositeType | undefined)?.field(field.name)?.sourceAST),


### PR DESCRIPTION
Change from `imply` to `implies` in SHAREABLE_HAS_MISMATCHED_RUNTIME_TYPES hint message.

New message: `This is not allowed as shared fields must resolve the same way in all subgraphs, and that implies at least some common runtime types between the subgraphs.`
