### PR TITLE
fix(composition): Suppress false INCONSISTENT_INTERFACE_VALUE_TYPE_FIELD

### DIFF
--- a/.changeset/shiny-planets-film.md
+++ b/.changeset/shiny-planets-film.md
@@ -1,0 +1,7 @@
+---
+"@apollo/composition": patch
+---
+
+Suppress false INCONSISTENT_INTERFACE_VALUE_TYPE_FIELD hints for `@interfaceObject`
+
+Skip the inconsistent value type field hint when a source is an `@interfaceObject` (which only contributes specific fields) or when the field is provided by an `@interfaceObject` in another subgraph (since non-`@interfaceObject` subgraphs are not expected to define those fields).

--- a/composition-js/src/__tests__/hints.test.ts
+++ b/composition-js/src/__tests__/hints.test.ts
@@ -399,6 +399,36 @@ test('*No* hint on field of interface _with @key_ not being in all subgraphs', (
   expect(result).toNotRaiseHints();
 })
 
+test('no hint for interface value type field missing from @interfaceObject subgraph', () => {
+  const subgraph1 = gql`
+    type Query {
+      a: Int
+    }
+
+    interface Product {
+      id: ID!
+      name: String
+      price: Int
+    }
+
+    type Book implements Product @key(fields: "id") {
+      id: ID!
+      name: String
+      price: Int
+    }
+  `;
+
+  const subgraph2 = gql`
+    type Product @interfaceObject @key(fields: "id") {
+      id: ID!
+      reviews: [String!]!
+    }
+  `;
+
+  const result = mergeDocuments(subgraph1, subgraph2);
+  expect(result).toNotRaiseHints();
+})
+
 test('hints on field of input object value type not being in all subgraphs', () => {
   const subgraph1 = gql`
     type Query {

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -1351,8 +1351,14 @@ class Merger {
         break;
     }
     for (const [index, source] of sources.entries()) {
-      // As soon as we find a subgraph that has the type but not the field, we hint.
-      if (source && !source.field(field.name) && !this.areAllFieldsExternal(index, source)) {
+      // @interfaceObject types only contribute specific fields and are not expected to have all interface fields.
+      if (source && isObjectType(source) && this.metadata(index).isInterfaceObjectType(source)) {
+        continue;
+      }
+      // As soon as we find a subgraph that has the type but not the field, we hint,
+      // unless the field is provided by an @interfaceObject in another subgraph.
+      if (source && !source.field(field.name) && !this.areAllFieldsExternal(index, source)
+        && !(isInterfaceType(dest) && this.isFieldProvidedByAnInterfaceObject(field.name, dest.name))) {
         this.mismatchReporter.reportMismatchHint({
           code: hintId,
           message: `Field "${field.coordinate}" of ${typeDescription} type "${dest}" is defined in some but not all subgraphs that define "${dest}": `,


### PR DESCRIPTION
Skip the inconsistent value type field hint when a source is an `@interfaceObject` (which only contributes specific fields) or when the field is provided by an `@interfaceObject` in another subgraph (since non-`@interfaceObject` subgraphs are not expected to define those fields).
