### PR TITLE
fix(gateway): export fleet-awareness metrics to the OTLP /v1/metrics route

### DIFF
--- a/.changeset/telemetry-bare-route-fix.md
+++ b/.changeset/telemetry-bare-route-fix.md
@@ -1,0 +1,7 @@
+---
+"@apollo/gateway": patch
+---
+
+Fix fleet-awareness telemetry exporting metrics to the bare usage-reporting endpoint instead of the OTLP `/v1/metrics` route
+
+The opt-out anonymous telemetry pipeline introduced in #3289 configured the OTLP metric exporter with a bare `https://usage-reporting.api.apollographql.com` URL. Because the URL is supplied programmatically (rather than via `OTEL_EXPORTER_OTLP_ENDPOINT`), the `@opentelemetry/exporter-metrics-otlp-http` package does not append the `/v1/metrics` signal path automatically, so every export POSTed to `/` instead of `/v1/metrics`. The exporter now targets the full OTLP metrics route.

--- a/gateway-js/src/__tests__/gateway/opentelemetry.test.ts
+++ b/gateway-js/src/__tests__/gateway/opentelemetry.test.ts
@@ -14,7 +14,10 @@ import {
   InMemoryMetricExporter,
   AggregationTemporality,
 } from '@opentelemetry/sdk-metrics';
-import { createDataCollectionMeterProvider } from '../../utilities/opentelemetry';
+import {
+  APOLLO_OTEL_METRICS_URL,
+  createDataCollectionMeterProvider,
+} from '../../utilities/opentelemetry';
 import {
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_INSTANCE_ID,
@@ -413,6 +416,12 @@ describe('opentelemetry', () => {
         );
         expect(unexpectedKeys).toEqual([]);
       }, 10000);
+    });
+
+    it('exports metrics to the /v1/metrics route', () => {
+      expect(APOLLO_OTEL_METRICS_URL).toBe(
+        'https://usage-reporting.api.apollographql.com/v1/metrics',
+      );
     });
   });
 });

--- a/gateway-js/src/utilities/opentelemetry.ts
+++ b/gateway-js/src/utilities/opentelemetry.ts
@@ -73,6 +73,8 @@ export enum OpenTelemetryAttributeNames {
 }
 
 const APOLLO_OTEL_ENDPOINT = "https://usage-reporting.api.apollographql.com";
+const METRIC_SIGNAL_PATH = "/v1/metrics";
+export const APOLLO_OTEL_METRICS_URL = `${APOLLO_OTEL_ENDPOINT}${METRIC_SIGNAL_PATH}`;
 const EXPORT_INTERVAL_SECONDS = 60 * 60; // one hour
 const EXPORT_INTERVAL_MILLIS = 1000 * EXPORT_INTERVAL_SECONDS;
 const NAME = "apollo/gateway-js";
@@ -263,5 +265,5 @@ export function createDataCollectionMeterProvider(metricExporter: PushMetricExpo
 }
 
 export function createDataCollectionExporter(): MeterProvider {
-  return createDataCollectionMeterProvider(new OTLPMetricExporter({ url: APOLLO_OTEL_ENDPOINT }));
+  return createDataCollectionMeterProvider(new OTLPMetricExporter({ url: APOLLO_OTEL_METRICS_URL }));
 }


### PR DESCRIPTION
# fix(gateway): export fleet-awareness metrics to the OTLP `/v1/metrics` route

## Problem

The opt-out fleet-awareness telemetry pipeline introduced in #3289 configures its
OTLP metric exporter with the bare host URL:

```ts
new OTLPMetricExporter({ url: "https://usage-reporting.api.apollographql.com" })
```

`@opentelemetry/exporter-metrics-otlp-http` treats its two configuration paths
differently:

- An endpoint supplied via `OTEL_EXPORTER_OTLP_ENDPOINT` gets the `/v1/metrics`
  signal path **appended automatically**.
- A `url` passed programmatically in the constructor is used **verbatim** — no
  path is appended.

Because this code uses the constructor path, hourly metric exports from
gateways running ≥2.14.0 have been going to `/` rather than the OTLP metrics
route, so they never reach the collection service. Pointing the exporter at
the proper `/v1/metrics` path lets fleet-awareness telemetry land where the
service actually receives it. The URL is not user-configurable, so this is
only fixable in the package itself.

## Fix

- Append the OTLP metrics signal path where the exporter is constructed, via a
  new exported constant:

  ```ts
  export const APOLLO_OTEL_METRICS_URL = `${APOLLO_OTEL_ENDPOINT}${METRIC_SIGNAL_PATH}`;
  ```

  `createDataCollectionExporter()` now passes `APOLLO_OTEL_METRICS_URL` to the
  exporter.

- Add a regression test pinning the full export URL. A wrong URL fails
  silently in production, and existing tests inject an in-memory exporter, so
  they never exercise it. The constant is exported so the test asserts it
  directly, without mocking.

## Testing

- `gateway-js` OpenTelemetry test suite passes (14 tests, 5 snapshots),
  including the new URL regression test.

## Scope

Changeset included: `patch` for `@apollo/gateway`.
