### PR TITLE
fix(composition): preserve user-defined `_service` fields

### DIFF
--- a/.changeset/quiet-elephants-attack.md
+++ b/.changeset/quiet-elephants-attack.md
@@ -1,0 +1,7 @@
+---
+"@apollo/federation-internals": patch
+---
+
+Preserve user-defined `_service` fields
+
+`ignoreParsedField` was stripping any field named `_service` or `_entities` from all types during fed1 schema parsing, but should only strip them from the Query root type where they are federation built-in operations.

--- a/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
+++ b/composition-js/src/__tests__/composeFed1Subgraphs.test.ts
@@ -795,3 +795,32 @@ describe('override', () => {
     assertCompositionSuccess(result);
   });
 });
+
+describe('user-defined fields named like federation built-ins', () => {
+  it('preserves _service field on non-Query types', () => {
+    const subgraphA = {
+      typeDefs: gql`
+        type Query {
+          product: Product
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          _service: ProductService
+        }
+
+        type ProductService {
+          name: String
+        }
+      `,
+      name: 'subgraphA',
+    };
+
+    const result = composeServices([subgraphA]);
+    assertCompositionSuccess(result);
+
+    const [_, api] = schemas(result);
+    const printed = printSchema(api);
+    expect(printed).toContain('_service: ProductService');
+  });
+});

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -1567,6 +1567,9 @@ export class FederationBlueprint extends SchemaBlueprint {
     if (!FEDERATION_OPERATION_FIELDS.includes(fieldName)) {
       return false;
     }
+    if (!isObjectType(type) || !type.isQueryRootType()) {
+      return false;
+    }
     const metadata = federationMetadata(type.schema());
     return !!metadata && !metadata.isFed2Schema();
   }


### PR DESCRIPTION
`ignoreParsedField` was stripping any field named `_service` or `_entities` from all types during fed1 schema parsing, but should only strip them from the `Query` root type where they are federation built-in operations.