### PR TITLE
Initial support for connect/v0.5

### DIFF
--- a/.changeset/connect-v05-initial.md
+++ b/.changeset/connect-v05-initial.md
@@ -1,0 +1,7 @@
+---
+"@apollo/composition": minor
+"@apollo/federation-internals": minor
+"@apollo/query-graphs": minor
+---
+
+Add initial support for `connect/v0.5` (preview) to unblock further development ([#3455](https://github.com/apollographql/federation/pull/3455)). The directive surface is currently identical to `connect/v0.4`; version-specific `@connect`/`@source` arguments will be added behind the v0.5 version gate as they are finalized.

--- a/composition-js/src/__tests__/connectors.test.ts
+++ b/composition-js/src/__tests__/connectors.test.ts
@@ -779,6 +779,44 @@ type Resource
     expect(printed).toContain(
       '@link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)'
     );
+    expect(printed).not.toContain('connect/v0.5');
+  });
+
+  it("uses v0.5 in supergraph @link when a subgraph explicitly links to v0.5", () => {
+    const subgraphs = [
+      {
+        name: "with-connectors-v0_5",
+        typeDefs: parse(`
+                    extend schema
+                    @link(
+                        url: "https://specs.apollo.dev/federation/v2.14"
+                        import: ["@key"]
+                    )
+                    @link(
+                        url: "https://specs.apollo.dev/connect/v0.5"
+                        import: ["@connect", "@source"]
+                    )
+                    @source(name: "v1", http: { baseURL: "http://v1" })
+
+                    type Query {
+                        resources: [Resource!]!
+                        @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    }
+
+                    type Resource @key(fields: "id") {
+                        id: ID!
+                        name: String!
+                    }
+                `),
+      },
+    ];
+
+    const result = composeServices(subgraphs);
+    expect(result.errors ?? []).toEqual([]);
+    const printed = printSchema(result.schema!);
+    expect(printed).toContain(
+      '@link(url: "https://specs.apollo.dev/connect/v0.5", for: EXECUTION)'
+    );
   });
 
   it("uses v0.3 (not v0.4) in supergraph @link when subgraphs only use v0.3 and earlier", () => {
@@ -817,6 +855,7 @@ type Resource
       '@link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION)'
     );
     expect(printed).not.toContain('connect/v0.4');
+    expect(printed).not.toContain('connect/v0.5');
   });
 
   it("composes with renames", () => {

--- a/internals-js/src/specs/connectSpec.ts
+++ b/internals-js/src/specs/connectSpec.ts
@@ -390,6 +390,13 @@ export const CONNECT_VERSIONS = new FeatureDefinitions<ConnectSpecDefinition>(
       new FeatureVersion(2, 13),
     ),
     { preview: true },
+  )
+  .add(
+    new ConnectSpecDefinition(
+      new FeatureVersion(0, 5),
+      new FeatureVersion(2, 14),
+    ),
+    { preview: true },
   );
 
 registerKnownFeature(CONNECT_VERSIONS);

--- a/internals-js/src/supergraphs.ts
+++ b/internals-js/src/supergraphs.ts
@@ -50,6 +50,7 @@ export const ROUTER_SUPPORTED_SUPERGRAPH_FEATURES: Set<string> = new Set([
   'https://specs.apollo.dev/connect/v0.2',
   'https://specs.apollo.dev/connect/v0.3',
   'https://specs.apollo.dev/connect/v0.4',
+  'https://specs.apollo.dev/connect/v0.5',
   'https://specs.apollo.dev/cacheTag/v0.1',
 ]);
 


### PR DESCRIPTION
## Summary

Adds initial support for `connect/v0.5` so we can release preview builds where `@link(url: "https://specs.apollo.dev/connect/v0.5")` can be enabled, similar to how we tested `connect/v0.3` and `connect/v0.4` before they were released.

- Registers `connect/v0.5` in `CONNECT_VERSIONS` as a **preview** version (`{ preview: true }`), so it does not leak into the supergraph `@link` automatically — only subgraphs that explicitly `@link` to v0.5 get it (`latestNonPreview()` continues to drive automatic selection). `connect/v0.4` remains preview as well.
- Maps `connect/v0.5` to a minimum federation version of `2.14`. Unlike the `connect/v0.4` work (#3349), this needs **no new federation spec version** — `2.14` already exists.
- Adds `https://specs.apollo.dev/connect/v0.5` to `ROUTER_SUPPORTED_SUPERGRAPH_FEATURES`.

The `@connect`/`@source` directive surface for v0.5 is currently **identical to v0.4** — this PR just stakes out the version to unblock further development (both composition-side and router-side). Version-specific `@connect`/`@source` arguments will be added behind the v0.5 version gate (`version.gte(new FeatureVersion(0, 5))`) as they are finalized, the same pattern `federationSpec.ts` uses for per-version directive args.

> **Note:** this PR also merges the current `main` into `next` (merge-forward), then adds the v0.5 changes on top, per the request to do it in a single PR.

## Test plan

- [x] New test: "uses v0.5 in supergraph @link when a subgraph explicitly links to v0.5"
- [x] Strengthened the neighboring v0.3/v0.4 selection tests to assert `connect/v0.5` does not leak
- [x] `npm run compile` + full `connectors.test.ts` suite passes (14 tests)

A changeset will be added in a follow-up commit so it can link back to this PR.
