### PR TITLE
feat: support variable arguments in @requires field sets

### DIFF
--- a/.changeset/requires-field-argument-variables.md
+++ b/.changeset/requires-field-argument-variables.md
@@ -1,0 +1,31 @@
+---
+"@apollo/federation-internals": minor
+"@apollo/composition": minor
+"@apollo/query-planner": minor
+"@apollo/gateway": minor
+---
+
+Support binding a required field's argument to a variable in a `@requires` field set.
+
+A `@requires` field set may now reference one of the annotated field's own arguments as a variable. At query
+planning time, the value the operation supplies for that argument is threaded through to the subgraph that owns the
+required field:
+
+```graphql
+type T @key(fields: "id") {
+  id: ID!
+  x(arg: Int): Int @external
+  # `$arg` names the `arg` argument of `y` (the field carrying @requires).
+  y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+}
+```
+
+- A client-supplied operation variable is **forwarded** into the subgraph fetch (`x(arg: $var)`).
+- A literal is **inlined** (`x(arg: 7)`).
+- An omitted nullable argument resolves to `null`, and an omitted argument with a schema default resolves to that
+  default.
+- Variables may appear nested inside list/object argument values, and a field set may bind multiple arguments.
+
+Composition rejects a variable that does not name an argument of the annotated field, a bound argument whose type
+is incompatible with the position where the variable is used, and any variable used in a `@provides` field set
+(all with `REQUIRES_INVALID_FIELDS`/`PROVIDES_INVALID_FIELDS`).

--- a/.cspell/cspell-dict.txt
+++ b/.cspell/cspell-dict.txt
@@ -109,6 +109,7 @@ inacessible
 incopatibilities
 ineffectient
 initalize
+inlines
 inputed
 insteances
 instrospection
@@ -280,6 +281,7 @@ unreacheable
 Unssupported
 Unsubscriber
 unuseful
+unvalidated
 updatets
 upgader
 Upgrader

--- a/composition-js/src/merging/merge.ts
+++ b/composition-js/src/merging/merge.ts
@@ -57,6 +57,9 @@ import {
   baseType,
   isEnumType,
   isNonNullType,
+  isListType,
+  isVariable,
+  fieldArgumentNames,
   isExecutableDirectiveLocation,
   parseFieldSetArgument,
   isCompositeType,
@@ -3772,11 +3775,23 @@ class Merger {
         assert(mergedType && isCompositeType(mergedType), () => `Merged type ${originalField.parent.name} should exist should have field ${originalField.name}`)
         assert(isCompositeType(mergedType), `${mergedType} should be a composite type but got ${mergedType.kind}`);
         try {
-          parseFieldSetArgument({
+          const parsedFieldSet = parseFieldSetArgument({
             parentType: mergedType,
             directive: requiresApplication,
             decorateValidationErrors: false,
+            // Tolerate variables binding to the field's arguments; their types are checked just below.
+            allowedFieldArgumentVariables: fieldArgumentNames(originalField),
           });
+          const variableTypeErrors: string[] = [];
+          collectRequiresVariableTypeErrors(parsedFieldSet, originalField, variableTypeErrors);
+          for (const message of variableTypeErrors) {
+            const nodes = requiresApplication.sourceAST ? [addSubgraphToASTNode(requiresApplication.sourceAST, subgraph.name)] : [];
+            const error = ERRORS.REQUIRES_INVALID_FIELDS.err(
+              `On field "${originalField.coordinate}", for ${requiresApplication}: ${message}`,
+              { nodes },
+            );
+            this.errors.push(addSubgraphToError(error, subgraph.name));
+          }
         } catch (e) {
           if (!(e instanceof GraphQLError)) {
             throw e;
@@ -4396,4 +4411,55 @@ class AuthRequirementsOnElement {
     result += ' }';
     return result;
   }
+}
+
+// For each variable in the field set bound to an argument of `annotatedField`, checks the bound argument's type is
+// compatible with the type expected at its usage, collecting any mismatch message into `errors`.
+function collectRequiresVariableTypeErrors(
+  selectionSet: SelectionSet,
+  annotatedField: FieldDefinition<CompositeType>,
+  errors: string[],
+): void {
+  for (const selection of selectionSet.selections()) {
+    if (selection.kind === 'FieldSelection') {
+      const field = selection.element;
+      if (field.args) {
+        for (const [argName, value] of Object.entries(field.args)) {
+          if (!isVariable(value)) {
+            continue;
+          }
+          const boundArgument = annotatedField.argument(value.name);
+          // Unbound variables are reported during subgraph validation; here we only type-check bound ones.
+          if (!boundArgument) {
+            continue;
+          }
+          const locationType = field.definition.argument(argName)?.type;
+          const boundType = boundArgument.type;
+          if (boundType && locationType && !argumentTypesCompatible(boundType, locationType)) {
+            errors.push(
+              `variable "$${value.name}" cannot be used for argument "${argName}" of field "${field.name}": `
+              + `it is bound to argument "${value.name}" of type "${boundType}", which is not compatible with the expected type "${locationType}"`
+            );
+          }
+        }
+      }
+      if (selection.selectionSet) {
+        collectRequiresVariableTypeErrors(selection.selectionSet, annotatedField, errors);
+      }
+    } else if (selection.kind === 'FragmentSelection') {
+      collectRequiresVariableTypeErrors(selection.selectionSet, annotatedField, errors);
+    }
+  }
+}
+
+// Nullability-blind input-type compatibility: equal inner named type and list nesting after stripping non-null
+// wrappers (a list and a non-list never match). Nullability is ignored on purpose — the nullable-into-non-null case
+// is handled by runtime coercion (omitted/null), not a composition error.
+function argumentTypesCompatible(variableType: Type, locationType: Type): boolean {
+  const v = isNonNullType(variableType) ? variableType.ofType : variableType;
+  const l = isNonNullType(locationType) ? locationType.ofType : locationType;
+  if (isListType(l) || isListType(v)) {
+    return isListType(l) && isListType(v) && argumentTypesCompatible(v.ofType, l.ofType);
+  }
+  return baseType(v).name === baseType(l).name;
 }

--- a/docs/source/schema-design/federated-schemas/entities/contribute-fields.mdx
+++ b/docs/source/schema-design/federated-schemas/entities/contribute-fields.mdx
@@ -123,9 +123,38 @@ type Product @key(fields: "id") {
 The following rules apply:
 
 - The router provides the specified values in its query to whichever subgraph defines the required field.
-- Each specified argument value is static; the router always provides the same value.
+- Each specified argument value is either a static literal (as shown in the preceding section) or a [variable that forwards the computed field's own argument](#forwarding-an-argument-value-with-a-variable).
 - You can omit values for nullable arguments. You must provide values for non-nullable arguments.
 - If you define your subgraph schema in an SDL file instead of programmatically, you must escape quotes for string and enum values with backslashes (as shown above).
+
+#### Forwarding an argument value with a variable
+
+<MinVersionBadge version="Federation v2.15.0" />
+
+Instead of a static literal, use a variable that references one of the computed field's own arguments. Router forwards the value your client supplies for that argument to the subgraph that defines the required field:
+
+```graphql title="Shipping subgraph"
+type Product @key(fields: "id") {
+  id: ID!
+  weight(units: String): Int @external
+  #highlight-start
+  shippingEstimate(units: String): String @requires(fields: "weight(units: $units)")
+  #highlight-end
+}
+```
+
+Here `$units` names the `units` argument of `shippingEstimate` (the field carrying `@requires`). For a query like `shippingEstimate(units: "KILOGRAMS")`, the router fetches `weight(units: "KILOGRAMS")` from the subgraph that owns `weight`.
+
+The value forwarded follows standard GraphQL argument coercion:
+
+- Operation variable (`shippingEstimate(units: $clientUnits)`): The variable is forwarded into the subgraph fetch and resolved at execution time.
+- Literal (`shippingEstimate(units: "POUNDS")`): The literal is forwarded as-is.
+- Omitted, nullable argument: Resolves to `null`.
+- Omitted argument with a schema default: Resolves to that default.
+
+A variable can also appear nested inside a list or object argument value (for example, `weight(unitsList: [$units])`), and a single `@requires` field set can forward multiple arguments.
+
+The variable's name must match an argument of the computed field, and that argument's type must be compatible with the type expected where the variable is used. Otherwise, composition fails with a `REQUIRES_INVALID_FIELDS` error. `@requires` field sets support variables, but `@provides` and `@key` do not.
 
 ## Referencing an entity without contributing fields
 

--- a/gateway-js/src/__tests__/integration/requiresFieldArguments.test.ts
+++ b/gateway-js/src/__tests__/integration/requiresFieldArguments.test.ts
@@ -1,0 +1,114 @@
+import gql from 'graphql-tag';
+import { execute } from '../execution-utils';
+import {
+  astSerializer,
+  queryPlanSerializer,
+} from 'apollo-federation-integration-testsuite';
+
+expect.addSnapshotSerializer(astSerializer);
+expect.addSnapshotSerializer(queryPlanSerializer);
+
+// Records the `arg` value the owning subgraph (B) receives for `x`, so we can assert the value supplied for the
+// `@requires` field argument actually reaches the subgraph that owns the required field.
+let receivedArg: number | null | undefined;
+
+const serviceA = {
+  name: 'a',
+  typeDefs: gql`
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.7"
+        import: ["@key", "@external", "@requires"]
+      )
+
+    type Query {
+      t: T
+    }
+
+    type T @key(fields: "id") {
+      id: ID!
+      x(arg: Int): Int @external
+      y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+    }
+  `,
+  resolvers: {
+    Query: {
+      t() {
+        return { id: '1' };
+      },
+    },
+    T: {
+      // `x` is provided as part of the entity representation fetched from subgraph B (the `@requires`).
+      y(t: any) {
+        return t.x;
+      },
+    },
+  },
+};
+
+const serviceB = {
+  name: 'b',
+  typeDefs: gql`
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"])
+
+    type T @key(fields: "id") {
+      id: ID!
+      x(arg: Int): Int
+    }
+  `,
+  resolvers: {
+    T: {
+      __resolveReference(reference: any) {
+        return reference;
+      },
+      x(_t: any, args: { arg: number | null }) {
+        receivedArg = args.arg;
+        return args.arg;
+      },
+    },
+  },
+};
+
+beforeEach(() => {
+  receivedArg = undefined;
+});
+
+it('forwards a client-supplied variable to the subgraph that owns the required field', async () => {
+  const { data, errors } = await execute(
+    {
+      query: `#graphql
+        query($v: Int) {
+          t {
+            y(arg: $v)
+          }
+        }
+      `,
+      variables: { v: 7 },
+    },
+    [serviceA, serviceB],
+  );
+
+  expect(errors).toBeUndefined();
+  expect(receivedArg).toBe(7);
+  expect(data).toEqual({ t: { y: 7 } });
+});
+
+it('inlines a literal argument for the subgraph that owns the required field', async () => {
+  const { data, errors } = await execute(
+    {
+      query: `#graphql
+        {
+          t {
+            y(arg: 7)
+          }
+        }
+      `,
+    },
+    [serviceA, serviceB],
+  );
+
+  expect(errors).toBeUndefined();
+  expect(receivedArg).toBe(7);
+  expect(data).toEqual({ t: { y: 7 } });
+});

--- a/internals-js/src/__tests__/substituteFieldArgumentVariables.test.ts
+++ b/internals-js/src/__tests__/substituteFieldArgumentVariables.test.ts
@@ -1,0 +1,85 @@
+import { CompositeType, Variable } from '../definitions';
+import { buildSchema } from '../buildSchema';
+import { parseSelectionSet } from '../operations';
+
+const schema = buildSchema(`
+  type Query {
+    t: T
+  }
+
+  type T {
+    scalar: Int
+    x(arg: Int): Int
+    xl(args: [Int]): Int
+    obj: T
+  }
+`);
+
+const tType = schema.type('T') as CompositeType;
+
+// Parses a field set on `T`, tolerating the given field-argument variable names, then substitutes them and returns
+// the resulting selection set as a normalized (whitespace-collapsed) string.
+function substitute(fieldSet: string, substitutions: Map<string, any>): string {
+  const selectionSet = parseSelectionSet({
+    parentType: tType,
+    source: fieldSet,
+    allowedFieldArgumentVariables: new Set(['arg', 'a', 'b']),
+  });
+  return selectionSet
+    .substituteFieldArgumentVariables(substitutions)
+    .toString()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+describe('SelectionSet.substituteFieldArgumentVariables', () => {
+  test('forwards an operation variable (substituting one variable for another)', () => {
+    expect(
+      substitute('x(arg: $arg)', new Map([['arg', new Variable('v')]])),
+    ).toContain('x(arg: $v)');
+  });
+
+  test('inlines a literal value', () => {
+    expect(
+      substitute('x(arg: $arg)', new Map<string, any>([['arg', 7]])),
+    ).toContain('x(arg: 7)');
+  });
+
+  test('substitutes null', () => {
+    expect(
+      substitute('x(arg: $arg)', new Map<string, any>([['arg', null]])),
+    ).toContain('x(arg: null)');
+  });
+
+  test('substitutes a variable nested inside a list value', () => {
+    expect(
+      substitute('xl(args: [$arg])', new Map<string, any>([['arg', 5]])),
+    ).toContain('xl(args: [5])');
+  });
+
+  test('leaves a variable that is not in the substitution map unchanged (forwarded)', () => {
+    expect(
+      substitute('x(arg: $arg)', new Map<string, any>([['other', 7]])),
+    ).toContain('x(arg: $arg)');
+  });
+
+  test('recurses into nested selections', () => {
+    const result = substitute(
+      'obj { x(arg: $arg) }',
+      new Map<string, any>([['arg', 3]]),
+    );
+    expect(result).toContain('x(arg: 3)');
+  });
+
+  test('substitutes multiple variables independently', () => {
+    const result = substitute(
+      'x(arg: $a) xl(args: [$b])',
+      new Map<string, any>([
+        ['a', new Variable('v1')],
+        ['b', 9],
+      ]),
+    );
+    expect(result).toContain('x(arg: $v1)');
+    expect(result).toContain('xl(args: [9])');
+  });
+});

--- a/internals-js/src/federation.ts
+++ b/internals-js/src/federation.ts
@@ -59,7 +59,7 @@ import {
 } from "graphql";
 import { KnownTypeNamesInFederationRule } from "./validation/KnownTypeNamesInFederationRule";
 import { buildSchema, buildSchemaFromAST } from "./buildSchema";
-import { FragmentSelection, hasSelectionWithPredicate, parseOperationAST, parseSelectionSet, Selection, SelectionSet } from './operations';
+import { fieldArgumentNames, FragmentSelection, hasSelectionWithPredicate, parseOperationAST, parseSelectionSet, Selection, SelectionSet } from './operations';
 import { TAG_VERSIONS } from "./specs/tagSpec";
 import {
   errorCodeDef,
@@ -254,6 +254,7 @@ function validateFieldSet({
   errorCollector,
   allowOnNonExternalLeafFields,
   allowFieldsWithArguments,
+  allowedFieldArgumentVariables,
   onFields,
 }: {
   type: CompositeType,
@@ -262,6 +263,7 @@ function validateFieldSet({
   errorCollector: GraphQLError[],
   allowOnNonExternalLeafFields: boolean,
   allowFieldsWithArguments: boolean,
+  allowedFieldArgumentVariables?: Set<string>,
   onFields?: (field: FieldDefinition<any>) => void,
 }): void {
   try {
@@ -280,7 +282,25 @@ function validateFieldSet({
         return field;
       }
       : undefined;
-    const selectionSet = parseFieldSetArgument({parentType: type, directive, fieldAccessor});
+    // A `@requires` variable must reference one of the annotated field's arguments. We check it explicitly (parsing
+    // unvalidated, which still enforces field existence) to give a precise message rather than a generic one.
+    if (allowedFieldArgumentVariables) {
+      const symbolic = parseFieldSetArgument({parentType: type, directive, validate: false, allowedFieldArgumentVariables});
+      let hasUnboundVariable = false;
+      for (const variable of symbolic.usedVariables()) {
+        if (!allowedFieldArgumentVariables.has(variable.name)) {
+          hasUnboundVariable = true;
+          errorCollector.push(handleFieldSetValidationError(
+            directive,
+            new GraphQLError(`variable "$${variable.name}" is not defined; a variable in a @requires field set must reference an argument of "${directive.parent?.coordinate}"`),
+          ));
+        }
+      }
+      if (hasUnboundVariable) {
+        return;
+      }
+    }
+    const selectionSet = parseFieldSetArgument({parentType: type, directive, fieldAccessor, allowedFieldArgumentVariables});
     validateFieldSetSelections({
       directiveName: directive.name,
       selectionSet,
@@ -732,6 +752,7 @@ function validateAllFieldSet<TParent extends SchemaElement<any, any>>({
   isOnParentType = false,
   allowOnNonExternalLeafFields = false,
   allowFieldsWithArguments = false,
+  allowFieldArgumentVariables = false,
   allowOnInterface = false,
   onFields,
 }: {
@@ -742,6 +763,8 @@ function validateAllFieldSet<TParent extends SchemaElement<any, any>>({
   isOnParentType?: boolean,
   allowOnNonExternalLeafFields?: boolean,
   allowFieldsWithArguments?: boolean,
+  // When true (only `@requires`), variables naming the field's arguments are accepted and kept symbolic.
+  allowFieldArgumentVariables?: boolean,
   allowOnInterface?: boolean,
   onFields?: (field: FieldDefinition<any>) => void,
 }): void {
@@ -758,6 +781,9 @@ function validateAllFieldSet<TParent extends SchemaElement<any, any>>({
         { nodes: sourceASTs(application).concat(isOnParentType ? [] : sourceASTs(type)) },
       ));
     }
+    const allowedFieldArgumentVariables = allowFieldArgumentVariables && elt instanceof FieldDefinition
+      ? fieldArgumentNames(elt)
+      : undefined;
     validateFieldSet({
       type,
       directive: application,
@@ -765,6 +791,7 @@ function validateAllFieldSet<TParent extends SchemaElement<any, any>>({
       errorCollector,
       allowOnNonExternalLeafFields,
       allowFieldsWithArguments,
+      allowedFieldArgumentVariables,
       onFields,
     });
   }
@@ -1663,6 +1690,7 @@ export class FederationBlueprint extends SchemaBlueprint {
       errorCollector,
       metadata,
       allowFieldsWithArguments: true,
+      allowFieldArgumentVariables: true,
     });
     // Note that like for @requires above, we error out if a leaf field of the selection is not
     // external in a @provides (we pass `false` for the `allowOnNonExternalLeafFields` parameter),
@@ -2259,6 +2287,7 @@ export function parseFieldSetArgument({
   validate,
   decorateValidationErrors = true,
   normalize = false,
+  allowedFieldArgumentVariables,
 }: {
   parentType: CompositeType,
   directive: Directive<SchemaElement<any, any>, {fields: any}>,
@@ -2266,6 +2295,8 @@ export function parseFieldSetArgument({
   validate?: boolean,
   decorateValidationErrors?: boolean,
   normalize?: boolean,
+  // Variable names allowed in the field set; for `@requires` only (see `fieldArgumentNames`), undefined elsewhere.
+  allowedFieldArgumentVariables?: Set<string>,
 }): SelectionSet {
   try {
     const selectionSet = parseSelectionSet({
@@ -2273,6 +2304,7 @@ export function parseFieldSetArgument({
       source: validateFieldSetValue(directive),
       fieldAccessor,
       validate,
+      allowedFieldArgumentVariables,
     });
     if (validate ?? true) {
       selectionSet.forEachElement((elt) => {

--- a/internals-js/src/operations.ts
+++ b/internals-js/src/operations.ts
@@ -38,6 +38,7 @@ import {
   isAbstractType,
   DeferDirectiveArgs,
   Variable,
+  isVariable,
   possibleRuntimeTypes,
   Type,
   sameDirectiveApplication,
@@ -290,10 +291,10 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
     return true;
   }
 
-  validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean) {
+  validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean, allowedFieldArgumentVariables?: Set<string>) {
     validate(this.name === this.definition.name, () => `Field name "${this.name}" cannot select field "${this.definition.coordinate}: name mismatch"`);
-    
-    
+
+
     // We need to make sure the field has valid values for every non-optional argument.
     for (const argDef of this.definition.arguments()) {
       const appliedValue = this.argumentValue(argDef.name);
@@ -311,7 +312,7 @@ export class Field<TArgs extends {[key: string]: any} = {[key: string]: any}> ex
           () => `Missing mandatory value for argument "${argDef.name}" of field "${this.definition.coordinate}" in selection "${this}"`);
       } else {
         validate(
-          (isContextualArg && !validateContextualArgs) || isValidValue(appliedValue, argDef, variableDefinitions),
+          (isContextualArg && !validateContextualArgs) || isValidValue(appliedValue, argDef, variableDefinitions, allowedFieldArgumentVariables),
           () => `Invalid value ${valueToString(appliedValue)} for argument "${argDef.coordinate}" of type ${argDef.type}`)
       }
     }
@@ -1750,6 +1751,37 @@ export class SelectionSet {
     }
   }
 
+  /**
+   * Returns a copy of this selection set with every field-argument variable named in `substitutions` replaced by its
+   * value. A variable not in the map is left as-is, which is how an operation variable is *forwarded* into a subgraph
+   * fetch. Used to bind a `@requires` field set's symbolic variables to a field's arguments at planning time.
+   */
+  substituteFieldArgumentVariables(substitutions: Map<string, any>): SelectionSet {
+    return this.lazyMap((selection) => {
+      if (selection.kind === 'FieldSelection') {
+        const field = selection.element;
+        const updatedSelectionSet = selection.selectionSet?.substituteFieldArgumentVariables(substitutions);
+        let updatedField = field;
+        if (field.args) {
+          let argsChanged = false;
+          const newArgs: {[key: string]: any} = {};
+          for (const [name, value] of Object.entries(field.args)) {
+            const newValue = substituteVariablesInValue(value, substitutions);
+            newArgs[name] = newValue;
+            argsChanged = argsChanged || newValue !== value;
+          }
+          if (argsChanged) {
+            updatedField = field.withUpdatedArguments(newArgs);
+          }
+        }
+        return selection.withUpdatedComponents(updatedField, updatedSelectionSet);
+      }
+      // Inline fragments have no arguments of their own, so we only recurse.
+      const updatedSelectionSet = selection.selectionSet.substituteFieldArgumentVariables(substitutions);
+      return selection.withUpdatedSelectionSet(updatedSelectionSet);
+    });
+  }
+
   collectUsedFragmentNames(collector: Map<string, number>) {
     for (const selection of this.selections()) {
       selection.collectUsedFragmentNames(collector);
@@ -2078,10 +2110,10 @@ export class SelectionSet {
     return this.selections().every((selection) => selection.canAddTo(parentTypeToTest));
   }
 
-  validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean = false) {
+  validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean = false, allowedFieldArgumentVariables?: Set<string>) {
     validate(!this.isEmpty(), () => `Invalid empty selection set`);
     for (const selection of this.selections()) {
-      selection.validate(variableDefinitions, validateContextualArgs);
+      selection.validate(variableDefinitions, validateContextualArgs, allowedFieldArgumentVariables);
     }
   }
 
@@ -2600,7 +2632,7 @@ abstract class AbstractSelection<TElement extends OperationElement, TIsLeaf exte
 
   abstract toSelectionNode(): SelectionNode;
 
-  abstract validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean): void;
+  abstract validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean, allowedFieldArgumentVariables?: Set<string>): void;
 
   abstract rebaseOn(args: { parentType: CompositeType, fragments: NamedFragments | undefined, errorIfCannotRebase: boolean}): TOwnType | undefined;
 
@@ -3128,8 +3160,8 @@ export class FieldSelection extends AbstractSelection<Field<any>, undefined, Fie
     return predicate(thisWithFilteredSelectionSet) ? thisWithFilteredSelectionSet : undefined;
   }
 
-  validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean) {
-    this.element.validate(variableDefinitions, validateContextualArgs);
+  validate(variableDefinitions: VariableDefinitions, validateContextualArgs: boolean, allowedFieldArgumentVariables?: Set<string>) {
+    this.element.validate(variableDefinitions, validateContextualArgs, allowedFieldArgumentVariables);
     // Note that validation is kind of redundant since `this.selectionSet.validate()` will check that it isn't empty. But doing it
     // allow to provide much better error messages.
     validate(
@@ -3137,7 +3169,7 @@ export class FieldSelection extends AbstractSelection<Field<any>, undefined, Fie
       () => `Invalid empty selection set for field "${this.element.definition.coordinate}" of non-leaf type ${this.element.definition.type}`,
       this.element.definition.sourceAST
     );
-    this.selectionSet?.validate(variableDefinitions);
+    this.selectionSet?.validate(variableDefinitions, false, allowedFieldArgumentVariables);
   }
 
   /**
@@ -3383,7 +3415,7 @@ class InlineFragmentSelection extends FragmentSelection {
     return new InlineFragmentSelection(fragment, selectionSet);
   }
 
-  validate(variableDefinitions: VariableDefinitions) {
+  validate(variableDefinitions: VariableDefinitions, _validateContextualArgs?: boolean, allowedFieldArgumentVariables?: Set<string>) {
     this.validateDeferAndStream();
     // Note that validation is kind of redundant since `this.selectionSet.validate()` will check that it isn't empty. But doing it
     // allow to provide much better error messages.
@@ -3391,7 +3423,7 @@ class InlineFragmentSelection extends FragmentSelection {
       !this.selectionSet.isEmpty(),
       () => `Invalid empty selection set for fragment "${this.element}"`
     );
-    this.selectionSet.validate(variableDefinitions);
+    this.selectionSet.validate(variableDefinitions, false, allowedFieldArgumentVariables);
   }
 
   rebaseOn({
@@ -4030,6 +4062,7 @@ export function parseSelectionSet({
   fragments,
   fieldAccessor,
   validate = true,
+  allowedFieldArgumentVariables,
 }: {
   parentType: CompositeType,
   source: string | SelectionSetNode,
@@ -4037,6 +4070,8 @@ export function parseSelectionSet({
   fragments?: NamedFragments,
   fieldAccessor?: (type: CompositeType, fieldName: string) => (FieldDefinition<any> | undefined),
   validate?: boolean,
+  // Variable names accepted during validation without a definition (kept symbolic); see `fieldArgumentNames`.
+  allowedFieldArgumentVariables?: Set<string>,
 }): SelectionSet {
   // TODO: we should maybe allow the selection, when a string, to contain fragment definitions?
   const node = typeof source === 'string'
@@ -4044,8 +4079,31 @@ export function parseSelectionSet({
     : source;
   const selectionSet = selectionSetOfNode(parentType, node, variableDefinitions ?? new VariableDefinitions(), fragments, fieldAccessor);
   if (validate)
-    selectionSet.validate(variableDefinitions);
+    selectionSet.validate(variableDefinitions, false, allowedFieldArgumentVariables);
   return selectionSet;
+}
+
+// Replaces every `Variable` named in `substitutions` within an argument value, recursing into lists and objects.
+function substituteVariablesInValue(value: any, substitutions: Map<string, any>): any {
+  if (isVariable(value)) {
+    return substitutions.has(value.name) ? substitutions.get(value.name) : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => substituteVariablesInValue(v, substitutions));
+  }
+  if (value && typeof value === 'object') {
+    const result: {[key: string]: any} = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = substituteVariablesInValue(v, substitutions);
+    }
+    return result;
+  }
+  return value;
+}
+
+// The variable names a `@requires` field set on `field` may reference (each binds to the like-named argument).
+export function fieldArgumentNames(field: FieldDefinition<any>): Set<string> {
+  return new Set(field.arguments().map((arg) => arg.name));
 }
 
 export function parseOperationAST(source: string): OperationDefinitionNode {

--- a/internals-js/src/values.ts
+++ b/internals-js/src/values.ts
@@ -496,19 +496,25 @@ function areTypesCompatible(variableType: InputType, locationType: InputType): b
   return !isListType(variableType) && sameType(variableType, locationType);
 }
 
-export function isValidValue(value: any, argument: ArgumentDefinition<any> | InputFieldDefinition, variableDefinitions: VariableDefinitions): boolean {
-  return isValidValueApplication(value, argument.type!, argument.defaultValue, variableDefinitions);
+export function isValidValue(value: any, argument: ArgumentDefinition<any> | InputFieldDefinition, variableDefinitions: VariableDefinitions, allowedVariableNames?: Set<string>): boolean {
+  return isValidValueApplication(value, argument.type!, argument.defaultValue, variableDefinitions, allowedVariableNames);
 }
 
-export function isValidValueApplication(value: any, locationType: InputType, locationDefault: any, variableDefinitions: VariableDefinitions): boolean {
+// Variables named in `allowedVariableNames` are accepted without a matching definition (and regardless of type): a
+// `@requires` field set may reference the annotated field's arguments as variables, which stay symbolic until query
+// planning (their types are checked separately during composition).
+export function isValidValueApplication(value: any, locationType: InputType, locationDefault: any, variableDefinitions: VariableDefinitions, allowedVariableNames?: Set<string>): boolean {
   // Note that this needs to be first, or the recursive call within 'isNonNullType' would break for variables
   if (isVariable(value)) {
+    if (allowedVariableNames?.has(value.name)) {
+      return true;
+    }
     const definition = variableDefinitions.definition(value);
     return !!definition && isValidVariable(definition, locationType, locationDefault);
   }
 
   if (isNonNullType(locationType)) {
-    return value !== null && isValidValueApplication(value, locationType.ofType, undefined, variableDefinitions);
+    return value !== null && isValidValueApplication(value, locationType.ofType, undefined, variableDefinitions, allowedVariableNames);
   }
 
   if (value === null || value === undefined) {
@@ -518,10 +524,10 @@ export function isValidValueApplication(value: any, locationType: InputType, loc
   if (isListType(locationType)) {
     const itemType: InputType = locationType.ofType;
     if (Array.isArray(value)) {
-      return value.every(item => isValidValueApplication(item, itemType, undefined, variableDefinitions));
+      return value.every(item => isValidValueApplication(item, itemType, undefined, variableDefinitions, allowedVariableNames));
     }
     // Equivalent of coercing non-null element as a list of one.
-    return isValidValueApplication(value, itemType, locationDefault, variableDefinitions);
+    return isValidValueApplication(value, itemType, locationDefault, variableDefinitions, allowedVariableNames);
   }
 
   if (isInputObjectType(locationType)) {
@@ -531,7 +537,7 @@ export function isValidValueApplication(value: any, locationType: InputType, loc
     const valueKeys = new Set(Object.keys(value));
     const fieldsAreValid = locationType.fields().every(field => {
       valueKeys.delete(field.name);
-      return isValidValueApplication(value[field.name], field.type!, field.defaultValue, variableDefinitions)
+      return isValidValueApplication(value[field.name], field.type!, field.defaultValue, variableDefinitions, allowedVariableNames)
     });
     const hasUnexpectedField = valueKeys.size !== 0
     return fieldsAreValid && !hasUnexpectedField;

--- a/query-graphs-js/src/graphPath.ts
+++ b/query-graphs-js/src/graphPath.ts
@@ -1962,6 +1962,9 @@ function canSatisfyConditions<TTrigger, V extends Vertex, TNullEdge extends null
   excludedEdges: ExcludedDestinations,
   excludedConditions: ExcludedConditions,
   getFieldParentType: (trigger: TTrigger) => CompositeType | null,
+  // Resolved instead of the edge's own `conditions` (an operation-specific `@requires` condition with its variables
+  // substituted). Being edge-specific, it bypasses the resolution cache (see `cachingConditionResolver`).
+  extraConditions?: SelectionSet,
 ): ConditionResolution {
   const { conditions, requiredContexts } = edge;
   if (!conditions && requiredContexts.length === 0) {
@@ -2063,8 +2066,8 @@ function canSatisfyConditions<TTrigger, V extends Vertex, TNullEdge extends null
     }
   }
   
-  debug.group(() => `Checking conditions ${conditions} on edge ${edge}`);
-  const resolution = conditionResolver(edge, context, excludedEdges, excludedConditions);
+  debug.group(() => `Checking conditions ${extraConditions ?? conditions} on edge ${edge}`);
+  const resolution = conditionResolver(edge, context, excludedEdges, excludedConditions, extraConditions);
   if (!resolution.satisfied) {
     debug.groupEnd('Conditions are not satisfied');
     return unsatisfiedConditionsResolution;
@@ -2926,8 +2929,40 @@ function addFieldEdge<V extends Vertex>(
   conditionResolver: ConditionResolver,
   context: PathContext
 ): OpGraphPath<V> | undefined {
-  const conditionResolution = canSatisfyConditions(path, edge, conditionResolver, context, [], [], getFieldParentTypeForOpTrigger);
+  const substitutedConditions = fieldArgumentSubstitutedConditions(edge, fieldOperation);
+  const conditionResolution = canSatisfyConditions(path, edge, conditionResolver, context, [], [], getFieldParentTypeForOpTrigger, substitutedConditions);
   return conditionResolution.satisfied ? path.add(fieldOperation, edge, conditionResolution) : undefined;
+}
+
+// Binds field-argument variables in the edge's `@requires` conditions to the values `operationField` supplies,
+// following argument coercion (supplied value, else schema default, else null); a supplied operation variable is
+// left in place and thus forwarded into the subgraph fetch. Returns `undefined` when there's nothing to substitute
+// (the common case, keeping resolution cacheable). Also used by the plan builder to compute the fetch's inputs, so
+// they match the fields actually fetched.
+export function fieldArgumentSubstitutedConditions(edge: Edge, operationField: Field<any>): SelectionSet | undefined {
+  const conditions = edge.conditions;
+  if (!conditions) {
+    return undefined;
+  }
+  const usedVariableNames = new Set(conditions.usedVariables().map((v) => v.name));
+  if (usedVariableNames.size === 0) {
+    return undefined;
+  }
+  const substitutions = new Map<string, any>();
+  for (const argDef of operationField.definition.arguments()) {
+    if (!usedVariableNames.has(argDef.name)) {
+      continue;
+    }
+    const suppliedValue = operationField.argumentValue(argDef.name);
+    const effectiveValue = suppliedValue !== undefined
+      ? suppliedValue
+      : (argDef.defaultValue !== undefined ? argDef.defaultValue : null);
+    substitutions.set(argDef.name, effectiveValue);
+  }
+  if (substitutions.size === 0) {
+    return undefined;
+  }
+  return conditions.substituteFieldArgumentVariables(substitutions);
 }
 
 function pathAsOptions<V extends Vertex>(path: OpGraphPath<V> | undefined): SimultaneousPaths<V>[] | undefined {

--- a/query-graphs-js/src/querygraph.ts
+++ b/query-graphs-js/src/querygraph.ts
@@ -18,6 +18,7 @@ import {
   FieldDefinition,
   isCompositeType,
   parseFieldSetArgument,
+  fieldArgumentNames,
   AbstractType,
   isAbstractType,
   possibleRuntimeTypes,
@@ -862,7 +863,9 @@ function federateSubgraphs(
           const field = e.transition.definition;
           assert(isCompositeType(type), () => `Non composite type "${type}" should not have field collection edge ${e}`);
           for (const requiresApplication of field.appliedDirectivesOf(requireDirective)) {
-            const conditions = parseFieldSetArgument({ parentType: type, directive: requiresApplication, normalize: true });
+            // Keep any field-argument variables symbolic on the edge; they're substituted at planning time
+            // (see `fieldArgumentSubstitutedConditions` in graphPath.ts).
+            const conditions = parseFieldSetArgument({ parentType: type, directive: requiresApplication, normalize: true, allowedFieldArgumentVariables: fieldArgumentNames(field) });
             const head = copyPointers[i].copiedVertex(e.head);
             // We rely on the fact that the edge indexes will be the same in the copied builder. But there is no real reason for
             // this to not be the case at this point so...

--- a/query-planner-js/src/__tests__/requiresFieldArguments.test.ts
+++ b/query-planner-js/src/__tests__/requiresFieldArguments.test.ts
@@ -1,0 +1,324 @@
+import {
+  operationFromDocument,
+  asFed2SubgraphDocument,
+  ServiceDefinition,
+} from '@apollo/federation-internals';
+import { composeServices } from '@apollo/composition';
+import gql from 'graphql-tag';
+import { composeAndCreatePlanner, findFetchNodes } from './testHelper';
+
+// Subgraph B owns the external field(s) referenced by `@requires` in subgraph A.
+const subgraphB: ServiceDefinition = {
+  name: 'B',
+  typeDefs: gql`
+    type T @key(fields: "id") {
+      id: ID!
+      x(arg: Int): Int
+    }
+  `,
+};
+
+// Composes `subgraphA` with `subgraphB` (both as Fed2 subgraphs) and returns the composition result so tests can
+// assert on either success or errors.
+function compose(subgraphA: ServiceDefinition) {
+  return composeServices([
+    { ...subgraphA, typeDefs: asFed2SubgraphDocument(subgraphA.typeDefs) },
+    { ...subgraphB, typeDefs: asFed2SubgraphDocument(subgraphB.typeDefs) },
+  ]);
+}
+
+// Returns the (whitespace-stripped) operation string of the fetch(es) sent to subgraph B for `operation`.
+// `composeAndCreatePlanner` turns the given subgraphs into Fed2 subgraphs itself, so the typeDefs are passed raw.
+function subgraphBFetch(
+  subgraphA: ServiceDefinition,
+  operation: string,
+): string {
+  const [api, queryPlanner] = composeAndCreatePlanner(subgraphA, subgraphB);
+  const plan = queryPlanner.buildQueryPlan(
+    operationFromDocument(api, gql(operation)),
+  );
+  const fetches = findFetchNodes('B', plan.node);
+  expect(fetches.length).toBeGreaterThan(0);
+  return fetches.map((f) => f.operation.replace(/\s/g, '')).join('\n');
+}
+
+describe('@requires with field arguments', () => {
+  test('a static literal argument value composes', () => {
+    const result = compose({
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y: Int @requires(fields: "x(arg: 42)")
+        }
+      `,
+    });
+    expect(result.errors).toBeUndefined();
+  });
+
+  test('a variable argument value composes', () => {
+    const result = compose({
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+        }
+      `,
+    });
+    expect(result.errors).toBeUndefined();
+  });
+
+  test('an unbound variable argument value is rejected', () => {
+    const result = compose({
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y: Int @requires(fields: "x(arg: $arg)")
+        }
+      `,
+    });
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.map((e) => e.message)).toContainEqual(
+      expect.stringContaining(
+        'variable "$arg" is not defined; a variable in a @requires field set must reference an argument of "T.y"',
+      ),
+    );
+    expect(
+      result.errors!.some(
+        (e) => (e.extensions?.code as string) === 'REQUIRES_INVALID_FIELDS',
+      ),
+    ).toBe(true);
+  });
+
+  test('a client-supplied variable is forwarded and a literal is inlined into the subgraph fetch', () => {
+    const subgraphA: ServiceDefinition = {
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+        }
+      `,
+    };
+
+    expect(
+      subgraphBFetch(subgraphA, 'query($v: Int) { t { y(arg: $v) } }'),
+    ).toContain('x(arg:$v)');
+    expect(subgraphBFetch(subgraphA, '{ t { y(arg: 7) } }')).toContain(
+      'x(arg:7)',
+    );
+  });
+
+  test('an omitted nullable argument substitutes null', () => {
+    const subgraphA: ServiceDefinition = {
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+        }
+      `,
+    };
+
+    expect(subgraphBFetch(subgraphA, '{ t { y } }')).toContain('x(arg:null)');
+  });
+
+  test('an omitted argument with a schema default substitutes the default', () => {
+    const subgraphA: ServiceDefinition = {
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int = 5): Int @requires(fields: "x(arg: $arg)")
+        }
+      `,
+    };
+
+    expect(subgraphBFetch(subgraphA, '{ t { y } }')).toContain('x(arg:5)');
+  });
+
+  test('a variable nested in a list argument threads through', () => {
+    const subgraphA: ServiceDefinition = {
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(args: [Int]): Int @external
+          y(arg: Int): Int @requires(fields: "x(args: [$arg])")
+        }
+      `,
+    };
+    const subgraphBList: ServiceDefinition = {
+      name: 'B',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          x(args: [Int]): Int
+        }
+      `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlanner(
+      subgraphA,
+      subgraphBList,
+    );
+    const plan = queryPlanner.buildQueryPlan(
+      operationFromDocument(
+        api,
+        gql`
+          query ($v: Int) {
+            t {
+              y(arg: $v)
+            }
+          }
+        `,
+      ),
+    );
+    const fetch = findFetchNodes('B', plan.node)
+      .map((f) => f.operation.replace(/\s/g, ''))
+      .join('\n');
+    expect(fetch).toContain('x(args:[$v])');
+  });
+
+  test('multiple variable arguments each thread through', () => {
+    const subgraphA: ServiceDefinition = {
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          z(arg: Int): Int @external
+          y(a: Int, b: Int): Int @requires(fields: "x(arg: $a) z(arg: $b)")
+        }
+      `,
+    };
+    const subgraphBMulti: ServiceDefinition = {
+      name: 'B',
+      typeDefs: gql`
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int
+          z(arg: Int): Int
+        }
+      `,
+    };
+
+    const [api, queryPlanner] = composeAndCreatePlanner(
+      subgraphA,
+      subgraphBMulti,
+    );
+    const plan = queryPlanner.buildQueryPlan(
+      operationFromDocument(
+        api,
+        gql`
+          query ($v1: Int, $v2: Int) {
+            t {
+              y(a: $v1, b: $v2)
+            }
+          }
+        `,
+      ),
+    );
+    const fetch = findFetchNodes('B', plan.node)
+      .map((f) => f.operation.replace(/\s/g, ''))
+      .join('\n');
+    expect(fetch).toContain('x(arg:$v1)');
+    expect(fetch).toContain('z(arg:$v2)');
+  });
+
+  test('an incompatible variable type is rejected', () => {
+    const result = compose({
+      name: 'A',
+      typeDefs: gql`
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: String): Int @requires(fields: "x(arg: $arg)")
+        }
+      `,
+    });
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.map((e) => e.message)).toContainEqual(
+      expect.stringContaining(
+        'variable "$arg" cannot be used for argument "arg" of field "x": it is bound to argument "arg" of type "String", which is not compatible with the expected type "Int"',
+      ),
+    );
+    expect(
+      result.errors!.some(
+        (e) => (e.extensions?.code as string) === 'REQUIRES_INVALID_FIELDS',
+      ),
+    ).toBe(true);
+  });
+
+  test('a variable in a @provides field set is rejected', () => {
+    const result = composeServices([
+      {
+        name: 'A',
+        typeDefs: asFed2SubgraphDocument(gql`
+          type Query {
+            u(arg: Int): U @provides(fields: "x(arg: $arg)")
+          }
+
+          type U @key(fields: "id") {
+            id: ID!
+            x(arg: Int): Int @external
+          }
+        `),
+      },
+      {
+        name: 'B',
+        typeDefs: asFed2SubgraphDocument(gql`
+          type U @key(fields: "id") {
+            id: ID!
+            x(arg: Int): Int
+          }
+        `),
+      },
+    ]);
+    expect(result.errors).toBeDefined();
+  });
+});

--- a/query-planner-js/src/buildPlan.ts
+++ b/query-planner-js/src/buildPlan.ts
@@ -95,6 +95,7 @@ import {
   SimultaneousPaths,
   terminateWithNonRequestedTypenameField,
   getLocallySatisfiableKey,
+  fieldArgumentSubstitutedConditions,
   createInitialOptions,
   buildFederatedQueryGraph,
   FEDERATED_GRAPH_ROOT_SOURCE,
@@ -4530,6 +4531,10 @@ function computeGroupsForTree(
             }
 
             if (edge.conditions) {
+              // Substitute any field-argument variables so the inputs match what's fetched (`x(arg: $v)`, not `$arg`).
+              const requireConditions = operation && operation.kind === 'Field'
+                ? (fieldArgumentSubstitutedConditions(edge, operation) ?? edge.conditions)
+                : edge.conditions;
               // This edge needs the conditions just fetched, to be provided via
               // _entities (@requires or fake interface object downcast). So we
               // create the post-@requires group, adding the subgraph jump (if
@@ -4541,6 +4546,7 @@ function computeGroupsForTree(
                 path,
                 context,
                 handleRequiresResult,
+                requireConditions,
               );
               updated.group = createPostRequiresResult.group;
               updated.path = createPostRequiresResult.path;
@@ -4810,7 +4816,9 @@ function createPostRequiresGroup(
     fullyLocalRequires: boolean,
     createdGroups: FetchGroup[],
     requiresParent: ParentRelation | undefined,
-  }
+  },
+  // The post-require inputs: `edge.conditions` with any field-argument variables substituted (see the caller).
+  requireConditions: SelectionSet,
 ): {
   group: FetchGroup,
   path: GroupPath,
@@ -4829,10 +4837,12 @@ function createPostRequiresGroup(
     if (createdGroups.length === 0) {
       group.addInputs(
         inputsForRequire(
-          dependencyGraph, 
-          entityType, 
+          dependencyGraph,
+          entityType,
           edge,
-          context, false).inputs);
+          context,
+          requireConditions,
+          false).inputs);
       return { group, path, createdGroups: [] };
     }
     // If we get here, it means that @requires needs the information from `createdGroups` (plus whatever has
@@ -4887,6 +4897,7 @@ function createPostRequiresGroup(
       context,
       preRequireGroup,
       postRequireGroup,
+      requireConditions,
     );
     return {
       group: postRequireGroup,
@@ -4924,6 +4935,7 @@ function createPostRequiresGroup(
       context,
       group,
       postRequireGroup,
+      requireConditions,
     );
     return {
       group: postRequireGroup,
@@ -5127,8 +5139,9 @@ function addPostRequireInputs(
   context: PathContext,
   preRequireGroup: FetchGroup,
   postRequireGroup: FetchGroup,
+  requireConditions: SelectionSet,
 ) {
-  const { inputs, keyInputs } = inputsForRequire(dependencyGraph, entityType, edge, context);
+  const { inputs, keyInputs } = inputsForRequire(dependencyGraph, entityType, edge, context, requireConditions);
   // Note that `computeInputRewritesOnKeyFetch` will return `undefined` in general, but if `entityType` is an interface/interface object,
   // then we need those rewrites to ensure the underlying fetch is valid.
   postRequireGroup.addInputs(
@@ -5153,6 +5166,8 @@ function inputsForRequire(
   entityType: ObjectType,
   edge: Edge,
   context: PathContext,
+  // Conditions to declare as inputs (field-argument variables already substituted); falls back to `edge.conditions`.
+  requireConditions: SelectionSet | undefined,
   includeKeyInputs: boolean = true
 ): {
   inputs: SelectionSet,
@@ -5169,8 +5184,9 @@ function inputsForRequire(
   assert(inputType && isCompositeType(inputType), () => `Type ${inputTypeName} should exist in the supergraph and be a composite type`);
 
   const fullSelectionSet = newCompositeTypeSelectionSet(inputType);
-  if (edge.conditions) {
-    fullSelectionSet.updates().add(edge.conditions);
+  const conditions = requireConditions ?? edge.conditions;
+  if (conditions) {
+    fullSelectionSet.updates().add(conditions);
   }
   let keyInputs: MutableSelectionSet | undefined = undefined;
   if (includeKeyInputs) {


### PR DESCRIPTION
`@requires(fields: "...")` previously only accepted static literal argument values for required fields that take arguments — there was no way to pass a per-request value (e.g. an end user's currency) through to the subgraph that owns the required field. This adds support for referencing the annotated field's own arguments as bare `$arg` variables, e.g.:

```graphql
price(currency: Currency!) @external
localizedPrice(currency: Currency!): Money @requires(fields: "price(currency: $currency)")
```

A @requires field set may now reference one of the annotated field's own arguments as a variable. At query planning time, the value the operation supplies for that argument is threaded into the subgraph that owns the required field: an operation variable is forwarded, a literal is inlined, and an omitted argument resolves to its schema default or null.

Variables are kept symbolic through parsing, composition, and query-graph building, and are only bound to concrete values during query planning. Composition rejects unbound variables, type-incompatible bindings, and any variable used in a @provides field set.

Fixes: https://github.com/apollographql/router/issues/9583
Mirrors: https://github.com/apollographql/router/pull/9604
Relates to:
- https://github.com/apollographql/federation/issues/2276
- https://github.com/apollographql/federation/issues/2645

**Note:**

👋 Hi folks. I've done my best here to make sure these changes are accurate and reasonable. I'm obviously not an expert in this codebase - I've tried to adopt the style of surrounding code and consider maintainability in my implementation. That said I'm sure folks closer to the codebase will have opinions here. I'm glad to make any updates you see fit, even if it's heading back to the drawing board to approach this from a different angle.